### PR TITLE
fix(dashboard): Fix mobile sidebar navigation showing blank

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -85,7 +85,7 @@ export default function DashboardLayout({
             <div className="fixed inset-0 z-40 lg:hidden">
               <div className="fixed inset-0 bg-black/40" onClick={() => setSidebarOpen(false)} />
               <div className="fixed top-14 bottom-0 left-0 w-72 bg-white shadow-xl overflow-y-auto">
-                <SidebarNav />
+                <SidebarNav mobile={true} />
               </div>
             </div>
           )}

--- a/components/dashboard/SidebarNav.tsx
+++ b/components/dashboard/SidebarNav.tsx
@@ -33,37 +33,41 @@ const items = [
 interface SidebarNavProps {
   collapsed?: boolean;
   onToggleCollapse?: () => void;
+  mobile?: boolean;
 }
 
-export default function SidebarNav({ collapsed = false, onToggleCollapse }: SidebarNavProps) {
+export default function SidebarNav({ collapsed = false, onToggleCollapse, mobile = false }: SidebarNavProps) {
   const pathname = usePathname();
 
   return (
     <aside
       className={cn(
-        "hidden lg:flex shrink-0 border-r bg-white transition-all duration-300 ease-in-out z-40",
-        collapsed ? "w-[80px]" : "w-[280px]"
+        "shrink-0 bg-white transition-all duration-300 ease-in-out z-40",
+        !mobile && "hidden lg:flex border-r",
+        mobile ? "w-full" : collapsed ? "w-[80px]" : "w-[280px]"
       )}
     >
-      <div className="flex h-screen sticky top-0 flex-col gap-2 p-4 w-full">
-        {/* Toggle Button */}
-        <div className={cn(
-          "flex items-center justify-end py-2",
-          collapsed ? "px-0" : "px-3"
-        )}>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onToggleCollapse}
-            className="h-8 w-8 hover:bg-gray-100"
-          >
-            {collapsed ? (
-              <ChevronRight className="h-5 w-5 text-gray-600" />
-            ) : (
-              <ChevronLeft className="h-5 w-5 text-gray-600" />
-            )}
-          </Button>
-        </div>
+      <div className={cn("flex flex-col gap-2 p-4 w-full", mobile ? "h-full" : "h-screen sticky top-0")}>
+        {/* Toggle Button - Only show on desktop */}
+        {!mobile && (
+          <div className={cn(
+            "flex items-center justify-end py-2",
+            collapsed ? "px-0" : "px-3"
+          )}>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onToggleCollapse}
+              className="h-8 w-8 hover:bg-gray-100"
+            >
+              {collapsed ? (
+                <ChevronRight className="h-5 w-5 text-gray-600" />
+              ) : (
+                <ChevronLeft className="h-5 w-5 text-gray-600" />
+              )}
+            </Button>
+          </div>
+        )}
 
         {/* Navigation */}
         <nav className="flex-1 space-y-1 overflow-y-auto pr-1">


### PR DESCRIPTION
## Summary
Fixes the mobile sidebar navigation in the customer dashboard that was showing blank on mobile devices.

## Problem
The mobile sidebar menu overlay was opening correctly, but the navigation content inside was not visible due to CSS classes that hid the component on mobile screens.

## Root Cause
The `SidebarNav` component had `hidden lg:flex` classes, which meant:
- Hidden on mobile/tablet screens
- Only visible on large desktop screens (lg breakpoint and above)

When the mobile menu overlay rendered this component, it was hidden by these classes.

## Solution
- Added `mobile` prop to `SidebarNav` component to handle mobile rendering mode
- Conditionally apply `hidden lg:flex` only when NOT in mobile mode
- Hide collapse toggle button on mobile (not needed in overlay)
- Pass `mobile={true}` to the mobile sidebar instance in the layout

## Changes
### Files Modified
1. **components/dashboard/SidebarNav.tsx**
   - Added `mobile?: boolean` prop to component interface
   - Conditional CSS: `!mobile && "hidden lg:flex border-r"`
   - Hide collapse toggle on mobile
   - Adjusted container height for mobile vs desktop

2. **app/dashboard/layout.tsx**
   - Updated mobile sidebar instance: `<SidebarNav mobile={true} />`

## Testing
- ✅ Mobile sidebar now displays navigation menu correctly
- ✅ Desktop sidebar maintains existing behavior (responsive collapse)
- ✅ No TypeScript errors introduced
- ✅ Overlay and click-outside-to-close functionality works

## Screenshots
The mobile sidebar will now show all 6 navigation items:
- Dashboard
- Accounts  
- Orders
- Billing
- Help & Support
- Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)