### PR TITLE
refactor: Remove commission calculator from partner landing page

### DIFF
--- a/app/become-a-partner/page.tsx
+++ b/app/become-a-partner/page.tsx
@@ -2,7 +2,6 @@ import { Metadata } from 'next';
 import { HeroSection } from '@/components/partner-landing/HeroSection';
 import { BenefitCards } from '@/components/partner-landing/BenefitCards';
 import { HowItWorks } from '@/components/partner-landing/HowItWorks';
-import { CommissionCalculator } from '@/components/partner-landing/CommissionCalculator';
 import { CommissionStructure } from '@/components/partner-landing/CommissionStructure';
 import { PartnerTestimonials } from '@/components/partner-landing/PartnerTestimonials';
 import { SuccessMetrics } from '@/components/partner-landing/SuccessMetrics';
@@ -29,9 +28,6 @@ export default function BecomeAPartnerPage() {
 
       {/* Success Metrics */}
       <SuccessMetrics />
-
-      {/* Interactive Commission Calculator (PRIORITY FEATURE) */}
-      <CommissionCalculator />
 
       {/* Commission Structure Table */}
       <CommissionStructure />

--- a/components/partner-landing/CommissionStructure.tsx
+++ b/components/partner-landing/CommissionStructure.tsx
@@ -14,7 +14,7 @@ const tiers = [
 
 export function CommissionStructure() {
   return (
-    <section className="py-20 bg-white">
+    <section id="commission-structure" className="py-20 bg-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <div className="text-center mb-16">

--- a/components/partner-landing/FinalCTA.tsx
+++ b/components/partner-landing/FinalCTA.tsx
@@ -84,11 +84,10 @@ export function FinalCTA() {
               variant="outline"
               className="border-2 border-white text-white hover:bg-white hover:text-circleTel-darkNeutral px-10 py-7 text-xl font-bold rounded-xl transition-all duration-300 w-full sm:w-auto"
               onClick={() => {
-                const element = document.getElementById('commission-calculator');
-                element?.scrollIntoView({ behavior: 'smooth' });
+                window.scrollTo({ top: 0, behavior: 'smooth' });
               }}
             >
-              Calculate Earnings
+              Back to Top
             </Button>
           </div>
         </div>

--- a/components/partner-landing/HeroSection.tsx
+++ b/components/partner-landing/HeroSection.tsx
@@ -78,12 +78,12 @@ export function HeroSection() {
                 variant="outline"
                 className="border-2 border-white text-white hover:bg-white hover:text-circleTel-darkNeutral px-8 py-6 text-lg font-semibold rounded-lg transition-all duration-300 w-full sm:w-auto"
                 onClick={() => {
-                  const element = document.getElementById('commission-calculator');
+                  const element = document.querySelector('#commission-structure');
                   element?.scrollIntoView({ behavior: 'smooth' });
                 }}
               >
                 <FileText className="mr-2 h-5 w-5" />
-                Calculate Earnings
+                View Commission Rates
               </Button>
             </div>
 


### PR DESCRIPTION
## Summary
Remove the interactive commission calculator from `/become-a-partner` landing page.

## Changes Made

### Removed Component
- ❌ **CommissionCalculator** - Interactive slider-based earnings calculator
  - No longer displayed on landing page
  - Component still exists in codebase for potential future use

### Updated CTAs
- **HeroSection**: "Calculate Earnings" → "View Commission Rates"
  - Scrolls to Commission Structure section
- **FinalCTA**: "Calculate Earnings" → "Back to Top"
  - Returns user to top of page

### Technical Updates
- Added `id="commission-structure"` to CommissionStructure for anchor linking
- Removed CommissionCalculator import from page
- Updated button onClick handlers

## Components Retained
✅ CommissionStructure - 7-tier rate table with examples  
✅ BenefitCards - Partner benefits overview  
✅ HowItWorks - 4-step timeline  
✅ SuccessMetrics - Statistics dashboard  
✅ PartnerTestimonials - Success stories  
✅ FAQSection - 10 FAQs  
✅ FinalCTA - Call to action  
✅ HeroSection - Hero with updated CTA  

## Files Changed
- `app/become-a-partner/page.tsx` (-2 lines)
- `components/partner-landing/HeroSection.tsx` (updated CTA)
- `components/partner-landing/FinalCTA.tsx` (updated CTA)
- `components/partner-landing/CommissionStructure.tsx` (added ID)

## Testing
✅ TypeScript type check passes  
✅ No breaking changes  
✅ All other components render correctly  
✅ Navigation still functional  

## Deployment Impact
- **Breaking Changes**: None
- **Database Changes**: None
- **Environment Variables**: None
- **User Impact**: Simplified landing page experience

## Post-Deployment Verification
1. Visit https://www.circletel.co.za/become-a-partner
2. Verify commission calculator section is removed
3. Test "View Commission Rates" button scrolls to structure
4. Confirm all other sections still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)