### PR TITLE
fix(auth): handle confirmation email failures gracefully during checkout signup

### DIFF
--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -1,0 +1,160 @@
+/**
+ * Resend Verification Email API Endpoint
+ *
+ * Fallback when Supabase's built-in mailer fails to send confirmation emails.
+ * Uses Supabase Admin API to generate a signup verification link,
+ * then sends a branded email via Resend.
+ *
+ * Pattern follows: app/api/auth/password-reset/route.ts
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { render } from '@react-email/render';
+import EmailVerificationEmail from '@/emails/templates/consumer/email-verification';
+import { apiLogger } from '@/lib/logging';
+
+const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  }
+);
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY;
+const FROM_EMAIL = process.env.RESEND_FROM_EMAIL || 'CircleTel <noreply@notifications.circletelsa.co.za>';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { email } = await request.json();
+
+    if (!email) {
+      return NextResponse.json(
+        { success: false, error: 'Email is required' },
+        { status: 400 }
+      );
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid email format' },
+        { status: 400 }
+      );
+    }
+
+    // Look up customer's first name
+    const { data: customer } = await supabaseAdmin
+      .from('customers')
+      .select('first_name')
+      .eq('email', email)
+      .maybeSingle();
+
+    const firstName = customer?.first_name || 'Customer';
+
+    // Generate signup verification link using Admin API
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.circletel.co.za';
+
+    const { data: linkData, error: linkError } = await supabaseAdmin.auth.admin.generateLink({
+      type: 'signup',
+      email: email,
+      options: {
+        redirectTo: `${baseUrl}/auth/callback`,
+      },
+    });
+
+    if (linkError) {
+      apiLogger.error('[Resend Verification] Error generating verification link', { error: linkError });
+      return NextResponse.json(
+        { success: false, error: 'Failed to generate verification link.' },
+        { status: 500 }
+      );
+    }
+
+    // Extract token_hash from the action_link or hashed_token
+    const actionLink = linkData.properties?.action_link;
+    let tokenHash: string | undefined = linkData.properties?.hashed_token;
+
+    if (!tokenHash && actionLink) {
+      try {
+        const actionUrl = new URL(actionLink);
+        tokenHash = actionUrl.searchParams.get('token') || undefined;
+      } catch (e) {
+        apiLogger.error('[Resend Verification] Failed to parse action_link', { error: e });
+      }
+    }
+
+    if (!actionLink && !tokenHash) {
+      apiLogger.error('[Resend Verification] No action_link or hashed_token', { linkData });
+      return NextResponse.json(
+        { success: false, error: 'Failed to generate verification link.' },
+        { status: 500 }
+      );
+    }
+
+    // Build verification URL through our /auth/confirm endpoint
+    let verifyUrl: string;
+    if (tokenHash) {
+      verifyUrl = `${baseUrl}/auth/confirm?token_hash=${tokenHash}&type=signup`;
+    } else {
+      verifyUrl = actionLink!;
+    }
+
+    // Render the email template
+    const emailHtml = await render(
+      EmailVerificationEmail({
+        firstName,
+        verifyUrl,
+        expiresIn: '10 minutes',
+      })
+    );
+
+    // Send via Resend
+    if (!RESEND_API_KEY) {
+      apiLogger.error('[Resend Verification] RESEND_API_KEY not configured');
+      return NextResponse.json(
+        { success: false, error: 'Email service not configured' },
+        { status: 500 }
+      );
+    }
+
+    const resendResponse = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: FROM_EMAIL,
+        to: email,
+        subject: 'Verify Your Email — CircleTel',
+        html: emailHtml,
+      }),
+    });
+
+    if (!resendResponse.ok) {
+      const errorData = await resendResponse.json();
+      apiLogger.error('[Resend Verification] Resend API error', { errorData });
+      return NextResponse.json(
+        { success: false, error: 'Failed to send verification email.' },
+        { status: 500 }
+      );
+    }
+
+    const resendResult = await resendResponse.json();
+    apiLogger.info('[Resend Verification] Email sent', { email, messageId: resendResult.id });
+
+    return NextResponse.json({ success: true });
+
+  } catch (error) {
+    apiLogger.error('[Resend Verification] Unexpected error', { error });
+    return NextResponse.json(
+      { success: false, error: 'An unexpected error occurred.' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -174,7 +174,15 @@ export default function CheckoutPage() {
         email: values.email,
         phone: values.phone,
       });
-      if (result.error) throw new Error(result.error);
+      // Fatal errors block checkout; email-send failures are non-fatal
+      if (result.error && !result.emailSendFailed) throw new Error(result.error);
+
+      if (result.emailSendFailed) {
+        toast.info(
+          'Account created! We had trouble sending the verification email — you can resend it from your dashboard.',
+          { duration: 8000 }
+        );
+      }
 
       actions.updateOrderData({
         account: {

--- a/emails/templates/consumer/email-verification.tsx
+++ b/emails/templates/consumer/email-verification.tsx
@@ -1,0 +1,94 @@
+/**
+ * Email Verification Template
+ * Sent when Supabase's built-in mailer fails and we fall back to Resend.
+ * Personalized greeting using customer's first name.
+ */
+
+import * as React from 'react';
+import { Html, Head, Body, Preview, Container } from '@react-email/components';
+import {
+  CircleTelHeader,
+  CircleTelHero,
+  CircleTelTextBlock,
+  CircleTelButton,
+  CircleTelFooter,
+  emailStyles,
+} from '../../slices';
+
+interface EmailVerificationProps {
+  firstName: string;
+  verifyUrl: string;
+  expiresIn?: string;
+}
+
+export const EmailVerificationEmail: React.FC<EmailVerificationProps> = ({
+  firstName = 'Customer',
+  verifyUrl = 'https://www.circletel.co.za/auth/confirm',
+  expiresIn = '10 minutes',
+}) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        Verify your email address — CircleTel
+      </Preview>
+      <Body style={emailStyles.body}>
+        <Container style={emailStyles.container}>
+          <CircleTelHeader />
+
+          <CircleTelHero
+            title="Verify Your Email"
+            subtitle="One click to activate your account"
+            variant="light"
+          />
+
+          <CircleTelTextBlock align="left">
+            <strong>Hello {firstName},</strong>
+          </CircleTelTextBlock>
+
+          <CircleTelTextBlock align="left">
+            Thank you for signing up with CircleTel! Please verify your email
+            address by clicking the button below:
+          </CircleTelTextBlock>
+
+          <CircleTelButton href={verifyUrl} variant="primary" align="center">
+            Verify Email Address
+          </CircleTelButton>
+
+          {/* Expiry Notice */}
+          <div style={{
+            backgroundColor: '#FEF3C7',
+            padding: '15px 20px',
+            borderRadius: '6px',
+            borderLeft: '4px solid #F59E0B',
+            margin: '20px 40px',
+          }}>
+            <p style={{ margin: '0 0 8px 0', fontWeight: 'bold', color: '#92400E' }}>
+              Link expires in {expiresIn}
+            </p>
+            <p style={{ margin: 0, fontSize: '13px', color: '#92400E', lineHeight: '1.5' }}>
+              For security reasons, this verification link will expire in {expiresIn}.
+              If it expires, you can request a new one from your account page.
+            </p>
+          </div>
+
+          <CircleTelTextBlock align="left" variant="small">
+            If the button doesn&apos;t work, copy and paste this link into your browser:
+            <br />
+            <a href={verifyUrl} style={{ color: '#F5831F', wordBreak: 'break-all' as const }}>
+              {verifyUrl}
+            </a>
+          </CircleTelTextBlock>
+
+          <CircleTelTextBlock align="left">
+            Welcome to CircleTel — we&apos;re excited to have you!
+          </CircleTelTextBlock>
+
+          <CircleTelFooter showSocialLinks={false} />
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+export default EmailVerificationEmail;

