### PR TITLE
feat(billing): customer statement preview with PDF download + 404 fix

### DIFF
--- a/app/admin/customers/[id]/statement/page.tsx
+++ b/app/admin/customers/[id]/statement/page.tsx
@@ -1,0 +1,16 @@
+import StatementPreview from '@/components/statements/StatementPreview';
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function AdminCustomerStatementPage({ params }: Props) {
+  const { id } = await params;
+  return (
+    <StatementPreview
+      customerId={id}
+      apiEndpoint="/api/admin/billing/statements"
+      showEmailButton={false}
+    />
+  );
+}

--- a/app/api/admin/billing/statements/[customerId]/route.ts
+++ b/app/api/admin/billing/statements/[customerId]/route.ts
@@ -1,0 +1,68 @@
+/**
+ * Admin Statement Data API
+ * GET /api/admin/billing/statements/[customerId]
+ *
+ * Fetches assembled statement data for a customer.
+ * Used by the admin billing statement preview page.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { assembleStatementData, StatementOptions } from '@/lib/billing/statement-data';
+import { apiLogger } from '@/lib/logging';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ customerId: string }> }
+) {
+  const { customerId } = await context.params;
+
+  const { searchParams } = new URL(request.url);
+  const period = (searchParams.get('period') ?? '3m') as StatementOptions['period'];
+  const from = searchParams.get('from') ?? undefined;
+  const to = searchParams.get('to') ?? undefined;
+
+  try {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+        },
+      }
+    );
+
+    const { statement, customerRecord } = await assembleStatementData(supabase, customerId, {
+      period,
+      from,
+      to,
+    });
+
+    return NextResponse.json({
+      success: true,
+      statement,
+      customer: customerRecord,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes('not found')) {
+      apiLogger.error('Statement customer not found', { customerId, error: message });
+      return NextResponse.json(
+        { success: false, error: `Customer ${customerId} not found` },
+        { status: 404 }
+      );
+    }
+
+    apiLogger.error('Error in statement data API', { customerId, error: message });
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch statement data' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/dashboard/statement/route.ts
+++ b/app/api/dashboard/statement/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { createClientWithSession } from '@/lib/supabase/server';
+import { assembleStatementData, StatementOptions } from '@/lib/billing/statement-data';
+import { billingLogger } from '@/lib/logging/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    // 1. Auth: check Bearer header first, then cookies
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+    let user: { id: string } | null = null;
+
+    if (token) {
+      const anonClient = createSupabaseClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      );
+      const { data: { user: tokenUser }, error } = await anonClient.auth.getUser(token);
+      if (error || !tokenUser) {
+        return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+      }
+      user = tokenUser;
+    } else {
+      const sessionClient = await createClientWithSession();
+      const { data: { session }, error } = await sessionClient.auth.getSession();
+      if (error || !session?.user) {
+        return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+      }
+      user = session.user;
+    }
+
+    // 2. Look up customer using service role client
+    const serviceClient = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    );
+    const { data: customer, error: customerError } = await serviceClient
+      .from('customers')
+      .select('id')
+      .eq('auth_user_id', user.id)
+      .single();
+
+    if (customerError || !customer) {
+      return NextResponse.json({ success: false, error: 'Customer not found' }, { status: 404 });
+    }
+
+    // 3. Parse query params
+    const { searchParams } = new URL(request.url);
+    const period = (searchParams.get('period') as StatementOptions['period']) || '3m';
+    const from = searchParams.get('from') || undefined;
+    const to = searchParams.get('to') || undefined;
+
+    // 4. Assemble statement
+    const { statement, customerRecord } = await assembleStatementData(
+      serviceClient,
+      customer.id,
+      { period, from, to }
+    );
+
+    return NextResponse.json({ success: true, statement, customer: customerRecord });
+  } catch (error) {
+    billingLogger.error('[Dashboard Statement API] Error', {
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return NextResponse.json({ success: false, error: 'Failed to generate statement' }, { status: 500 });
+  }
+}

--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -80,8 +80,19 @@ export default async function InvoicesPage() {
   return (
     <div className="container mx-auto py-6">
       <div className="mb-6">
-        <h1 className="text-3xl font-bold">My Invoices</h1>
-        <p className="text-muted-foreground">View and manage your invoices</p>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold">My Invoices</h1>
+            <p className="text-muted-foreground">View and manage your invoices</p>
+          </div>
+          <Link
+            href="/dashboard/statement"
+            className="inline-flex items-center gap-2 text-sm text-circleTel-orange hover:underline font-medium"
+          >
+            <PiFileTextBold className="h-4 w-4" />
+            View Account Statement
+          </Link>
+        </div>
       </div>
 
       {invoices && invoices.length > 0 ? (

--- a/app/dashboard/statement/page.tsx
+++ b/app/dashboard/statement/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import StatementPreview from '@/components/statements/StatementPreview';
+
+export default async function DashboardStatementPage() {
+  const supabase = await createClient();
+  const { data: { user }, error } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    redirect('/login?redirect=/dashboard/statement');
+  }
+
+  return (
+    <StatementPreview
+      customerId=""
+      apiEndpoint="/api/dashboard/statement"
+      showEmailButton={false}
+    />
+  );
+}

--- a/components/admin/customers/CustomerBillingTab.tsx
+++ b/components/admin/customers/CustomerBillingTab.tsx
@@ -351,11 +351,19 @@ export function CustomerBillingTab({ customerId }: CustomerBillingTabProps) {
             <PiFileTextBold className="h-5 w-5 text-blue-500" />
             Invoice History
           </CardTitle>
-          <Link href={`/admin/billing/invoices?customer=${customerId}`}>
-            <Button variant="ghost" size="sm">
-              View All <PiArrowSquareOutBold className="h-4 w-4 ml-1" />
-            </Button>
-          </Link>
+          <div className="flex items-center gap-2">
+            <Link href={`/admin/customers/${customerId}/statement`} target="_blank">
+              <Button variant="outline" size="sm" className="text-circleTel-orange border-circleTel-orange hover:bg-orange-50">
+                <PiFileTextBold className="h-4 w-4 mr-1" />
+                View Statement
+              </Button>
+            </Link>
+            <Link href={`/admin/billing/invoices?customer=${customerId}`}>
+              <Button variant="ghost" size="sm">
+                View All <PiArrowSquareOutBold className="h-4 w-4 ml-1" />
+              </Button>
+            </Link>
+          </div>
         </CardHeader>
         <CardContent>
           {invoices.length === 0 ? (

--- a/components/statements/StatementPreview.tsx
+++ b/components/statements/StatementPreview.tsx
@@ -1,0 +1,593 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Image from 'next/image';
+import {
+  PiPrinterBold,
+  PiDownloadSimpleBold,
+  PiPaperPlaneRightBold,
+  PiSpinnerBold,
+  PiFileTextBold,
+} from 'react-icons/pi';
+import { Card, CardContent } from '@/components/ui/card';
+import { COMPANY_DETAILS } from '@/lib/invoices/invoice-pdf-generator';
+import type {
+  StatementData,
+} from '@/lib/billing/statement-pdf-generator';
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface StatementPreviewProps {
+  customerId: string;
+  apiEndpoint: string;
+  showEmailButton?: boolean;
+  emailEndpoint?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-ZA', {
+    style: 'currency',
+    currency: 'ZAR',
+    minimumFractionDigits: 2,
+  }).format(amount);
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-ZA', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function formatShortDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-ZA', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function StatementPreview({
+  customerId,
+  apiEndpoint,
+  showEmailButton = false,
+  emailEndpoint,
+}: StatementPreviewProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statement, setStatement] = useState<StatementData | null>(null);
+  const [period, setPeriod] = useState<'3m' | '6m' | '12m' | 'all'>('3m');
+  const [showEmailDialog, setShowEmailDialog] = useState(false);
+  const [emailRecipient, setEmailRecipient] = useState('');
+  const [emailSending, setEmailSending] = useState(false);
+
+  // Inject print-specific CSS
+  useEffect(() => {
+    const style = document.createElement('style');
+    style.textContent = `
+      @media print {
+        @page { size: A4; margin: 15mm; }
+        body { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+        .statement-header, .customer-section, .transactions-section, .aging-section, .banking-section {
+          page-break-inside: avoid;
+          break-inside: avoid;
+        }
+        table { page-break-inside: auto; }
+        tr { page-break-inside: avoid; }
+      }
+    `;
+    document.head.appendChild(style);
+    return () => {
+      document.head.removeChild(style);
+    };
+  }, []);
+
+  // Fetch statement data
+  useEffect(() => {
+    const fetchStatement = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const url = customerId
+          ? `${apiEndpoint}/${customerId}?period=${period}`
+          : `${apiEndpoint}?period=${period}`;
+        const response = await fetch(url);
+        const data = await response.json();
+        if (data.success) {
+          setStatement(data.statement);
+        } else {
+          setError(data.error || 'Failed to load statement');
+        }
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Failed to load statement');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchStatement();
+  }, [period, customerId, apiEndpoint]);
+
+  const handleEmailStatement = async () => {
+    if (!emailRecipient || !statement || !emailEndpoint) return;
+
+    setEmailSending(true);
+    try {
+      const response = await fetch(emailEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          customerId,
+          recipientEmail: emailRecipient,
+          period,
+        }),
+      });
+      const data = await response.json();
+      if (!data.success) {
+        throw new Error(data.error || 'Failed to send email');
+      }
+      alert(`Statement successfully sent to ${emailRecipient}`);
+      setShowEmailDialog(false);
+      setEmailRecipient('');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to send email';
+      console.error('Email error:', err);
+      alert(`Failed to send email: ${message}`);
+    } finally {
+      setEmailSending(false);
+    }
+  };
+
+  const openEmailDialog = () => {
+    if (statement) {
+      setEmailRecipient(statement.customer.email || '');
+      setShowEmailDialog(true);
+    }
+  };
+
+  // ── Loading ──────────────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-circleTel-lightNeutral">
+        <div className="text-center">
+          <PiSpinnerBold className="w-12 h-12 animate-spin mx-auto text-circleTel-orange mb-4" />
+          <p className="text-circleTel-secondaryNeutral">Loading statement...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Error ────────────────────────────────────────────────────────────────────
+  if (error || !statement) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-circleTel-lightNeutral p-4">
+        <Card className="max-w-md w-full">
+          <CardContent className="pt-6">
+            <div className="text-center">
+              <PiFileTextBold className="w-12 h-12 mx-auto text-red-500 mb-4" />
+              <h2 className="text-xl font-bold text-circleTel-navy mb-2">Statement Not Available</h2>
+              <p className="text-circleTel-secondaryNeutral">
+                {error || 'This statement could not be loaded.'}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // ── Running balance ───────────────────────────────────────────────────────────
+  let runningBalance = 0;
+  const transactionsWithBalance = statement.transactions.map((tx) => {
+    runningBalance += parseFloat(String(tx.debit || 0)) - parseFloat(String(tx.credit || 0));
+    return { ...tx, runningBalance };
+  });
+
+  const { aging, totalDue, totalPaid, customer, statementDate } = statement;
+
+  // ── Render ───────────────────────────────────────────────────────────────────
+  return (
+    <div className="min-h-screen bg-white print:bg-white">
+      <div className="max-w-4xl mx-auto p-8 print:p-0 print:max-w-none">
+
+        {/* ── 1. ACTION BAR ── */}
+        <div className="print:hidden flex flex-wrap justify-center items-center gap-3 mb-6">
+          {/* Period selector */}
+          {(['3m', '6m', '12m', 'all'] as const).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPeriod(p)}
+              className={`px-4 py-2 rounded text-sm font-medium border transition-colors ${
+                period === p
+                  ? 'bg-circleTel-orange text-white border-circleTel-orange'
+                  : 'bg-white text-gray-600 border-gray-300 hover:border-circleTel-orange'
+              }`}
+            >
+              {p === '3m'
+                ? 'Last 3 months'
+                : p === '6m'
+                ? 'Last 6 months'
+                : p === '12m'
+                ? 'Last 12 months'
+                : 'All time'}
+            </button>
+          ))}
+
+          <div className="w-px h-6 bg-gray-300 hidden sm:block" />
+
+          {/* Print */}
+          <button
+            onClick={() => window.print()}
+            className="bg-white text-circleTel-orange border-2 border-circleTel-orange px-6 py-2.5 rounded-lg shadow-md hover:bg-orange-50 transition-colors flex items-center gap-2"
+          >
+            <PiPrinterBold className="w-4 h-4" />
+            Print
+          </button>
+
+          {/* Download PDF */}
+          <button
+            onClick={() => window.print()}
+            className="bg-white text-circleTel-orange border-2 border-circleTel-orange px-6 py-2.5 rounded-lg shadow-md hover:bg-orange-50 transition-colors flex items-center gap-2"
+          >
+            <PiDownloadSimpleBold className="w-4 h-4" />
+            Download PDF
+          </button>
+
+          {/* Email (optional) */}
+          {showEmailButton && (
+            <button
+              onClick={openEmailDialog}
+              className="bg-circleTel-orange text-white px-6 py-2.5 rounded-lg shadow-md hover:bg-orange-600 transition-colors flex items-center gap-2"
+            >
+              <PiPaperPlaneRightBold className="w-4 h-4" />
+              Email Statement
+            </button>
+          )}
+        </div>
+
+        {/* ── 2. EMAIL DIALOG ── */}
+        {showEmailDialog && (
+          <div className="print:hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+            <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+              <h3 className="text-xl font-bold text-circleTel-navy mb-4">Email Statement</h3>
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Recipient Email <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="email"
+                    value={emailRecipient}
+                    onChange={(e) => setEmailRecipient(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-circleTel-orange"
+                    placeholder="email@example.com"
+                  />
+                </div>
+              </div>
+              <div className="flex gap-2 mt-6">
+                <button
+                  onClick={() => {
+                    setShowEmailDialog(false);
+                    setEmailRecipient('');
+                  }}
+                  disabled={emailSending}
+                  className="flex-1 px-4 py-2 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleEmailStatement}
+                  disabled={!emailRecipient || emailSending}
+                  className="flex-1 px-4 py-2 bg-circleTel-orange text-white rounded-md hover:bg-orange-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                >
+                  {emailSending ? (
+                    <>
+                      <PiSpinnerBold className="w-4 h-4 animate-spin" />
+                      Sending...
+                    </>
+                  ) : (
+                    <>
+                      <PiPaperPlaneRightBold className="w-4 h-4" />
+                      Send Statement
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ── 3. HEADER ── */}
+        <div className="bg-white mb-6 statement-header">
+          <div className="flex justify-between items-center mb-4 pb-2 border-b-4 border-circleTel-orange">
+            <Image
+              src="/images/circletel-enclosed-logo.png"
+              alt="CircleTel Logo"
+              width={240}
+              height={96}
+              className="h-24 w-auto"
+              priority
+            />
+            <div className="text-right">
+              <div className="text-2xl font-bold text-gray-900 uppercase tracking-wide">Statement</div>
+              <div className="text-sm text-gray-600 mt-1">
+                Statement Date: {formatDate(statementDate)}
+              </div>
+              <div className="text-sm text-gray-600">
+                Account: <span className="font-semibold">{customer.accountNumber}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── 4. FROM / TO GRID ── */}
+        <div className="grid grid-cols-2 gap-8 mb-8 customer-section">
+          {/* FROM */}
+          <div>
+            <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">From</h3>
+            <div className="text-sm space-y-0.5">
+              <p className="font-bold text-gray-900">{COMPANY_DETAILS.name}</p>
+              <p className="text-gray-600">{COMPANY_DETAILS.address.line1}</p>
+              <p className="text-gray-600">
+                {COMPANY_DETAILS.address.line2}, {COMPANY_DETAILS.address.province}{' '}
+                {COMPANY_DETAILS.address.postalCode}
+              </p>
+              <p className="text-gray-600">{COMPANY_DETAILS.address.country}</p>
+              <p className="text-gray-600 mt-1">VAT No: {COMPANY_DETAILS.vatNumber}</p>
+              <p className="text-gray-600">Reg No: {COMPANY_DETAILS.registrationNumber}</p>
+              <p className="text-gray-600">{COMPANY_DETAILS.contact.email}</p>
+              <p className="text-gray-600">{COMPANY_DETAILS.contact.website}</p>
+            </div>
+          </div>
+
+          {/* TO */}
+          <div>
+            <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-2">To</h3>
+            <div className="text-sm space-y-0.5">
+              <p className="font-bold text-gray-900">{customer.name}</p>
+              <p className="text-gray-600">Account: {customer.accountNumber}</p>
+              {customer.email && <p className="text-gray-600">{customer.email}</p>}
+              {customer.phone && <p className="text-gray-600">{customer.phone}</p>}
+              {customer.vatNumber && (
+                <p className="text-gray-600">VAT No: {customer.vatNumber}</p>
+              )}
+              {customer.address && (
+                <>
+                  {customer.address.line1 && (
+                    <p className="text-gray-600 mt-1">{customer.address.line1}</p>
+                  )}
+                  {customer.address.line2 && (
+                    <p className="text-gray-600">{customer.address.line2}</p>
+                  )}
+                  {(customer.address.city || customer.address.province) && (
+                    <p className="text-gray-600">
+                      {[customer.address.city, customer.address.province]
+                        .filter(Boolean)
+                        .join(', ')}
+                      {customer.address.postalCode ? ` ${customer.address.postalCode}` : ''}
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* ── 5. TRANSACTIONS TABLE ── */}
+        <div className="mb-8 transactions-section">
+          <h3 className="text-base font-bold text-gray-900 mb-4 uppercase tracking-wide">
+            Transaction History
+          </h3>
+          {transactionsWithBalance.length === 0 ? (
+            <div className="text-center py-8 text-gray-500 border rounded-lg">
+              No transactions found for the selected period.
+            </div>
+          ) : (
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="text-left px-3 py-2 font-semibold text-gray-700 border border-gray-200">
+                    Date
+                  </th>
+                  <th className="text-left px-3 py-2 font-semibold text-gray-700 border border-gray-200">
+                    Reference
+                  </th>
+                  <th className="text-left px-3 py-2 font-semibold text-gray-700 border border-gray-200">
+                    Description
+                  </th>
+                  <th className="text-right px-3 py-2 font-semibold text-gray-700 border border-gray-200">
+                    Debit (R)
+                  </th>
+                  <th className="text-right px-3 py-2 font-semibold text-gray-700 border border-gray-200">
+                    Credit (R)
+                  </th>
+                  <th className="text-right px-3 py-2 font-semibold text-gray-700 border border-gray-200">
+                    Balance (R)
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {transactionsWithBalance.map((tx, index) => (
+                  <tr
+                    key={`${tx.reference}-${index}`}
+                    className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}
+                  >
+                    <td className="px-3 py-2 border border-gray-200 text-gray-700 whitespace-nowrap">
+                      {formatShortDate(tx.date)}
+                    </td>
+                    <td className="px-3 py-2 border border-gray-200 text-gray-700 font-mono text-xs">
+                      {tx.reference}
+                    </td>
+                    <td className="px-3 py-2 border border-gray-200 text-gray-700">
+                      {tx.description}
+                    </td>
+                    <td className="px-3 py-2 border border-gray-200 text-right text-gray-700">
+                      {tx.debit ? formatCurrency(parseFloat(String(tx.debit))) : '—'}
+                    </td>
+                    <td className="px-3 py-2 border border-gray-200 text-right text-green-600">
+                      {tx.credit ? formatCurrency(parseFloat(String(tx.credit))) : '—'}
+                    </td>
+                    <td
+                      className={`px-3 py-2 border border-gray-200 text-right font-medium ${
+                        tx.runningBalance > 0 ? 'text-red-600' : 'text-green-600'
+                      }`}
+                    >
+                      {formatCurrency(tx.runningBalance)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* ── 6. AGING BUCKETS TABLE ── */}
+        <div className="mb-8 aging-section">
+          <h3 className="text-base font-bold text-gray-900 mb-4 uppercase tracking-wide">
+            Aging Analysis
+          </h3>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="px-3 py-2 font-semibold text-gray-700 border border-gray-200 text-right">
+                    120+ Days
+                  </th>
+                  <th className="px-3 py-2 font-semibold text-gray-700 border border-gray-200 text-right">
+                    90 Days
+                  </th>
+                  <th className="px-3 py-2 font-semibold text-gray-700 border border-gray-200 text-right">
+                    60 Days
+                  </th>
+                  <th className="px-3 py-2 font-semibold text-gray-700 border border-gray-200 text-right">
+                    30 Days
+                  </th>
+                  <th className="px-3 py-2 font-semibold text-gray-700 border border-gray-200 text-right">
+                    Current
+                  </th>
+                  <th className="px-3 py-2 font-semibold text-gray-700 border border-gray-200 text-right">
+                    Amount Due
+                  </th>
+                  <th className="px-3 py-2 font-semibold text-gray-700 border border-gray-200 text-right">
+                    Amount Paid
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="bg-white">
+                  <td
+                    className={`px-3 py-2 border border-gray-200 text-right font-medium ${
+                      parseFloat(String(aging.over120Days)) > 0
+                        ? 'text-red-600 font-bold'
+                        : 'text-gray-700'
+                    }`}
+                  >
+                    {formatCurrency(parseFloat(String(aging.over120Days)))}
+                  </td>
+                  <td
+                    className={`px-3 py-2 border border-gray-200 text-right font-medium ${
+                      parseFloat(String(aging.days90)) > 0 ? 'text-red-500' : 'text-gray-700'
+                    }`}
+                  >
+                    {formatCurrency(parseFloat(String(aging.days90)))}
+                  </td>
+                  <td
+                    className={`px-3 py-2 border border-gray-200 text-right font-medium ${
+                      parseFloat(String(aging.days60)) > 0 ? 'text-orange-500' : 'text-gray-700'
+                    }`}
+                  >
+                    {formatCurrency(parseFloat(String(aging.days60)))}
+                  </td>
+                  <td
+                    className={`px-3 py-2 border border-gray-200 text-right font-medium ${
+                      parseFloat(String(aging.days30)) > 0 ? 'text-yellow-600' : 'text-gray-700'
+                    }`}
+                  >
+                    {formatCurrency(parseFloat(String(aging.days30)))}
+                  </td>
+                  <td className="px-3 py-2 border border-gray-200 text-right font-medium text-gray-700">
+                    {formatCurrency(parseFloat(String(aging.current)))}
+                  </td>
+                  <td className="px-3 py-2 border border-gray-200 text-right font-bold text-circleTel-orange">
+                    {formatCurrency(parseFloat(String(totalDue)))}
+                  </td>
+                  <td className="px-3 py-2 border border-gray-200 text-right font-bold text-green-600">
+                    {formatCurrency(parseFloat(String(totalPaid)))}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* ── 7. BANKING DETAILS ── */}
+        <div className="mb-8 banking-section">
+          <h3 className="text-base font-bold text-gray-900 mb-4 uppercase tracking-wide">
+            Banking Details
+          </h3>
+          <div className="grid grid-cols-2 gap-4 text-sm bg-gray-50 p-4 rounded border border-gray-200">
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-gray-500">Bank</span>
+                <span className="font-medium text-gray-900">{COMPANY_DETAILS.banking.bankName}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Account Name</span>
+                <span className="font-medium text-gray-900">
+                  {COMPANY_DETAILS.banking.accountName}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Account Number</span>
+                <span className="font-medium text-gray-900 font-mono">
+                  {COMPANY_DETAILS.banking.accountNumber}
+                </span>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-gray-500">Branch Code</span>
+                <span className="font-medium text-gray-900 font-mono">
+                  {COMPANY_DETAILS.banking.branchCode}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Account Type</span>
+                <span className="font-medium text-gray-900">
+                  {COMPANY_DETAILS.banking.accountType}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Reference</span>
+                <span className="font-medium text-circleTel-orange font-mono">
+                  {customer.accountNumber}
+                </span>
+              </div>
+            </div>
+          </div>
+          <p className="text-sm text-gray-600 mt-2">
+            Please use your account number as payment reference:{' '}
+            <strong>{customer.accountNumber}</strong>
+          </p>
+        </div>
+
+        {/* ── 8. FOOTER ── */}
+        <div className="border-t border-gray-200 pt-4 mt-8 text-center text-xs text-gray-400">
+          <p>
+            {COMPANY_DETAILS.name} | Reg: {COMPANY_DETAILS.registrationNumber} | VAT:{' '}
+            {COMPANY_DETAILS.vatNumber}
+          </p>
+          <p>
+            {COMPANY_DETAILS.address.line1}, {COMPANY_DETAILS.address.line2} |{' '}
+            {COMPANY_DETAILS.contact.email} | {COMPANY_DETAILS.contact.website}
+          </p>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/lib/billing/statement-data.ts
+++ b/lib/billing/statement-data.ts
@@ -92,7 +92,6 @@ interface CustomerRow {
   email: string | null;
   phone: string | null;
   account_number: string | null;
-  billing_address: Record<string, string | undefined> | null | unknown;
 }
 
 interface InvoiceRow {
@@ -141,33 +140,16 @@ export async function assembleStatementData(
   // 2. Fetch customer
   const { data: rawCustomer, error: customerError } = await supabase
     .from('customers')
-    .select('id, first_name, last_name, email, phone, account_number, billing_address')
+    .select('id, first_name, last_name, email, phone, account_number')
     .eq('id', customerId)
     .single();
 
   if (customerError || !rawCustomer) {
+    console.error(`[statement-data] Customer lookup failed for ${customerId}:`, customerError?.message ?? 'no data returned');
     throw new Error(`Customer ${customerId} not found`);
   }
 
   const customer = rawCustomer as CustomerRow;
-
-  // Build billing address safely from JSONB
-  let address: StatementCustomer['address'];
-  if (
-    customer.billing_address !== null &&
-    customer.billing_address !== undefined &&
-    typeof customer.billing_address === 'object' &&
-    !Array.isArray(customer.billing_address)
-  ) {
-    const ba = customer.billing_address as Record<string, unknown>;
-    address = {
-      line1: typeof ba.line1 === 'string' ? ba.line1 : undefined,
-      line2: typeof ba.line2 === 'string' ? ba.line2 : undefined,
-      city: typeof ba.city === 'string' ? ba.city : undefined,
-      province: typeof ba.province === 'string' ? ba.province : undefined,
-      postalCode: typeof ba.postalCode === 'string' ? ba.postalCode : undefined,
-    };
-  }
 
   const customerData: StatementCustomer = {
     name: `${customer.first_name ?? ''} ${customer.last_name ?? ''}`.trim(),
@@ -175,7 +157,7 @@ export async function assembleStatementData(
       customer.account_number ?? `CT-${customer.id.slice(0, 8)}`,
     email: customer.email ?? undefined,
     phone: customer.phone ?? undefined,
-    address,
+    address: undefined,
   };
 
   // 3. Fetch invoices

--- a/lib/billing/statement-data.ts
+++ b/lib/billing/statement-data.ts
@@ -1,0 +1,259 @@
+/**
+ * Statement Data Assembly
+ * Shared library for building StatementData from the database.
+ * Used by both admin and customer-dashboard API routes.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  StatementData,
+  StatementTransaction,
+  StatementCustomer,
+  AgingBuckets,
+} from './statement-pdf-generator';
+
+export interface StatementOptions {
+  period?: '3m' | '6m' | '12m' | 'all';
+  from?: string; // YYYY-MM-DD
+  to?: string;   // YYYY-MM-DD
+}
+
+// --------------------------------------------------------------------------
+// Internal helpers
+// --------------------------------------------------------------------------
+
+function toYMD(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function subtractMonths(date: Date, months: number): Date {
+  const d = new Date(date);
+  d.setMonth(d.getMonth() - months);
+  return d;
+}
+
+function formatMonthYear(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-ZA', { month: 'long', year: 'numeric' });
+}
+
+function buildDescription(invoice: {
+  period_start?: string | null;
+  period_end?: string | null;
+}): string {
+  if (invoice.period_start && invoice.period_end) {
+    return `Monthly Service - ${formatMonthYear(invoice.period_start)}`;
+  }
+  return 'Service Invoice';
+}
+
+function computeAgingBuckets(invoices: InvoiceRow[], today: Date): AgingBuckets {
+  const buckets: AgingBuckets = {
+    over120Days: 0,
+    days90: 0,
+    days60: 0,
+    days30: 0,
+    current: 0,
+  };
+
+  for (const inv of invoices) {
+    if (['paid', 'cancelled', 'refunded'].includes(inv.status ?? '')) continue;
+
+    const dueDate = new Date(inv.due_date);
+    const daysOverdue = Math.floor(
+      (today.getTime() - dueDate.getTime()) / 86400000
+    );
+    const outstanding = parseFloat(String(inv.amount_due ?? '0'));
+
+    if (daysOverdue > 120) {
+      buckets.over120Days += outstanding;
+    } else if (daysOverdue > 90) {
+      buckets.days90 += outstanding;
+    } else if (daysOverdue > 60) {
+      buckets.days60 += outstanding;
+    } else if (daysOverdue > 30) {
+      buckets.days30 += outstanding;
+    } else {
+      buckets.current += outstanding;
+    }
+  }
+
+  return buckets;
+}
+
+// --------------------------------------------------------------------------
+// Internal row types (narrow DB return shape)
+// --------------------------------------------------------------------------
+
+interface CustomerRow {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  phone: string | null;
+  account_number: string | null;
+  billing_address: Record<string, string | undefined> | null | unknown;
+}
+
+interface InvoiceRow {
+  id: string;
+  invoice_number: string | null;
+  invoice_date: string;
+  due_date: string;
+  total_amount: string | number | null;
+  amount_paid: string | number | null;
+  amount_due: string | number | null;
+  status: string | null;
+  period_start: string | null;
+  period_end: string | null;
+  payment_reference: string | null;
+}
+
+// --------------------------------------------------------------------------
+// Main export
+// --------------------------------------------------------------------------
+
+export async function assembleStatementData(
+  supabase: SupabaseClient,
+  customerId: string,
+  options: StatementOptions = {}
+): Promise<{ statement: StatementData; customerRecord: CustomerRow }> {
+  const today = new Date();
+
+  // 1. Resolve date range
+  let fromDate: string | null = null;
+  let toDate: string | null = null;
+
+  if (options.from && options.to) {
+    fromDate = options.from;
+    toDate = options.to;
+  } else if (options.period && options.period !== 'all') {
+    const monthsMap: Record<'3m' | '6m' | '12m', number> = {
+      '3m': 3,
+      '6m': 6,
+      '12m': 12,
+    };
+    fromDate = toYMD(subtractMonths(today, monthsMap[options.period]));
+    toDate = toYMD(today);
+  }
+  // 'all' or no options → no date filter (fromDate/toDate stay null)
+
+  // 2. Fetch customer
+  const { data: rawCustomer, error: customerError } = await supabase
+    .from('customers')
+    .select('id, first_name, last_name, email, phone, account_number, billing_address')
+    .eq('id', customerId)
+    .single();
+
+  if (customerError || !rawCustomer) {
+    throw new Error(`Customer ${customerId} not found`);
+  }
+
+  const customer = rawCustomer as CustomerRow;
+
+  // Build billing address safely from JSONB
+  let address: StatementCustomer['address'];
+  if (
+    customer.billing_address !== null &&
+    customer.billing_address !== undefined &&
+    typeof customer.billing_address === 'object' &&
+    !Array.isArray(customer.billing_address)
+  ) {
+    const ba = customer.billing_address as Record<string, unknown>;
+    address = {
+      line1: typeof ba.line1 === 'string' ? ba.line1 : undefined,
+      line2: typeof ba.line2 === 'string' ? ba.line2 : undefined,
+      city: typeof ba.city === 'string' ? ba.city : undefined,
+      province: typeof ba.province === 'string' ? ba.province : undefined,
+      postalCode: typeof ba.postalCode === 'string' ? ba.postalCode : undefined,
+    };
+  }
+
+  const customerData: StatementCustomer = {
+    name: `${customer.first_name ?? ''} ${customer.last_name ?? ''}`.trim(),
+    accountNumber:
+      customer.account_number ?? `CT-${customer.id.slice(0, 8)}`,
+    email: customer.email ?? undefined,
+    phone: customer.phone ?? undefined,
+    address,
+  };
+
+  // 3. Fetch invoices
+  let query = supabase
+    .from('customer_invoices')
+    .select(
+      'id, invoice_number, invoice_date, due_date, total_amount, amount_paid, amount_due, status, period_start, period_end, payment_reference'
+    )
+    .eq('customer_id', customerId)
+    .order('invoice_date', { ascending: true });
+
+  if (fromDate !== null && toDate !== null) {
+    query = query.gte('invoice_date', fromDate).lte('invoice_date', toDate);
+  }
+
+  const { data: invoicesRaw, error: invoicesError } = await query;
+
+  if (invoicesError) {
+    throw new Error(
+      `Failed to fetch invoices for customer ${customerId}: ${invoicesError.message}`
+    );
+  }
+
+  const invoices: InvoiceRow[] = (invoicesRaw ?? []) as InvoiceRow[];
+
+  // 4. Build transactions
+  const transactions: StatementTransaction[] = [];
+
+  for (const inv of invoices) {
+    // Debit row: the invoice amount
+    transactions.push({
+      date: inv.invoice_date,
+      reference: inv.invoice_number ?? inv.id,
+      description: buildDescription(inv),
+      debit: parseFloat(String(inv.total_amount ?? '0')),
+    });
+
+    // Credit row: only if payment exists and invoice is paid/partial
+    const amountPaid = parseFloat(String(inv.amount_paid ?? '0'));
+    if (
+      amountPaid > 0 &&
+      (inv.status === 'paid' || inv.status === 'partial')
+    ) {
+      transactions.push({
+        date: inv.due_date,
+        reference: `PMT-${inv.invoice_number ?? inv.id}`,
+        description: 'Payment received - thank you',
+        credit: amountPaid,
+      });
+    }
+  }
+
+  // 5. Compute aging buckets
+  const aging = computeAgingBuckets(invoices, today);
+
+  // 6. Compute totals
+  const unpaidStatuses = new Set(['unpaid', 'partial', 'overdue']);
+
+  let totalDue = 0;
+  let totalPaid = 0;
+
+  for (const inv of invoices) {
+    if (unpaidStatuses.has(inv.status ?? '')) {
+      totalDue += parseFloat(String(inv.amount_due ?? '0'));
+    }
+    totalPaid += parseFloat(String(inv.amount_paid ?? '0'));
+  }
+
+  // 7. Return
+  return {
+    statement: {
+      statementDate: toYMD(today),
+      customer: customerData,
+      transactions,
+      aging,
+      totalDue,
+      totalPaid,
+    },
+    customerRecord: customer,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds customer statement preview page at `/admin/customers/[id]/statement`
- Adds customer-facing statement page at `/dashboard/statement`
- Admin and dashboard API routes (`/api/admin/billing/statements/[customerId]` and `/api/dashboard/statement`)
- Branded HTML preview with print-to-PDF, date range filter (3m/6m/12m/all), running balance, and aging analysis
- "View Statement" button added to CustomerBillingTab and dashboard invoices page
- **Bug fix**: Removes non-existent `billing_address` column from Supabase SELECT query — was causing every statement API call to return 404 "Customer not found"

## Test Plan

- [ ] Navigate to `/admin/customers/[known-id]/statement` — statement renders with real invoice data
- [ ] Change period filter — transactions update
- [ ] Click Print — browser print dialog shows A4 statement
- [ ] Verify aging buckets match unpaid invoice dates
- [ ] Navigate to `/dashboard/statement` as logged-in customer — own data only

🤖 Generated with [Claude Code](https://claude.com/claude-code)