### PR TITLE
docs(agent-os): add archive/ convention and PROPOSAL/DESIGN templates

### DIFF
--- a/.claude/commands/generate-spec.md
+++ b/.claude/commands/generate-spec.md
@@ -50,6 +50,19 @@ mkdir -p "agent-os/specs/$specId"
 
 Generate the following files for the spec:
 
+### 4.0 (Optional) PROPOSAL.md + DESIGN.md — large initiatives only
+
+For specs flagged `priority: high` or `critical`, or any feature that touches 4+ task groups / multiple integrations, scaffold the optional pre-spec artifacts **first**:
+
+```bash
+cp agent-os/specs/_templates/PROPOSAL.md "agent-os/specs/$specId/"
+cp agent-os/specs/_templates/DESIGN.md   "agent-os/specs/$specId/"
+```
+
+These let stakeholders sign off on *why* (PROPOSAL) and *how* (DESIGN) before committing to a fully-detailed SPEC + TASKS. See `agent-os/specs/_templates/README.md` for guidance on when to use them.
+
+For small/medium specs (default), skip 4.0 and go straight to README + SPEC + TASKS below.
+
 ### 4.1 README.md
 Quick overview with:
 - Spec ID and title

--- a/agent-os/README.md
+++ b/agent-os/README.md
@@ -70,6 +70,35 @@ agent-os/specs/[spec-id]/
     └── final-verification.md
 ```
 
+#### Optional pre-spec artifacts (large initiatives)
+
+For initiatives that need stakeholder alignment **before** committing engineering effort to a full spec, two extra documents are available:
+
+- **`PROPOSAL.md`** — lightweight problem statement + proposed direction. Goal: get a yes/no on *whether* to build this.
+- **`DESIGN.md`** — technical approach, trade-offs, rollout plan. Goal: lock down architecture decisions before SPEC + TASKS are written.
+
+Both live alongside `SPEC.md` / `TASKS.md` inside the spec folder. Templates are in `agent-os/specs/_templates/` — see `_templates/README.md` for when to use each.
+
+```
+PROPOSAL.md  →  approved?  →  DESIGN.md  →  approved?  →  SPEC.md + TASKS.md  →  implement  →  archive/
+   (why)                       (how)                        (what + when)
+```
+
+For small/medium specs, skip straight to `SPEC.md` + `TASKS.md` as before. The PM Agent and `/generate-spec` continue to scaffold those directly.
+
+#### Active vs archived specs
+
+Active specs live in `agent-os/specs/`. Completed, superseded, or withdrawn specs move to `agent-os/specs/archive/<spec-id>/` (folder kept as-is — the spec ID already encodes its creation date).
+
+Archive when any of these is true:
+- `PROGRESS.md` shows 100% and final verification passed
+- Feature deployed to production and verified
+- Proposal/design rejected or withdrawn
+- Superseded by a newer spec (link the successor)
+- No activity for 90+ days and no owner
+
+See `agent-os/specs/archive/README.md` for the full archive procedure (closing PROGRESS entry, `git mv`, optional `/compound` capture).
+
 ---
 
 ## Implementation Workflow
@@ -370,6 +399,12 @@ circletel-nextjs/
 │   │   ├── implementers.yml       # 5 implementer agents
 │   │   └── verifiers.yml          # 3 verifier agents
 │   └── specs/
+│       ├── _templates/            # Optional PROPOSAL.md / DESIGN.md starters
+│       │   ├── README.md
+│       │   ├── PROPOSAL.md
+│       │   └── DESIGN.md
+│       ├── archive/               # Completed / superseded / withdrawn specs
+│       │   └── README.md
 │       └── 20251101-b2b-quote-to-contract-kyc/
 │           ├── spec.md
 │           ├── tasks.md

--- a/agent-os/specs/_templates/DESIGN.md
+++ b/agent-os/specs/_templates/DESIGN.md
@@ -1,0 +1,141 @@
+# Design: <feature-name>
+
+| Field | Value |
+|-------|-------|
+| **Spec ID** | `YYYYMMDD-feature-name` |
+| **Author** | <name> |
+| **Created** | YYYY-MM-DD |
+| **Status** | DRAFT |
+| **Proposal** | `./PROPOSAL.md` |
+| **Reviewers** | <names or roles> |
+
+> **Purpose of this document**: lock down the *technical approach* before we commit to a detailed `SPEC.md` and `TASKS.md`. Surfaces architecture decisions, trade-offs, and risks for review. If approved, the SPEC + TASKS can be generated with confidence.
+
+---
+
+## 1. Context
+
+One paragraph. Pulled from `PROPOSAL.md` Section 1-2. Skim-friendly — readers should understand the problem without leaving this doc.
+
+## 2. Approach
+
+High-level shape of the solution. Two or three paragraphs explaining **how** the pieces fit together. No code yet — diagrams + prose.
+
+```
+┌─────────────┐      ┌──────────────┐      ┌──────────────┐
+│  User flow  │ ───▶ │  System X    │ ───▶ │  Persistence │
+└─────────────┘      └──────────────┘      └──────────────┘
+```
+
+## 3. Architecture
+
+### Components
+
+| Component | Responsibility | New / Modified |
+|-----------|----------------|----------------|
+| `lib/foo/...` | ... | new |
+| `app/api/foo/route.ts` | ... | new |
+| `components/foo/Bar.tsx` | ... | modified |
+
+### Data flow
+
+Describe the request/response or event flow. Bullet points or sequence diagram.
+
+1. User submits ...
+2. API validates ...
+3. Service writes to ...
+4. Webhook fires ...
+
+### Reusable assets
+
+Per CircleTel's code-reuse policy, list existing code we will extend rather than duplicate:
+
+- `lib/payments/netcash-service.ts` — extend for ...
+- `lib/quotes/pdf-generator-v2.ts` — reuse for ...
+- `lib/rbac/permissions.ts` — add new permission ...
+
+## 4. Data model
+
+### New tables
+
+| Table | Purpose | Key columns |
+|-------|---------|-------------|
+| `foo_bar` | ... | `id`, `customer_id`, `status` |
+
+### Schema changes
+
+```sql
+-- High-level only; full migration generated during implementation
+ALTER TABLE customers ADD COLUMN foo_status text;
+```
+
+### RLS policies
+
+- `customers SELECT`: own rows only
+- `admin_users ALL`: full access
+
+## 5. API surface
+
+| Method | Path | Purpose | Auth |
+|--------|------|---------|------|
+| POST | `/api/foo` | Create | customer cookie + bearer |
+| GET | `/api/foo/:id` | Read | admin only |
+| POST | `/api/webhooks/foo` | External callback | HMAC-SHA256 |
+
+## 6. External integrations
+
+| Provider | Endpoint | Auth | Failure mode |
+|----------|----------|------|--------------|
+| e.g. Didit | `https://...` | OAuth | retry 3x, then fail event |
+| e.g. NetCash | `https://...` | service key | webhook retry |
+
+## 7. Trade-offs
+
+| Decision | Alternatives | Why we chose this |
+|----------|--------------|-------------------|
+| Sync vs async | Inngest event vs inline | ... |
+| Server vs client | RSC vs client component | ... |
+| Build vs buy | ... | ... |
+
+## 8. Risks & mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Provider rate limits | M | H | Cache + backoff |
+| RLS bypass | L | H | Explicit policy tests |
+| Migration on hot table | M | H | Backfill in batches |
+
+## 9. Rollout plan
+
+- [ ] Migration applied to staging
+- [ ] Feature flag wired (if applicable)
+- [ ] Internal QA on staging
+- [ ] Limited production rollout (e.g. 10% via flag)
+- [ ] Full rollout
+- [ ] Flag removed / cleanup
+
+## 10. Observability
+
+| Signal | Where | Why |
+|--------|-------|-----|
+| Logs | `apiLogger.info('[foo]', ...)` | Debug |
+| Errors | Sentry | Triage |
+| Metrics | Inngest dashboard / Supabase | SLA |
+
+## 11. Decision
+
+> Filled in by reviewers when status moves to APPROVED.
+
+- **Decision**: APPROVED / REVISE / REJECTED
+- **Date**: YYYY-MM-DD
+- **Decided by**: <names>
+- **Open items to resolve before SPEC.md**: ...
+
+---
+
+## References
+
+- `PROPOSAL.md` (this folder)
+- `docs/architecture/SYSTEM_OVERVIEW.md`
+- Related specs: `agent-os/specs/<other-spec-id>/`
+- External docs: ...

