### PR TITLE
fix(payments): NetCash webhook P0 fixes — customer_email mapping + invoice auth gate

### DIFF
--- a/__tests__/lib/payments/netcash-webhook-auth.test.ts
+++ b/__tests__/lib/payments/netcash-webhook-auth.test.ts
@@ -1,0 +1,35 @@
+import { amountIsSane, decideWebhookAction } from '@/lib/payments/netcash-webhook-auth';
+
+describe('amountIsSane', () => {
+  it('accepts a positive amount not exceeding what is owed', () => {
+    expect(amountIsSane(899, 899)).toBe(true);   // exact
+    expect(amountIsSane(1, 899)).toBe(true);      // valid partial / R1 auth
+  });
+  it('rejects zero, negative, NaN', () => {
+    expect(amountIsSane(0, 899)).toBe(false);
+    expect(amountIsSane(-5, 899)).toBe(false);
+    expect(amountIsSane(Number.NaN, 899)).toBe(false);
+  });
+  it('rejects overpayment beyond a 1-cent tolerance', () => {
+    expect(amountIsSane(900, 899)).toBe(false);
+    expect(amountIsSane(899.005, 899)).toBe(true); // within 1c tolerance
+  });
+  it('rejects when owed amount is unknown', () => {
+    expect(amountIsSane(899, null)).toBe(false);
+  });
+});
+
+describe('decideWebhookAction', () => {
+  it('authorizes when entity matched and amount sane', () => {
+    expect(decideWebhookAction({ entityMatched: true, owedAmount: 899, receivedAmount: 899 }))
+      .toEqual({ action: 'authorize', reason: expect.any(String) });
+  });
+  it('routes to manual_review when no entity matched', () => {
+    expect(decideWebhookAction({ entityMatched: false, owedAmount: 899, receivedAmount: 899 }).action)
+      .toBe('manual_review');
+  });
+  it('routes to manual_review on amount mismatch', () => {
+    expect(decideWebhookAction({ entityMatched: true, owedAmount: 899, receivedAmount: 5000 }).action)
+      .toBe('manual_review');
+  });
+});

