### PR TITLE
feat(sales-engine): add coverage enrichment layer

### DIFF
--- a/app/admin/sales-engine/leads/page.tsx
+++ b/app/admin/sales-engine/leads/page.tsx
@@ -175,6 +175,9 @@ export default function LeadScoringPage() {
                   <th className="text-center px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Revenue</th>
                   <th className="text-center px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Competition</th>
                   <th className="text-center px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Speed</th>
+                  <th className="text-center px-4 py-3 text-xs font-semibold text-gray-500 uppercase">SkyFibre</th>
+                  <th className="text-center px-4 py-3 text-xs font-semibold text-gray-500 uppercase">DFA</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Eligible</th>
                   <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Product</th>
                   <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Track</th>
                   <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Est. MRR</th>
@@ -213,6 +216,46 @@ export default function LeadScoringPage() {
                     </td>
                     <td className="px-4 py-3 text-center">
                       <ScoreBar value={lead.conversion_speed_score} weight={15} />
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      {lead.skyfibre_confidence ? (
+                        <span className={`inline-flex px-1.5 py-0.5 rounded text-xs font-medium ${
+                          lead.skyfibre_confidence === 'high' ? 'bg-green-100 text-green-700' :
+                          lead.skyfibre_confidence === 'medium' ? 'bg-amber-100 text-amber-700' :
+                          lead.skyfibre_confidence === 'low' ? 'bg-orange-100 text-orange-700' :
+                          'bg-red-100 text-red-700'
+                        }`}>
+                          {lead.skyfibre_confidence}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-gray-400">--</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      {lead.dfa_coverage_type ? (
+                        <span className={`inline-flex px-1.5 py-0.5 rounded text-xs font-medium ${
+                          lead.dfa_coverage_type === 'connected' ? 'bg-purple-100 text-purple-700' :
+                          lead.dfa_coverage_type === 'near-net' ? 'bg-yellow-100 text-yellow-700' :
+                          'bg-gray-100 text-gray-500'
+                        }`}>
+                          {lead.dfa_coverage_type}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-gray-400">--</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {lead.coverage_product_eligible && lead.coverage_product_eligible.length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {lead.coverage_product_eligible.map((product) => (
+                            <span key={product} className="inline-flex px-1.5 py-0.5 rounded text-xs bg-blue-50 text-blue-700">
+                              {product}
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-xs text-gray-400">--</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-700">
                       {lead.recommended_product || '—'}

--- a/app/admin/sales-engine/map/page.tsx
+++ b/app/admin/sales-engine/map/page.tsx
@@ -1,13 +1,21 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { ZoneHeatMap } from '@/components/admin/sales-engine/ZoneHeatMap';
+import type { BaseStationLayer, DFABuildingLayer } from '@/components/admin/sales-engine/ZoneHeatMap';
 import type { SalesZone } from '@/lib/sales-engine/types';
 
 export default function SalesEngineMapPage() {
   const [zones, setZones] = useState<SalesZone[]>([]);
   const [selectedZone, setSelectedZone] = useState<SalesZone | null>(null);
   const [loading, setLoading] = useState(true);
+
+  // Infrastructure layer state
+  const [baseStations, setBaseStations] = useState<BaseStationLayer[]>([]);
+  const [dfaBuildings, setDfaBuildings] = useState<DFABuildingLayer[]>([]);
+  const [showBaseStations, setShowBaseStations] = useState(false);
+  const [showDFABuildings, setShowDFABuildings] = useState(false);
+  const [layersLoading, setLayersLoading] = useState(false);
 
   useEffect(() => {
     async function fetchZones() {
@@ -24,11 +32,86 @@ export default function SalesEngineMapPage() {
     fetchZones();
   }, []);
 
+  // Fetch coverage layers when toggled on
+  const fetchCoverageLayers = useCallback(async (layers: string[]) => {
+    if (layers.length === 0) return;
+    try {
+      setLayersLoading(true);
+      const params = new URLSearchParams({
+        layers: layers.join(','),
+        dfa_limit: '2000',
+      });
+      const res = await fetch(`/api/admin/sales-engine/map/coverage-layers?${params}`);
+      const json = await res.json();
+
+      if (json.data?.base_stations) {
+        setBaseStations(json.data.base_stations);
+      }
+      if (json.data?.dfa_buildings) {
+        setDfaBuildings(json.data.dfa_buildings);
+      }
+    } catch (error) {
+      console.error('Failed to fetch coverage layers:', error);
+    } finally {
+      setLayersLoading(false);
+    }
+  }, []);
+
+  function handleToggleBaseStations() {
+    const newState = !showBaseStations;
+    setShowBaseStations(newState);
+    if (newState && baseStations.length === 0) {
+      fetchCoverageLayers(['base_stations']);
+    }
+  }
+
+  function handleToggleDFABuildings() {
+    const newState = !showDFABuildings;
+    setShowDFABuildings(newState);
+    if (newState && dfaBuildings.length === 0) {
+      fetchCoverageLayers(['dfa_buildings']);
+    }
+  }
+
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-3xl font-bold text-gray-900">Territory Heat Map</h1>
-        <p className="text-gray-500 mt-1">Geographic visualization of sales zones and penetration</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Territory Heat Map</h1>
+          <p className="text-gray-500 mt-1">Geographic visualization of sales zones, coverage infrastructure, and penetration</p>
+        </div>
+
+        {/* Layer toggle buttons */}
+        <div className="flex gap-2">
+          <button
+            onClick={handleToggleBaseStations}
+            className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+              showBaseStations
+                ? 'bg-orange-100 text-orange-700 border-orange-300'
+                : 'bg-white text-gray-600 border-gray-200 hover:border-gray-300'
+            }`}
+          >
+            <div className="w-2.5 h-2.5 rounded-full bg-orange-500" />
+            Base Stations {baseStations.length > 0 && `(${baseStations.length})`}
+          </button>
+          <button
+            onClick={handleToggleDFABuildings}
+            className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+              showDFABuildings
+                ? 'bg-purple-100 text-purple-700 border-purple-300'
+                : 'bg-white text-gray-600 border-gray-200 hover:border-gray-300'
+            }`}
+          >
+            <div className="w-2.5 h-2.5 rounded-full bg-purple-500" />
+            DFA Buildings {dfaBuildings.length > 0 && `(${dfaBuildings.length})`}
+          </button>
+          {layersLoading && (
+            <div className="flex items-center text-xs text-gray-400">
+              <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-gray-400 mr-1" />
+              Loading...
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
@@ -44,6 +127,10 @@ export default function SalesEngineMapPage() {
               onZoneSelect={setSelectedZone}
               selectedZoneId={selectedZone?.id}
               height="600px"
+              baseStations={baseStations}
+              dfaBuildings={dfaBuildings}
+              showBaseStations={showBaseStations}
+              showDFABuildings={showDFABuildings}
             />
           )}
         </div>
@@ -89,6 +176,44 @@ export default function SalesEngineMapPage() {
                 </div>
               </div>
 
+              {/* Coverage Data */}
+              {selectedZone.coverage_confidence && (
+                <div className="mt-3 pt-3 border-t border-gray-100 space-y-2">
+                  <p className="text-xs font-semibold text-gray-500 uppercase">Coverage Intelligence</p>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-500">Confidence</span>
+                    <span className={`font-bold px-1.5 py-0.5 rounded text-xs ${
+                      selectedZone.coverage_confidence === 'high' ? 'bg-green-100 text-green-700' :
+                      selectedZone.coverage_confidence === 'medium' ? 'bg-amber-100 text-amber-700' :
+                      selectedZone.coverage_confidence === 'low' ? 'bg-orange-100 text-orange-700' :
+                      'bg-red-100 text-red-700'
+                    }`}>
+                      {selectedZone.coverage_confidence}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-500">Base Stations</span>
+                    <span className="font-medium text-gray-900">
+                      {selectedZone.base_station_count} ({selectedZone.base_station_connections} conn.)
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-500">DFA Connected</span>
+                    <span className="font-medium text-gray-900">{selectedZone.dfa_connected_count}</span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-500">DFA Near-Net</span>
+                    <span className="font-medium text-gray-900">{selectedZone.dfa_near_net_count}</span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-500">Enriched Score</span>
+                    <span className="font-bold text-gray-900">
+                      {Number(selectedZone.enriched_zone_score).toFixed(0)}
+                    </span>
+                  </div>
+                </div>
+              )}
+
               {selectedZone.notes && (
                 <p className="mt-3 text-xs text-gray-500 border-t border-gray-100 pt-3">{selectedZone.notes}</p>
               )}
@@ -118,7 +243,10 @@ export default function SalesEngineMapPage() {
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-sm font-medium text-gray-900">{zone.name}</p>
-                      <p className="text-xs text-gray-400">{zone.active_customers} customers</p>
+                      <p className="text-xs text-gray-400">
+                        {zone.active_customers} customers
+                        {zone.coverage_confidence && ` · ${zone.coverage_confidence} coverage`}
+                      </p>
                     </div>
                     <span className={`text-xs font-bold px-2 py-0.5 rounded ${
                       Number(zone.zone_score) >= 70 ? 'bg-green-100 text-green-700' :

--- a/app/admin/sales-engine/page.tsx
+++ b/app/admin/sales-engine/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PiChartBarBold, PiMapPinBold, PiTargetBold, PiTrendUpBold, PiUsersBold, PiWarningCircleBold } from 'react-icons/pi';
+import { PiChartBarBold, PiMapPinBold, PiTargetBold, PiTrendUpBold, PiUsersBold, PiWarningCircleBold, PiWifiBold } from 'react-icons/pi';
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import {
@@ -17,6 +17,7 @@ import {
 } from 'recharts';
 import { StatCard } from '@/components/admin/shared/StatCard';
 import type { SalesZone, ZoneMetric, MSCPeriod, PipelineStageSummary } from '@/lib/sales-engine/types';
+import type { CoverageGapAnalysis } from '@/lib/sales-engine/types';
 import { PIPELINE_STAGE_ORDER, PIPELINE_STAGE_LABELS } from '@/lib/sales-engine/types';
 
 interface ScorecardData {
@@ -35,6 +36,7 @@ interface ScorecardData {
     total_active_rns: number;
   };
   pipeline_summary: PipelineStageSummary[];
+  coverage_analysis: CoverageGapAnalysis | null;
 }
 
 export default function SalesEngineDashboard() {
@@ -48,18 +50,20 @@ export default function SalesEngineDashboard() {
   async function fetchDashboardData() {
     try {
       setLoading(true);
-      const [scorecardRes, pipelineRes, mscRes, zonesRes] = await Promise.all([
+      const [scorecardRes, pipelineRes, mscRes, zonesRes, coverageAnalysisRes] = await Promise.all([
         fetch('/api/admin/sales-engine/scorecard'),
         fetch('/api/admin/sales-engine/pipeline?limit=0'),
         fetch('/api/admin/sales-engine/msc'),
         fetch('/api/admin/sales-engine/zones'),
+        fetch('/api/admin/sales-engine/coverage-analysis'),
       ]);
 
-      const [scorecardJson, pipelineJson, mscJson, zonesJson] = await Promise.all([
+      const [scorecardJson, pipelineJson, mscJson, zonesJson, coverageAnalysisJson] = await Promise.all([
         scorecardRes.json(),
         pipelineRes.json(),
         mscRes.json(),
         zonesRes.json(),
+        coverageAnalysisRes.json(),
       ]);
 
       // Build pipeline summary from stage counts
@@ -112,6 +116,7 @@ export default function SalesEngineDashboard() {
           total_active_rns: activeZones.reduce((sum: number, z: SalesZone) => sum + (z.active_customers || 0), 0),
         },
         pipeline_summary: pipelineSummary,
+        coverage_analysis: coverageAnalysisJson.data ?? null,
       });
     } catch (error) {
       console.error('Failed to fetch dashboard data:', error);
@@ -241,6 +246,84 @@ export default function SalesEngineDashboard() {
           subtitle={currentMSC ? `Target: ${currentMSC.required_rns} RNs` : undefined}
         />
       </div>
+
+      {/* Coverage Intelligence */}
+      {data?.coverage_analysis && (
+        <div className="space-y-4">
+          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wider flex items-center gap-2">
+            <PiWifiBold className="h-4 w-4" />
+            Coverage Intelligence
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <StatCard
+              label="High Coverage Zones"
+              value={data.coverage_analysis.coverage_summary.high}
+              iconBgColor="bg-green-100"
+              iconColor="text-green-600"
+            />
+            <StatCard
+              label="Coverage Gaps"
+              value={data.coverage_analysis.coverage_summary.none + data.coverage_analysis.coverage_summary.low}
+              iconBgColor="bg-red-100"
+              iconColor="text-red-600"
+            />
+            <StatCard
+              label="Investment Needed"
+              value={data.coverage_analysis.investment_needed.length}
+              subtitle="Zones with leads but poor coverage"
+              iconBgColor="bg-amber-100"
+              iconColor="text-amber-600"
+            />
+            <StatCard
+              label="Untapped Opportunity"
+              value={data.coverage_analysis.untapped_opportunity.length}
+              subtitle="Good coverage, few leads"
+              iconBgColor="bg-blue-100"
+              iconColor="text-blue-600"
+            />
+          </div>
+
+          {/* Gap Analysis Details */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {data.coverage_analysis.investment_needed.length > 0 && (
+              <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
+                <h3 className="text-sm font-semibold text-red-600 mb-3">Coverage Investment Needed</h3>
+                <div className="space-y-2">
+                  {data.coverage_analysis.investment_needed.slice(0, 5).map((item) => (
+                    <div key={item.zone.id} className="flex justify-between items-center text-sm">
+                      <span className="text-gray-700">{item.zone.name}</span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-gray-500">{item.lead_count} leads</span>
+                        <span className={`px-1.5 py-0.5 rounded text-xs font-medium ${
+                          item.coverage_confidence === 'none' ? 'bg-red-100 text-red-700' :
+                          item.coverage_confidence === 'low' ? 'bg-amber-100 text-amber-700' :
+                          'bg-gray-100 text-gray-500'
+                        }`}>
+                          {item.coverage_confidence ?? 'not enriched'}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {data.coverage_analysis.untapped_opportunity.length > 0 && (
+              <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
+                <h3 className="text-sm font-semibold text-blue-600 mb-3">Untapped Opportunity</h3>
+                <div className="space-y-2">
+                  {data.coverage_analysis.untapped_opportunity.slice(0, 5).map((item) => (
+                    <div key={item.zone.id} className="flex justify-between items-center text-sm">
+                      <span className="text-gray-700">{item.zone.name}</span>
+                      <span className="text-gray-500">{item.base_station_count} BS / {item.dfa_count} DFA</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Pipeline Funnel + Zone Performance */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/app/admin/sales-engine/zones/page.tsx
+++ b/app/admin/sales-engine/zones/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PiMapPinBold, PiPlusBold, PiTargetBold, PiXBold } from 'react-icons/pi';
+import { PiArrowsClockwiseBold, PiMapPinBold, PiPlusBold, PiTargetBold, PiXBold } from 'react-icons/pi';
 import React, { useState, useEffect, useCallback } from 'react';
 import { StatCard } from '@/components/admin/shared/StatCard';
 import type { SalesZone, CreateZoneInput, ZoneType, ZonePriority } from '@/lib/sales-engine/types';
@@ -20,6 +20,7 @@ export default function ZonesPage() {
   const [editingZone, setEditingZone] = useState<SalesZone | null>(null);
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [saving, setSaving] = useState(false);
+  const [enriching, setEnriching] = useState(false);
 
   const fetchZones = useCallback(async () => {
     try {
@@ -69,6 +70,18 @@ export default function ZonesPage() {
     }
   }
 
+  async function handleEnrichAll() {
+    try {
+      setEnriching(true);
+      await fetch('/api/admin/sales-engine/zones?enrich=true');
+      fetchZones();
+    } catch (error) {
+      console.error('Failed to enrich zones:', error);
+    } finally {
+      setEnriching(false);
+    }
+  }
+
   async function handleDeleteZone(id: string) {
     if (!confirm('Park this zone? It will be marked as inactive.')) return;
     try {
@@ -95,13 +108,23 @@ export default function ZonesPage() {
           <h1 className="text-3xl font-bold text-gray-900">Sales Zones</h1>
           <p className="text-gray-500 mt-1">Territory intelligence map — manage and score your sales zones</p>
         </div>
-        <button
-          onClick={() => { setEditingZone(null); setShowCreateModal(true); }}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-circleTel-orange text-white rounded-lg text-sm font-medium hover:bg-circleTel-orange/90"
-        >
-          <PiPlusBold className="h-4 w-4" />
-          Add Zone
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleEnrichAll}
+            disabled={enriching}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            <PiArrowsClockwiseBold className={`h-4 w-4 ${enriching ? 'animate-spin' : ''}`} />
+            {enriching ? 'Enriching...' : 'Enrich Coverage'}
+          </button>
+          <button
+            onClick={() => { setEditingZone(null); setShowCreateModal(true); }}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-circleTel-orange text-white rounded-lg text-sm font-medium hover:bg-circleTel-orange/90"
+          >
+            <PiPlusBold className="h-4 w-4" />
+            Add Zone
+          </button>
+        </div>
       </div>
 
       {/* Stats */}
@@ -147,6 +170,8 @@ export default function ZonesPage() {
                 <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Zone</th>
                 <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Type</th>
                 <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Score</th>
+                <th className="text-center px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Coverage</th>
+                <th className="text-center px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Infrastructure</th>
                 <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Penetration</th>
                 <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Customers</th>
                 <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">Addresses</th>
@@ -173,6 +198,27 @@ export default function ZonesPage() {
                     }`}>
                       {Number(zone.zone_score).toFixed(0)}
                     </span>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    {zone.coverage_confidence ? (
+                      <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium ${
+                        zone.coverage_confidence === 'high' ? 'bg-green-100 text-green-700' :
+                        zone.coverage_confidence === 'medium' ? 'bg-amber-100 text-amber-700' :
+                        zone.coverage_confidence === 'low' ? 'bg-orange-100 text-orange-700' :
+                        'bg-red-100 text-red-700'
+                      }`}>
+                        {zone.coverage_confidence}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-gray-400">--</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-center text-xs text-gray-600">
+                    {zone.base_station_count > 0 || zone.dfa_connected_count > 0 ? (
+                      <span>{zone.base_station_count} BS / {zone.dfa_connected_count + zone.dfa_near_net_count} DFA</span>
+                    ) : (
+                      <span className="text-gray-400">--</span>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-right text-sm text-gray-700">
                     {Number(zone.penetration_rate).toFixed(1)}%

--- a/app/api/admin/sales-engine/coverage-analysis/route.ts
+++ b/app/api/admin/sales-engine/coverage-analysis/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { apiLogger } from '@/lib/logging/logger';
+import { getCoverageGapAnalysis } from '@/lib/sales-engine/coverage-enrichment-service';
+
+export const runtime = 'nodejs';
+export const maxDuration = 15;
+
+/**
+ * GET /api/admin/sales-engine/coverage-analysis
+ * Returns coverage gap analysis: zones needing investment, untapped opportunities,
+ * and overall coverage confidence distribution.
+ */
+export async function GET() {
+  try {
+    const result = await getCoverageGapAnalysis();
+
+    if (result.error) {
+      apiLogger.error('[Sales Engine] Coverage analysis failed', { error: result.error });
+      return NextResponse.json({ error: result.error, success: false }, { status: 500 });
+    }
+
+    return NextResponse.json({ data: result.data, success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    apiLogger.error('[Sales Engine] Coverage analysis error', { error: message });
+    return NextResponse.json({ error: message, success: false }, { status: 500 });
+  }
+}

--- a/app/api/admin/sales-engine/map/coverage-layers/route.ts
+++ b/app/api/admin/sales-engine/map/coverage-layers/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { apiLogger } from '@/lib/logging/logger';
+
+export const runtime = 'nodejs';
+export const maxDuration = 15;
+
+/**
+ * GET /api/admin/sales-engine/map/coverage-layers
+ * Returns base stations and DFA buildings within viewport bounds.
+ * Used by the map page to render infrastructure overlay layers.
+ *
+ * Query params:
+ *   sw_lat, sw_lng, ne_lat, ne_lng — viewport bounds
+ *   layers — comma-separated: "base_stations", "dfa_buildings" (default: both)
+ *   dfa_limit — max DFA buildings to return (default: 2000, for clustering)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { searchParams } = new URL(request.url);
+
+    const swLat = parseFloat(searchParams.get('sw_lat') ?? '-35');
+    const swLng = parseFloat(searchParams.get('sw_lng') ?? '16');
+    const neLat = parseFloat(searchParams.get('ne_lat') ?? '-22');
+    const neLng = parseFloat(searchParams.get('ne_lng') ?? '33');
+    const layers = (searchParams.get('layers') ?? 'base_stations,dfa_buildings').split(',');
+    const dfaLimit = parseInt(searchParams.get('dfa_limit') ?? '2000', 10);
+
+    const result: {
+      base_stations?: Array<Record<string, unknown>>;
+      dfa_buildings?: Array<Record<string, unknown>>;
+    } = {};
+
+    // Fetch base stations within viewport
+    if (layers.includes('base_stations')) {
+      const { data: stations, error: bsError } = await supabase
+        .from('tarana_base_stations')
+        .select('id, serial_number, hostname, site_name, active_connections, market, lat, lng')
+        .gte('lat', swLat)
+        .lte('lat', neLat)
+        .gte('lng', swLng)
+        .lte('lng', neLng);
+
+      if (bsError) {
+        apiLogger.error('[Sales Engine] Base stations layer query failed', { error: bsError.message });
+      }
+
+      result.base_stations = stations ?? [];
+    }
+
+    // Fetch DFA buildings within viewport (limited for performance)
+    if (layers.includes('dfa_buildings')) {
+      const { data: buildings, error: dfaError } = await supabase
+        .from('dfa_buildings')
+        .select('id, building_name, building_id, street_address, latitude, longitude, coverage_type, ftth, precinct')
+        .gte('latitude', swLat)
+        .lte('latitude', neLat)
+        .gte('longitude', swLng)
+        .lte('longitude', neLng)
+        .limit(dfaLimit);
+
+      if (dfaError) {
+        apiLogger.error('[Sales Engine] DFA buildings layer query failed', { error: dfaError.message });
+      }
+
+      result.dfa_buildings = buildings ?? [];
+    }
+
+    return NextResponse.json({
+      data: result,
+      bounds: { sw_lat: swLat, sw_lng: swLng, ne_lat: neLat, ne_lng: neLng },
+      success: true,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    apiLogger.error('[Sales Engine] Coverage layers error', { error: message });
+    return NextResponse.json({ error: message, success: false }, { status: 500 });
+  }
+}

--- a/app/api/admin/sales-engine/zones/[id]/coverage/route.ts
+++ b/app/api/admin/sales-engine/zones/[id]/coverage/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { apiLogger } from '@/lib/logging/logger';
+import { enrichZoneCoverage } from '@/lib/sales-engine/coverage-enrichment-service';
+
+export const runtime = 'nodejs';
+export const maxDuration = 15;
+
+/**
+ * GET /api/admin/sales-engine/zones/[id]/coverage
+ * Get detailed coverage infrastructure data for a zone.
+ * Returns base stations and DFA buildings within the zone's radius.
+ */
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await context.params;
+    const supabase = await createClient();
+
+    // Fetch the zone
+    const { data: zone, error: zoneError } = await supabase
+      .from('sales_zones')
+      .select('id, name, center_lat, center_lng, radius_km, base_station_count, base_station_connections, dfa_connected_count, dfa_near_net_count, coverage_confidence, coverage_score, enriched_zone_score, coverage_enriched_at')
+      .eq('id', id)
+      .single();
+
+    if (zoneError) {
+      return NextResponse.json(
+        { error: zoneError.message, success: false },
+        { status: zoneError.code === 'PGRST116' ? 404 : 500 }
+      );
+    }
+
+    const radiusKm = zone.radius_km ?? 3.0;
+
+    // Fetch actual base stations within radius
+    const { data: baseStations, error: bsError } = await supabase.rpc(
+      'find_nearest_tarana_base_station',
+      { p_lat: zone.center_lat, p_lng: zone.center_lng, p_limit: 50 }
+    );
+
+    const nearbyBaseStations = !bsError && Array.isArray(baseStations)
+      ? baseStations.filter((bs: { distance_km: number }) => Number(bs.distance_km) <= radiusKm)
+      : [];
+
+    // Fetch nearby DFA buildings within radius
+    const { data: dfaBuildings, error: dfaError } = await supabase.rpc(
+      'find_nearest_dfa_building',
+      { p_lat: zone.center_lat, p_lng: zone.center_lng, p_limit: 100 }
+    );
+
+    const nearbyDfaBuildings = !dfaError && Array.isArray(dfaBuildings)
+      ? dfaBuildings.filter((b: { distance_km: number }) => Number(b.distance_km) <= radiusKm)
+      : [];
+
+    return NextResponse.json({
+      data: {
+        zone: {
+          id: zone.id,
+          name: zone.name,
+          center_lat: zone.center_lat,
+          center_lng: zone.center_lng,
+          radius_km: radiusKm,
+          coverage_confidence: zone.coverage_confidence,
+          coverage_score: zone.coverage_score,
+          enriched_zone_score: zone.enriched_zone_score,
+          coverage_enriched_at: zone.coverage_enriched_at,
+        },
+        infrastructure: {
+          base_stations: {
+            count: zone.base_station_count,
+            total_connections: zone.base_station_connections,
+            details: nearbyBaseStations,
+          },
+          dfa_buildings: {
+            connected_count: zone.dfa_connected_count,
+            near_net_count: zone.dfa_near_net_count,
+            details: nearbyDfaBuildings,
+          },
+        },
+      },
+      success: true,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    apiLogger.error('[Sales Engine] Zone coverage GET error', { error: message });
+    return NextResponse.json({ error: message, success: false }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/admin/sales-engine/zones/[id]/coverage
+ * Refresh coverage data for a single zone by re-running enrichment.
+ */
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await context.params;
+
+    const result = await enrichZoneCoverage(id);
+
+    if (result.error) {
+      apiLogger.error('[Sales Engine] Zone coverage enrichment failed', { error: result.error, zone_id: id });
+      return NextResponse.json({ error: result.error, success: false }, { status: 500 });
+    }
+
+    apiLogger.info('[Sales Engine] Zone coverage enriched', { zone_id: id, data: result.data });
+    return NextResponse.json({ data: result.data, success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    apiLogger.error('[Sales Engine] Zone coverage POST error', { error: message });
+    return NextResponse.json({ error: message, success: false }, { status: 500 });
+  }
+}

--- a/app/api/admin/sales-engine/zones/route.ts
+++ b/app/api/admin/sales-engine/zones/route.ts
@@ -1,13 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { apiLogger } from '@/lib/logging/logger';
+import { enrichAllZones } from '@/lib/sales-engine/coverage-enrichment-service';
 
 export const runtime = 'nodejs';
-export const maxDuration = 15;
+export const maxDuration = 30;
 
 /**
  * GET /api/admin/sales-engine/zones
- * List sales zones with optional filtering and sorting
+ * List sales zones with optional filtering and sorting.
+ * Pass ?enrich=true to refresh coverage data from base stations & DFA buildings before returning.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -17,6 +19,20 @@ export async function GET(request: NextRequest) {
     const status = searchParams.get('status');
     const priority = searchParams.get('priority');
     const sortBy = searchParams.get('sort_by') || 'zone_score';
+    const enrich = searchParams.get('enrich') === 'true';
+
+    // Optionally enrich all zones with coverage data before returning
+    if (enrich) {
+      const enrichResult = await enrichAllZones();
+      if (enrichResult.error) {
+        apiLogger.error('[Sales Engine] Zone enrichment failed', { error: enrichResult.error });
+      } else {
+        apiLogger.info('[Sales Engine] Zones enriched', {
+          enriched: enrichResult.data?.enriched,
+          errors: enrichResult.data?.errors?.length ?? 0,
+        });
+      }
+    }
 
     let query = supabase
       .from('sales_zones')

--- a/components/admin/sales-engine/ZoneHeatMap.tsx
+++ b/components/admin/sales-engine/ZoneHeatMap.tsx
@@ -3,11 +3,37 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import type { SalesZone } from '@/lib/sales-engine/types';
 
+export interface BaseStationLayer {
+  id: string;
+  site_name: string;
+  hostname: string;
+  active_connections: number;
+  market: string;
+  lat: number;
+  lng: number;
+}
+
+export interface DFABuildingLayer {
+  id: string;
+  building_name: string | null;
+  building_id: string | null;
+  street_address: string | null;
+  latitude: number;
+  longitude: number;
+  coverage_type: 'connected' | 'near-net';
+  ftth: string | null;
+  precinct: string | null;
+}
+
 interface ZoneHeatMapProps {
   zones: SalesZone[];
   onZoneSelect?: (zone: SalesZone) => void;
   selectedZoneId?: string;
   height?: string;
+  baseStations?: BaseStationLayer[];
+  dfaBuildings?: DFABuildingLayer[];
+  showBaseStations?: boolean;
+  showDFABuildings?: boolean;
 }
 
 // Color based on zone score (green = high, red = low)
@@ -22,11 +48,22 @@ function getZoneOpacity(score: number): number {
   return 0.2 + (score / 100) * 0.4; // 0.2 to 0.6
 }
 
-export function ZoneHeatMap({ zones, onZoneSelect, selectedZoneId, height = '600px' }: ZoneHeatMapProps) {
+export function ZoneHeatMap({
+  zones,
+  onZoneSelect,
+  selectedZoneId,
+  height = '600px',
+  baseStations = [],
+  dfaBuildings = [],
+  showBaseStations = false,
+  showDFABuildings = false,
+}: ZoneHeatMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const googleMapRef = useRef<google.maps.Map | null>(null);
   const markersRef = useRef<google.maps.Marker[]>([]);
   const circlesRef = useRef<google.maps.Circle[]>([]);
+  const bsMarkersRef = useRef<google.maps.Marker[]>([]);
+  const dfaMarkersRef = useRef<google.maps.Marker[]>([]);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -72,6 +109,8 @@ export function ZoneHeatMap({ zones, onZoneSelect, selectedZoneId, height = '600
       // Cleanup markers and circles
       markersRef.current.forEach((m) => m.setMap(null));
       circlesRef.current.forEach((c) => c.setMap(null));
+      bsMarkersRef.current.forEach((m) => m.setMap(null));
+      dfaMarkersRef.current.forEach((m) => m.setMap(null));
     };
   }, [initMap]);
 
@@ -163,6 +202,109 @@ export function ZoneHeatMap({ zones, onZoneSelect, selectedZoneId, height = '600
     }
   }, [zones, mapLoaded, selectedZoneId, onZoneSelect]);
 
+  // Render base station markers
+  useEffect(() => {
+    if (!googleMapRef.current || !mapLoaded) return;
+
+    // Clear existing base station markers
+    bsMarkersRef.current.forEach((m) => m.setMap(null));
+    bsMarkersRef.current = [];
+
+    if (!showBaseStations || baseStations.length === 0) return;
+
+    const map = googleMapRef.current;
+
+    for (const bs of baseStations) {
+      const connections = bs.active_connections ?? 0;
+      // Color by connection count: red < 5, orange 5-10, green > 10
+      const fillColor = connections >= 10 ? '#f97316' : connections >= 5 ? '#fb923c' : '#fbbf24';
+
+      const marker = new google.maps.Marker({
+        map,
+        position: { lat: Number(bs.lat), lng: Number(bs.lng) },
+        icon: {
+          path: 'M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z', // tower pin
+          scale: 1.2,
+          fillColor,
+          fillOpacity: 0.9,
+          strokeColor: '#7c2d12',
+          strokeWeight: 1,
+          anchor: new google.maps.Point(12, 24),
+        },
+        title: `${bs.site_name} (${connections} connections)`,
+        zIndex: 100,
+      });
+
+      marker.addListener('click', () => {
+        new google.maps.InfoWindow({
+          content: `
+            <div style="font-family: system-ui; font-size: 12px; max-width: 200px;">
+              <p style="font-weight: 700; margin-bottom: 4px;">${bs.site_name}</p>
+              <p style="color: #6b7280;">${bs.hostname}</p>
+              <p style="margin-top: 4px;"><strong>${connections}</strong> active connections</p>
+              <p style="color: #6b7280;">${bs.market}</p>
+            </div>
+          `,
+        }).open(map, marker);
+      });
+
+      bsMarkersRef.current.push(marker);
+    }
+  }, [baseStations, showBaseStations, mapLoaded]);
+
+  // Render DFA building markers
+  useEffect(() => {
+    if (!googleMapRef.current || !mapLoaded) return;
+
+    // Clear existing DFA markers
+    dfaMarkersRef.current.forEach((m) => m.setMap(null));
+    dfaMarkersRef.current = [];
+
+    if (!showDFABuildings || dfaBuildings.length === 0) return;
+
+    const map = googleMapRef.current;
+
+    for (const building of dfaBuildings) {
+      const isConnected = building.coverage_type === 'connected';
+      const fillColor = isConnected ? '#a855f7' : '#eab308'; // purple or yellow
+
+      const marker = new google.maps.Marker({
+        map,
+        position: { lat: building.latitude, lng: building.longitude },
+        icon: {
+          path: google.maps.SymbolPath.CIRCLE,
+          scale: 4,
+          fillColor,
+          fillOpacity: 0.7,
+          strokeColor: isConnected ? '#7e22ce' : '#a16207',
+          strokeWeight: 1,
+        },
+        title: building.building_name ?? building.building_id ?? 'DFA Building',
+        zIndex: 50,
+      });
+
+      marker.addListener('click', () => {
+        new google.maps.InfoWindow({
+          content: `
+            <div style="font-family: system-ui; font-size: 12px; max-width: 220px;">
+              <p style="font-weight: 700; margin-bottom: 4px;">${building.building_name ?? 'DFA Building'}</p>
+              ${building.street_address ? `<p style="color: #6b7280;">${building.street_address}</p>` : ''}
+              <p style="margin-top: 4px;">
+                <span style="display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 11px; font-weight: 600; background: ${isConnected ? '#f3e8ff' : '#fef9c3'}; color: ${isConnected ? '#7e22ce' : '#a16207'};">
+                  ${building.coverage_type}
+                </span>
+              </p>
+              ${building.ftth ? `<p style="margin-top: 4px; color: #6b7280;">FTTH: ${building.ftth}</p>` : ''}
+              ${building.precinct ? `<p style="color: #6b7280;">Precinct: ${building.precinct}</p>` : ''}
+            </div>
+          `,
+        }).open(map, marker);
+      });
+
+      dfaMarkersRef.current.push(marker);
+    }
+  }, [dfaBuildings, showDFABuildings, mapLoaded]);
+
   if (error) {
     return (
       <div className="flex items-center justify-center bg-gray-50 rounded-lg border border-gray-200" style={{ height }}>
@@ -196,6 +338,31 @@ export function ZoneHeatMap({ zones, onZoneSelect, selectedZoneId, height = '600
             <span>&lt;30 (Park)</span>
           </div>
         </div>
+        {(showBaseStations || showDFABuildings) && (
+          <div className="mt-3 pt-2 border-t border-gray-200">
+            <p className="font-semibold text-gray-700 mb-2">Infrastructure</p>
+            <div className="space-y-1">
+              {showBaseStations && (
+                <div className="flex items-center gap-2">
+                  <div className="w-3 h-3 rounded-full bg-orange-500" />
+                  <span>Base Stations ({baseStations.length})</span>
+                </div>
+              )}
+              {showDFABuildings && (
+                <>
+                  <div className="flex items-center gap-2">
+                    <div className="w-3 h-3 rounded-full bg-purple-500" />
+                    <span>DFA Connected</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="w-3 h-3 rounded-full bg-yellow-500" />
+                    <span>DFA Near-Net</span>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/lib/sales-engine/coverage-enrichment-service.ts
+++ b/lib/sales-engine/coverage-enrichment-service.ts
@@ -1,0 +1,593 @@
+/**
+ * Coverage Enrichment Service
+ * Integrates Tarana base station and DFA building data into the sales engine.
+ * Uses PostGIS RPC calls for efficient bulk spatial queries.
+ *
+ * @module lib/sales-engine/coverage-enrichment-service
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import type {
+  SalesZone,
+  CoverageConfidenceLevel,
+  ZoneCoverageEnrichment,
+  LeadCoverageEnrichment,
+  CoverageGapAnalysis,
+} from './types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface ServiceResult<T> {
+  data: T | null;
+  error: string | null;
+}
+
+// Coverage confidence thresholds (from base-station-service.ts)
+const COVERAGE_THRESHOLD_HIGH_KM = 3.0;
+const COVERAGE_THRESHOLD_MAX_KM = 5.0;
+const MIN_CONNECTIONS_HIGH = 10;
+const MIN_CONNECTIONS_MEDIUM = 5;
+
+// =============================================================================
+// Zone Coverage Enrichment
+// =============================================================================
+
+/**
+ * Enrich a single zone with coverage data from base stations and DFA buildings.
+ * Queries both datasets within the zone's radius_km, computes coverage_score
+ * and enriched_zone_score, and persists to the database.
+ */
+export async function enrichZoneCoverage(
+  zoneId: string
+): Promise<ServiceResult<ZoneCoverageEnrichment>> {
+  try {
+    const supabase = await createClient();
+
+    // Fetch the zone
+    const { data: zone, error: zoneError } = await supabase
+      .from('sales_zones')
+      .select('id, center_lat, center_lng, radius_km, sme_density_score, penetration_rate, competitor_weakness_score')
+      .eq('id', zoneId)
+      .single();
+
+    if (zoneError || !zone) {
+      return { data: null, error: `Zone not found: ${zoneError?.message ?? 'no data'}` };
+    }
+
+    const radiusKm = zone.radius_km ?? 3.0;
+
+    // Query base stations within radius (PostGIS RPC)
+    const { data: bsData, error: bsError } = await supabase.rpc(
+      'count_base_stations_in_radius',
+      { p_lat: zone.center_lat, p_lng: zone.center_lng, p_radius_km: radiusKm }
+    );
+
+    if (bsError) {
+      return { data: null, error: `Base station query failed: ${bsError.message}` };
+    }
+
+    const bsResult = Array.isArray(bsData) ? bsData[0] : bsData;
+    const baseStationCount = bsResult?.station_count ?? 0;
+    const baseStationConnections = bsResult?.total_connections ?? 0;
+
+    // Query DFA buildings within radius (PostGIS RPC)
+    const { data: dfaData, error: dfaError } = await supabase.rpc(
+      'count_dfa_buildings_in_radius',
+      { p_lat: zone.center_lat, p_lng: zone.center_lng, p_radius_km: radiusKm }
+    );
+
+    if (dfaError) {
+      return { data: null, error: `DFA building query failed: ${dfaError.message}` };
+    }
+
+    const dfaResult = Array.isArray(dfaData) ? dfaData[0] : dfaData;
+    const dfaConnectedCount = dfaResult?.connected_count ?? 0;
+    const dfaNearNetCount = dfaResult?.near_net_count ?? 0;
+
+    // Compute coverage confidence for the zone
+    const coverageConfidence = computeZoneCoverageConfidence(
+      baseStationCount,
+      baseStationConnections,
+      dfaConnectedCount
+    );
+
+    // Compute coverage score (0-100)
+    const coverageScore = computeCoverageScore(
+      baseStationCount,
+      baseStationConnections,
+      dfaConnectedCount,
+      dfaNearNetCount
+    );
+
+    // Compute enriched zone score with coverage weight
+    const enrichedZoneScore = computeEnrichedZoneScore(
+      zone.sme_density_score ?? 0,
+      zone.penetration_rate ?? 0,
+      zone.competitor_weakness_score ?? 0,
+      coverageScore
+    );
+
+    // Persist enrichment data
+    const { error: updateError } = await supabase
+      .from('sales_zones')
+      .update({
+        base_station_count: baseStationCount,
+        base_station_connections: baseStationConnections,
+        dfa_connected_count: dfaConnectedCount,
+        dfa_near_net_count: dfaNearNetCount,
+        coverage_confidence: coverageConfidence,
+        coverage_score: coverageScore,
+        enriched_zone_score: enrichedZoneScore,
+        coverage_enriched_at: new Date().toISOString(),
+      })
+      .eq('id', zoneId);
+
+    if (updateError) {
+      return { data: null, error: `Failed to update zone: ${updateError.message}` };
+    }
+
+    const enrichment: ZoneCoverageEnrichment = {
+      zone_id: zoneId,
+      base_station_count: baseStationCount,
+      base_station_connections: baseStationConnections,
+      dfa_connected_count: dfaConnectedCount,
+      dfa_near_net_count: dfaNearNetCount,
+      coverage_confidence: coverageConfidence,
+      coverage_score: coverageScore,
+      enriched_zone_score: enrichedZoneScore,
+    };
+
+    return { data: enrichment, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { data: null, error: `Failed to enrich zone ${zoneId}: ${message}` };
+  }
+}
+
+/**
+ * Batch enrich all active zones with coverage data.
+ */
+export async function enrichAllZones(): Promise<
+  ServiceResult<{ enriched: number; errors: string[] }>
+> {
+  try {
+    const supabase = await createClient();
+
+    const { data: zones, error: zonesError } = await supabase
+      .from('sales_zones')
+      .select('id')
+      .eq('status', 'active');
+
+    if (zonesError) {
+      return { data: null, error: `Failed to fetch zones: ${zonesError.message}` };
+    }
+
+    const activeZones = zones ?? [];
+    let enriched = 0;
+    const errors: string[] = [];
+
+    for (const zone of activeZones) {
+      const result = await enrichZoneCoverage(zone.id);
+      if (result.error) {
+        errors.push(`Zone ${zone.id}: ${result.error}`);
+      } else {
+        enriched++;
+      }
+    }
+
+    return { data: { enriched, errors }, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { data: null, error: `Failed to enrich all zones: ${message}` };
+  }
+}
+
+// =============================================================================
+// Lead Coverage Enrichment
+// =============================================================================
+
+/**
+ * Enrich a single lead with coverage proximity data.
+ * Finds nearest base station (SkyFibre) and nearest DFA building (BizFibre),
+ * computes confidence levels, and determines product eligibility.
+ */
+export async function enrichLeadCoverage(
+  leadScoreId: string
+): Promise<ServiceResult<LeadCoverageEnrichment>> {
+  try {
+    const supabase = await createClient();
+
+    // Fetch the lead score and its coverage_lead coordinates
+    const { data: leadScore, error: lsError } = await supabase
+      .from('lead_scores')
+      .select(`
+        id,
+        coverage_lead_id,
+        recommended_product,
+        coverage_lead:coverage_leads (
+          id, latitude, longitude, customer_type
+        )
+      `)
+      .eq('id', leadScoreId)
+      .single();
+
+    if (lsError || !leadScore) {
+      return { data: null, error: `Lead score not found: ${lsError?.message ?? 'no data'}` };
+    }
+
+    const coverageLead = leadScore.coverage_lead as {
+      id: string;
+      latitude: number | null;
+      longitude: number | null;
+      customer_type?: string;
+    } | null;
+
+    if (!coverageLead?.latitude || !coverageLead?.longitude) {
+      return { data: null, error: 'Lead has no coordinates' };
+    }
+
+    const lat = coverageLead.latitude;
+    const lng = coverageLead.longitude;
+
+    // Find nearest base station via existing PostGIS function
+    const { data: bsData, error: bsError } = await supabase.rpc(
+      'find_nearest_tarana_base_station',
+      { p_lat: lat, p_lng: lng, p_limit: 1 }
+    );
+
+    let nearestBsKm: number | null = null;
+    let skyfibreConfidence: CoverageConfidenceLevel = 'none';
+
+    if (!bsError && Array.isArray(bsData) && bsData.length > 0) {
+      const nearest = bsData[0];
+      nearestBsKm = Number(nearest.distance_km);
+      skyfibreConfidence = calculateSkyFibreConfidence(
+        nearestBsKm,
+        nearest.active_connections ?? 0
+      );
+    }
+
+    // Find nearest DFA building via new PostGIS function
+    const { data: dfaData, error: dfaError } = await supabase.rpc(
+      'find_nearest_dfa_building',
+      { p_lat: lat, p_lng: lng, p_limit: 1 }
+    );
+
+    let nearestDfaKm: number | null = null;
+    let dfaCoverageType: 'connected' | 'near-net' | 'none' = 'none';
+
+    if (!dfaError && Array.isArray(dfaData) && dfaData.length > 0) {
+      const nearest = dfaData[0];
+      nearestDfaKm = Number(nearest.distance_km);
+      // Consider DFA coverage if within 1km (connected) or 2km (near-net)
+      if (nearest.coverage_type === 'connected' && nearestDfaKm <= 1.0) {
+        dfaCoverageType = 'connected';
+      } else if (nearestDfaKm <= 2.0) {
+        dfaCoverageType = nearest.coverage_type === 'connected' ? 'connected' : 'near-net';
+      }
+    }
+
+    // Determine product eligibility
+    const coverageProductEligible: string[] = [];
+    if (skyfibreConfidence === 'high' || skyfibreConfidence === 'medium') {
+      coverageProductEligible.push('SkyFibre');
+    }
+    if (dfaCoverageType === 'connected') {
+      coverageProductEligible.push('BizFibreConnect');
+    } else if (dfaCoverageType === 'near-net') {
+      coverageProductEligible.push('BizFibreConnect (Near-Net)');
+    }
+
+    // Auto product recommendation
+    const customerType = coverageLead.customer_type ?? '';
+    const recommendedProduct = getAutoProductRecommendation(
+      skyfibreConfidence,
+      dfaCoverageType,
+      customerType
+    );
+
+    // Persist enrichment data to lead_scores
+    const { error: updateError } = await supabase
+      .from('lead_scores')
+      .update({
+        nearest_base_station_km: nearestBsKm,
+        skyfibre_confidence: skyfibreConfidence,
+        nearest_dfa_building_km: nearestDfaKm,
+        dfa_coverage_type: dfaCoverageType,
+        coverage_product_eligible: coverageProductEligible,
+        recommended_product: recommendedProduct,
+      })
+      .eq('id', leadScoreId);
+
+    if (updateError) {
+      return { data: null, error: `Failed to update lead score: ${updateError.message}` };
+    }
+
+    const enrichment: LeadCoverageEnrichment = {
+      lead_score_id: leadScoreId,
+      nearest_base_station_km: nearestBsKm,
+      skyfibre_confidence: skyfibreConfidence,
+      nearest_dfa_building_km: nearestDfaKm,
+      dfa_coverage_type: dfaCoverageType,
+      coverage_product_eligible: coverageProductEligible,
+      recommended_product: recommendedProduct,
+    };
+
+    return { data: enrichment, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { data: null, error: `Failed to enrich lead ${leadScoreId}: ${message}` };
+  }
+}
+
+// =============================================================================
+// Coverage Gap Analysis
+// =============================================================================
+
+/**
+ * Analyze zones for coverage gaps and untapped opportunities.
+ * Returns zones that need infrastructure investment and zones with
+ * high coverage but low lead activity.
+ */
+export async function getCoverageGapAnalysis(): Promise<ServiceResult<CoverageGapAnalysis>> {
+  try {
+    const supabase = await createClient();
+
+    // Fetch all zones with their coverage data and lead counts
+    const { data: zones, error: zonesError } = await supabase
+      .from('sales_zones')
+      .select('*')
+      .eq('status', 'active');
+
+    if (zonesError) {
+      return { data: null, error: `Failed to fetch zones: ${zonesError.message}` };
+    }
+
+    const allZones = (zones ?? []) as SalesZone[];
+
+    // Get lead counts per zone
+    const { data: leadCounts, error: lcError } = await supabase
+      .from('lead_scores')
+      .select('zone_id');
+
+    const leadCountMap: Record<string, number> = {};
+    if (!lcError && leadCounts) {
+      for (const lc of leadCounts) {
+        if (lc.zone_id) {
+          leadCountMap[lc.zone_id] = (leadCountMap[lc.zone_id] ?? 0) + 1;
+        }
+      }
+    }
+
+    // Classify zones
+    const investmentNeeded: CoverageGapAnalysis['investment_needed'] = [];
+    const untappedOpportunity: CoverageGapAnalysis['untapped_opportunity'] = [];
+    const coverageSummary = { high: 0, medium: 0, low: 0, none: 0, not_enriched: 0 };
+
+    for (const zone of allZones) {
+      const leadCount = leadCountMap[zone.id] ?? 0;
+      const confidence = zone.coverage_confidence;
+
+      // Count by confidence
+      if (!confidence) {
+        coverageSummary.not_enriched++;
+      } else {
+        coverageSummary[confidence]++;
+      }
+
+      // Investment needed: has leads but poor coverage
+      if (leadCount >= 3 && (confidence === 'none' || confidence === 'low' || !confidence)) {
+        investmentNeeded.push({
+          zone,
+          lead_count: leadCount,
+          coverage_confidence: confidence,
+        });
+      }
+
+      // Untapped opportunity: good coverage but few leads
+      const totalInfra = zone.base_station_count + zone.dfa_connected_count;
+      if (totalInfra >= 3 && leadCount < 3) {
+        untappedOpportunity.push({
+          zone,
+          base_station_count: zone.base_station_count,
+          dfa_count: zone.dfa_connected_count + zone.dfa_near_net_count,
+        });
+      }
+    }
+
+    // Sort by priority
+    investmentNeeded.sort((a, b) => b.lead_count - a.lead_count);
+    untappedOpportunity.sort(
+      (a, b) => (b.base_station_count + b.dfa_count) - (a.base_station_count + a.dfa_count)
+    );
+
+    return {
+      data: {
+        investment_needed: investmentNeeded,
+        untapped_opportunity: untappedOpportunity,
+        coverage_summary: coverageSummary,
+      },
+      error: null,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { data: null, error: `Failed to analyze coverage gaps: ${message}` };
+  }
+}
+
+// =============================================================================
+// Product Recommendation
+// =============================================================================
+
+/**
+ * Determine the best product recommendation based on coverage availability.
+ * Pure function — no database calls.
+ */
+export function getAutoProductRecommendation(
+  skyfibreConfidence: CoverageConfidenceLevel,
+  dfaCoverageType: 'connected' | 'near-net' | 'none',
+  customerType: string
+): string {
+  const ct = customerType.toLowerCase().trim();
+  const isBusinessType = ['business', 'enterprise', 'office_park', 'commercial'].includes(ct);
+  const hasSkyFibre = skyfibreConfidence === 'high' || skyfibreConfidence === 'medium';
+  const hasBizFibre = dfaCoverageType === 'connected';
+  const hasNearNet = dfaCoverageType === 'near-net';
+
+  // Both available: recommend based on customer type
+  if (hasBizFibre && hasSkyFibre) {
+    return isBusinessType ? 'BizFibreConnect' : 'SkyFibre SMB';
+  }
+
+  // BizFibre connected only
+  if (hasBizFibre) {
+    return 'BizFibreConnect';
+  }
+
+  // SkyFibre only
+  if (hasSkyFibre) {
+    if (isBusinessType) return 'SkyFibre SMB';
+    if (['clinic', 'healthcare'].includes(ct)) return 'ClinicConnect';
+    if (ct === 'residential') return 'SkyFibre Home';
+    return 'WorkConnect SOHO';
+  }
+
+  // Near-net DFA (requires build-out)
+  if (hasNearNet) {
+    return 'BizFibreConnect (Near-Net)';
+  }
+
+  // No coverage — fallback to static recommendation
+  const FALLBACK_PRODUCTS: Record<string, string> = {
+    business: 'SkyFibre SMB',
+    enterprise: 'ParkConnect DUNE',
+    office_park: 'ParkConnect DUNE',
+    clinic: 'ClinicConnect',
+    healthcare: 'ClinicConnect',
+    residential: 'SkyFibre Home',
+    soho: 'WorkConnect SOHO',
+  };
+
+  return FALLBACK_PRODUCTS[ct] ?? 'WorkConnect SOHO';
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Compute zone-level coverage confidence from infrastructure counts.
+ */
+function computeZoneCoverageConfidence(
+  baseStationCount: number,
+  baseStationConnections: number,
+  dfaConnectedCount: number
+): CoverageConfidenceLevel {
+  // High: multiple base stations with strong connections, or strong DFA presence
+  if (
+    (baseStationCount >= 2 && baseStationConnections >= MIN_CONNECTIONS_HIGH) ||
+    (baseStationCount >= 1 && dfaConnectedCount >= 10)
+  ) {
+    return 'high';
+  }
+
+  // Medium: some base station presence or moderate DFA coverage
+  if (
+    (baseStationCount >= 1 && baseStationConnections >= MIN_CONNECTIONS_MEDIUM) ||
+    dfaConnectedCount >= 5
+  ) {
+    return 'medium';
+  }
+
+  // Low: minimal infrastructure
+  if (baseStationCount >= 1 || dfaConnectedCount >= 1) {
+    return 'low';
+  }
+
+  return 'none';
+}
+
+/**
+ * Compute a coverage score (0-100) from infrastructure metrics.
+ */
+function computeCoverageScore(
+  baseStationCount: number,
+  baseStationConnections: number,
+  dfaConnectedCount: number,
+  dfaNearNetCount: number
+): number {
+  let score = 0;
+
+  // Base station component (up to 60 points)
+  if (baseStationCount > 0) {
+    if (baseStationConnections >= MIN_CONNECTIONS_HIGH) {
+      score += 40 + Math.min(baseStationCount * 5, 20); // 40-60
+    } else if (baseStationConnections >= MIN_CONNECTIONS_MEDIUM) {
+      score += 25 + Math.min(baseStationCount * 5, 15); // 25-40
+    } else {
+      score += 10 + Math.min(baseStationCount * 5, 15); // 10-25
+    }
+  }
+
+  // DFA connected component (up to 30 points)
+  if (dfaConnectedCount > 0) {
+    score += Math.min(dfaConnectedCount * 2, 30);
+  }
+
+  // DFA near-net component (up to 10 points)
+  if (dfaNearNetCount > 0) {
+    score += Math.min(dfaNearNetCount, 10);
+  }
+
+  return Math.min(score, 100);
+}
+
+/**
+ * Compute enriched zone score incorporating coverage data.
+ * Formula: (sme * 0.30) + ((100 - penetration) * 0.30) + (competitor * 0.15) + (coverage * 0.25)
+ */
+function computeEnrichedZoneScore(
+  smeDensityScore: number,
+  penetrationRate: number,
+  competitorWeaknessScore: number,
+  coverageScore: number
+): number {
+  const score =
+    smeDensityScore * 0.3 +
+    (100 - Math.min(penetrationRate, 100)) * 0.3 +
+    competitorWeaknessScore * 0.15 +
+    coverageScore * 0.25;
+
+  return Math.round(score * 100) / 100;
+}
+
+/**
+ * Calculate SkyFibre confidence for a lead based on distance and connections.
+ * Mirrors the logic in base-station-service.ts.
+ */
+function calculateSkyFibreConfidence(
+  distanceKm: number,
+  activeConnections: number
+): CoverageConfidenceLevel {
+  if (distanceKm > COVERAGE_THRESHOLD_MAX_KM) return 'none';
+
+  if (distanceKm <= COVERAGE_THRESHOLD_HIGH_KM && activeConnections >= MIN_CONNECTIONS_HIGH) {
+    return 'high';
+  }
+
+  if (distanceKm <= COVERAGE_THRESHOLD_HIGH_KM && activeConnections >= MIN_CONNECTIONS_MEDIUM) {
+    return 'medium';
+  }
+
+  if (distanceKm <= COVERAGE_THRESHOLD_MAX_KM && activeConnections >= MIN_CONNECTIONS_MEDIUM) {
+    return 'medium';
+  }
+
+  if (distanceKm <= COVERAGE_THRESHOLD_MAX_KM && activeConnections >= 1) {
+    return 'low';
+  }
+
+  return 'none';
+}

--- a/lib/sales-engine/lead-scoring-service.ts
+++ b/lib/sales-engine/lead-scoring-service.ts
@@ -8,6 +8,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import type { LeadScore, ScoreLeadInput, OutreachTrack } from './types';
+import { enrichLeadCoverage, getAutoProductRecommendation } from './coverage-enrichment-service';
 
 // =============================================================================
 // Types
@@ -209,7 +210,7 @@ export async function autoScoreLead(
     const estimatedMrr = ESTIMATED_MRR[recommendedProduct] ?? 599;
 
     // Delegate to scoreAddress for persistence
-    return scoreAddress({
+    const scoreResult = await scoreAddress({
       coverage_lead_id: coverageLeadId,
       zone_id: zoneId,
       product_fit_score: productFitScore,
@@ -222,10 +223,58 @@ export async function autoScoreLead(
       competitor_identified: competitor || null,
       scored_by: 'auto',
     });
+
+    // Enrich with coverage data (non-blocking — if it fails, scoring still succeeds)
+    if (scoreResult.data?.id) {
+      const enrichResult = await enrichLeadCoverage(scoreResult.data.id);
+      if (enrichResult.data) {
+        // Apply coverage bonus to product_fit_score
+        const coverageBonus = getCoverageBonus(
+          enrichResult.data.skyfibre_confidence,
+          enrichResult.data.dfa_coverage_type
+        );
+
+        if (coverageBonus > 0) {
+          const boostedFit = Math.min(productFitScore + coverageBonus, 100);
+          const coverageProduct = enrichResult.data.recommended_product;
+
+          // Re-persist with coverage-adjusted scores
+          const supabaseUpdate = await createClient();
+          await supabaseUpdate
+            .from('lead_scores')
+            .update({
+              product_fit_score: boostedFit,
+              recommended_product: coverageProduct,
+              estimated_mrr: ESTIMATED_MRR[coverageProduct] ?? estimatedMrr,
+            })
+            .eq('id', scoreResult.data.id);
+
+          // Update the returned data
+          scoreResult.data.product_fit_score = boostedFit;
+          scoreResult.data.recommended_product = coverageProduct;
+        }
+      }
+    }
+
+    return scoreResult;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { data: null, error: `Failed to auto-score lead ${coverageLeadId}: ${message}` };
   }
+}
+
+/**
+ * Get product_fit bonus based on coverage availability.
+ * +10 for high confidence SkyFibre or connected DFA.
+ * +5 for medium confidence or near-net.
+ */
+function getCoverageBonus(
+  skyfibreConfidence: string,
+  dfaCoverageType: string
+): number {
+  if (skyfibreConfidence === 'high' || dfaCoverageType === 'connected') return 10;
+  if (skyfibreConfidence === 'medium' || dfaCoverageType === 'near-net') return 5;
+  return 0;
 }
 
 /**

--- a/lib/sales-engine/types.ts
+++ b/lib/sales-engine/types.ts
@@ -10,6 +10,7 @@
 export type ZoneType = 'office_park' | 'commercial_strip' | 'clinic_cluster' | 'residential_estate' | 'mixed';
 export type ZoneStatus = 'active' | 'parked' | 'saturated';
 export type ZonePriority = 'high' | 'medium' | 'low';
+export type CoverageConfidenceLevel = 'high' | 'medium' | 'low' | 'none';
 
 export interface SalesZone {
   id: string;
@@ -30,6 +31,16 @@ export interface SalesZone {
   province: string;
   suburb: string | null;
   notes: string | null;
+  // Coverage enrichment fields
+  base_station_count: number;
+  base_station_connections: number;
+  dfa_connected_count: number;
+  dfa_near_net_count: number;
+  coverage_confidence: CoverageConfidenceLevel | null;
+  coverage_enriched_at: string | null;
+  radius_km: number;
+  coverage_score: number;
+  enriched_zone_score: number;
   created_at: string;
   updated_at: string;
 }
@@ -77,6 +88,12 @@ export interface LeadScore {
   competitor_identified: string | null;
   scoring_date: string;
   scored_by: string;
+  // Coverage enrichment fields
+  nearest_base_station_km: number | null;
+  skyfibre_confidence: CoverageConfidenceLevel | null;
+  nearest_dfa_building_km: number | null;
+  dfa_coverage_type: 'connected' | 'near-net' | 'none' | null;
+  coverage_product_eligible: string[] | null;
   created_at: string;
   updated_at: string;
   // Joined fields
@@ -313,4 +330,49 @@ export interface PipelineStageSummary {
   label: string;
   count: number;
   total_mrr: number;
+}
+
+// =============================================================================
+// Coverage Enrichment Types
+// =============================================================================
+
+export interface ZoneCoverageEnrichment {
+  zone_id: string;
+  base_station_count: number;
+  base_station_connections: number;
+  dfa_connected_count: number;
+  dfa_near_net_count: number;
+  coverage_confidence: CoverageConfidenceLevel;
+  coverage_score: number;
+  enriched_zone_score: number;
+}
+
+export interface LeadCoverageEnrichment {
+  lead_score_id: string;
+  nearest_base_station_km: number | null;
+  skyfibre_confidence: CoverageConfidenceLevel;
+  nearest_dfa_building_km: number | null;
+  dfa_coverage_type: 'connected' | 'near-net' | 'none';
+  coverage_product_eligible: string[];
+  recommended_product: string;
+}
+
+export interface CoverageGapAnalysis {
+  investment_needed: Array<{
+    zone: SalesZone;
+    lead_count: number;
+    coverage_confidence: CoverageConfidenceLevel | null;
+  }>;
+  untapped_opportunity: Array<{
+    zone: SalesZone;
+    base_station_count: number;
+    dfa_count: number;
+  }>;
+  coverage_summary: {
+    high: number;
+    medium: number;
+    low: number;
+    none: number;
+    not_enriched: number;
+  };
 }

--- a/supabase/migrations/20260322000000_sales_engine_coverage_enrichment.sql
+++ b/supabase/migrations/20260322000000_sales_engine_coverage_enrichment.sql
@@ -1,0 +1,154 @@
+-- =============================================================================
+-- Sales Engine: Coverage Data Integration
+-- Adds coverage enrichment columns to sales_zones and lead_scores,
+-- plus PostGIS functions for spatial aggregation against
+-- tarana_base_stations and dfa_buildings tables.
+-- =============================================================================
+
+-- =============================================================================
+-- 1. New columns on sales_zones for coverage enrichment
+-- =============================================================================
+ALTER TABLE sales_zones ADD COLUMN IF NOT EXISTS base_station_count INTEGER DEFAULT 0;
+ALTER TABLE sales_zones ADD COLUMN IF NOT EXISTS base_station_connections INTEGER DEFAULT 0;
+ALTER TABLE sales_zones ADD COLUMN IF NOT EXISTS dfa_connected_count INTEGER DEFAULT 0;
+ALTER TABLE sales_zones ADD COLUMN IF NOT EXISTS dfa_near_net_count INTEGER DEFAULT 0;
+ALTER TABLE sales_zones ADD COLUMN IF NOT EXISTS coverage_confidence TEXT CHECK (coverage_confidence IN ('high', 'medium', 'low', 'none'));
+ALTER TABLE sales_zones ADD COLUMN IF NOT EXISTS coverage_enriched_at TIMESTAMPTZ;
+ALTER TABLE sales_zones ADD COLUMN IF NOT EXISTS radius_km DOUBLE PRECISION DEFAULT 3.0;
+ALTER TABLE sales_zones ADD COLUMN IF NOT EXISTS coverage_score DECIMAL(5,2) DEFAULT 0;
+ALTER TABLE sales_zones ADD COLUMN IF NOT EXISTS enriched_zone_score DECIMAL(5,2) DEFAULT 0;
+
+-- =============================================================================
+-- 2. New columns on lead_scores for per-lead coverage data
+-- =============================================================================
+ALTER TABLE lead_scores ADD COLUMN IF NOT EXISTS nearest_base_station_km DOUBLE PRECISION;
+ALTER TABLE lead_scores ADD COLUMN IF NOT EXISTS skyfibre_confidence TEXT CHECK (skyfibre_confidence IN ('high', 'medium', 'low', 'none'));
+ALTER TABLE lead_scores ADD COLUMN IF NOT EXISTS nearest_dfa_building_km DOUBLE PRECISION;
+ALTER TABLE lead_scores ADD COLUMN IF NOT EXISTS dfa_coverage_type TEXT CHECK (dfa_coverage_type IN ('connected', 'near-net', 'none'));
+ALTER TABLE lead_scores ADD COLUMN IF NOT EXISTS coverage_product_eligible TEXT[];
+
+-- =============================================================================
+-- 3. PostGIS function: Count base stations within radius of a point
+-- Reuses existing idx_tarana_base_stations_geography GIST index
+-- =============================================================================
+CREATE OR REPLACE FUNCTION count_base_stations_in_radius(
+  p_lat DOUBLE PRECISION,
+  p_lng DOUBLE PRECISION,
+  p_radius_km DOUBLE PRECISION
+)
+RETURNS TABLE (
+  station_count INTEGER,
+  total_connections INTEGER
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    COUNT(*)::INTEGER AS station_count,
+    COALESCE(SUM(t.active_connections), 0)::INTEGER AS total_connections
+  FROM tarana_base_stations t
+  WHERE ST_DWithin(
+    ST_SetSRID(ST_MakePoint(t.lng, t.lat), 4326)::geography,
+    ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
+    p_radius_km * 1000  -- ST_DWithin uses meters for geography
+  );
+$$;
+
+-- =============================================================================
+-- 4. PostGIS function: Count DFA buildings within radius of a point
+-- Reuses existing idx_dfa_buildings_location GIST index
+-- =============================================================================
+CREATE OR REPLACE FUNCTION count_dfa_buildings_in_radius(
+  p_lat DOUBLE PRECISION,
+  p_lng DOUBLE PRECISION,
+  p_radius_km DOUBLE PRECISION
+)
+RETURNS TABLE (
+  connected_count INTEGER,
+  near_net_count INTEGER
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    COUNT(*) FILTER (WHERE d.coverage_type = 'connected')::INTEGER AS connected_count,
+    COUNT(*) FILTER (WHERE d.coverage_type = 'near-net')::INTEGER AS near_net_count
+  FROM dfa_buildings d
+  WHERE ST_DWithin(
+    ST_SetSRID(ST_MakePoint(d.longitude, d.latitude), 4326)::geography,
+    ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
+    p_radius_km * 1000
+  );
+$$;
+
+-- =============================================================================
+-- 5. PostGIS function: Find nearest DFA building to a point
+-- Mirrors find_nearest_tarana_base_station pattern
+-- =============================================================================
+CREATE OR REPLACE FUNCTION find_nearest_dfa_building(
+  p_lat DOUBLE PRECISION,
+  p_lng DOUBLE PRECISION,
+  p_limit INTEGER DEFAULT 3
+)
+RETURNS TABLE (
+  id UUID,
+  building_name TEXT,
+  building_id TEXT,
+  street_address TEXT,
+  coverage_type TEXT,
+  ftth TEXT,
+  precinct TEXT,
+  latitude DOUBLE PRECISION,
+  longitude DOUBLE PRECISION,
+  distance_km NUMERIC
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    d.id,
+    d.building_name,
+    d.building_id,
+    d.street_address,
+    d.coverage_type,
+    d.ftth,
+    d.precinct,
+    d.latitude,
+    d.longitude,
+    ROUND(
+      (ST_Distance(
+        ST_SetSRID(ST_MakePoint(d.longitude, d.latitude), 4326)::geography,
+        ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography
+      ) / 1000)::numeric,
+      2
+    ) AS distance_km
+  FROM dfa_buildings d
+  ORDER BY ST_SetSRID(ST_MakePoint(d.longitude, d.latitude), 4326)::geography <->
+           ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography
+  LIMIT p_limit;
+$$;
+
+-- =============================================================================
+-- 6. Indexes for the new columns
+-- =============================================================================
+CREATE INDEX IF NOT EXISTS idx_sales_zones_coverage_confidence ON sales_zones(coverage_confidence);
+CREATE INDEX IF NOT EXISTS idx_sales_zones_enriched_score ON sales_zones(enriched_zone_score DESC);
+CREATE INDEX IF NOT EXISTS idx_lead_scores_skyfibre ON lead_scores(skyfibre_confidence);
+CREATE INDEX IF NOT EXISTS idx_lead_scores_dfa_type ON lead_scores(dfa_coverage_type);
+
+-- =============================================================================
+-- 7. Grant permissions for the new functions
+-- =============================================================================
+GRANT EXECUTE ON FUNCTION count_base_stations_in_radius TO authenticated;
+GRANT EXECUTE ON FUNCTION count_dfa_buildings_in_radius TO authenticated;
+GRANT EXECUTE ON FUNCTION find_nearest_dfa_building TO authenticated;
+GRANT EXECUTE ON FUNCTION count_base_stations_in_radius TO anon;
+GRANT EXECUTE ON FUNCTION count_dfa_buildings_in_radius TO anon;
+GRANT EXECUTE ON FUNCTION find_nearest_dfa_building TO anon;
+
+-- =============================================================================
+-- Comments
+-- =============================================================================
+COMMENT ON FUNCTION count_base_stations_in_radius IS 'Count Tarana base stations and total connections within radius_km of a point. Used by sales engine zone enrichment.';
+COMMENT ON FUNCTION count_dfa_buildings_in_radius IS 'Count DFA buildings (connected and near-net) within radius_km of a point. Used by sales engine zone enrichment.';
+COMMENT ON FUNCTION find_nearest_dfa_building IS 'Find nearest DFA buildings to a point with distance. Mirrors find_nearest_tarana_base_station pattern.';


### PR DESCRIPTION
## Summary

- **Phase 1**: Database migration adding 9 columns to `sales_zones`, 5 to `lead_scores`, and 3 PostGIS spatial functions for coverage proximity calculations
- **Phase 2**: `coverage-enrichment-service.ts` with `enrichZoneCoverage()`, `enrichAllZones()`, `enrichLeadCoverage()`, `getAutoProductRecommendation()`, `getCoverageGapAnalysis()`
- **Phase 3**: Type updates (`CoverageConfidenceLevel`, coverage fields on `SalesZone`/`LeadScore`, `CoverageGapAnalysis`) and lead scoring integration (+10/+5 coverage bonus)
- **Phase 4**: 4 API endpoints — zone enrichment (`?enrich=true`), per-zone coverage detail, gap analysis dashboard, viewport-bounded coverage layers
- **Phase 5**: UI enhancements — Coverage Intelligence dashboard section, zone confidence badges, lead coverage columns, toggleable base station/DFA building map layers

## Files Changed (13 files, +1,587 lines)

| Phase | Files |
|-------|-------|
| Migration | `20260322000000_sales_engine_coverage_enrichment.sql` |
| Service | `coverage-enrichment-service.ts` |
| Types | `types.ts`, `lead-scoring-service.ts` |
| APIs | `zones/route.ts`, `zones/[id]/coverage/route.ts`, `coverage-analysis/route.ts`, `map/coverage-layers/route.ts` |
| UI | `page.tsx` (dashboard), `zones/page.tsx`, `leads/page.tsx`, `map/page.tsx`, `ZoneHeatMap.tsx` |

## Test plan

- [ ] Verify migration applies cleanly on Supabase
- [ ] Test zone enrichment via `?enrich=true` param
- [ ] Test per-zone coverage detail endpoint
- [ ] Test coverage gap analysis endpoint
- [ ] Test map coverage layers with viewport bounds
- [ ] Verify lead scoring includes coverage bonus
- [ ] Verify dashboard shows Coverage Intelligence section
- [ ] Verify map toggles for base stations and DFA buildings

🤖 Generated with [Claude Code](https://claude.com/claude-code)