### PR TITLE
feat(marketing): add marketing intelligence layer for campaign targeting

### DIFF
--- a/app/admin/marketing/campaign-builder/page.tsx
+++ b/app/admin/marketing/campaign-builder/page.tsx
@@ -1,0 +1,885 @@
+'use client';
+
+import {
+  PiArrowsClockwiseBold,
+  PiBuildingsBold,
+  PiDownloadSimpleBold,
+  PiFireBold,
+  PiMapPinBold,
+  PiRadioBold,
+  PiTargetBold,
+  PiWarningBold,
+} from 'react-icons/pi';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+type TabType = 'dfa' | 'demand' | 'tarana';
+
+interface DFACampaignItem {
+  id: string;
+  buildingName: string;
+  streetAddress: string;
+  coverageType: string;
+  ftth: string | null;
+  broadband: string | null;
+  precinct: string | null;
+  promotion: string | null;
+  latitude: number;
+  longitude: number;
+}
+
+interface TaranaItem {
+  id: string;
+  serialNumber: string;
+  hostname: string;
+  siteName: string;
+  market: string | null;
+  latitude: number;
+  longitude: number;
+  activeConnections: number | null;
+}
+
+interface DemandHotspot {
+  latitude: number;
+  longitude: number;
+  sampleAddresses: string[];
+  totalSearches: number;
+  withCoverage: number;
+  withoutCoverage: number;
+  noCoverageLeads: number;
+  demandScore: number;
+  gapScore: number;
+  serviceInterest: Record<string, number>;
+}
+
+export default function CampaignBuilderPage() {
+  const [activeTab, setActiveTab] = useState<TabType>('dfa');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // DFA state
+  const [dfaItems, setDfaItems] = useState<DFACampaignItem[]>([]);
+  const [dfaSummary, setDfaSummary] = useState<{
+    totalBuildings: number;
+    connected: number;
+    nearNet: number;
+    filteredCount: number;
+    precincts: { name: string; count: number }[];
+  } | null>(null);
+  const [dfaCoverageType, setDfaCoverageType] = useState('');
+  const [dfaPrecinct, setDfaPrecinct] = useState('');
+  const [dfaSearch, setDfaSearch] = useState('');
+  const [dfaPage, setDfaPage] = useState(1);
+  const [dfaTotalPages, setDfaTotalPages] = useState(0);
+
+  // Tarana state
+  const [taranaItems, setTaranaItems] = useState<TaranaItem[]>([]);
+  const [taranaSummary, setTaranaSummary] = useState<{
+    totalStations: number;
+    markets: { name: string; count: number }[];
+  } | null>(null);
+  const [taranaSearch, setTaranaSearch] = useState('');
+  const [taranaPage, setTaranaPage] = useState(1);
+  const [taranaTotalPages, setTaranaTotalPages] = useState(0);
+
+  // Demand state
+  const [hotspots, setHotspots] = useState<DemandHotspot[]>([]);
+  const [demandSummary, setDemandSummary] = useState<{
+    totalCoverageSearches: number;
+    totalNoCoverageLeads: number;
+    coverageRate: number;
+    hotspotsFound: number;
+    infrastructure: { dfaBuildings: number; taranaBaseStations: number };
+  } | null>(null);
+  const [demandDays, setDemandDays] = useState(30);
+
+  const fetchDFA = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const params = new URLSearchParams({
+        source: 'dfa',
+        page: dfaPage.toString(),
+        pageSize: '50',
+      });
+      if (dfaCoverageType) params.set('coverage_type', dfaCoverageType);
+      if (dfaPrecinct) params.set('precinct', dfaPrecinct);
+      if (dfaSearch) params.set('search', dfaSearch);
+
+      const response = await fetch(
+        `/api/admin/marketing/campaign-lists?${params}`
+      );
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to fetch DFA data');
+      }
+
+      setDfaItems(data.data.items);
+      setDfaSummary(data.data.summary);
+      setDfaTotalPages(data.data.pagination.totalPages);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error loading DFA data');
+    } finally {
+      setLoading(false);
+    }
+  }, [dfaPage, dfaCoverageType, dfaPrecinct, dfaSearch]);
+
+  const fetchTarana = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const params = new URLSearchParams({
+        source: 'tarana',
+        page: taranaPage.toString(),
+        pageSize: '50',
+      });
+      if (taranaSearch) params.set('search', taranaSearch);
+
+      const response = await fetch(
+        `/api/admin/marketing/campaign-lists?${params}`
+      );
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to fetch Tarana data');
+      }
+
+      setTaranaItems(data.data.items);
+      setTaranaSummary(data.data.summary);
+      setTaranaTotalPages(data.data.pagination.totalPages);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error loading Tarana data');
+    } finally {
+      setLoading(false);
+    }
+  }, [taranaPage, taranaSearch]);
+
+  const fetchDemand = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const params = new URLSearchParams({
+        days: demandDays.toString(),
+        minSearches: '3',
+      });
+
+      const response = await fetch(
+        `/api/admin/marketing/coverage-demand?${params}`
+      );
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to fetch demand data');
+      }
+
+      setHotspots(data.data.hotspots);
+      setDemandSummary(data.data.summary);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error loading demand data');
+    } finally {
+      setLoading(false);
+    }
+  }, [demandDays]);
+
+  useEffect(() => {
+    if (activeTab === 'dfa') fetchDFA();
+    else if (activeTab === 'tarana') fetchTarana();
+    else if (activeTab === 'demand') fetchDemand();
+  }, [activeTab, fetchDFA, fetchTarana, fetchDemand]);
+
+  const exportDFAToCSV = async () => {
+    try {
+      const params = new URLSearchParams({
+        source: 'dfa',
+        page: '1',
+        pageSize: '5000',
+      });
+      if (dfaCoverageType) params.set('coverage_type', dfaCoverageType);
+      if (dfaPrecinct) params.set('precinct', dfaPrecinct);
+      if (dfaSearch) params.set('search', dfaSearch);
+
+      const response = await fetch(
+        `/api/admin/marketing/campaign-lists?${params}`
+      );
+      const data = await response.json();
+      if (!data.success) throw new Error('Export failed');
+
+      const csvRows = [
+        ['Building Name', 'Address', 'Coverage Type', 'FTTH', 'Broadband', 'Precinct', 'Promotion', 'Latitude', 'Longitude'].join(','),
+        ...data.data.items.map((b: DFACampaignItem) =>
+          [
+            `"${(b.buildingName || '').replace(/"/g, '""')}"`,
+            `"${(b.streetAddress || '').replace(/"/g, '""')}"`,
+            b.coverageType,
+            b.ftth || '',
+            b.broadband || '',
+            b.precinct || '',
+            b.promotion || '',
+            b.latitude,
+            b.longitude,
+          ].join(',')
+        ),
+      ];
+
+      const blob = new Blob([csvRows.join('\n')], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `dfa-campaign-${dfaCoverageType || 'all'}-${new Date().toISOString().split('T')[0]}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Export failed:', err);
+    }
+  };
+
+  const exportTaranaToCSV = async () => {
+    try {
+      const params = new URLSearchParams({
+        source: 'tarana',
+        page: '1',
+        pageSize: '5000',
+      });
+      if (taranaSearch) params.set('search', taranaSearch);
+
+      const response = await fetch(
+        `/api/admin/marketing/campaign-lists?${params}`
+      );
+      const data = await response.json();
+      if (!data.success) throw new Error('Export failed');
+
+      const csvRows = [
+        ['Site Name', 'Hostname', 'Serial Number', 'Market', 'Active Connections', 'Latitude', 'Longitude'].join(','),
+        ...data.data.items.map((s: TaranaItem) =>
+          [
+            `"${(s.siteName || '').replace(/"/g, '""')}"`,
+            s.hostname || '',
+            s.serialNumber || '',
+            s.market || '',
+            s.activeConnections ?? '',
+            s.latitude,
+            s.longitude,
+          ].join(',')
+        ),
+      ];
+
+      const blob = new Blob([csvRows.join('\n')], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `tarana-stations-${new Date().toISOString().split('T')[0]}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Export failed:', err);
+    }
+  };
+
+  const exportDemanToCSV = () => {
+    if (hotspots.length === 0) return;
+
+    const csvRows = [
+      ['Latitude', 'Longitude', 'Total Searches', 'With Coverage', 'Without Coverage', 'No Coverage Leads', 'Demand Score', 'Gap Score', 'Sample Addresses'].join(','),
+      ...hotspots.map((h) =>
+        [
+          h.latitude,
+          h.longitude,
+          h.totalSearches,
+          h.withCoverage,
+          h.withoutCoverage,
+          h.noCoverageLeads,
+          h.demandScore,
+          h.gapScore,
+          `"${h.sampleAddresses.join('; ').replace(/"/g, '""')}"`,
+        ].join(',')
+      ),
+    ];
+
+    const blob = new Blob([csvRows.join('\n')], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `demand-hotspots-${demandDays}d-${new Date().toISOString().split('T')[0]}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const tabs: { id: TabType; label: string; icon: React.ReactNode }[] = [
+    { id: 'dfa', label: 'DFA Buildings', icon: <PiBuildingsBold className="h-4 w-4" /> },
+    { id: 'demand', label: 'Demand Hotspots', icon: <PiFireBold className="h-4 w-4" /> },
+    { id: 'tarana', label: 'Tarana Capacity', icon: <PiRadioBold className="h-4 w-4" /> },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        {/* Header */}
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
+            <PiTargetBold className="h-8 w-8 text-purple-600" />
+            Campaign Builder
+          </h1>
+          <p className="text-gray-600 mt-1">
+            Build targeted campaign lists from DFA buildings, Tarana coverage, and demand data
+          </p>
+        </div>
+
+        {error && (
+          <Alert className="border-red-200 bg-red-50">
+            <PiWarningBold className="h-4 w-4 text-red-600" />
+            <AlertDescription className="text-red-800">{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Tabs */}
+        <div className="flex gap-1 bg-gray-100 p-1 rounded-lg w-fit">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-all ${
+                activeTab === tab.id
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* DFA Tab */}
+        {activeTab === 'dfa' && (
+          <>
+            {/* DFA Stats */}
+            {dfaSummary && (
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <Card>
+                  <CardContent className="pt-6">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm text-gray-500">Total Buildings</p>
+                        <p className="text-3xl font-bold">
+                          {dfaSummary.totalBuildings.toLocaleString()}
+                        </p>
+                      </div>
+                      <PiBuildingsBold className="h-8 w-8 text-purple-500" />
+                    </div>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-gray-500">Connected (Active Fibre)</p>
+                    <p className="text-3xl font-bold text-green-600">
+                      {dfaSummary.connected.toLocaleString()}
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-gray-500">Near-Net (Within 200m)</p>
+                    <p className="text-3xl font-bold text-yellow-600">
+                      {dfaSummary.nearNet.toLocaleString()}
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <CardTitle>DFA Building Campaign List</CardTitle>
+                    <CardDescription>
+                      Filter and export building addresses for targeted campaigns
+                    </CardDescription>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button onClick={fetchDFA} disabled={loading} variant="outline" size="sm">
+                      <PiArrowsClockwiseBold className={`h-4 w-4 mr-1 ${loading ? 'animate-spin' : ''}`} />
+                      Refresh
+                    </Button>
+                    <Button onClick={exportDFAToCSV} variant="outline" size="sm">
+                      <PiDownloadSimpleBold className="h-4 w-4 mr-1" />
+                      Export CSV
+                    </Button>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {/* Filters */}
+                <div className="flex flex-wrap gap-3 mb-4">
+                  <input
+                    type="text"
+                    placeholder="Search building or address..."
+                    value={dfaSearch}
+                    onChange={(e) => {
+                      setDfaSearch(e.target.value);
+                      setDfaPage(1);
+                    }}
+                    className="flex-1 min-w-[200px] px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  />
+                  <select
+                    value={dfaCoverageType}
+                    onChange={(e) => {
+                      setDfaCoverageType(e.target.value);
+                      setDfaPage(1);
+                    }}
+                    className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                  >
+                    <option value="">All Coverage Types</option>
+                    <option value="connected">Connected</option>
+                    <option value="near-net">Near-Net</option>
+                  </select>
+                  {dfaSummary && dfaSummary.precincts.length > 0 && (
+                    <select
+                      value={dfaPrecinct}
+                      onChange={(e) => {
+                        setDfaPrecinct(e.target.value);
+                        setDfaPage(1);
+                      }}
+                      className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                    >
+                      <option value="">All Precincts</option>
+                      {dfaSummary.precincts.map((p) => (
+                        <option key={p.name} value={p.name}>
+                          {p.name} ({p.count})
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+
+                {/* Table */}
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-gray-200">
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Building</th>
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Address</th>
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Type</th>
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">FTTH</th>
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Precinct</th>
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Promo</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {loading && dfaItems.length === 0 ? (
+                        <tr>
+                          <td colSpan={6} className="py-12 text-center text-gray-500">
+                            Loading buildings...
+                          </td>
+                        </tr>
+                      ) : dfaItems.length === 0 ? (
+                        <tr>
+                          <td colSpan={6} className="py-12 text-center text-gray-500">
+                            No buildings match your filters
+                          </td>
+                        </tr>
+                      ) : (
+                        dfaItems.map((b) => (
+                          <tr key={b.id} className="border-b border-gray-100 hover:bg-gray-50">
+                            <td className="py-3 px-2 font-medium">{b.buildingName || '-'}</td>
+                            <td className="py-3 px-2 text-gray-600 max-w-[200px] truncate">
+                              {b.streetAddress || '-'}
+                            </td>
+                            <td className="py-3 px-2">
+                              <span
+                                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                                  b.coverageType === 'connected'
+                                    ? 'bg-green-100 text-green-800'
+                                    : 'bg-yellow-100 text-yellow-800'
+                                }`}
+                              >
+                                {b.coverageType}
+                              </span>
+                            </td>
+                            <td className="py-3 px-2 text-xs">{b.ftth || '-'}</td>
+                            <td className="py-3 px-2 text-xs">{b.precinct || '-'}</td>
+                            <td className="py-3 px-2 text-xs">{b.promotion || '-'}</td>
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Pagination */}
+                {dfaTotalPages > 1 && (
+                  <div className="flex items-center justify-end mt-4 pt-4 border-t gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={dfaPage <= 1}
+                      onClick={() => setDfaPage((p) => p - 1)}
+                    >
+                      Previous
+                    </Button>
+                    <span className="text-sm text-gray-600">
+                      Page {dfaPage} of {dfaTotalPages}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={dfaPage >= dfaTotalPages}
+                      onClick={() => setDfaPage((p) => p + 1)}
+                    >
+                      Next
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        )}
+
+        {/* Demand Hotspots Tab */}
+        {activeTab === 'demand' && (
+          <>
+            {demandSummary && (
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <Card>
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-gray-500">Coverage Searches</p>
+                    <p className="text-3xl font-bold">
+                      {demandSummary.totalCoverageSearches.toLocaleString()}
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-gray-500">No Coverage Leads</p>
+                    <p className="text-3xl font-bold text-orange-600">
+                      {demandSummary.totalNoCoverageLeads.toLocaleString()}
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-gray-500">Coverage Rate</p>
+                    <p className="text-3xl font-bold text-green-600">
+                      {demandSummary.coverageRate}%
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-gray-500">Hotspots Found</p>
+                    <p className="text-3xl font-bold text-red-600">
+                      {demandSummary.hotspotsFound}
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <CardTitle className="flex items-center gap-2">
+                      <PiFireBold className="h-5 w-5 text-orange-500" />
+                      Demand Hotspots
+                    </CardTitle>
+                    <CardDescription>
+                      Areas with high search volume — prioritize for infrastructure expansion
+                    </CardDescription>
+                  </div>
+                  <div className="flex gap-2 items-center">
+                    <select
+                      value={demandDays}
+                      onChange={(e) => setDemandDays(parseInt(e.target.value))}
+                      className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                    >
+                      <option value="7">Last 7 days</option>
+                      <option value="30">Last 30 days</option>
+                      <option value="90">Last 90 days</option>
+                      <option value="180">Last 6 months</option>
+                      <option value="365">Last year</option>
+                    </select>
+                    <Button onClick={fetchDemand} disabled={loading} variant="outline" size="sm">
+                      <PiArrowsClockwiseBold className={`h-4 w-4 mr-1 ${loading ? 'animate-spin' : ''}`} />
+                      Refresh
+                    </Button>
+                    <Button onClick={exportDemanToCSV} variant="outline" size="sm">
+                      <PiDownloadSimpleBold className="h-4 w-4 mr-1" />
+                      Export CSV
+                    </Button>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-gray-200">
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Location</th>
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Sample Addresses</th>
+                        <th className="py-3 px-2 text-right font-medium text-gray-500">Searches</th>
+                        <th className="py-3 px-2 text-right font-medium text-gray-500">No Coverage</th>
+                        <th className="py-3 px-2 text-right font-medium text-gray-500">Demand Score</th>
+                        <th className="py-3 px-2 text-right font-medium text-gray-500">Gap Score</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {loading && hotspots.length === 0 ? (
+                        <tr>
+                          <td colSpan={6} className="py-12 text-center text-gray-500">
+                            Analyzing demand patterns...
+                          </td>
+                        </tr>
+                      ) : hotspots.length === 0 ? (
+                        <tr>
+                          <td colSpan={6} className="py-12 text-center text-gray-500">
+                            No demand hotspots found for this period
+                          </td>
+                        </tr>
+                      ) : (
+                        hotspots.map((h, i) => (
+                          <tr key={i} className="border-b border-gray-100 hover:bg-gray-50">
+                            <td className="py-3 px-2">
+                              <div className="flex items-center gap-1">
+                                <PiMapPinBold className="h-3 w-3 text-gray-400" />
+                                <span className="text-xs text-gray-500">
+                                  {h.latitude.toFixed(3)}, {h.longitude.toFixed(3)}
+                                </span>
+                              </div>
+                            </td>
+                            <td className="py-3 px-2 max-w-[250px]">
+                              <div className="space-y-0.5">
+                                {h.sampleAddresses.slice(0, 2).map((addr, j) => (
+                                  <p key={j} className="text-xs text-gray-600 truncate">
+                                    {addr}
+                                  </p>
+                                ))}
+                                {h.sampleAddresses.length > 2 && (
+                                  <p className="text-xs text-gray-400">
+                                    +{h.sampleAddresses.length - 2} more
+                                  </p>
+                                )}
+                              </div>
+                            </td>
+                            <td className="py-3 px-2 text-right font-medium">
+                              {h.totalSearches}
+                            </td>
+                            <td className="py-3 px-2 text-right">
+                              <span className="text-orange-600 font-medium">
+                                {h.noCoverageLeads}
+                              </span>
+                            </td>
+                            <td className="py-3 px-2 text-right">
+                              <span
+                                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                                  h.demandScore >= 10
+                                    ? 'bg-red-100 text-red-800'
+                                    : h.demandScore >= 5
+                                    ? 'bg-yellow-100 text-yellow-800'
+                                    : 'bg-gray-100 text-gray-600'
+                                }`}
+                              >
+                                {h.demandScore}
+                              </span>
+                            </td>
+                            <td className="py-3 px-2 text-right">
+                              <span className="text-red-600 font-medium">
+                                {h.gapScore}
+                              </span>
+                            </td>
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          </>
+        )}
+
+        {/* Tarana Tab */}
+        {activeTab === 'tarana' && (
+          <>
+            {taranaSummary && (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Card>
+                  <CardContent className="pt-6">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm text-gray-500">Total Base Stations</p>
+                        <p className="text-3xl font-bold">
+                          {taranaSummary.totalStations.toLocaleString()}
+                        </p>
+                      </div>
+                      <PiRadioBold className="h-8 w-8 text-blue-500" />
+                    </div>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardContent className="pt-6">
+                    <p className="text-sm text-gray-500">Markets Covered</p>
+                    <p className="text-3xl font-bold">
+                      {taranaSummary.markets.length}
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <CardTitle>Tarana Base Station Network</CardTitle>
+                    <CardDescription>
+                      SkyFibre coverage for geo-targeted wireless campaigns
+                    </CardDescription>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button onClick={fetchTarana} disabled={loading} variant="outline" size="sm">
+                      <PiArrowsClockwiseBold className={`h-4 w-4 mr-1 ${loading ? 'animate-spin' : ''}`} />
+                      Refresh
+                    </Button>
+                    <Button onClick={exportTaranaToCSV} variant="outline" size="sm">
+                      <PiDownloadSimpleBold className="h-4 w-4 mr-1" />
+                      Export CSV
+                    </Button>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="mb-4">
+                  <input
+                    type="text"
+                    placeholder="Search site, hostname, or market..."
+                    value={taranaSearch}
+                    onChange={(e) => {
+                      setTaranaSearch(e.target.value);
+                      setTaranaPage(1);
+                    }}
+                    className="w-full max-w-md px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-gray-200">
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Site Name</th>
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Hostname</th>
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Market</th>
+                        <th className="py-3 px-2 text-right font-medium text-gray-500">Active Connections</th>
+                        <th className="py-3 px-2 text-left font-medium text-gray-500">Location</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {loading && taranaItems.length === 0 ? (
+                        <tr>
+                          <td colSpan={5} className="py-12 text-center text-gray-500">
+                            Loading stations...
+                          </td>
+                        </tr>
+                      ) : taranaItems.length === 0 ? (
+                        <tr>
+                          <td colSpan={5} className="py-12 text-center text-gray-500">
+                            No stations found
+                          </td>
+                        </tr>
+                      ) : (
+                        taranaItems.map((s) => (
+                          <tr key={s.id} className="border-b border-gray-100 hover:bg-gray-50">
+                            <td className="py-3 px-2 font-medium">{s.siteName || '-'}</td>
+                            <td className="py-3 px-2 text-gray-600 text-xs">{s.hostname || '-'}</td>
+                            <td className="py-3 px-2">{s.market || '-'}</td>
+                            <td className="py-3 px-2 text-right">
+                              {s.activeConnections != null ? (
+                                <span
+                                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                                    s.activeConnections > 50
+                                      ? 'bg-red-100 text-red-800'
+                                      : s.activeConnections > 20
+                                      ? 'bg-yellow-100 text-yellow-800'
+                                      : 'bg-green-100 text-green-800'
+                                  }`}
+                                >
+                                  {s.activeConnections}
+                                </span>
+                              ) : (
+                                '-'
+                              )}
+                            </td>
+                            <td className="py-3 px-2 text-xs text-gray-500">
+                              {s.latitude.toFixed(4)}, {s.longitude.toFixed(4)}
+                            </td>
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+
+                {taranaTotalPages > 1 && (
+                  <div className="flex items-center justify-end mt-4 pt-4 border-t gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={taranaPage <= 1}
+                      onClick={() => setTaranaPage((p) => p - 1)}
+                    >
+                      Previous
+                    </Button>
+                    <span className="text-sm text-gray-600">
+                      Page {taranaPage} of {taranaTotalPages}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={taranaPage >= taranaTotalPages}
+                      onClick={() => setTaranaPage((p) => p + 1)}
+                    >
+                      Next
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Market Breakdown */}
+            {taranaSummary && taranaSummary.markets.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-sm">Market Distribution</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex flex-wrap gap-4 text-sm">
+                    {taranaSummary.markets.map((m) => (
+                      <div key={m.name} className="flex items-center gap-2">
+                        <div className="w-3 h-3 rounded bg-blue-500" />
+                        <span>{m.name}</span>
+                        <span className="text-gray-500">({m.count})</span>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/marketing/no-coverage-leads/page.tsx
+++ b/app/admin/marketing/no-coverage-leads/page.tsx
@@ -1,0 +1,697 @@
+'use client';
+
+import {
+  PiArrowsClockwiseBold,
+  PiCheckCircleBold,
+  PiDownloadSimpleBold,
+  PiEnvelopeBold,
+  PiFunnelBold,
+  PiMapPinBold,
+  PiPhoneBold,
+  PiTrendUpBold,
+  PiUserPlusBold,
+  PiWarningBold,
+} from 'react-icons/pi';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { formatDistanceToNow } from 'date-fns';
+
+interface NoCoverageLead {
+  id: string;
+  fullName: string;
+  email: string;
+  phone: string | null;
+  address: string;
+  latitude: number | null;
+  longitude: number | null;
+  serviceType: string | null;
+  expectedUsage: string | null;
+  budgetRange: string | null;
+  urgency: string | null;
+  notes: string | null;
+  marketingConsent: boolean;
+  source: string | null;
+  status: string;
+  contactedAt: string | null;
+  convertedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Stats {
+  total: number;
+  new: number;
+  newThisWeek: number;
+  contacted: number;
+  qualified: number;
+  converted: number;
+  conversionRate: number;
+  serviceTypes: { name: string; count: number }[];
+}
+
+interface Pagination {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  new: 'bg-blue-100 text-blue-800',
+  contacted: 'bg-yellow-100 text-yellow-800',
+  qualified: 'bg-purple-100 text-purple-800',
+  converted: 'bg-green-100 text-green-800',
+  declined: 'bg-gray-100 text-gray-600',
+};
+
+const URGENCY_COLORS: Record<string, string> = {
+  low: 'bg-gray-100 text-gray-600',
+  medium: 'bg-yellow-100 text-yellow-800',
+  high: 'bg-red-100 text-red-800',
+};
+
+export default function NoCoverageLeadsPage() {
+  const [leads, setLeads] = useState<NoCoverageLead[]>([]);
+  const [stats, setStats] = useState<Stats>({
+    total: 0,
+    new: 0,
+    newThisWeek: 0,
+    contacted: 0,
+    qualified: 0,
+    converted: 0,
+    conversionRate: 0,
+    serviceTypes: [],
+  });
+  const [pagination, setPagination] = useState<Pagination>({
+    page: 1,
+    pageSize: 25,
+    total: 0,
+    totalPages: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [updating, setUpdating] = useState(false);
+
+  // Filter state
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState('');
+  const [serviceType, setServiceType] = useState('');
+  const [urgency, setUrgency] = useState('');
+  const [sortBy, setSortBy] = useState('created_at');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const params = new URLSearchParams({
+        page: pagination.page.toString(),
+        pageSize: pagination.pageSize.toString(),
+        sortBy,
+        sortOrder,
+      });
+
+      if (search) params.set('search', search);
+      if (status) params.set('status', status);
+      if (serviceType) params.set('service_type', serviceType);
+      if (urgency) params.set('urgency', urgency);
+
+      const response = await fetch(
+        `/api/admin/marketing/no-coverage-leads?${params}`
+      );
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to fetch leads');
+      }
+
+      setLeads(data.data.leads);
+      setStats(data.data.stats);
+      setPagination(data.data.pagination);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    pagination.page,
+    pagination.pageSize,
+    search,
+    status,
+    serviceType,
+    urgency,
+    sortBy,
+    sortOrder,
+  ]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handlePageChange = (page: number) => {
+    setPagination((prev) => ({ ...prev, page }));
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setPagination((prev) => ({ ...prev, page: 1 }));
+  };
+
+  const handleStatusChange = (value: string) => {
+    setStatus(value);
+    setPagination((prev) => ({ ...prev, page: 1 }));
+  };
+
+  const handleServiceTypeChange = (value: string) => {
+    setServiceType(value);
+    setPagination((prev) => ({ ...prev, page: 1 }));
+  };
+
+  const handleUrgencyChange = (value: string) => {
+    setUrgency(value);
+    setPagination((prev) => ({ ...prev, page: 1 }));
+  };
+
+  const handleSortChange = (field: string) => {
+    if (sortBy === field) {
+      setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(field);
+      setSortOrder('desc');
+    }
+    setPagination((prev) => ({ ...prev, page: 1 }));
+  };
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
+    );
+  };
+
+  const toggleSelectAll = () => {
+    if (selectedIds.length === leads.length) {
+      setSelectedIds([]);
+    } else {
+      setSelectedIds(leads.map((l) => l.id));
+    }
+  };
+
+  const bulkUpdateStatus = async (newStatus: string) => {
+    if (selectedIds.length === 0) return;
+
+    try {
+      setUpdating(true);
+      const response = await fetch('/api/admin/marketing/no-coverage-leads', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: selectedIds, status: newStatus }),
+      });
+
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to update leads');
+      }
+
+      setSelectedIds([]);
+      fetchData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed');
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  const exportToCSV = async () => {
+    try {
+      const params = new URLSearchParams({
+        page: '1',
+        pageSize: '5000',
+        sortBy,
+        sortOrder,
+      });
+      if (search) params.set('search', search);
+      if (status) params.set('status', status);
+      if (serviceType) params.set('service_type', serviceType);
+      if (urgency) params.set('urgency', urgency);
+
+      const response = await fetch(
+        `/api/admin/marketing/no-coverage-leads?${params}`
+      );
+      const data = await response.json();
+
+      if (!data.success) throw new Error('Failed to export');
+
+      const csvRows = [
+        [
+          'Name',
+          'Email',
+          'Phone',
+          'Address',
+          'Service Type',
+          'Budget Range',
+          'Urgency',
+          'Status',
+          'Marketing Consent',
+          'Notes',
+          'Created',
+        ].join(','),
+        ...data.data.leads.map((l: NoCoverageLead) =>
+          [
+            `"${(l.fullName || '').replace(/"/g, '""')}"`,
+            l.email || '',
+            l.phone || '',
+            `"${(l.address || '').replace(/"/g, '""')}"`,
+            l.serviceType || '',
+            l.budgetRange || '',
+            l.urgency || '',
+            l.status || '',
+            l.marketingConsent ? 'Yes' : 'No',
+            `"${(l.notes || '').replace(/"/g, '""')}"`,
+            l.createdAt || '',
+          ].join(',')
+        ),
+      ];
+
+      const blob = new Blob([csvRows.join('\n')], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `no-coverage-leads-${new Date().toISOString().split('T')[0]}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Export failed:', err);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
+              <PiMapPinBold className="h-8 w-8 text-orange-600" />
+              No Coverage Leads
+            </h1>
+            <p className="text-gray-600 mt-1">
+              Demand signals from users searching for service in uncovered areas
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button onClick={fetchData} disabled={loading} variant="outline">
+              <PiArrowsClockwiseBold
+                className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`}
+              />
+              Refresh
+            </Button>
+            <Button onClick={exportToCSV} variant="outline">
+              <PiDownloadSimpleBold className="h-4 w-4 mr-2" />
+              Export CSV
+            </Button>
+          </div>
+        </div>
+
+        {/* Error Alert */}
+        {error && (
+          <Alert className="border-red-200 bg-red-50">
+            <PiWarningBold className="h-4 w-4 text-red-600" />
+            <AlertDescription className="text-red-800">{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Stats Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-500">Total Leads</p>
+                  <p className="text-3xl font-bold text-gray-900">
+                    {stats.total.toLocaleString()}
+                  </p>
+                </div>
+                <PiUserPlusBold className="h-8 w-8 text-blue-500" />
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-500">New This Week</p>
+                  <p className="text-3xl font-bold text-orange-600">
+                    {stats.newThisWeek.toLocaleString()}
+                  </p>
+                </div>
+                <PiFunnelBold className="h-8 w-8 text-orange-500" />
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-500">Contacted</p>
+                  <p className="text-3xl font-bold text-yellow-600">
+                    {stats.contacted.toLocaleString()}
+                  </p>
+                </div>
+                <PiEnvelopeBold className="h-8 w-8 text-yellow-500" />
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-500">Conversion Rate</p>
+                  <p className="text-3xl font-bold text-green-600">
+                    {stats.conversionRate}%
+                  </p>
+                </div>
+                <PiTrendUpBold className="h-8 w-8 text-green-500" />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Bulk Actions */}
+        {selectedIds.length > 0 && (
+          <Card className="border-blue-200 bg-blue-50">
+            <CardContent className="py-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-blue-800">
+                  {selectedIds.length} lead{selectedIds.length > 1 ? 's' : ''} selected
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => bulkUpdateStatus('contacted')}
+                    disabled={updating}
+                  >
+                    Mark Contacted
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => bulkUpdateStatus('qualified')}
+                    disabled={updating}
+                  >
+                    Mark Qualified
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => bulkUpdateStatus('converted')}
+                    disabled={updating}
+                  >
+                    <PiCheckCircleBold className="h-4 w-4 mr-1" />
+                    Mark Converted
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => bulkUpdateStatus('declined')}
+                    disabled={updating}
+                  >
+                    Decline
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Table */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <PiMapPinBold className="h-5 w-5" />
+              Lead Directory
+            </CardTitle>
+            <CardDescription>
+              {pagination.total.toLocaleString()} leads from coverage check requests
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {/* Filters */}
+            <div className="flex flex-wrap gap-3 mb-4">
+              <input
+                type="text"
+                placeholder="Search name, email, or address..."
+                value={search}
+                onChange={(e) => handleSearchChange(e.target.value)}
+                className="flex-1 min-w-[200px] px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+              <select
+                value={status}
+                onChange={(e) => handleStatusChange(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              >
+                <option value="">All Statuses</option>
+                <option value="new">New</option>
+                <option value="contacted">Contacted</option>
+                <option value="qualified">Qualified</option>
+                <option value="converted">Converted</option>
+                <option value="declined">Declined</option>
+              </select>
+              <select
+                value={serviceType}
+                onChange={(e) => handleServiceTypeChange(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              >
+                <option value="">All Services</option>
+                <option value="fibre">Fibre</option>
+                <option value="lte">LTE</option>
+                <option value="5g">5G</option>
+                <option value="wireless">Wireless</option>
+                <option value="any">Any</option>
+              </select>
+              <select
+                value={urgency}
+                onChange={(e) => handleUrgencyChange(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              >
+                <option value="">All Urgency</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </div>
+
+            {/* Table */}
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-200">
+                    <th className="py-3 px-2 text-left">
+                      <input
+                        type="checkbox"
+                        checked={
+                          leads.length > 0 &&
+                          selectedIds.length === leads.length
+                        }
+                        onChange={toggleSelectAll}
+                        className="rounded border-gray-300"
+                      />
+                    </th>
+                    <th
+                      className="py-3 px-2 text-left font-medium text-gray-500 cursor-pointer hover:text-gray-900"
+                      onClick={() => handleSortChange('full_name')}
+                    >
+                      Name {sortBy === 'full_name' && (sortOrder === 'asc' ? '↑' : '↓')}
+                    </th>
+                    <th className="py-3 px-2 text-left font-medium text-gray-500">
+                      Contact
+                    </th>
+                    <th
+                      className="py-3 px-2 text-left font-medium text-gray-500 cursor-pointer hover:text-gray-900"
+                      onClick={() => handleSortChange('address')}
+                    >
+                      Address {sortBy === 'address' && (sortOrder === 'asc' ? '↑' : '↓')}
+                    </th>
+                    <th className="py-3 px-2 text-left font-medium text-gray-500">
+                      Service
+                    </th>
+                    <th className="py-3 px-2 text-left font-medium text-gray-500">
+                      Budget
+                    </th>
+                    <th className="py-3 px-2 text-left font-medium text-gray-500">
+                      Urgency
+                    </th>
+                    <th className="py-3 px-2 text-left font-medium text-gray-500">
+                      Status
+                    </th>
+                    <th
+                      className="py-3 px-2 text-left font-medium text-gray-500 cursor-pointer hover:text-gray-900"
+                      onClick={() => handleSortChange('created_at')}
+                    >
+                      Created{' '}
+                      {sortBy === 'created_at' && (sortOrder === 'asc' ? '↑' : '↓')}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading && leads.length === 0 ? (
+                    <tr>
+                      <td colSpan={9} className="py-12 text-center text-gray-500">
+                        Loading leads...
+                      </td>
+                    </tr>
+                  ) : leads.length === 0 ? (
+                    <tr>
+                      <td colSpan={9} className="py-12 text-center text-gray-500">
+                        No leads found matching your filters
+                      </td>
+                    </tr>
+                  ) : (
+                    leads.map((lead) => (
+                      <tr
+                        key={lead.id}
+                        className={`border-b border-gray-100 hover:bg-gray-50 ${
+                          selectedIds.includes(lead.id) ? 'bg-blue-50' : ''
+                        }`}
+                      >
+                        <td className="py-3 px-2">
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.includes(lead.id)}
+                            onChange={() => toggleSelect(lead.id)}
+                            className="rounded border-gray-300"
+                          />
+                        </td>
+                        <td className="py-3 px-2 font-medium text-gray-900">
+                          {lead.fullName}
+                        </td>
+                        <td className="py-3 px-2">
+                          <div className="space-y-1">
+                            <div className="flex items-center gap-1 text-gray-600">
+                              <PiEnvelopeBold className="h-3 w-3" />
+                              <span className="text-xs">{lead.email}</span>
+                            </div>
+                            {lead.phone && (
+                              <div className="flex items-center gap-1 text-gray-600">
+                                <PiPhoneBold className="h-3 w-3" />
+                                <span className="text-xs">{lead.phone}</span>
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                        <td className="py-3 px-2 text-gray-600 max-w-[200px] truncate">
+                          {lead.address}
+                        </td>
+                        <td className="py-3 px-2">
+                          <span className="text-xs capitalize">
+                            {lead.serviceType || '-'}
+                          </span>
+                        </td>
+                        <td className="py-3 px-2">
+                          <span className="text-xs">
+                            {lead.budgetRange
+                              ? lead.budgetRange.replace(/_/g, ' ')
+                              : '-'}
+                          </span>
+                        </td>
+                        <td className="py-3 px-2">
+                          {lead.urgency && (
+                            <span
+                              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                                URGENCY_COLORS[lead.urgency] || ''
+                              }`}
+                            >
+                              {lead.urgency}
+                            </span>
+                          )}
+                        </td>
+                        <td className="py-3 px-2">
+                          <span
+                            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                              STATUS_COLORS[lead.status] || ''
+                            }`}
+                          >
+                            {lead.status}
+                          </span>
+                        </td>
+                        <td className="py-3 px-2 text-gray-500 text-xs">
+                          {formatDistanceToNow(new Date(lead.createdAt))} ago
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Pagination */}
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-200">
+                <p className="text-sm text-gray-500">
+                  Showing {(pagination.page - 1) * pagination.pageSize + 1} to{' '}
+                  {Math.min(
+                    pagination.page * pagination.pageSize,
+                    pagination.total
+                  )}{' '}
+                  of {pagination.total.toLocaleString()} leads
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={pagination.page <= 1}
+                    onClick={() => handlePageChange(pagination.page - 1)}
+                  >
+                    Previous
+                  </Button>
+                  <span className="flex items-center px-3 text-sm text-gray-600">
+                    Page {pagination.page} of {pagination.totalPages}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={pagination.page >= pagination.totalPages}
+                    onClick={() => handlePageChange(pagination.page + 1)}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Service Type Breakdown */}
+        {stats.serviceTypes.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Service Interest Breakdown</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-4 text-sm">
+                {stats.serviceTypes.map((st) => (
+                  <div key={st.name} className="flex items-center gap-2">
+                    <div className="w-3 h-3 rounded bg-orange-500" />
+                    <span className="capitalize">{st.name}</span>
+                    <span className="text-gray-500">({st.count})</span>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/marketing/campaign-lists/route.ts
+++ b/app/api/admin/marketing/campaign-lists/route.ts
@@ -1,0 +1,242 @@
+/**
+ * Admin API: Campaign Lists
+ * GET - Generate targetable lists from DFA buildings and Tarana base stations
+ *
+ * Query Parameters:
+ * - source: 'dfa' | 'tarana' (default: 'dfa')
+ * - coverage_type: 'connected' | 'near-net' (DFA only)
+ * - precinct: Filter by precinct (DFA only)
+ * - ftth: Filter by FTTH status (DFA only)
+ * - search: Search building name or address
+ * - page: Page number (default: 1)
+ * - pageSize: Items per page (default: 50, max: 500)
+ * - format: 'json' | 'summary' (default: 'json')
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { apiLogger } from '@/lib/logging';
+import { createClient } from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const supabase = await createClient();
+    const { searchParams } = new URL(request.url);
+
+    const source = searchParams.get('source') || 'dfa';
+    const coverageType = searchParams.get('coverage_type') || undefined;
+    const precinct = searchParams.get('precinct') || undefined;
+    const ftth = searchParams.get('ftth') || undefined;
+    const search = searchParams.get('search') || undefined;
+    const page = parseInt(searchParams.get('page') || '1');
+    const pageSize = Math.min(parseInt(searchParams.get('pageSize') || '50'), 500);
+    const format = searchParams.get('format') || 'json';
+
+    if (source === 'dfa') {
+      // Build DFA buildings query
+      let query = supabase.from('dfa_buildings').select('*', { count: 'exact' });
+
+      if (coverageType) {
+        query = query.eq('coverage_type', coverageType);
+      }
+      if (precinct) {
+        query = query.eq('precinct', precinct);
+      }
+      if (ftth) {
+        query = query.eq('ftth', ftth);
+      }
+      if (search) {
+        query = query.or(
+          `building_name.ilike.%${search}%,street_address.ilike.%${search}%`
+        );
+      }
+
+      query = query.order('building_name', { ascending: true });
+
+      const from = (page - 1) * pageSize;
+      const to = from + pageSize - 1;
+      query = query.range(from, to);
+
+      const { data: buildings, error, count } = await query;
+
+      if (error) {
+        apiLogger.error('[Campaign Lists API] DFA query error', {
+          error: error.message,
+        });
+        return NextResponse.json(
+          { success: false, error: 'Failed to fetch DFA buildings' },
+          { status: 500 }
+        );
+      }
+
+      // Get coverage summary for this filter set
+      const [connectedCount, nearNetCount, precinctList] = await Promise.all([
+        supabase
+          .from('dfa_buildings')
+          .select('id', { count: 'exact', head: true })
+          .eq('coverage_type', 'connected'),
+        supabase
+          .from('dfa_buildings')
+          .select('id', { count: 'exact', head: true })
+          .eq('coverage_type', 'near-net'),
+        supabase
+          .from('dfa_buildings')
+          .select('precinct')
+          .not('precinct', 'is', null),
+      ]);
+
+      const precinctCounts: Record<string, number> = {};
+      precinctList.data?.forEach((s) => {
+        const p = s.precinct || 'Unknown';
+        precinctCounts[p] = (precinctCounts[p] || 0) + 1;
+      });
+
+      const precincts = Object.entries(precinctCounts)
+        .map(([name, cnt]) => ({ name, count: cnt }))
+        .sort((a, b) => b.count - a.count);
+
+      if (format === 'summary') {
+        return NextResponse.json({
+          success: true,
+          data: {
+            source: 'dfa',
+            summary: {
+              totalBuildings: (connectedCount.count || 0) + (nearNetCount.count || 0),
+              connected: connectedCount.count || 0,
+              nearNet: nearNetCount.count || 0,
+              filteredCount: count || 0,
+              precincts,
+            },
+          },
+        });
+      }
+
+      const campaignList =
+        buildings?.map((b) => ({
+          id: b.id,
+          buildingName: b.building_name,
+          streetAddress: b.street_address,
+          coverageType: b.coverage_type,
+          ftth: b.ftth,
+          broadband: b.broadband,
+          precinct: b.precinct,
+          promotion: b.promotion,
+          latitude: b.latitude,
+          longitude: b.longitude,
+        })) || [];
+
+      return NextResponse.json({
+        success: true,
+        data: {
+          source: 'dfa',
+          items: campaignList,
+          summary: {
+            totalBuildings: (connectedCount.count || 0) + (nearNetCount.count || 0),
+            connected: connectedCount.count || 0,
+            nearNet: nearNetCount.count || 0,
+            filteredCount: count || 0,
+            precincts,
+          },
+          pagination: {
+            page,
+            pageSize,
+            total: count || 0,
+            totalPages: Math.ceil((count || 0) / pageSize),
+          },
+        },
+      });
+    } else if (source === 'tarana') {
+      // Query Tarana base stations
+      let query = supabase
+        .from('tarana_base_stations')
+        .select('*', { count: 'exact' });
+
+      if (search) {
+        query = query.or(
+          `site_name.ilike.%${search}%,hostname.ilike.%${search}%,market.ilike.%${search}%`
+        );
+      }
+
+      query = query.order('site_name', { ascending: true });
+
+      const from = (page - 1) * pageSize;
+      const to = from + pageSize - 1;
+      query = query.range(from, to);
+
+      const { data: stations, error, count } = await query;
+
+      if (error) {
+        apiLogger.error('[Campaign Lists API] Tarana query error', {
+          error: error.message,
+        });
+        return NextResponse.json(
+          { success: false, error: 'Failed to fetch Tarana base stations' },
+          { status: 500 }
+        );
+      }
+
+      // Get market breakdown
+      const marketStats = await supabase
+        .from('tarana_base_stations')
+        .select('market');
+
+      const marketCounts: Record<string, number> = {};
+      marketStats.data?.forEach((s) => {
+        const market = s.market || 'Unknown';
+        marketCounts[market] = (marketCounts[market] || 0) + 1;
+      });
+
+      const markets = Object.entries(marketCounts)
+        .map(([name, cnt]) => ({ name, count: cnt }))
+        .sort((a, b) => b.count - a.count);
+
+      const stationList =
+        stations?.map((s) => ({
+          id: s.id,
+          serialNumber: s.serial_number,
+          hostname: s.hostname,
+          siteName: s.site_name,
+          market: s.market,
+          latitude: s.lat,
+          longitude: s.lng,
+          activeConnections: s.active_connections,
+        })) || [];
+
+      return NextResponse.json({
+        success: true,
+        data: {
+          source: 'tarana',
+          items: stationList,
+          summary: {
+            totalStations: count || 0,
+            markets,
+          },
+          pagination: {
+            page,
+            pageSize,
+            total: count || 0,
+            totalPages: Math.ceil((count || 0) / pageSize),
+          },
+        },
+      });
+    } else {
+      return NextResponse.json(
+        { success: false, error: 'Invalid source. Use "dfa" or "tarana".' },
+        { status: 400 }
+      );
+    }
+  } catch (error) {
+    apiLogger.error('[Campaign Lists API] Unexpected error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to generate campaign list',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/marketing/coverage-demand/route.ts
+++ b/app/api/admin/marketing/coverage-demand/route.ts
@@ -1,0 +1,226 @@
+/**
+ * Admin API: Coverage Demand Analysis
+ * GET - Aggregate coverage check demand by area, cross-referenced with infrastructure
+ *
+ * Returns demand hotspots: areas where users searched for coverage but service
+ * may not be available, helping identify expansion opportunities.
+ *
+ * Query Parameters:
+ * - days: Look back period in days (default: 30, max: 365)
+ * - minSearches: Minimum searches to qualify as hotspot (default: 3)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { apiLogger } from '@/lib/logging';
+import { createClient } from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const supabase = await createClient();
+    const { searchParams } = new URL(request.url);
+
+    const days = Math.min(parseInt(searchParams.get('days') || '30'), 365);
+    const minSearches = parseInt(searchParams.get('minSearches') || '3');
+
+    const fromDate = new Date();
+    fromDate.setDate(fromDate.getDate() - days);
+
+    // Get coverage leads for the period
+    const { data: coverageLeads, error: leadsError } = await supabase
+      .from('coverage_leads')
+      .select('id, address, latitude, longitude, coverage_available, created_at')
+      .gte('created_at', fromDate.toISOString())
+      .order('created_at', { ascending: false });
+
+    if (leadsError) {
+      apiLogger.error('[Coverage Demand API] Coverage leads query error', {
+        error: leadsError.message,
+      });
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch coverage leads' },
+        { status: 500 }
+      );
+    }
+
+    // Get no-coverage leads for the period
+    const { data: noCoverageLeads, error: ncError } = await supabase
+      .from('no_coverage_leads')
+      .select('id, address, latitude, longitude, service_type, status, created_at')
+      .gte('created_at', fromDate.toISOString())
+      .order('created_at', { ascending: false });
+
+    if (ncError) {
+      apiLogger.error('[Coverage Demand API] No coverage leads query error', {
+        error: ncError.message,
+      });
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch no-coverage leads' },
+        { status: 500 }
+      );
+    }
+
+    // Get infrastructure counts for context
+    const [dfaCount, taranaCount] = await Promise.all([
+      supabase
+        .from('dfa_buildings')
+        .select('id', { count: 'exact', head: true }),
+      supabase
+        .from('tarana_base_stations')
+        .select('id', { count: 'exact', head: true }),
+    ]);
+
+    // Aggregate by approximate area (round lat/lng to ~1km grid)
+    const areaMap = new Map<
+      string,
+      {
+        lat: number;
+        lng: number;
+        addresses: string[];
+        totalSearches: number;
+        withCoverage: number;
+        withoutCoverage: number;
+        noCoverageLeads: number;
+        serviceTypes: Record<string, number>;
+      }
+    >();
+
+    // Process coverage leads
+    const allLeads = coverageLeads || [];
+    for (const lead of allLeads) {
+      if (lead.latitude == null || lead.longitude == null) continue;
+
+      // Round to ~1km grid (0.01 degree ≈ 1.1km)
+      const gridLat = Math.round(lead.latitude * 100) / 100;
+      const gridLng = Math.round(lead.longitude * 100) / 100;
+      const key = `${gridLat},${gridLng}`;
+
+      const existing = areaMap.get(key) || {
+        lat: gridLat,
+        lng: gridLng,
+        addresses: [],
+        totalSearches: 0,
+        withCoverage: 0,
+        withoutCoverage: 0,
+        noCoverageLeads: 0,
+        serviceTypes: {},
+      };
+
+      existing.totalSearches++;
+      if (lead.coverage_available) {
+        existing.withCoverage++;
+      } else {
+        existing.withoutCoverage++;
+      }
+      if (lead.address && existing.addresses.length < 5) {
+        existing.addresses.push(lead.address);
+      }
+
+      areaMap.set(key, existing);
+    }
+
+    // Process no-coverage leads
+    const ncLeads = noCoverageLeads || [];
+    for (const lead of ncLeads) {
+      if (lead.latitude == null || lead.longitude == null) continue;
+
+      const gridLat = Math.round(lead.latitude * 100) / 100;
+      const gridLng = Math.round(lead.longitude * 100) / 100;
+      const key = `${gridLat},${gridLng}`;
+
+      const existing = areaMap.get(key) || {
+        lat: gridLat,
+        lng: gridLng,
+        addresses: [],
+        totalSearches: 0,
+        withCoverage: 0,
+        withoutCoverage: 0,
+        noCoverageLeads: 0,
+        serviceTypes: {},
+      };
+
+      existing.noCoverageLeads++;
+      if (lead.service_type) {
+        existing.serviceTypes[lead.service_type] =
+          (existing.serviceTypes[lead.service_type] || 0) + 1;
+      }
+      if (lead.address && existing.addresses.length < 5) {
+        existing.addresses.push(lead.address);
+      }
+
+      areaMap.set(key, existing);
+    }
+
+    // Filter to hotspots (areas with minimum searches)
+    const hotspots = Array.from(areaMap.values())
+      .filter(
+        (area) =>
+          area.totalSearches + area.noCoverageLeads >= minSearches
+      )
+      .sort(
+        (a, b) =>
+          b.totalSearches +
+          b.noCoverageLeads -
+          (a.totalSearches + a.noCoverageLeads)
+      )
+      .map((area) => ({
+        latitude: area.lat,
+        longitude: area.lng,
+        sampleAddresses: area.addresses,
+        totalSearches: area.totalSearches,
+        withCoverage: area.withCoverage,
+        withoutCoverage: area.withoutCoverage,
+        noCoverageLeads: area.noCoverageLeads,
+        demandScore: area.totalSearches + area.noCoverageLeads * 2,
+        gapScore: area.withoutCoverage + area.noCoverageLeads,
+        serviceInterest: area.serviceTypes,
+      }));
+
+    // Summary metrics
+    const totalSearches = allLeads.length;
+    const totalNoCoverage = ncLeads.length;
+    const coverageRate =
+      totalSearches > 0
+        ? Math.round(
+            (allLeads.filter((l) => l.coverage_available).length /
+              totalSearches) *
+              100
+          )
+        : 0;
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        period: {
+          days,
+          from: fromDate.toISOString(),
+          to: new Date().toISOString(),
+        },
+        summary: {
+          totalCoverageSearches: totalSearches,
+          totalNoCoverageLeads: totalNoCoverage,
+          coverageRate,
+          hotspotsFound: hotspots.length,
+          infrastructure: {
+            dfaBuildings: dfaCount.count || 0,
+            taranaBaseStations: taranaCount.count || 0,
+          },
+        },
+        hotspots,
+      },
+    });
+  } catch (error) {
+    apiLogger.error('[Coverage Demand API] Unexpected error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to analyze coverage demand',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/marketing/no-coverage-leads/route.ts
+++ b/app/api/admin/marketing/no-coverage-leads/route.ts
@@ -1,0 +1,296 @@
+/**
+ * Admin API: No Coverage Leads
+ * GET - List leads with filters, pagination, and aggregate stats
+ * PATCH - Bulk update lead statuses
+ *
+ * Query Parameters:
+ * - page: Page number (default: 1)
+ * - pageSize: Items per page (default: 25, max: 100)
+ * - search: Search by name, email, or address
+ * - status: Filter by status ('new' | 'contacted' | 'qualified' | 'converted' | 'declined')
+ * - service_type: Filter by service type
+ * - urgency: Filter by urgency ('low' | 'medium' | 'high')
+ * - dateFrom: Filter from date (ISO string)
+ * - dateTo: Filter to date (ISO string)
+ * - sortBy: Sort field (default: 'created_at')
+ * - sortOrder: 'asc' | 'desc' (default: 'desc')
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { apiLogger } from '@/lib/logging';
+import { createClient } from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+interface NoCoverageLeadQueryParams {
+  page: number;
+  pageSize: number;
+  search?: string;
+  status?: string;
+  service_type?: string;
+  urgency?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  sortBy: string;
+  sortOrder: 'asc' | 'desc';
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const supabase = await createClient();
+    const { searchParams } = new URL(request.url);
+
+    const params: NoCoverageLeadQueryParams = {
+      page: parseInt(searchParams.get('page') || '1'),
+      pageSize: Math.min(parseInt(searchParams.get('pageSize') || '25'), 100),
+      search: searchParams.get('search') || undefined,
+      status: searchParams.get('status') || undefined,
+      service_type: searchParams.get('service_type') || undefined,
+      urgency: searchParams.get('urgency') || undefined,
+      dateFrom: searchParams.get('dateFrom') || undefined,
+      dateTo: searchParams.get('dateTo') || undefined,
+      sortBy: searchParams.get('sortBy') || 'created_at',
+      sortOrder: (searchParams.get('sortOrder') as 'asc' | 'desc') || 'desc',
+    };
+
+    // Build query
+    let query = supabase.from('no_coverage_leads').select('*', { count: 'exact' });
+
+    if (params.search) {
+      query = query.or(
+        `full_name.ilike.%${params.search}%,email.ilike.%${params.search}%,address.ilike.%${params.search}%`
+      );
+    }
+
+    if (params.status) {
+      query = query.eq('status', params.status);
+    }
+
+    if (params.service_type) {
+      query = query.eq('service_type', params.service_type);
+    }
+
+    if (params.urgency) {
+      query = query.eq('urgency', params.urgency);
+    }
+
+    if (params.dateFrom) {
+      query = query.gte('created_at', params.dateFrom);
+    }
+
+    if (params.dateTo) {
+      query = query.lte('created_at', params.dateTo);
+    }
+
+    query = query.order(params.sortBy, {
+      ascending: params.sortOrder === 'asc',
+      nullsFirst: false,
+    });
+
+    const from = (params.page - 1) * params.pageSize;
+    const to = from + params.pageSize - 1;
+    query = query.range(from, to);
+
+    const { data: leads, error, count } = await query;
+
+    if (error) {
+      apiLogger.error('[No Coverage Leads API] Database error', {
+        error: error.message,
+      });
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch leads', details: error.message },
+        { status: 500 }
+      );
+    }
+
+    // Fetch aggregate stats
+    const [totalStats, newStats, contactedStats, qualifiedStats, convertedStats] =
+      await Promise.all([
+        supabase
+          .from('no_coverage_leads')
+          .select('id', { count: 'exact', head: true }),
+        supabase
+          .from('no_coverage_leads')
+          .select('id', { count: 'exact', head: true })
+          .eq('status', 'new'),
+        supabase
+          .from('no_coverage_leads')
+          .select('id', { count: 'exact', head: true })
+          .eq('status', 'contacted'),
+        supabase
+          .from('no_coverage_leads')
+          .select('id', { count: 'exact', head: true })
+          .eq('status', 'qualified'),
+        supabase
+          .from('no_coverage_leads')
+          .select('id', { count: 'exact', head: true })
+          .eq('status', 'converted'),
+      ]);
+
+    // Count new this week
+    const weekAgo = new Date();
+    weekAgo.setDate(weekAgo.getDate() - 7);
+    const newThisWeekStats = await supabase
+      .from('no_coverage_leads')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'new')
+      .gte('created_at', weekAgo.toISOString());
+
+    // Service type breakdown
+    const serviceTypeStats = await supabase
+      .from('no_coverage_leads')
+      .select('service_type');
+
+    const serviceTypeCounts: Record<string, number> = {};
+    serviceTypeStats.data?.forEach((s) => {
+      const sType = s.service_type || 'unknown';
+      serviceTypeCounts[sType] = (serviceTypeCounts[sType] || 0) + 1;
+    });
+
+    const serviceTypes = Object.entries(serviceTypeCounts)
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count);
+
+    const transformedLeads =
+      leads?.map((lead) => ({
+        id: lead.id,
+        fullName: lead.full_name,
+        email: lead.email,
+        phone: lead.phone,
+        address: lead.address,
+        latitude: lead.latitude,
+        longitude: lead.longitude,
+        serviceType: lead.service_type,
+        expectedUsage: lead.expected_usage,
+        budgetRange: lead.budget_range,
+        urgency: lead.urgency,
+        notes: lead.notes,
+        marketingConsent: lead.marketing_consent,
+        source: lead.source,
+        status: lead.status,
+        contactedAt: lead.contacted_at,
+        convertedAt: lead.converted_at,
+        createdAt: lead.created_at,
+        updatedAt: lead.updated_at,
+      })) || [];
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        leads: transformedLeads,
+        stats: {
+          total: totalStats.count || 0,
+          new: newStats.count || 0,
+          newThisWeek: newThisWeekStats.count || 0,
+          contacted: contactedStats.count || 0,
+          qualified: qualifiedStats.count || 0,
+          converted: convertedStats.count || 0,
+          conversionRate:
+            (totalStats.count || 0) > 0
+              ? Math.round(
+                  ((convertedStats.count || 0) / (totalStats.count || 1)) * 100
+                )
+              : 0,
+          serviceTypes,
+        },
+        pagination: {
+          page: params.page,
+          pageSize: params.pageSize,
+          total: count || 0,
+          totalPages: Math.ceil((count || 0) / params.pageSize),
+        },
+      },
+    });
+  } catch (error) {
+    apiLogger.error('[No Coverage Leads API] Unexpected error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to fetch leads',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest): Promise<NextResponse> {
+  try {
+    const supabase = await createClient();
+    const body = await request.json();
+
+    const { ids, status } = body as { ids: string[]; status: string };
+
+    if (!ids || !Array.isArray(ids) || ids.length === 0) {
+      return NextResponse.json(
+        { success: false, error: 'Missing required field: ids (array of lead IDs)' },
+        { status: 400 }
+      );
+    }
+
+    const validStatuses = ['new', 'contacted', 'qualified', 'converted', 'declined'];
+    if (!status || !validStatuses.includes(status)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Invalid status. Must be one of: ${validStatuses.join(', ')}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    const updateData: Record<string, string> = {
+      status,
+      updated_at: new Date().toISOString(),
+    };
+
+    if (status === 'contacted') {
+      updateData.contacted_at = new Date().toISOString();
+    } else if (status === 'converted') {
+      updateData.converted_at = new Date().toISOString();
+    }
+
+    const { data, error } = await supabase
+      .from('no_coverage_leads')
+      .update(updateData)
+      .in('id', ids)
+      .select('id, status');
+
+    if (error) {
+      apiLogger.error('[No Coverage Leads API] Update error', {
+        error: error.message,
+      });
+      return NextResponse.json(
+        { success: false, error: 'Failed to update leads', details: error.message },
+        { status: 500 }
+      );
+    }
+
+    apiLogger.info('[No Coverage Leads API] Bulk status update', {
+      count: data?.length || 0,
+      status,
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        updated: data?.length || 0,
+        status,
+      },
+    });
+  } catch (error) {
+    apiLogger.error('[No Coverage Leads API] Update error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to update leads',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -203,6 +203,8 @@ const navigationSections: NavSection[] = [
           { name: 'Dashboard', href: '/admin/marketing', icon: PiSquaresFourBold },
           { name: 'Promotions', href: '/admin/marketing/promotions', icon: PiPercentBold },
           { name: 'Campaigns', href: '/admin/marketing/campaigns', icon: PiTargetBold },
+          { name: 'No Coverage Leads', href: '/admin/marketing/no-coverage-leads', icon: PiMapPinBold },
+          { name: 'Campaign Builder', href: '/admin/marketing/campaign-builder', icon: PiTargetBold },
           { name: 'Analytics', href: '/admin/marketing/analytics', icon: PiChartBarBold }
         ]
       },

--- a/lib/inngest/functions/marketing-triggers.ts
+++ b/lib/inngest/functions/marketing-triggers.ts
@@ -1,0 +1,193 @@
+/**
+ * Marketing Campaign Triggers
+ *
+ * Automated marketing intelligence triggers that fire when
+ * infrastructure changes create new outreach opportunities.
+ *
+ * 1. DFA Near-Net Alert: When DFA sync finds new connected buildings,
+ *    check for no-coverage leads within proximity and flag for outreach.
+ *
+ * 2. Demand Threshold Alert: When no-coverage leads for an area
+ *    exceed a threshold, flag for expansion review.
+ */
+
+import { inngest } from '../client';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * After DFA sync completes, check if any newly connected buildings
+ * are near existing no-coverage leads. If so, flag those leads
+ * as potential outreach targets.
+ */
+export const marketingDfaLeadMatchFunction = inngest.createFunction(
+  {
+    id: 'marketing-dfa-lead-match',
+    name: 'Marketing: Match DFA Buildings to No-Coverage Leads',
+    retries: 2,
+  },
+  { event: 'dfa/sync.completed' },
+  async ({ event, step }) => {
+    const result = await step.run('match-leads-to-buildings', async () => {
+      const supabase = await createClient();
+
+      // Get recently synced connected buildings (last 24 hours)
+      const oneDayAgo = new Date();
+      oneDayAgo.setHours(oneDayAgo.getHours() - 24);
+
+      const { data: recentBuildings, error: buildingsError } = await supabase
+        .from('dfa_buildings')
+        .select('id, building_name, street_address, latitude, longitude')
+        .eq('coverage_type', 'connected')
+        .gte('last_synced_at', oneDayAgo.toISOString());
+
+      if (buildingsError || !recentBuildings?.length) {
+        return {
+          matched: 0,
+          message: buildingsError
+            ? `Error: ${buildingsError.message}`
+            : 'No recently synced connected buildings found',
+        };
+      }
+
+      // Get all new/contacted no-coverage leads with coordinates
+      const { data: leads, error: leadsError } = await supabase
+        .from('no_coverage_leads')
+        .select('id, full_name, address, latitude, longitude, status')
+        .in('status', ['new', 'contacted'])
+        .not('latitude', 'is', null)
+        .not('longitude', 'is', null);
+
+      if (leadsError || !leads?.length) {
+        return {
+          matched: 0,
+          buildings: recentBuildings.length,
+          message: leadsError
+            ? `Error: ${leadsError.message}`
+            : 'No eligible leads with coordinates found',
+        };
+      }
+
+      // Match leads within ~1km of connected buildings
+      const PROXIMITY_DEGREES = 0.01; // ~1.1km
+      const matchedLeadIds: string[] = [];
+
+      for (const lead of leads) {
+        if (lead.latitude == null || lead.longitude == null) continue;
+
+        const isNearBuilding = recentBuildings.some((building) => {
+          if (building.latitude == null || building.longitude == null) return false;
+          const latDiff = Math.abs(building.latitude - lead.latitude!);
+          const lngDiff = Math.abs(building.longitude - lead.longitude!);
+          return latDiff <= PROXIMITY_DEGREES && lngDiff <= PROXIMITY_DEGREES;
+        });
+
+        if (isNearBuilding) {
+          matchedLeadIds.push(lead.id);
+        }
+      }
+
+      // Update matched leads status to 'qualified' with a note
+      if (matchedLeadIds.length > 0) {
+        await supabase
+          .from('no_coverage_leads')
+          .update({
+            status: 'qualified',
+            notes: `Auto-qualified: DFA fibre now available near this address (${new Date().toISOString().split('T')[0]})`,
+            updated_at: new Date().toISOString(),
+          })
+          .in('id', matchedLeadIds);
+      }
+
+      return {
+        matched: matchedLeadIds.length,
+        buildings: recentBuildings.length,
+        leadsChecked: leads.length,
+      };
+    });
+
+    return result;
+  }
+);
+
+/**
+ * Periodic check (weekly) for areas with high demand but no coverage.
+ * Flags areas that exceed a threshold of no-coverage leads.
+ */
+export const marketingDemandThresholdFunction = inngest.createFunction(
+  {
+    id: 'marketing-demand-threshold-check',
+    name: 'Marketing: Demand Threshold Alert',
+    retries: 2,
+  },
+  [
+    { cron: '0 8 * * 1' }, // Weekly on Monday at 8 AM
+  ],
+  async ({ step }) => {
+    const result = await step.run('check-demand-thresholds', async () => {
+      const supabase = await createClient();
+      const THRESHOLD = 5; // Minimum leads in an area to flag
+
+      // Get all no-coverage leads with coordinates from last 90 days
+      const ninetyDaysAgo = new Date();
+      ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+
+      const { data: leads, error } = await supabase
+        .from('no_coverage_leads')
+        .select('id, address, latitude, longitude, service_type, status')
+        .in('status', ['new', 'contacted'])
+        .not('latitude', 'is', null)
+        .not('longitude', 'is', null)
+        .gte('created_at', ninetyDaysAgo.toISOString());
+
+      if (error || !leads?.length) {
+        return {
+          hotspots: 0,
+          message: error ? `Error: ${error.message}` : 'No leads to analyze',
+        };
+      }
+
+      // Group by ~1km grid
+      const areaMap = new Map<string, { count: number; lat: number; lng: number; addresses: string[] }>();
+
+      for (const lead of leads) {
+        if (lead.latitude == null || lead.longitude == null) continue;
+
+        const gridLat = Math.round(lead.latitude * 100) / 100;
+        const gridLng = Math.round(lead.longitude * 100) / 100;
+        const key = `${gridLat},${gridLng}`;
+
+        const existing = areaMap.get(key) || {
+          count: 0,
+          lat: gridLat,
+          lng: gridLng,
+          addresses: [],
+        };
+
+        existing.count++;
+        if (lead.address && existing.addresses.length < 3) {
+          existing.addresses.push(lead.address);
+        }
+
+        areaMap.set(key, existing);
+      }
+
+      // Find hotspots above threshold
+      const hotspots = Array.from(areaMap.values())
+        .filter((area) => area.count >= THRESHOLD)
+        .sort((a, b) => b.count - a.count);
+
+      return {
+        totalLeadsAnalyzed: leads.length,
+        hotspots: hotspots.length,
+        topAreas: hotspots.slice(0, 10).map((h) => ({
+          lat: h.lat,
+          lng: h.lng,
+          leads: h.count,
+          sampleAddresses: h.addresses,
+        })),
+      };
+    });
+
+    return result;
+  }
+);

--- a/lib/inngest/index.ts
+++ b/lib/inngest/index.ts
@@ -89,6 +89,11 @@ export {
   paynowReconciliationFailedFunction,
 } from './functions/paynow-reconciliation';
 
+export {
+  marketingDfaLeadMatchFunction,
+  marketingDemandThresholdFunction,
+} from './functions/marketing-triggers';
+
 // Collect all functions for the serve handler
 import {
   competitorScrapeFunction,
@@ -171,6 +176,11 @@ import {
   paynowReconciliationFailedFunction,
 } from './functions/paynow-reconciliation';
 
+import {
+  marketingDfaLeadMatchFunction,
+  marketingDemandThresholdFunction,
+} from './functions/marketing-triggers';
+
 export const functions = [
   // Competitor analysis
   competitorScrapeFunction,
@@ -223,4 +233,7 @@ export const functions = [
   paynowReconciliationFunction,
   paynowReconciliationCompletedFunction,
   paynowReconciliationFailedFunction,
+  // Marketing campaign triggers
+  marketingDfaLeadMatchFunction,
+  marketingDemandThresholdFunction,
 ];


### PR DESCRIPTION
Build admin tools to turn existing DFA building data and Tarana base station
coverage into actionable marketing campaign lists and demand intelligence.

New features:
- No Coverage Leads admin page with filters, bulk actions, CSV export
- Campaign Builder with DFA buildings, demand hotspots, and Tarana tabs
- Coverage demand API aggregating search patterns into geographic hotspots
- Inngest triggers: auto-qualify leads when DFA fibre reaches their area
- Weekly demand threshold alerts for expansion planning

https://claude.ai/code/session_01XkoJ8nJUkGTo7FHsoEe9fm