--- a/lib/auth/customer-auth-service.ts
+++ b/lib/auth/customer-auth-service.ts
@@ -28,6 +28,7 @@ export interface SignUpResult {
   customer: any | null;
   session: Session | null;
   error: string | null;
+  emailSendFailed?: boolean;
 }
 
 export interface SignInResult {
@@ -64,6 +65,9 @@ export class CustomerAuthService {
         }
       });
 
+      // Track whether the confirmation email failed to send (non-fatal)
+      let emailSendFailed = false;
+
       if (authError) {
         // Handle rate limiting specifically
         if (authError.message.includes('429') || authError.message.toLowerCase().includes('rate limit')) {
@@ -74,7 +78,7 @@ export class CustomerAuthService {
             error: 'Too many signup attempts. Please wait a few minutes and try again.'
           };
         }
-        
+
         // Handle duplicate user (user already exists)
         if (authError.message.toLowerCase().includes('already registered')) {
           return {
@@ -84,13 +88,27 @@ export class CustomerAuthService {
             error: 'This email is already registered. Please sign in instead.'
           };
         }
-        
-        return {
-          user: null,
-          customer: null,
-          session: null,
-          error: authError.message
-        };
+
+        // Handle email sending failures — user may still be created in Supabase
+        const lowerMsg = authError.message.toLowerCase();
+        const isEmailError = lowerMsg.includes('sending confirmation') ||
+          lowerMsg.includes('sending email') ||
+          lowerMsg.includes('confirmation email') ||
+          lowerMsg.includes('smtp');
+
+        if (isEmailError && authData?.user) {
+          // User was created but confirmation email failed — continue with signup flow
+          console.warn('[CustomerAuthService] Email sending failed but user was created:', authError.message);
+          emailSendFailed = true;
+        } else {
+          // Fatal auth error — return immediately
+          return {
+            user: null,
+            customer: null,
+            session: null,
+            error: authError.message
+          };
+        }
       }
 
       if (!authData.user) {
@@ -181,11 +199,28 @@ export class CustomerAuthService {
 
       const customer = customerResult.customer;
 
+      // Try sending verification email via Resend if Supabase mailer failed
+      if (emailSendFailed) {
+        try {
+          const resendRes = await fetch('/api/auth/resend-verification', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email }),
+          });
+          if (resendRes.ok) {
+            console.info('[CustomerAuthService] Verification email sent via Resend fallback');
+          }
+        } catch (e) {
+          console.warn('[CustomerAuthService] Resend fallback also failed:', e);
+        }
+      }
+
       return {
         user: authData.user,
         customer,
         session: authData.session,
-        error: null
+        error: null,
+        emailSendFailed,
       };
 
     } catch (error) {
@@ -549,7 +584,23 @@ export class CustomerAuthService {
       });
 
       if (error) {
-        return { success: false, error: error.message };
+        // Fallback: use custom API route with Resend when Supabase mailer fails
+        console.warn('[CustomerAuthService] Supabase resend failed, trying Resend fallback:', error.message);
+        try {
+          const res = await fetch('/api/auth/resend-verification', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email }),
+          });
+          const result = await res.json();
+          if (result.success) {
+            return { success: true, error: null };
+          }
+          return { success: false, error: result.error || 'Failed to resend verification' };
+        } catch (fallbackError) {
+          console.error('Resend fallback error:', fallbackError);
+          return { success: false, error: error.message };
+        }
       }
 
       return { success: true, error: null };


### PR DESCRIPTION
When Supabase's built-in mailer fails to send confirmation emails, the signup
flow now continues instead of blocking checkout. Adds a Resend-based fallback
API route for sending verification emails, and updates the resend button on
the verify-email page to use this fallback when Supabase's native resend fails.

https://claude.ai/code/session_01Bax6NFNzBJZZH4rRgdKv1D