--- a/agent-os/specs/_templates/PROPOSAL.md
+++ b/agent-os/specs/_templates/PROPOSAL.md
@@ -1,0 +1,94 @@
+# Proposal: <feature-name>
+
+| Field | Value |
+|-------|-------|
+| **Spec ID** | `YYYYMMDD-feature-name` |
+| **Author** | <name> |
+| **Created** | YYYY-MM-DD |
+| **Status** | DRAFT |
+| **Priority** | low / medium / high / critical |
+| **Reviewers** | <names or roles> |
+
+> **Purpose of this document**: align on *why* we should do this and *what* roughly we'd build, **before** committing engineering effort to a full `SPEC.md`. Keep it short — one page if possible. If approved, move on to `DESIGN.md`.
+
+---
+
+## 1. Problem
+
+What pain point, opportunity, or strategic need does this address? Quote real customer feedback, support tickets, or business metrics where possible.
+
+## 2. Proposed solution
+
+One paragraph. What are we proposing to build, in plain language? No implementation detail yet — that's `DESIGN.md`.
+
+## 3. Goals
+
+- Goal 1 (measurable)
+- Goal 2 (measurable)
+- Goal 3 (measurable)
+
+## 4. Non-goals
+
+Things we are explicitly **not** doing in this initiative. Equally important as goals.
+
+- Non-goal 1
+- Non-goal 2
+
+## 5. Success metrics
+
+How we'll know it worked. Tie to numbers where possible.
+
+| Metric | Baseline | Target | Measurement window |
+|--------|----------|--------|-------------------|
+| e.g. B2B onboarding time | 7 days | <1 day | 30 days post-launch |
+| e.g. RICA first-time approval | 70% | 95% | 30 days post-launch |
+
+## 6. Scope
+
+**In scope**
+- Item 1
+- Item 2
+
+**Out of scope**
+- Item 1 (defer to future spec)
+- Item 2 (handled elsewhere)
+
+## 7. Stakeholders & impact
+
+| Stakeholder | Impact |
+|-------------|--------|
+| Customers (B2B / B2C) | ... |
+| Sales / Support | ... |
+| Operations / Compliance | ... |
+| Engineering | ... |
+
+## 8. Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Do nothing | ... |
+| Buy off-the-shelf | ... |
+| Different approach | ... |
+
+## 9. Open questions
+
+- [ ] Question 1 (owner: <name>)
+- [ ] Question 2 (owner: <name>)
+
+## 10. Decision
+
+> Filled in by reviewers when status moves to APPROVED.
+
+- **Decision**: APPROVED / REJECTED / DEFERRED
+- **Date**: YYYY-MM-DD
+- **Decided by**: <names>
+- **Rationale**: ...
+- **Next step**: Proceed to `DESIGN.md` / `SPEC.md` / abandon.
+
+---
+
+## References
+
+- Related specs: `agent-os/specs/<other-spec-id>/`
+- Source docs: `docs/...`
+- External links: ...