--- a/__tests__/lib/payments/netcash-webhook-email.test.ts
+++ b/__tests__/lib/payments/netcash-webhook-email.test.ts
@@ -1,0 +1,42 @@
+import { extractCustomerEmail } from '@/lib/payments/netcash-webhook-email';
+
+describe('extractCustomerEmail', () => {
+  it('returns the email from the Email field', () => {
+    expect(extractCustomerEmail({ Email: 'shaunr07@gmail.com' })).toBe('shaunr07@gmail.com');
+  });
+
+  it('falls back to CustomerEmail when Email is absent', () => {
+    expect(extractCustomerEmail({ CustomerEmail: 'raycdfg@gmail.com' })).toBe('raycdfg@gmail.com');
+  });
+
+  it('prefers Email over CustomerEmail when both present', () => {
+    expect(extractCustomerEmail({ Email: 'a@x.com', CustomerEmail: 'b@x.com' })).toBe('a@x.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(extractCustomerEmail({ Email: '  user@x.com  ' })).toBe('user@x.com');
+  });
+
+  // Regression: the original bug read Extra2 (the notify URL) into customer_email.
+  it('never returns Extra2 (the notify URL)', () => {
+    expect(
+      extractCustomerEmail({ Extra2: 'https://www.circletel.co.za/api/payment/netcash/webhook' })
+    ).toBeNull();
+  });
+
+  it('rejects a URL even if it somehow lands in an email field', () => {
+    expect(extractCustomerEmail({ Email: 'https://www.circletel.co.za/api/payments' })).toBeNull();
+  });
+
+  it('returns null when no email fields are present', () => {
+    expect(extractCustomerEmail({ Reference: 'CT-PAY-ORD-20260529-1561', Amount: '1.00' })).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(extractCustomerEmail({ Email: '' })).toBeNull();
+  });
+
+  it('returns null for a value with no @', () => {
+    expect(extractCustomerEmail({ Email: 'not-an-email' })).toBeNull();
+  });
+});

--- a/app/api/payments/netcash/webhook/route.ts
+++ b/app/api/payments/netcash/webhook/route.ts
@@ -19,6 +19,7 @@ import { EnhancedEmailService } from '@/lib/emails/enhanced-notification-service
 import { formatPaymentMethod } from '@/lib/payments/types';
 import { webhookLogger } from '@/lib/logging';
 import { matchInvoiceByReference } from '@/lib/billing/invoice-matcher';
+import { extractCustomerEmail } from '@/lib/payments/netcash-webhook-email';
 
 /**
  * Verify NetCash webhook signature
@@ -353,7 +354,7 @@ export async function POST(request: NextRequest) {
           currency: 'ZAR',
           status: paymentStatus,
           payment_method: bodyParsed.PaymentMethod || bodyParsed.payment_method || null,
-          customer_email: bodyParsed.Extra2 || null, // NetCash Extra2 for email
+          customer_email: extractCustomerEmail(bodyParsed), // Email/CustomerEmail only — never Extra2 (it holds the notify URL)
           provider_response: bodyParsed,
           initiated_at: new Date().toISOString(),
           completed_at: paymentStatus === 'completed' ? new Date().toISOString() : null

--- a/app/api/payments/netcash/webhook/route.ts
+++ b/app/api/payments/netcash/webhook/route.ts
@@ -20,6 +20,7 @@ import { formatPaymentMethod } from '@/lib/payments/types';
 import { webhookLogger } from '@/lib/logging';
 import { matchInvoiceByReference } from '@/lib/billing/invoice-matcher';
 import { extractCustomerEmail } from '@/lib/payments/netcash-webhook-email';
+import { decideWebhookAction } from '@/lib/payments/netcash-webhook-auth';
 
 /**
  * Verify NetCash webhook signature
@@ -474,6 +475,31 @@ export async function POST(request: NextRequest) {
 
         if (invoiceMatch.matched && invoiceMatch.invoice) {
           const invoice = invoiceMatch.invoice;
+
+          // AUTHORIZATION GATE: NetCash Pay Now does not sign webhooks, so we fail
+          // safe — only mutate the invoice when the amount is sane for it.
+          const owed = Number(invoice.amount_due ?? invoice.total_amount ?? 0);
+          const invoiceDecision = decideWebhookAction({
+            entityMatched: true,
+            owedAmount: owed,
+            receivedAmount: amount,
+          });
+          if (invoiceDecision.action === 'manual_review') {
+            webhookLogger.warn('[Invoice Payment] Blocked — manual review required', {
+              reference, invoiceNumber: invoice.invoice_number, amount, owed, reason: invoiceDecision.reason,
+            });
+            if (webhookLog) {
+              await supabase.from('payment_webhook_logs')
+                .update({ status: 'manual_review', success: false, error_message: invoiceDecision.reason,
+                          processing_completed_at: new Date().toISOString() })
+                .eq('id', webhookLog.id);
+            }
+            return NextResponse.json(
+              { success: true, message: 'Webhook received; held for manual review', reference },
+              { status: 200 }
+            );
+          }
+
           webhookLogger.info('[Invoice Payment] Invoice matched', {
             reference,
             matchMethod: invoiceMatch.matchMethod,

--- a/docs/audits/2026-06-02-netcash-payment-reconciliation.md
+++ b/docs/audits/2026-06-02-netcash-payment-reconciliation.md
@@ -218,3 +218,94 @@ was therefore scoped to the **invoice** branch (the only live money-mutation pat
 2. Derive the order's owed amount from `package_price + installation_fee + router_fee + prorata_amount`
    (there is **no** single `total_amount` column on `consumer_orders`).
 3. Apply the same `decideWebhookAction()` gate before mutating the order.
+
+---
+
+## 9. Billing-Cycle Diagnosis — "payments not showing up / not reconciled / billing not updating"
+
+Investigation (read-only, 2026-06-02) of the live order → payment → invoice → recurring-billing
+pipeline. **No billing data was mutated.**
+
+### Funnel snapshot (production)
+
+| Stage | State |
+|-------|-------|
+| `consumer_orders` | 21 total — **all** `payment_status='pending'`; only 2 `billing_active=true` |
+| billing-active orders | `CT-2025-00012` next_billing **2025-12-01** (frozen 6 mo); `CT-2025-00030` next_billing **2026-05-25** (passed, not advanced) |
+| `customer_invoices` | 9 ever; newest **created 2026-05-05**; 7 paid, 1 overdue, 1 sent; R1,998 outstanding |
+| `customer_services` | **28 active, all `billing_day=1`, all `last_invoice_date = NULL`** |
+| `payment_transactions` | 12 completed, 3 failed, **35 pending** (stuck); **9 completed orphans** (no invoice/order link) |
+| `payment_webhook_logs` | 16 ever; all `signature_verified=false`; newest 2026-05-29 |
+
+### PRIMARY ROOT CAUSE — recurring invoice generation is not executing in production
+
+All **28 active `customer_services` have `last_invoice_date = NULL`** — the `MonthlyInvoiceGenerator`
+(`lib/billing/monthly-invoice-generator.ts:240-275`, sets `last_invoice_date` after billing) has
+**never successfully billed any of them**. No invoice batch exists on any 1st-of-month; nothing was
+generated for the 2026-06-01 run. The endpoint (`/api/cron/generate-monthly-invoices`) exists, is
+wired, supports `dryRun`, and defaults `billingDay` to today.
+
+**Why it isn't running:** all cron schedules live in `vercel.json` (`0 4 1 * *` for this job), but
+**Vercel was decommissioned in the 2026-04-05 Coolify migration (Vercel builds disabled).** `vercel.json`
+crons do not execute on Coolify. Whether the equivalent Coolify scheduled tasks exist / fire / succeed
+is **external config not visible in the repo** — it must be checked in Coolify + prod logs.
+
+**CONFIRMED (2026-06-02):** the `billing_cron_logs` table — which the generator writes to on **every**
+run (`monthly-invoice-generator.ts:561`), including dry runs — has **0 rows**. The generator has
+**never executed in production**. This, plus all 28 services at `last_invoice_date=NULL` and no
+invoice batch on any 1st-of-month, is conclusive: the cron is not firing. The remaining unknown
+(Coolify task missing vs present-but-failing) is immaterial — the fix is on the scheduling/infra side.
+
+**Pre-enable check (safe, non-mutating), before turning the real cron on:**
+`POST /api/cron/generate-monthly-invoices` with `{ "dryRun": true, "billingDay": 1 }` +
+`Authorization: Bearer $CRON_SECRET`. Expect ~28 services eligible. `dryRun` returns before any
+invoice/`last_invoice_date`/ZOHO write (`monthly-invoice-generator.ts:332`), so it is safe to run
+against production. (Use `billingDay:1` explicitly — the GET form defaults to *today*, which would
+match 0 services since all are `billing_day=1`.)
+
+### Contributing defects (verified in code/data)
+
+1. **Order webhooks are dead (Finding 7)** → order payments never mark orders paid; no order ever
+   becomes `billing_active`. There is also **no traced bridge** from a paid `consumer_order` to a
+   `customer_services` row, so new orders never enter the billing engine.
+2. **Transaction↔invoice link gap.** The webhook marks invoices paid but leaves
+   `payment_transactions.invoice_id = NULL` (9 orphans, incl. real R899 payments whose invoices ARE
+   paid). The ledger is unreliable for "which payment paid which invoice" → payments appear "missing"
+   in any transaction→invoice view.
+3. **Overlapping/ambiguous billing crons** — `generate-invoices` (daily), `generate-monthly-invoices`
+   (1st), `generate-invoices-25th` (25th), `process-billing-day` (daily) all exist. Unclear which is
+   authoritative; this ambiguity likely contributed to none reliably running post-migration.
+
+### Business impact (who isn't being billed)
+
+The 28 active `customer_services` break down as:
+
+| Segment | Count | Monthly | Notes |
+|---------|-------|---------|-------|
+| Unjani clinic sites (`*@unjani.org`, R450, `billing_day=1`) | 19 | R8,550 | Created **2026-05-12**; first invoice due **2026-06-01** — never generated |
+| Real consumer customers (Prins Mhlanga R999; Shaun Robertson R899) | 2 | R1,898 | Invoiced sporadically/manually |
+| Test/system accounts (R0, `CTF-*`, `*@circletel.co.za`) | 6 | R0 | Should be excluded from billing runs |
+
+**~R8,550/mo of Unjani recurring revenue has never been invoiced** because the cron has never fired,
+and the Unjani billing relationship (live since ~2026-05-12) has never started. This is the most likely
+real-world manifestation of the reported symptom.
+
+### Remediation path
+
+1. **Infra (Coolify — requires operator access):** create/repair the scheduled task that POSTs
+   `/api/cron/generate-monthly-invoices` (`0 4 1 * *`, Bearer `CRON_SECRET`). Verify it appears in
+   Coolify's scheduled tasks and check its run history. The `vercel.json` crons are dead post-migration.
+2. **Data cleanup:** exclude/deactivate the 6 R0 `CTF-*` test services so they don't generate noise
+   invoices + emails on the first real run.
+3. **Controlled catch-up run:** `dryRun:true, billingDay:1` first (preview the ~21 real invoices), then
+   a real run **with explicit go-ahead** (it creates invoices, syncs ZOHO, and sends PayNow
+   notifications to 19 clinics + 2 customers).
+4. **Consolidate billing crons:** decide the authoritative job among `generate-invoices` (daily),
+   `generate-monthly-invoices` (1st), `generate-invoices-25th` (25th), `process-billing-day` (daily);
+   retire the rest to prevent double-billing once scheduling is restored.
+
+### What this means for the webhook-hardening branch
+
+The `feature/netcash-webhook-auth-hardening` branch is correct and safe but is **orthogonal** to these
+symptoms — it hardens/cleans, it does not start the billing engine. The user-felt problem is the
+**billing cron execution gap (PRIMARY)**, not the webhook.

--- a/docs/audits/2026-06-02-netcash-payment-reconciliation.md
+++ b/docs/audits/2026-06-02-netcash-payment-reconciliation.md
@@ -17,6 +17,7 @@
 | 4 | R899 order payment (real revenue) has **null `customer_id`/`customer_email`** on the transaction despite being invoice-linked | **P2** | 1 row |
 | 5 | 3 payment methods marked `token_status=active` + `is_primary` with **null `card_token`** — uncharffeable | **P1** | 3 rows |
 | 6 | Ashwyn's two 08-May order payments never produced a webhook | **Investigated** | Not revenue — see §5 |
+| 7 | Order webhook branch is **dead for real `CT-PAY-ORD-*` refs** (regex `/^CT-\d{8}-/` never matches) → orders never marked paid by webhook | **P1 (functional)** | Confirmed — see §8 |
 
 **Bottom line on money:** Of the 7 supplied transactions, **only one is real revenue** — the R899 Ozow payment (`CT-20260505-95ppe6nm`) for invoice **INV-2026-00008**, which is correctly recorded as fully `paid`. The remaining six are R1 card-authorization / payment-method-validation charges, not package revenue. **No revenue has been lost.**
 
@@ -182,10 +183,38 @@ WHERE id = 'fc21435a-6c7a-44a4-9444-30b8f15c97b9' AND customer_email LIKE 'http%
 
 | Item | Action | Status |
 |------|--------|--------|
-| Finding 1 (Extra2) | `extractCustomerEmail()` helper (`lib/payments/netcash-webhook-email.ts`) wired into `route.ts:356`; 9 unit tests incl. Extra2 regression | ✅ **Done** (type-check clean, tests pass) |
-| Finding 2 (signature) | Design hardening (txn+amount validation) — **needs decision**, not a flip | ⏸ Recommended, deferred (awaiting sign-off) |
+| Finding 1 (Extra2) | `extractCustomerEmail()` helper (`lib/payments/netcash-webhook-email.ts`) wired into route; 9 unit tests incl. Extra2 regression | ✅ **Done** (type-check clean, tests pass) |
+| Finding 2 (signature/auth) | Fail-safe **authorization gate** on the **invoice** mutation: `decideWebhookAction()` (`lib/payments/netcash-webhook-auth.ts`, 7 unit tests) requires amount-sanity vs the invoice before marking paid; mismatches → `manual_review`, no mutation, HTTP 200 | ✅ **Done** (invoice path; branch `feature/netcash-webhook-auth-hardening`) |
 | Finding 3 (dead route) | Deprecate/remove singular stack | Recommended |
 | Finding 4 (R899 linkage) | Data backfill 6.1 applied — txn `d778c220…` → `96cbba3b` / shaunr07@gmail.com | ✅ **Done** |
 | Finding 1 cleanup | 6.2 applied — 2 corrupted URL emails repaired; 0 URL-emails remain | ✅ **Done** |
 | Finding 5 (null tokens) | Re-tokenization + insert-guard (only mark `active` when token present) | Recommended |
+| Finding 7 (dead order branch) | Fix routing regex + derive order total from `package_price`+fees, then gate — **separate scoped work** (see §8) | Recommended (own branch) |
 | Ashwyn | No action (not revenue — card tokenized OK, orders correctly pending) | Closed |
+
+> **Verification of Finding 2 fix:** the decision logic has 7 isolated unit tests (`netcash-webhook-auth.test.ts`) and the wiring is type-checked + peer-reviewed (gate provably precedes the `customer_invoices` update). A live webhook replay was **deliberately not run** because the webhook uses the service-role client against the production database — replaying would mutate real rows and pollute `payment_webhook_logs`. Confidence rests on unit tests + static review, not a prod-mutating replay.
+>
+> **Pre-existing test debt (not introduced here):** `__tests__/lib/payments/payment-processor.test.ts` and `netcash-provider.test.ts` fail on `main` (broken Supabase mocks — `Cannot read properties of undefined (reading 'from')`). Out of scope; flagged for separate cleanup.
+
+---
+
+## 8. Finding 7 — Order Webhook Branch Is Dead for Real References
+
+The order-payment branch in `app/api/payments/netcash/webhook/route.ts` is gated on
+`else if (reference && /^CT-\d{8}-/i.test(reference))`. Real order references arrive as
+`CT-PAY-ORD-20260529-1561-<ts>` — after `CT-` comes `PAY`, **not 8 digits**, so the regex never
+matches. Consequently `updateOrderFromPayment()` is **never called for real order payments**; they
+fall through to the "No invoice or order matched — manual review" warning. This is consistent with the
+DB: orders `ORD-20260529-1561`, `ORD-20260519-3375`, `ORD-20260508-5728/2875` all remain
+`payment_status='pending'`, `total_paid=0`.
+
+**Security note:** this is a *functional* bug, **not** a security hole — a forged webhook cannot mutate
+an order via a branch that never executes for order-shaped references. The Finding 2 authorization gate
+was therefore scoped to the **invoice** branch (the only live money-mutation path).
+
+**Recommended separate fix (own branch, with tests):**
+1. Correct the order-branch condition to match `CT-PAY-ORD-*` (or route by `normalizeNetcashReference()`
+   resolving to a `consumer_orders.payment_reference`).
+2. Derive the order's owed amount from `package_price + installation_fee + router_fee + prorata_amount`
+   (there is **no** single `total_amount` column on `consumer_orders`).
+3. Apply the same `decideWebhookAction()` gate before mutating the order.

--- a/docs/audits/2026-06-02-netcash-payment-reconciliation.md
+++ b/docs/audits/2026-06-02-netcash-payment-reconciliation.md
@@ -1,0 +1,191 @@
+# NetCash Pay Now — Payment Reconciliation & Webhook Audit
+
+**Date:** 2026-06-02
+**Author:** Claude Code
+**Scope:** Reconcile 3 customer auth records + 7 NetCash payment transactions (supplied by user) against the live Supabase database (`agyjovdugmtopasyvlng`), identify payment-integrity defects, and define a remediation + data-cleanup plan.
+**Status:** Findings confirmed against live DB. Code fixes and data cleanup tracked in follow-up sections.
+
+---
+
+## 1. Executive Summary
+
+| # | Finding | Severity | State |
+|---|---------|----------|-------|
+| 1 | Webhook writes the **NetCash notify URL into `customer_email`** (reads `Extra2`, which holds a URL) | **P0** | 2 rows corrupted in prod |
+| 2 | Webhook **signature is never verified** for NetCash Pay Now (header-gated dead path) — unauthenticated POSTs can mark payments succeeded | **P0** | All 16 webhooks `signature_verified=false`, processed anyway |
+| 3 | **Two parallel NetCash implementations**; the singular route + its validator are dead code (0 webhooks ever) | **P1** | Confirmed |
+| 4 | R899 order payment (real revenue) has **null `customer_id`/`customer_email`** on the transaction despite being invoice-linked | **P2** | 1 row |
+| 5 | 3 payment methods marked `token_status=active` + `is_primary` with **null `card_token`** — uncharffeable | **P1** | 3 rows |
+| 6 | Ashwyn's two 08-May order payments never produced a webhook | **Investigated** | Not revenue — see §5 |
+
+**Bottom line on money:** Of the 7 supplied transactions, **only one is real revenue** — the R899 Ozow payment (`CT-20260505-95ppe6nm`) for invoice **INV-2026-00008**, which is correctly recorded as fully `paid`. The remaining six are R1 card-authorization / payment-method-validation charges, not package revenue. **No revenue has been lost.**
+
+---
+
+## 2. Data Sources
+
+- `payment_transactions` — internal transaction ledger
+- `payment_webhook_logs` — **live** webhook sink (16 rows; latest 2026-05-29 15:09)
+- `payment_webhooks` — **0 rows, ever** (sink for the dead singular route)
+- `consumer_orders`, `customer_invoices`, `customer_payment_methods`
+- Code: `app/api/payments/netcash/webhook/route.ts` (live), `app/api/payment/netcash/webhook/route.ts` (dead), `lib/payment/netcash-webhook-validator.ts` (dead), `app/api/payment/netcash/initiate/route.ts`
+
+### Which route is live? (empirical)
+
+```
+payment_webhook_logs : 16 rows  (latest 2026-05-29)   <- LIVE  (plural /api/payments/…)
+payment_webhooks      : 0 rows                          <- DEAD  (singular /api/payment/…)
+```
+
+NetCash Pay Now posts notifications to the **account-level notify URL**, which resolves to the **plural** route. All findings and fixes below target the plural route. The singular route, `lib/payment/netcash-webhook-validator.ts`, and `lib/payment/netcash-webhook-processor.ts` have never executed in production.
+
+---
+
+## 3. Transaction Reconciliation (the 7 supplied records)
+
+| # | Date | Ref | Amount | Type | DB status | Linked to | Notes |
+|---|------|-----|--------|------|-----------|-----------|-------|
+| 1 | 2026-05-06 | `CT-20260505-95ppe6nm` | R899 | Invoice payment | `completed` | INV-2026-00008 (`paid`) | **Real revenue.** `customer_id`/`email` null on txn → backfill (§6) |
+| 2 | 2026-05-08 | `PAY-ORD-20260508-5728` | R1 | Card auth (order) | order `pending` | Ashwyn / order ORD-…-5728 | No webhook. Card tokenized OK (method `ddff8c36`). Not revenue |
+| 3 | 2026-05-08 | `PAY-ORD-20260508-2875` | R1 | Card auth (order) | order `pending` | Ashwyn / order ORD-…-2875 | No webhook. Not revenue |
+| 4 | 2026-05-11 | `CT-PM-VAL-914e4946-…` | R1 | PM validation | `completed` | jeffrey.de.wee | Method stored but `card_token` null (§Finding 5) |
+| 5 | 2026-05-19 | `CT-PAY-ORD-20260519-3375-…` | R1 | Card auth (order) | `completed` | ORD-…-3375 (tkmultimedia) | **`customer_email` = notify URL** (corrupt). order still `pending` |
+| 6 | 2026-05-29 | `CT-PM-VAL-412b8047-…` | R1 | PM validation | `completed` | raycdfg (Raymund) | Method stored but `card_token` null |
+| 7 | 2026-05-29 | `CT-PAY-ORD-20260529-1561-…` | R1 | Card auth (order, declined) | `failed` | ORD-…-1561 (raycdfg) | **`customer_email` = notify URL** (corrupt) |
+
+---
+
+## 4. Findings (detail)
+
+### Finding 1 — `Extra2` (notify URL) written into `customer_email` — P0
+
+**Location:** `app/api/payments/netcash/webhook/route.ts:356`
+
+```ts
+customer_email: bodyParsed.Extra2 || null, // NetCash Extra2 for email  <-- WRONG
+```
+
+`Extra2` does **not** carry the customer email. For order-payment flows it carries the notify URL
+(`https://www.circletel.co.za/api/payment/netcash/we…`, truncated to the column width). The real
+customer email arrives in `Email` / `CustomerEmail`, which NetCash frequently omits on the notify.
+
+This INSERT branch (line 346–362) only runs as a **fallback** when the webhook can't match an
+existing transaction. PM-VAL transactions are pre-created and matched (UPDATE path), so they keep
+correct emails — **only order payments corrupt**, because the order flow does not pre-create a
+`payment_transactions` row.
+
+**Live impact:** 2 rows corrupted —
+`2bdb1f17-603c-4c29-8b52-90fea595572b` (ORD-3375) and `fc21435a-6c7a-44a4-9444-30b8f15c97b9` (ORD-1561).
+
+**Fix:** map `customer_email` from `Email`/`CustomerEmail`, reject non-email values, never `Extra2`. (§ remediation)
+
+### Finding 2 — Signature never verified for NetCash Pay Now — P0
+
+**Location:** `app/api/payments/netcash/webhook/route.ts:134-172`
+
+```ts
+if (webhookSecret && signature) {        // signature only present if x-netcash-signature header exists
+  signatureVerified = verifyWebhookSignature(...)
+  if (!signatureVerified) return 401
+} else {
+  // No signature verification (webhook secret not configured)  <-- ALWAYS taken
+}
+```
+
+NetCash Pay Now notifications **do not include an HMAC signature header**, so `signature` is always
+empty and the verification branch never runs. Every one of the 16 stored webhooks has
+`signature_verified=false`, yet all were processed and several marked invoices/transactions as
+completed. An unauthenticated party who knows the endpoint and a plausible reference could POST
+`TransactionAccepted=true` and mark an invoice paid.
+
+> ⚠️ **Do not "just turn on" verification.** Because NetCash Pay Now does not sign Pay Now webhooks,
+> enabling hard signature rejection would reject **all** live webhooks and break payments. The correct
+> hardening is **transaction-existence + amount validation** (only act on a webhook whose reference
+> matches a transaction *we* initiated, and whose amount matches), plus retaining the IP allowlist as
+> defense-in-depth. This is a design change, tracked separately — not a one-line flip.
+
+### Finding 3 — Duplicate dead NetCash route — P1
+
+`app/api/payment/netcash/initiate/route.ts:96` registers the **singular** notify URL, but production
+webhooks land in the **plural** route's table (`payment_webhook_logs`). The singular route
+(`payment_webhooks`, 0 rows), `netcash-webhook-validator.ts`, and `netcash-webhook-processor.ts` are
+dead. The singular route also hardcodes `signatureValid=true` (`route.ts:412`) — inert but misleading.
+**Recommendation:** consolidate on the plural route; delete or clearly deprecate the singular stack.
+
+### Finding 4 — Real-revenue transaction missing customer linkage — P2
+
+`payment_transactions` row `d778c220-8d38-4d5e-baae-950cb247ded7` (R899, `CT-20260505-95ppe6nm`) has
+`customer_id=null`, `customer_email=null`, but `invoice_id=3a9a0644…` → INV-2026-00008 (customer
+`96cbba3b`, Shaun Robertson). Backfillable from the invoice. (§6)
+
+### Finding 5 — Tokenized methods with null token — P1
+
+Three `customer_payment_methods` rows are `token_status='active'`, `is_active=true`, `is_primary=true`
+but have `card_token=null` / `card_masked_number=null` / `last_four='****'`:
+
+| id | customer | verified |
+|----|----------|----------|
+| `0f1d1466…` | 412b8047 (raycdfg) | 2026-05-29 |
+| `f32d111b…` | 914e4946 (jeffrey.de.wee) | 2026-05-11 |
+| `ddd040a4…` | 7914e319 (pheello) | 2026-04-06 |
+
+The PM-validation branch (`route.ts:411-432`) inserts the method as `active` even when NetCash returns
+no `CardToken`/`MaskedPan`. These methods **cannot be charged**. (Ashwyn's `ddff8c36` is the only one
+with a real token — proof the data path *can* work.) **Not auto-fixable** (no source of truth for the
+missing tokens); requires re-tokenization. Recommend: only mark `active` when a token is actually
+present; otherwise `pending`.
+
+---
+
+## 5. Ashwyn "Dropped Payments" — Reconciliation Outcome
+
+The two 08-May R1 charges (`ORD-20260508-5728`, `-2875`) produced **no webhook** in either table and no
+`payment_transactions` row. However, Ashwyn's card was **successfully tokenized** on 2026-05-08
+(`customer_payment_methods.ddff8c36`, token `408137452`, masked `4483 XXXX XXXX 9809`).
+
+**Conclusion:** these were **card-authorization / tokenization** charges during checkout, not package
+payments. The tokenization succeeded via the return/redirect path; the corresponding notify either was
+not sent by NetCash for an R1 auth, or was not retried. **No package revenue was due or lost** — both
+orders are *correctly* `pending` for their actual package amount. No order-status change is warranted.
+Action: none beyond linking the existing token to the order if desired (out of scope for cleanup).
+
+---
+
+## 6. Data Cleanup Plan (Phase 3)
+
+All statements are scoped by primary key. **Run after review.**
+
+```sql
+-- 6.1 Backfill real-revenue R899 transaction from its invoice's customer
+UPDATE payment_transactions pt
+SET customer_id = ci.customer_id,
+    customer_email = c.email
+FROM customer_invoices ci
+JOIN customers c ON c.id = ci.customer_id
+WHERE pt.id = 'd778c220-8d38-4d5e-baae-950cb247ded7'
+  AND ci.id = '3a9a0644-d491-44fc-ba38-c9407ceff2e2';
+
+-- 6.2 Repair the 2 corrupted customer_email values (URL -> correct order email)
+UPDATE payment_transactions SET customer_email = 'info.tkmultimedia@gmail.com'
+WHERE id = '2bdb1f17-603c-4c29-8b52-90fea595572b' AND customer_email LIKE 'http%';
+
+UPDATE payment_transactions SET customer_email = 'raycdfg@gmail.com'
+WHERE id = 'fc21435a-6c7a-44a4-9444-30b8f15c97b9' AND customer_email LIKE 'http%';
+```
+
+> Order→customer backfill for the order-payment transactions is intentionally **excluded**: those
+> orders themselves have `customer_id=null` (guest checkouts), so there is no customer to link.
+
+---
+
+## 7. Remediation Status
+
+| Item | Action | Status |
+|------|--------|--------|
+| Finding 1 (Extra2) | `extractCustomerEmail()` helper (`lib/payments/netcash-webhook-email.ts`) wired into `route.ts:356`; 9 unit tests incl. Extra2 regression | ✅ **Done** (type-check clean, tests pass) |
+| Finding 2 (signature) | Design hardening (txn+amount validation) — **needs decision**, not a flip | ⏸ Recommended, deferred (awaiting sign-off) |
+| Finding 3 (dead route) | Deprecate/remove singular stack | Recommended |
+| Finding 4 (R899 linkage) | Data backfill 6.1 applied — txn `d778c220…` → `96cbba3b` / shaunr07@gmail.com | ✅ **Done** |
+| Finding 1 cleanup | 6.2 applied — 2 corrupted URL emails repaired; 0 URL-emails remain | ✅ **Done** |
+| Finding 5 (null tokens) | Re-tokenization + insert-guard (only mark `active` when token present) | Recommended |
+| Ashwyn | No action (not revenue — card tokenized OK, orders correctly pending) | Closed |

--- a/docs/superpowers/plans/2026-06-02-billing-cron-remediation.md
+++ b/docs/superpowers/plans/2026-06-02-billing-cron-remediation.md
@@ -1,0 +1,190 @@
+# Billing Cron Remediation — Runbook / Implementation Plan
+
+> **For operators:** This is an ops + data runbook with hard decision gates. Steps use checkbox
+> (`- [ ]`) syntax. Several steps create real invoices and notify real customers — do NOT skip the
+> dry-run gates. Source of evidence: `docs/audits/2026-06-02-netcash-payment-reconciliation.md` §9.
+
+**Goal:** Restore recurring invoice generation so active customers (19 Unjani sites + 2 consumers) are
+billed monthly, and reconcile the immediate June gap — without double-billing or notifying test accounts.
+
+**Confirmed root cause:** The invoice-generation crons have **never executed** in production
+(`billing_cron_logs` empty; `cron_execution_log` shows only `payment-reconciliation` + `stats-snapshot`).
+The Coolify scheduler itself is healthy (those two ran today) — the billing crons were simply never added
+to it. Schedules live only in `vercel.json`, which is dead post-Coolify-migration (2026-04-05).
+
+**Key facts:**
+- Coolify cron IS alive: `payment-reconciliation` (94 runs, last 2026-06-02 07:00), `stats-snapshot` (227 runs, last 2026-06-02 03:01).
+- 28 active `customer_services`, all `billing_day=1`, all `last_invoice_date=NULL`. Breakdown: 19 Unjani (R450), 2 consumers (Prins R999, Shaun R899), **6 R0 test accounts**.
+- Three overlapping invoice generators exist (must enable exactly ONE):
+  | Endpoint | Schedule (vercel.json) | Engine | Dedup | dryRun | Audit table |
+  |----------|------------------------|--------|-------|--------|-------------|
+  | `/api/cron/generate-monthly-invoices` | `0 4 1 * *` | `MonthlyInvoiceGenerator` | `last_invoice_date` | ✅ | `billing_cron_logs` |
+  | `/api/cron/generate-invoices-25th` | `0 4 25 * *` | window `[1..5]`, fires Inngest PayNow notif | (verify) | ✅ | `cron_execution_log` |
+  | `/api/cron/generate-invoices` | `0 0 * * *` (daily) | older Task 2.4 | (verify) | (verify) | `cron_execution_log` |
+
+---
+
+## DECISION GATE 0 — Choose the authoritative generator (operator/business decision)
+
+Exactly one invoice generator may be scheduled, or customers get double/triple-billed.
+
+- **Recommendation:** Use `generate-monthly-invoices` (bills on the 1st, `billing_day`-matched) as the
+  authoritative engine for the **catch-up** and ongoing recurring billing. Rationale: it has the safest
+  `dryRun` (returns before any write — verified at `monthly-invoice-generator.ts:332`), idempotent dedup
+  via `last_invoice_date` (prevents re-billing within a month), and a dedicated audit table.
+- **Alternative (business model "generate 25th / due 1st", per PR #493):** Use `generate-invoices-25th`.
+  If chosen, read that route fully and confirm its dedup before enabling — it fires customer PayNow
+  notifications on every run.
+- **Required action:** Pick ONE. The rest of this plan assumes `generate-monthly-invoices`. If you pick
+  the 25th engine, swap the endpoint in Phases 3–5 accordingly.
+
+- [ ] **Decision recorded:** authoritative generator = `__________________`
+
+---
+
+## Phase 1 — Deactivate the 6 test/system services (do FIRST)
+
+Prevents R0 noise invoices + emails to test addresses on the catch-up run.
+
+**Service IDs (verified 2026-06-02):**
+`ffd59805-ed3b-4470-b73a-1a957a004ef8` (CTF-02630942), `08509cb3-b9cf-4c2c-85ae-4fc89a6476a5` (CTF-02633590/echo),
+`39c268ca-1789-471f-880e-b83cc1a1c7c0` (CTF-03314099), `687694d5-5f9f-42ca-9735-2c0667ddd075` (CTF-35B741C8),
+`506f87c9-f88a-4daa-bc83-bbc73322de7c` (CTF-AMOEBA-001), `6786c68b-af29-4026-8e7c-e6248a976f7a` (CTF-TEST-001).
+
+- [ ] **Step 1 — Preview (read-only):**
+
+```sql
+SELECT id, customer_id, monthly_price, status FROM customer_services
+WHERE id IN ('ffd59805-ed3b-4470-b73a-1a957a004ef8','08509cb3-b9cf-4c2c-85ae-4fc89a6476a5',
+             '39c268ca-1789-471f-880e-b83cc1a1c7c0','687694d5-5f9f-42ca-9735-2c0667ddd075',
+             '506f87c9-f88a-4daa-bc83-bbc73322de7c','6786c68b-af29-4026-8e7c-e6248a976f7a');
+```
+Expected: 6 rows, all `monthly_price=0`, `status='active'`.
+
+- [ ] **Step 2 — Deactivate (mutating):**
+
+```sql
+UPDATE customer_services SET status = 'inactive', updated_at = now()
+WHERE id IN ('ffd59805-ed3b-4470-b73a-1a957a004ef8','08509cb3-b9cf-4c2c-85ae-4fc89a6476a5',
+             '39c268ca-1789-471f-880e-b83cc1a1c7c0','687694d5-5f9f-42ca-9735-2c0667ddd075',
+             '506f87c9-f88a-4daa-bc83-bbc73322de7c','6786c68b-af29-4026-8e7c-e6248a976f7a')
+  AND monthly_price = 0
+RETURNING id, status;
+```
+Expected: 6 rows returned, `status='inactive'`.
+
+- [ ] **Step 3 — Verify the billable set is now 22:**
+
+```sql
+SELECT count(*) AS active_billable, count(*) FILTER (WHERE monthly_price>0) AS paid
+FROM customer_services WHERE status='active' AND billing_day=1;
+```
+Expected: 22 active, 21 paid (19 Unjani + Prins + Shaun). (One R0 may remain if not in the CTF set — investigate any R0 still active before proceeding.)
+
+---
+
+## Phase 2 — Dry-run preview of the catch-up run (no writes)
+
+Confirms exactly who would be billed before any invoice is created. `dryRun` returns before all writes
+(`monthly-invoice-generator.ts:332`). Run this yourself so `CRON_SECRET` stays in your shell:
+
+- [ ] **Step 1 — Dry run against production (type with the `!` prefix in chat, or run in your terminal):**
+
+```bash
+! set -a; source /home/circletel/.env.local; set +a; \
+curl -s -X POST https://www.circletel.co.za/api/cron/generate-monthly-invoices \
+  -H "Authorization: Bearer $CRON_SECRET" -H "content-type: application/json" \
+  -d '{"dryRun":true,"billingDay":1}' | jq '{totalServices,servicesProcessed,invoicesCreated,failed,skipped,dryRun}'
+```
+Expected: `dryRun:true`, `totalServices` ≈ 21, `invoicesCreated` (preview count) ≈ 21, `failed:0`.
+
+- [ ] **Step 2 — GATE:** If `failed > 0` or `totalServices` is unexpected, STOP and investigate the
+  `results[]` array (full response without the `jq` filter). Do not proceed to Phase 3.
+
+---
+
+## Phase 3 — Catch-up run for June (creates real invoices + notifications) — GATED
+
+> ⚠️ This creates ~21 real invoices, syncs them to ZOHO, and sends Pay Now notifications to 19 clinics +
+> 2 customers. Requires explicit operator go-ahead AFTER Phase 2 looks correct.
+
+- [ ] **Step 1 — Real run:**
+
+```bash
+! set -a; source /home/circletel/.env.local; set +a; \
+curl -s -X POST https://www.circletel.co.za/api/cron/generate-monthly-invoices \
+  -H "Authorization: Bearer $CRON_SECRET" -H "content-type: application/json" \
+  -d '{"billingDay":1}' | jq '{runId,totalServices,invoicesCreated,failed,skipped}'
+```
+Expected: `invoicesCreated` ≈ 21, `failed:0`.
+
+- [ ] **Step 2 — Verify invoices + audit row:**
+
+```sql
+SELECT count(*) AS new_invoices FROM customer_invoices WHERE created_at::date = current_date;
+SELECT created_at, services_processed, invoices_created, dry_run FROM billing_cron_logs ORDER BY created_at DESC LIMIT 1;
+SELECT count(*) AS still_null FROM customer_services WHERE status='active' AND billing_day=1 AND last_invoice_date IS NULL;
+```
+Expected: ~21 new invoices; one fresh `billing_cron_logs` row (`dry_run=false`); `still_null = 0`.
+
+- [ ] **Step 3 — Re-run idempotency check:** repeat Step 1. Expected: `invoicesCreated:0`, all `skipped`
+  ("Already billed this month"). Confirms no double-billing.
+
+---
+
+## Phase 4 — Restore recurring scheduling on Coolify (operator, infra)
+
+The endpoint works; it just needs to be on the Coolify schedule like `payment-reconciliation` is.
+
+- [ ] **Step 1 — Inspect the working reference task:** In Coolify, open the existing scheduled task for
+  `payment-reconciliation` (it ran 2026-06-02 07:00). Note its exact command form (curl to the app +
+  `Authorization: Bearer` header) and container.
+
+- [ ] **Step 2 — Create the billing scheduled task**, mirroring that pattern:
+  - **Command:** `curl -s -X POST http://localhost:3000/api/cron/generate-monthly-invoices -H "Authorization: Bearer $CRON_SECRET" -H "content-type: application/json" -d '{}'`
+    (use the same internal URL the reference task uses; `$CRON_SECRET` from the app env).
+  - **Schedule:** `0 4 1 * *` (04:00 UTC = 06:00 SAST on the 1st), matching `vercel.json`.
+  - On the 1st, an empty body makes `billingDay` default to today (= 1), matching all `billing_day=1` services.
+
+- [ ] **Step 3 — Smoke test the task:** trigger it manually from Coolify once (it is idempotent — same
+  month → all skipped). Confirm a new `billing_cron_logs` row appears with `dry_run=false`, `invoices_created=0`.
+
+---
+
+## Phase 5 — Retire the redundant generators (prevent double-billing)
+
+- [ ] **Step 1 — Ensure ONLY the chosen generator is scheduled on Coolify.** Do NOT create Coolify tasks
+  for `generate-invoices` or `generate-invoices-25th` (unless one of them was chosen in Gate 0, in which
+  case it is the only one scheduled).
+
+- [ ] **Step 2 — Mark the dead schedules in `vercel.json`** with a comment/PR note that they are
+  superseded (vercel.json is inert post-migration, but it misleads readers). Modify
+  `vercel.json` to remove or annotate the two non-authoritative invoice-generation cron entries. Commit:
+
+```bash
+git add vercel.json
+git commit -m "chore(billing): mark non-authoritative invoice crons as superseded (Coolify uses one generator)"
+```
+
+- [ ] **Step 3 — Document the decision** in `docs/audits/2026-06-02-netcash-payment-reconciliation.md`
+  §9 (which generator is authoritative and why).
+
+---
+
+## Phase 6 — Final verification
+
+- [ ] All 21 billable services have `last_invoice_date = current month`.
+- [ ] `billing_cron_logs` has a real (non-dry) run row dated today.
+- [ ] Exactly ONE invoice-generation Coolify task exists.
+- [ ] Re-running the generator the same month creates 0 invoices (idempotent).
+- [ ] (Next cycle) On the next scheduled date, a new `billing_cron_logs` row appears automatically.
+
+---
+
+## Out of scope (track separately)
+
+- **Finding 7** (order-webhook dead branch) and the **order→`customer_services` bridge** — new consumer
+  orders still won't auto-create billable services. Separate branch.
+- **Transaction↔invoice link gap** (9 orphan `payment_transactions`) — ledger hygiene; separate task.
+- **35 stuck `pending` transactions** — PM-VAL validations never confirmed; separate cleanup.
+- The `feature/netcash-webhook-auth-hardening` branch (P0 webhook fixes) — still pending PR/merge.

--- a/docs/superpowers/plans/2026-06-02-billing-cron-remediation.md
+++ b/docs/superpowers/plans/2026-06-02-billing-cron-remediation.md
@@ -67,15 +67,18 @@ Expected: 6 rows, all `monthly_price=0`, `status='active'`.
 
 - [ ] **Step 2 — Deactivate (mutating):**
 
+> ⚠️ `customer_services.status` has a `valid_status` CHECK allowing only
+> `pending / active / suspended / cancelled`. Use **`cancelled`** — `inactive` would violate it.
+
 ```sql
-UPDATE customer_services SET status = 'inactive', updated_at = now()
+UPDATE customer_services SET status = 'cancelled', updated_at = now()
 WHERE id IN ('ffd59805-ed3b-4470-b73a-1a957a004ef8','08509cb3-b9cf-4c2c-85ae-4fc89a6476a5',
              '39c268ca-1789-471f-880e-b83cc1a1c7c0','687694d5-5f9f-42ca-9735-2c0667ddd075',
              '506f87c9-f88a-4daa-bc83-bbc73322de7c','6786c68b-af29-4026-8e7c-e6248a976f7a')
   AND monthly_price = 0
 RETURNING id, status;
 ```
-Expected: 6 rows returned, `status='inactive'`.
+Expected: 6 rows returned, `status='cancelled'`.
 
 - [ ] **Step 3 — Verify the billable set is now 22:**
 
@@ -88,6 +91,13 @@ Expected: 22 active, 21 paid (19 Unjani + Prins + Shaun). (One R0 may remain if 
 ---
 
 ## Phase 2 — Dry-run preview of the catch-up run (no writes)
+
+> ⚠️ PREREQUISITE — **deploy the engine fix first.** The `dryRun`/catch-up curls hit
+> **production**, which runs the **deployed** code. The currently-deployed `MonthlyInvoiceGenerator`
+> has two bugs (branch `fix/billing-invoice-generator`, commit `33f136f3` fixes them): it over-bills
+> 15% (treats VAT-inclusive `monthly_price` as net) and inserts no `invoice_number` (NOT NULL, no
+> sequence → every insert fails). **Do NOT run Phase 2/3 against production until `fix/billing-invoice-generator`
+> is merged and deployed**, or the preview reflects the broken engine and a real run would fail/misbill.
 
 Confirms exactly who would be billed before any invoice is created. `dryRun` returns before all writes
 (`monthly-invoice-generator.ts:332`). Run this yourself so `CRON_SECRET` stays in your shell:
@@ -112,24 +122,38 @@ Expected: `dryRun:true`, `totalServices` ≈ 21, `invoicesCreated` (preview coun
 > ⚠️ This creates ~21 real invoices, syncs them to ZOHO, and sends Pay Now notifications to 19 clinics +
 > 2 customers. Requires explicit operator go-ahead AFTER Phase 2 looks correct.
 
-- [ ] **Step 1 — Real run:**
+- [ ] **Step 1 — Real run, but SILENT first (`skipPayNow:true`).** Create the invoices without
+  notifying customers, so we can verify amounts/numbers before any email/SMS goes out on this
+  first-ever real run:
 
 ```bash
 ! set -a; source /home/circletel/.env.local; set +a; \
 curl -s -X POST https://www.circletel.co.za/api/cron/generate-monthly-invoices \
   -H "Authorization: Bearer $CRON_SECRET" -H "content-type: application/json" \
-  -d '{"billingDay":1}' | jq '{runId,totalServices,invoicesCreated,failed,skipped}'
+  -d '{"billingDay":1,"skipPayNow":true}' | jq '{runId,totalServices,invoicesCreated,failed,skipped}'
 ```
 Expected: `invoicesCreated` ≈ 21, `failed:0`.
 
-- [ ] **Step 2 — Verify invoices + audit row:**
+- [ ] **Step 2 — Verify amounts, numbers + audit row (CRITICAL gate before notifying):**
 
 ```sql
-SELECT count(*) AS new_invoices FROM customer_invoices WHERE created_at::date = current_date;
+-- Amounts must be VAT-INCLUSIVE: total = price (450/899/999), not price*1.15
+SELECT invoice_number, total_amount, subtotal, tax_amount, status
+FROM customer_invoices WHERE created_at::date = current_date ORDER BY invoice_number;
+-- Expect: Unjani total 450 (391.30+58.70), Shaun 899 (781.74+117.26), Prins 999 (868.70+130.30)
+-- Numbers continue the sequence: INV-2026-00009, 00010, ...
 SELECT created_at, services_processed, invoices_created, dry_run FROM billing_cron_logs ORDER BY created_at DESC LIMIT 1;
 SELECT count(*) AS still_null FROM customer_services WHERE status='active' AND billing_day=1 AND last_invoice_date IS NULL;
 ```
-Expected: ~21 new invoices; one fresh `billing_cron_logs` row (`dry_run=false`); `still_null = 0`.
+Expected: ~21 new invoices with **correct VAT-inclusive totals**; fresh `billing_cron_logs` row
+(`dry_run=false`); `still_null = 0`. **If any total = price×1.15, STOP — the fix isn't deployed.**
+
+- [ ] **Step 2b — Send notifications** only after Step 2 is verified. ⚠️ Re-running the generator will
+  NOT notify these invoices — it `skip`s already-billed services, and the Pay Now send lives inside the
+  create branch. Notifications for already-created invoices must come from a separate path: the
+  `process-billing-day` cron (sends Pay Now links for invoices due today to non-eMandate customers) or a
+  per-invoice Pay Now send (`processPayNowForInvoice`). Verify that path picks up these invoices before
+  relying on it; confirm channel (email/SMS) with the operator.
 
 - [ ] **Step 3 — Re-run idempotency check:** repeat Step 1. Expected: `invoicesCreated:0`, all `skipped`
   ("Already billed this month"). Confirms no double-billing.

--- a/docs/superpowers/plans/2026-06-02-billing-cron-remediation.md
+++ b/docs/superpowers/plans/2026-06-02-billing-cron-remediation.md
@@ -24,21 +24,25 @@ to it. Schedules live only in `vercel.json`, which is dead post-Coolify-migratio
 
 ---
 
-## DECISION GATE 0 — Choose the authoritative generator (operator/business decision)
+## DECISION GATE 0 — Authoritative generator: **DECIDED ✅**
 
 Exactly one invoice generator may be scheduled, or customers get double/triple-billed.
 
-- **Recommendation:** Use `generate-monthly-invoices` (bills on the 1st, `billing_day`-matched) as the
-  authoritative engine for the **catch-up** and ongoing recurring billing. Rationale: it has the safest
-  `dryRun` (returns before any write — verified at `monthly-invoice-generator.ts:332`), idempotent dedup
-  via `last_invoice_date` (prevents re-billing within a month), and a dedicated audit table.
-- **Alternative (business model "generate 25th / due 1st", per PR #493):** Use `generate-invoices-25th`.
-  If chosen, read that route fully and confirm its dedup before enabling — it fires customer PayNow
-  notifications on every run.
-- **Required action:** Pick ONE. The rest of this plan assumes `generate-monthly-invoices`. If you pick
-  the 25th engine, swap the endpoint in Phases 3–5 accordingly.
+**DECISION (2026-06-02): `generate-monthly-invoices` is the single authoritative engine for BOTH the
+catch-up and ongoing recurring billing, scheduled `0 4 1 * *` (1st of month).**
 
-- [ ] **Decision recorded:** authoritative generator = `__________________`
+Rationale: one engine = least moving parts for a small team; safest `dryRun` (returns before any write,
+verified `monthly-invoice-generator.ts:332`); idempotent dedup via `last_invoice_date`; dedicated audit
+table (`billing_cron_logs`). **Accepted trade-off:** invoices generate on the 1st and are **due the same
+day** — customers get no advance-notice window (weaker for collections than the 25th→due-1st model).
+
+The other two engines are **retired** (see Phase 5):
+- `generate-invoices` (daily) — **broken**: queries `customer_services.next_billing_date`, a column that
+  does not exist → throws on every run. Delete or fix; never schedule.
+- `generate-invoices-25th` (25th) — viable alternative model (25th→due-1st) but NOT used here. Leave
+  unscheduled.
+
+- [x] **Decision recorded:** authoritative generator = **`generate-monthly-invoices` (1st, both catch-up + ongoing)**
 
 ---
 
@@ -153,17 +157,21 @@ The endpoint works; it just needs to be on the Coolify schedule like `payment-re
 
 ## Phase 5 — Retire the redundant generators (prevent double-billing)
 
-- [ ] **Step 1 — Ensure ONLY the chosen generator is scheduled on Coolify.** Do NOT create Coolify tasks
-  for `generate-invoices` or `generate-invoices-25th` (unless one of them was chosen in Gate 0, in which
-  case it is the only one scheduled).
+- [ ] **Step 1 — Ensure ONLY `generate-monthly-invoices` is scheduled on Coolify.** Do NOT create Coolify
+  tasks for `generate-invoices` or `generate-invoices-25th`.
 
-- [ ] **Step 2 — Mark the dead schedules in `vercel.json`** with a comment/PR note that they are
-  superseded (vercel.json is inert post-migration, but it misleads readers). Modify
-  `vercel.json` to remove or annotate the two non-authoritative invoice-generation cron entries. Commit:
+- [ ] **Step 2 — Fix or remove the broken `generate-invoices` job.** It queries the non-existent column
+  `customer_services.next_billing_date` (verified 2026-06-02 — `column does not exist`), so it errors on
+  every invocation. Either delete `app/api/cron/generate-invoices/route.ts` or correct its eligibility
+  query. At minimum it must never be scheduled.
+
+- [ ] **Step 3 — Remove/annotate the dead schedules in `vercel.json`** (inert post-migration, but
+  misleads readers). Keep only `generate-monthly-invoices`; remove or comment the
+  `generate-invoices` and `generate-invoices-25th` cron entries. Commit:
 
 ```bash
-git add vercel.json
-git commit -m "chore(billing): mark non-authoritative invoice crons as superseded (Coolify uses one generator)"
+git add vercel.json app/api/cron/generate-invoices/route.ts
+git commit -m "chore(billing): retire broken/duplicate invoice crons; generate-monthly-invoices is authoritative"
 ```
 
 - [ ] **Step 3 — Document the decision** in `docs/audits/2026-06-02-netcash-payment-reconciliation.md`

--- a/docs/superpowers/plans/2026-06-02-netcash-webhook-auth-hardening.md
+++ b/docs/superpowers/plans/2026-06-02-netcash-webhook-auth-hardening.md
@@ -10,6 +10,12 @@
 
 **Out of scope (documented separately in `docs/audits/2026-06-02-netcash-payment-reconciliation.md`):** Finding 3 (removing the dead singular route stack) and Finding 5 (null-token payment methods). Do not touch those here.
 
+> ## Execution outcome (2026-06-02) — branch `feature/netcash-webhook-auth-hardening`
+> - **Task 1 — DONE** (`437b444a`): pure decider `lib/payments/netcash-webhook-auth.ts` + 7 unit tests. Spec + quality reviewed ✅.
+> - **Task 2 — DONE** (`10184f48`): invoice-branch authorization gate. Type-check clean, spec + quality reviewed ✅. This secures the only **live** money-mutation path.
+> - **Task 3 — DESCOPED.** Investigation found both of this task's assumptions are false: the order branch regex `/^CT-\d{8}-/` never matches real `CT-PAY-ORD-*` refs (so `updateOrderFromPayment` is dead code — not a live attack surface), and `consumer_orders` has **no** `total_amount` column (owed must be derived from `package_price`+fees). Gating dead code adds no security value (YAGNI). The underlying functional bug is recorded as **Finding 7 / §8** in the audit and recommended as separate, properly-tested work.
+> - **Task 4 — ADAPTED.** Live prod-mutating replay deliberately skipped (the webhook uses the service-role client against the production DB). Verification = 7 decider unit tests + type-check + peer review confirming the gate precedes the invoice mutation.
+
 ---
 
 ## Background facts the implementer must know

--- a/docs/superpowers/plans/2026-06-02-netcash-webhook-auth-hardening.md
+++ b/docs/superpowers/plans/2026-06-02-netcash-webhook-auth-hardening.md
@@ -1,0 +1,360 @@
+# NetCash Webhook Authorization Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the live NetCash webhook from mutating financial state (marking invoices/orders paid) on unauthenticated, unverified, or amount-mismatched requests — without breaking any legitimate live payment flow.
+
+**Architecture:** NetCash Pay Now does **not** HMAC-sign its webhooks, so signature verification can never run and must not be made a hard gate (it would reject every real webhook). Instead we add a **fail-safe authorization gate**: before any money mutation, the webhook must (1) resolve its reference to an entity *we* created (a `customer_invoices` or `consumer_orders` row — both already exist at webhook time, proven empirically), and (2) pass an amount sanity check against that entity (positive, not exceeding what's owed). On failure, the webhook is recorded as `manual_review`, **no financial state is changed**, and we still return HTTP 200 so NetCash does not retry-storm. All decision logic lives in a pure, unit-tested module; the route only fetches data and calls the decider.
+
+**Tech Stack:** Next.js 15 route handler (`app/api/payments/netcash/webhook/route.ts`), Supabase service-role client, Jest + ts-jest.
+
+**Out of scope (documented separately in `docs/audits/2026-06-02-netcash-payment-reconciliation.md`):** Finding 3 (removing the dead singular route stack) and Finding 5 (null-token payment methods). Do not touch those here.
+
+---
+
+## Background facts the implementer must know
+
+- **Live route:** `app/api/payments/netcash/webhook/route.ts` (writes `payment_webhook_logs`). The singular `app/api/payment/netcash/webhook/route.ts` is **dead** (0 webhooks ever) — do not modify it.
+- **Reference formats:** NetCash sends e.g. `CT-PAY-ORD-20260529-1561-1780059893449` (order) or `CT-INV2026-00002-...` (invoice). Normalize with `normalizeNetcashReference()` from `lib/payment/netcash-webhook-validator.ts` → `PAY-ORD-20260529-1561`. This already matches `consumer_orders.payment_reference`.
+- **Existing matchers:** `matchInvoiceByReference(reference, supabase)` in `lib/billing/invoice-matcher.ts` returns `{ matched, invoice }`. The order branch calls `updateOrderFromPayment(reference, txId, amount)` in `lib/orders/payment-order-updater.ts`.
+- **The mutation branches to gate** (current line anchors — re-grep before editing, the file is under active change):
+  - Invoice: `matchInvoiceByReference(reference, supabase)` at ~line 473, invoice update at ~line 496.
+  - Order: `updateOrderFromPayment(reference, paymentTransaction.id, amount)` at ~line 557.
+  - `amount` is parsed at ~line 183: `const amount = parseFloat(String(bodyParsed.Amount || bodyParsed.amount || '0'));`
+- **Amounts are in Rands** in this route (e.g. `899.00`, `1.00`). Do not divide by 100 here (that bug belongs to the dead singular route).
+- The PM-VAL branch (`txMetadata.type === 'payment_method_validation'`, ~line 382) is a fixed R1 charge and returns early; **leave it unchanged** — it is not a financial-ledger mutation and is already matched by pre-created transaction.
+
+---
+
+## File Structure
+
+- **Create** `lib/payments/netcash-webhook-auth.ts` — pure decision helpers (no DB, no I/O). One responsibility: decide authorize vs manual_review from already-fetched facts.
+- **Create** `__tests__/lib/payments/netcash-webhook-auth.test.ts` — unit tests for the pure helpers.
+- **Modify** `app/api/payments/netcash/webhook/route.ts` — fetch expected amounts and wrap the invoice and order mutation branches in the gate.
+
+---
+
+## Task 1: Pure authorization-decision module
+
+**Files:**
+- Create: `lib/payments/netcash-webhook-auth.ts`
+- Test: `__tests__/lib/payments/netcash-webhook-auth.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/lib/payments/netcash-webhook-auth.test.ts
+import { amountIsSane, decideWebhookAction } from '@/lib/payments/netcash-webhook-auth';
+
+describe('amountIsSane', () => {
+  it('accepts a positive amount not exceeding what is owed', () => {
+    expect(amountIsSane(899, 899)).toBe(true);   // exact
+    expect(amountIsSane(1, 899)).toBe(true);      // valid partial / R1 auth
+  });
+  it('rejects zero, negative, NaN', () => {
+    expect(amountIsSane(0, 899)).toBe(false);
+    expect(amountIsSane(-5, 899)).toBe(false);
+    expect(amountIsSane(Number.NaN, 899)).toBe(false);
+  });
+  it('rejects overpayment beyond a 1-cent tolerance', () => {
+    expect(amountIsSane(900, 899)).toBe(false);
+    expect(amountIsSane(899.005, 899)).toBe(true); // within 1c tolerance
+  });
+  it('rejects when owed amount is unknown', () => {
+    expect(amountIsSane(899, null)).toBe(false);
+  });
+});
+
+describe('decideWebhookAction', () => {
+  it('authorizes when entity matched and amount sane', () => {
+    expect(decideWebhookAction({ entityMatched: true, owedAmount: 899, receivedAmount: 899 }))
+      .toEqual({ action: 'authorize', reason: expect.any(String) });
+  });
+  it('routes to manual_review when no entity matched', () => {
+    expect(decideWebhookAction({ entityMatched: false, owedAmount: 899, receivedAmount: 899 }).action)
+      .toBe('manual_review');
+  });
+  it('routes to manual_review on amount mismatch', () => {
+    expect(decideWebhookAction({ entityMatched: true, owedAmount: 899, receivedAmount: 5000 }).action)
+      .toBe('manual_review');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/lib/payments/netcash-webhook-auth.test.ts`
+Expected: FAIL — `Cannot find module '@/lib/payments/netcash-webhook-auth'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// lib/payments/netcash-webhook-auth.ts
+/**
+ * Pure authorization-decision helpers for the NetCash Pay Now webhook.
+ *
+ * NetCash Pay Now does NOT sign its notify webhooks, so we cannot verify a
+ * signature. Instead we fail safe: only mutate financial state when the webhook
+ * resolves to an entity we created AND the amount is sane for that entity.
+ * No DB or I/O here so this stays unit-testable in isolation.
+ */
+
+const CENT = 0.01;
+
+/**
+ * An amount is "sane" for a target entity when it is a positive value that does
+ * not exceed what is owed (allowing a 1-cent rounding tolerance, and allowing
+ * partials / R1 card-authorisations which are < owed).
+ */
+export function amountIsSane(receivedAmount: number, owedAmount: number | null | undefined): boolean {
+  if (owedAmount == null || Number.isNaN(receivedAmount)) return false;
+  if (receivedAmount <= 0) return false;
+  return receivedAmount <= owedAmount + CENT;
+}
+
+export type WebhookAction = 'authorize' | 'manual_review';
+
+export interface DecideInput {
+  entityMatched: boolean;
+  owedAmount: number | null;
+  receivedAmount: number;
+}
+
+export function decideWebhookAction(input: DecideInput): { action: WebhookAction; reason: string } {
+  if (!input.entityMatched) {
+    return { action: 'manual_review', reason: 'reference did not resolve to a known invoice or order' };
+  }
+  if (!amountIsSane(input.receivedAmount, input.owedAmount)) {
+    return {
+      action: 'manual_review',
+      reason: `amount failed sanity check: received ${input.receivedAmount}, owed ${input.owedAmount}`,
+    };
+  }
+  return { action: 'authorize', reason: 'reference resolved and amount sane' };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest __tests__/lib/payments/netcash-webhook-auth.test.ts`
+Expected: PASS — all cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/payments/netcash-webhook-auth.ts __tests__/lib/payments/netcash-webhook-auth.test.ts
+git commit -m "feat(payments): add pure NetCash webhook authorization decider"
+```
+
+---
+
+## Task 2: Gate the invoice-payment mutation
+
+**Files:**
+- Modify: `app/api/payments/netcash/webhook/route.ts` (invoice branch, ~line 473–552)
+
+- [ ] **Step 1: Add the import**
+
+At the top of the file, alongside the existing `extractCustomerEmail` import:
+
+```ts
+import { decideWebhookAction } from '@/lib/payments/netcash-webhook-auth';
+```
+
+- [ ] **Step 2: Insert the gate immediately after the invoice is matched**
+
+Locate (re-grep): `const invoiceMatch = await matchInvoiceByReference(reference, supabase);` then the
+`if (invoiceMatch.matched && invoiceMatch.invoice) {` block. Immediately inside that `if`, before
+`const invoice = invoiceMatch.invoice;` is used to mutate, add:
+
+```ts
+          const invoice = invoiceMatch.invoice;
+
+          // AUTHORIZATION GATE: only mutate when amount is sane for this invoice.
+          const owed = Number(invoice.amount_due ?? invoice.total_amount ?? 0);
+          const decision = decideWebhookAction({
+            entityMatched: true,
+            owedAmount: owed,
+            receivedAmount: amount,
+          });
+          if (decision.action === 'manual_review') {
+            webhookLogger.warn('[Invoice Payment] Blocked — manual review required', {
+              reference, invoiceNumber: invoice.invoice_number, amount, owed, reason: decision.reason,
+            });
+            if (webhookLog) {
+              await supabase.from('payment_webhook_logs')
+                .update({ status: 'manual_review', success: false, error_message: decision.reason,
+                          processing_completed_at: new Date().toISOString() })
+                .eq('id', webhookLog.id);
+            }
+            return NextResponse.json(
+              { success: true, message: 'Webhook received; held for manual review', reference },
+              { status: 200 }
+            );
+          }
+```
+
+Remove the now-duplicate `const invoice = invoiceMatch.invoice;` line that previously followed the
+`if` (there must be exactly one declaration).
+
+- [ ] **Step 3: Type-check**
+
+Run: `node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc --noEmit 2>&1 | grep 'payments/netcash/webhook/route' || echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/api/payments/netcash/webhook/route.ts
+git commit -m "feat(payments): gate invoice webhook mutation on amount sanity"
+```
+
+---
+
+## Task 3: Gate the order-payment mutation
+
+**Files:**
+- Modify: `app/api/payments/netcash/webhook/route.ts` (order branch, ~line 553–569)
+
+- [ ] **Step 1: Add the order import**
+
+At the top of the file:
+
+```ts
+import { normalizeNetcashReference } from '@/lib/payment/netcash-webhook-validator';
+```
+
+- [ ] **Step 2: Replace the order branch body with a gated version**
+
+Locate (re-grep): the `else if (reference && /^CT-\d{8}-/i.test(reference)) {` branch **and** confirm
+whether order references actually match this regex. NOTE: order refs look like
+`CT-PAY-ORD-20260529-1561-...` — verify the branch condition that currently routes them (it may be a
+different `else if`). Wrap whichever branch calls `updateOrderFromPayment(...)` so that, before the
+call, the order is fetched and amount-checked:
+
+```ts
+          // AUTHORIZATION GATE for order payments.
+          const normalizedRef = normalizeNetcashReference(reference);
+          const { data: orderRow } = await supabase
+            .from('consumer_orders')
+            .select('id, order_number, total_amount, total_paid')
+            .eq('payment_reference', normalizedRef)
+            .single();
+
+          const owedOrder = orderRow ? Number(orderRow.total_amount ?? 0) : null;
+          const orderDecision = decideWebhookAction({
+            entityMatched: !!orderRow,
+            owedAmount: owedOrder,
+            receivedAmount: amount,
+          });
+          if (orderDecision.action === 'manual_review') {
+            webhookLogger.warn('[Order Payment] Blocked — manual review required', {
+              reference, normalizedRef, amount, owedOrder, reason: orderDecision.reason,
+            });
+            if (webhookLog) {
+              await supabase.from('payment_webhook_logs')
+                .update({ status: 'manual_review', success: false, error_message: orderDecision.reason,
+                          processing_completed_at: new Date().toISOString() })
+                .eq('id', webhookLog.id);
+            }
+            return NextResponse.json(
+              { success: true, message: 'Webhook received; held for manual review', reference },
+              { status: 200 }
+            );
+          }
+
+          webhookLogger.info('[Payment Processing] Updating order for reference', { reference });
+          updateOrderFromPayment(reference, paymentTransaction.id, amount)
+            .then((orderResult) => { /* keep existing .then/.catch body unchanged */ });
+```
+
+> Confirm `consumer_orders` has a `total_amount` column before relying on it; if the order total lives
+> in a different column (e.g. `total` or `monthly_total`), use that. Verify with:
+> `select column_name from information_schema.columns where table_name='consumer_orders' and column_name ilike '%total%';`
+
+- [ ] **Step 3: Type-check**
+
+Run: `node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc --noEmit 2>&1 | grep 'payments/netcash/webhook/route' || echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Run the full payments unit suite**
+
+Run: `npx jest __tests__/lib/payments`
+Expected: PASS (existing suites + the new auth + email suites).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/payments/netcash/webhook/route.ts
+git commit -m "feat(payments): gate order webhook mutation on order existence + amount sanity"
+```
+
+---
+
+## Task 4: Manual replay verification (real webhook payloads)
+
+**Goal:** prove the gate lets real webhooks through and blocks forged/mismatched ones. Uses actual
+historical payloads from `payment_webhook_logs.body`.
+
+- [ ] **Step 1: Capture a known-good payload**
+
+Run (Supabase SQL): get the raw body of the successful R899 invoice webhook —
+```sql
+SELECT body FROM payment_webhook_logs WHERE reference = 'CT-20260505-95ppe6nm' LIMIT 1;
+```
+Save it as `scratch/webhook-good.txt` (in `.claude/scratch/`, gitignored).
+
+- [ ] **Step 2: Start dev server**
+
+Run: `npm run dev:memory`
+
+- [ ] **Step 3: Replay the good payload**
+
+Run:
+```bash
+curl -s -X POST http://localhost:3000/api/payments/netcash/webhook \
+  -H 'content-type: application/x-www-form-urlencoded' \
+  --data @.claude/scratch/webhook-good.txt | jq .
+```
+Expected: `{"success": true, ... "status": "completed"}` — processed normally (the invoice is already
+paid; idempotency or a re-mark to paid is fine). Confirm logs show the gate emitted **authorize**.
+
+- [ ] **Step 4: Replay a forged-amount payload**
+
+Copy the good payload to `.claude/scratch/webhook-forged.txt`, change `Amount` to `5000.00` and
+`Reference`/`Extra1` to a real invoice reference. Replay:
+```bash
+curl -s -X POST http://localhost:3000/api/payments/netcash/webhook \
+  -H 'content-type: application/x-www-form-urlencoded' \
+  --data @.claude/scratch/webhook-forged.txt | jq .
+```
+Expected: `{"success": true, "message": "Webhook received; held for manual review", ...}` and the
+invoice is **NOT** further modified. Verify with:
+```sql
+SELECT status, amount_paid FROM customer_invoices WHERE invoice_number = '<that invoice>';
+SELECT status, error_message FROM payment_webhook_logs ORDER BY received_at DESC LIMIT 1;
+```
+Expected: invoice unchanged; latest webhook log `status = 'manual_review'`.
+
+- [ ] **Step 5: Document the result** in `docs/audits/2026-06-02-netcash-payment-reconciliation.md`
+(update Finding 2 status to Done) and commit.
+
+```bash
+git add docs/audits/2026-06-02-netcash-payment-reconciliation.md
+git commit -m "docs(payments): record webhook auth hardening verification"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Finding 2 (signature/auth) is addressed by Tasks 1–4. The "don't break live flow"
+  constraint is satisfied because (a) we never hard-reject on missing signature, (b) we resolve against
+  invoice/order rows that already exist at webhook time, (c) partial/R1 amounts pass `amountIsSane`.
+- **Edge case — order branch condition:** Task 3 Step 2 explicitly flags that order references may not
+  match the existing `^CT-\d{8}-` regex; the implementer must confirm the real routing branch before
+  wrapping it. This is the highest-risk step — verify against a real `CT-PAY-ORD-*` payload.
+- **No migration needed:** `payment_webhook_logs.status` is free-text; `'manual_review'` is a new value,
+  not a schema change.
+- **Idempotency preserved:** the gate runs after the existing duplicate-check, so replays still short-circuit.
+```

--- a/lib/payments/netcash-webhook-auth.ts
+++ b/lib/payments/netcash-webhook-auth.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure authorization-decision helpers for the NetCash Pay Now webhook.
+ *
+ * NetCash Pay Now does NOT sign its notify webhooks, so we cannot verify a
+ * signature. Instead we fail safe: only mutate financial state when the webhook
+ * resolves to an entity we created AND the amount is sane for that entity.
+ * No DB or I/O here so this stays unit-testable in isolation.
+ */
+
+const CENT = 0.01;
+
+/**
+ * An amount is "sane" for a target entity when it is a positive value that does
+ * not exceed what is owed (allowing a 1-cent rounding tolerance, and allowing
+ * partials / R1 card-authorisations which are < owed).
+ */
+export function amountIsSane(receivedAmount: number, owedAmount: number | null | undefined): boolean {
+  if (owedAmount == null || Number.isNaN(receivedAmount)) return false;
+  if (receivedAmount <= 0) return false;
+  return receivedAmount <= owedAmount + CENT;
+}
+
+export type WebhookAction = 'authorize' | 'manual_review';
+
+export interface DecideInput {
+  entityMatched: boolean;
+  owedAmount: number | null;
+  receivedAmount: number;
+}
+
+export function decideWebhookAction(input: DecideInput): { action: WebhookAction; reason: string } {
+  if (!input.entityMatched) {
+    return { action: 'manual_review', reason: 'reference did not resolve to a known invoice or order' };
+  }
+  if (!amountIsSane(input.receivedAmount, input.owedAmount)) {
+    return {
+      action: 'manual_review',
+      reason: `amount failed sanity check: received ${input.receivedAmount}, owed ${input.owedAmount}`,
+    };
+  }
+  return { action: 'authorize', reason: 'reference resolved and amount sane' };
+}

--- a/lib/payments/netcash-webhook-email.ts
+++ b/lib/payments/netcash-webhook-email.ts
@@ -1,0 +1,22 @@
+/**
+ * Helpers for extracting customer data from NetCash Pay Now webhook payloads.
+ *
+ * Kept as a small pure module so it can be unit-tested in isolation without
+ * pulling in the webhook route's server-only dependencies.
+ */
+
+/**
+ * Extract a customer email from a NetCash webhook payload.
+ *
+ * NetCash sends the email in `Email` / `CustomerEmail` (frequently omitted on Pay Now notifies).
+ * `Extra2` carries the notify/return URL, NOT the email — it must never be used here.
+ *
+ * @returns the email if it is a plausible address (contains "@", not a URL), otherwise null.
+ */
+export function extractCustomerEmail(payload: Record<string, unknown>): string | null {
+  const candidate = String(payload.Email ?? payload.CustomerEmail ?? '').trim();
+  if (candidate && candidate.includes('@') && !/^https?:\/\//i.test(candidate)) {
+    return candidate;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
Two P0 fixes to the **live** NetCash Pay Now webhook (\`app/api/payments/netcash/webhook/route.ts\`), plus the payment reconciliation audit and billing-cron diagnosis docs.

1. **\`Extra2\` → \`customer_email\` corruption** — the new-transaction fallback wrote \`bodyParsed.Extra2\` (the NetCash notify URL) into \`customer_email\`, corrupting order-payment rows. Now uses a pure, tested \`extractCustomerEmail()\` (Email/CustomerEmail only, rejects URLs).
2. **Unauthenticated invoice mutation** — NetCash Pay Now does not sign webhooks, so the signature check never ran and any POST could mark an invoice paid. Added a fail-safe **authorization gate** (\`decideWebhookAction\`): the invoice mutation only runs when the amount is sane for the matched invoice; mismatches → \`manual_review\`, no mutation, HTTP 200 (no retry storm).

Order-branch gating was intentionally descoped (it is dead code for real \`CT-PAY-ORD-*\` refs — documented as Finding 7).

New pure modules: \`lib/payments/netcash-webhook-email.ts\`, \`lib/payments/netcash-webhook-auth.ts\` (9 + 7 unit tests). Production data was already cleaned (2 corrupted emails repaired, R899 txn backfilled) — see audit doc §6.

## Test Plan
- [x] \`npx jest __tests__/lib/payments/netcash-webhook-email.test.ts __tests__/lib/payments/netcash-webhook-auth.test.ts\` — 16/16 pass (incl. Extra2 regression)
- [x] Type-check clean
- [x] Independent spec + code-quality review per task — approved
- [ ] Staging: replay a known-good webhook payload (processes) and a forged-amount payload (→ manual_review, no mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)