--- a/agent-os/specs/_templates/README.md
+++ b/agent-os/specs/_templates/README.md
@@ -1,0 +1,59 @@
+# Spec Templates
+
+Optional starter templates for new specs in `agent-os/specs/`.
+
+## When to use what
+
+| Situation | Recommended files |
+|-----------|-------------------|
+| Small change (1-3 task groups, low risk) | `SPEC.md` + `TASKS.md` |
+| Standard feature (4-10 task groups) | `SPEC.md` + `TASKS.md` + `PROGRESS.md` + `architecture.md` |
+| Large initiative needing stakeholder alignment **before** engineering effort | Start with `PROPOSAL.md`, then `DESIGN.md`, then full spec |
+| Cross-team / multi-quarter work | `PROPOSAL.md` + `DESIGN.md` + everything else |
+
+The `PROPOSAL.md` and `DESIGN.md` templates are **additive** — they don't replace `SPEC.md`/`TASKS.md`. They're for cases where it pays to align on the *why* and *how* before committing to a fully-detailed spec.
+
+## Lifecycle of a large spec
+
+```
+PROPOSAL.md  →  approved?  →  DESIGN.md  →  approved?  →  SPEC.md + TASKS.md  →  implement  →  archive/
+   (why)                       (how)                        (what + when)
+```
+
+For small/medium specs, skip straight to `SPEC.md` + `TASKS.md` as before. The PM-Agent and `/generate-spec` command continue to scaffold those directly.
+
+## Files in this folder
+
+| File | Purpose |
+|------|---------|
+| `PROPOSAL.md` | Lightweight problem statement + proposed direction. Goal: get a yes/no before deeper design work. |
+| `DESIGN.md` | Technical approach, trade-offs, rollout. Goal: surface architecture decisions before coding. |
+
+## How to use
+
+```bash
+# Copy templates into a new spec folder
+mkdir -p agent-os/specs/$(date +%Y%m%d)-my-feature
+cp agent-os/specs/_templates/PROPOSAL.md agent-os/specs/$(date +%Y%m%d)-my-feature/
+cp agent-os/specs/_templates/DESIGN.md   agent-os/specs/$(date +%Y%m%d)-my-feature/
+```
+
+Then fill them in, get sign-off, and proceed to `SPEC.md`/`TASKS.md` when ready.
+
+## Status field
+
+Both templates carry a `Status:` line. Valid values:
+
+- `DRAFT` — being written
+- `IN REVIEW` — awaiting feedback
+- `APPROVED` — ready to advance to the next stage
+- `SUPERSEDED` — replaced by a newer proposal/design (link the replacement)
+- `WITHDRAWN` — abandoned without replacement
+
+Update the status as the document moves through review.
+
+## See also
+
+- `agent-os/README.md` — full framework overview
+- `agent-os/specs/archive/README.md` — archive convention
+- `.claude/commands/generate-spec.md` — `/generate-spec` slash command

--- a/agent-os/specs/archive/README.md
+++ b/agent-os/specs/archive/README.md
@@ -1,0 +1,89 @@
+# Archived Specs
+
+Completed, abandoned, or superseded specs live here. Active work lives one level up in `agent-os/specs/`.
+
+## Why archive
+
+`agent-os/specs/` accumulates folders fast. Without archiving:
+
+- It's hard to tell at a glance which specs are still in flight
+- `/generate-spec` listings get noisy
+- New contributors can't find the work that matters
+
+Moving completed specs into `archive/` keeps the active list short and intentional.
+
+## When to archive
+
+Archive a spec when **any** of these is true:
+
+| Trigger | Why |
+|---------|-----|
+| `PROGRESS.md` shows 100% and final verification passed | Implementation shipped |
+| Feature deployed to production and verified | No more work |
+| Proposal or design rejected/withdrawn | Won't be built |
+| Superseded by a newer spec | Pointer to replacement |
+| No activity for 90+ days and no clear owner | Stale; revive from archive if needed |
+
+## How to archive
+
+1. **Update the spec's `PROGRESS.md`** (or `README.md` if no PROGRESS exists) with a closing entry:
+   ```markdown
+   ## Archived: YYYY-MM-DD
+   - **Outcome**: shipped / rejected / superseded / withdrawn
+   - **Final verification**: <link to verification report or PR>
+   - **Successor** (if superseded): `agent-os/specs/<new-spec-id>/`
+   - **Notes**: <one paragraph summarising what was learned>
+   ```
+
+2. **Move the folder as-is** under `archive/`:
+   ```bash
+   git mv agent-os/specs/20251130-invoice-email-reminder \
+          agent-os/specs/archive/20251130-invoice-email-reminder
+   ```
+
+3. **Do NOT rename** the folder. The spec ID already encodes its creation date — re-prefixing with the archive date is redundant and breaks back-references in commit messages, code comments (`@see agent-os/specs/...`), and PR descriptions.
+
+4. **Update inbound links** (optional): `grep -rn "agent-os/specs/<spec-id>"` to find code/doc references and update them to `agent-os/specs/archive/<spec-id>`. Code-level `@see` references can be left alone — they still point to git history.
+
+5. **Capture learnings** if any (per CLAUDE.md Stage 6):
+   - Run `/compound` for reusable patterns
+   - Update `memory-os/long-term/patterns.md` if a new pattern emerged
+
+## What lives here
+
+```
+agent-os/specs/archive/
+├── README.md                          # this file
+└── <spec-id>/                          # archived spec, structure preserved
+    ├── README.md
+    ├── SPEC.md / spec.md
+    ├── TASKS.md / tasks.md
+    ├── PROGRESS.md                     # closing "Archived: ..." section appended
+    ├── architecture.md
+    ├── implementation/
+    └── verification/
+```
+
+Folder layout inside an archived spec is **identical** to active specs — nothing is stripped or compacted. This makes reviving a spec a one-line `git mv` if requirements change.
+
+## Reviving an archived spec
+
+If an archived spec needs to come back to life:
+
+1. `git mv agent-os/specs/archive/<spec-id> agent-os/specs/<spec-id>`
+2. Append a new `Revived: YYYY-MM-DD` entry to `PROGRESS.md` explaining why.
+3. Update status fields and resume work.
+
+## Status field mapping
+
+If the spec uses `PROPOSAL.md` / `DESIGN.md` from `_templates/`, map their `Status:` line to one of:
+
+- `APPROVED` (still active) — keep in `agent-os/specs/`
+- `SUPERSEDED` — move to archive, link to successor
+- `WITHDRAWN` — move to archive, no successor needed
+
+## See also
+
+- `agent-os/README.md` — full framework overview
+- `agent-os/specs/_templates/README.md` — proposal/design templates
+- `.claude/rules/compound-learnings.md` — Stage 6 LEARN gate


### PR DESCRIPTION
## Summary

Borrows the two ideas worth taking from OpenSpec without introducing the framework itself:

- **Optional `PROPOSAL.md` / `DESIGN.md` templates** in `agent-os/specs/_templates/` for large initiatives that need stakeholder alignment *before* committing engineering effort to a full SPEC.
- **`agent-os/specs/archive/` convention** so completed, superseded, or withdrawn specs stop cluttering the active list.

No existing spec is touched. The PROPOSAL → DESIGN → SPEC → TASKS lifecycle is **opt-in** — small/medium specs continue using `SPEC.md` + `TASKS.md` as before, and `/generate-spec` keeps scaffolding those by default.

## What changed

| File | Type | Purpose |
|------|------|---------|
| `agent-os/specs/_templates/README.md` | new | When to use what; lifecycle diagram; status field values |
| `agent-os/specs/_templates/PROPOSAL.md` | new | Template: problem, proposed solution, goals/non-goals, metrics, scope, alternatives, decision |
| `agent-os/specs/_templates/DESIGN.md` | new | Template: context, approach, architecture, data model, API surface, integrations, trade-offs, risks, rollout, observability |
| `agent-os/specs/archive/README.md` | new | Archive triggers, `git mv` procedure, revival steps, status field mapping |
| `agent-os/README.md` | modified | New "Optional pre-spec artifacts" + "Active vs archived" subsections; directory tree updated |
| `.claude/commands/generate-spec.md` | modified | Optional Step 4.0 referencing the templates for high/critical priority specs |

## Why these two ideas (and not OpenSpec wholesale)

CircleTel already has agent-os, the Superpowers Pipeline, Memory OS, and `/compound`/`compound-learnings` covering propose → plan → implement → verify → ship → learn. Adopting OpenSpec's `/opsx:*` commands would create a parallel pipeline competing with the existing one. The two missing pieces from the current setup were:

1. **Splitting *why* (proposal) from *how* (design)** — current `SPEC.md` mixes both, which makes early review heavy.
2. **An archive convention** — 10 spec folders sit in `agent-os/specs/` today with no clear active-vs-completed distinction.

This PR addresses both without adding any new tooling, dependencies, or commands.

## Integration with the existing setup

- **CLAUDE.md Stage 6 (LEARN)**: archive procedure references `/compound` and `memory-os/long-term/patterns.md` for capture on shipping.
- **`/generate-spec`**: gains an optional Step 4.0; default behaviour unchanged.
- **PM Agent (`lib/agents/pm/`)**: no code changes — `specsOutputDirectory` already points at `agent-os/specs/`, and the new sibling folders (`_templates/`, `archive/`) don't interfere with spec ID lookups (no consumer iterates spec folders blindly).
- **Folder naming**: `_templates` (underscore prefix) and `archive/` sort separately from dated spec folders and are obviously meta-folders.
- **Filename casing**: matches the active convention (uppercase `SPEC.md` / `TASKS.md` / `PROGRESS.md` used by all specs since 2025-11-30).

## Test plan

- [ ] Confirm `agent-os/specs/_templates/` and `agent-os/specs/archive/` render correctly on GitHub
- [ ] Confirm `agent-os/README.md` renders with the new diagram + tree
- [ ] Confirm `/generate-spec` still scaffolds default (medium-priority) specs unchanged
- [ ] Spot-check by copying templates into a sample spec folder and filling them in
- [ ] Optional: archive one already-shipped spec (e.g. `20251208-supplier-product-detail` if PROGRESS shows 100%) as a smoke test of the procedure

## Out of scope

- Migrating existing specs into `archive/` (left for follow-up — needs owner sign-off per spec)
- Renaming inconsistent existing files (some specs use lowercase `spec.md` / `tasks.md`)
- Adding npm tooling or CLI helpers — fully manual `git mv` flow

https://claude.ai/code/session_0116iawxdMPqx5TLB9Lenepm

---
_Generated by [Claude Code](https://claude.ai/code/session_0116iawxdMPqx5TLB9Lenepm)_