### PR TITLE
fix(activation): use verified Resend sender for activation welcome email

### DIFF
--- a/app/api/admin/orders/[orderId]/activate/route.ts
+++ b/app/api/admin/orders/[orderId]/activate/route.ts
@@ -583,7 +583,10 @@ async function sendActivationNotification(
       : '';
 
     await resend.emails.send({
-      from: 'CircleTel <service@circletel.co.za>',
+      // Use the verified Resend sender — circletel.co.za is NOT a verified domain, so
+      // hardcoding it silently fails every activation email (Resend rejects unverified domains).
+      from: `CircleTel <${process.env.RESEND_FROM_EMAIL || 'notifications@notify.circletel.co.za'}>`,
+      replyTo: process.env.RESEND_REPLY_TO_EMAIL || 'contactus@circletel.co.za',
       to: order.email,
       subject: `Your CircleTel Service is Now Active!`,
       html: `


### PR DESCRIPTION
## Summary
The order activation endpoint (\`app/api/admin/orders/[orderId]/activate/route.ts\`) hardcoded the welcome-email sender as \`service@circletel.co.za\` — a domain that is **not verified in Resend**. As a result, **every activation's welcome email silently fails in production** (\`The circletel.co.za domain is not verified\`).

Fix: use the verified \`RESEND_FROM_EMAIL\` (\`notifications@notify.circletel.co.za\`) like the rest of the notification system, plus a \`replyTo\`.

Found while activating a real customer (Ashwyn) — the welcome email failed with exactly this error until sent from the verified domain.

## Test Plan
- [ ] Activate an order (or trigger the welcome email) and confirm Resend accepts it (no "domain not verified" error)
- [x] Other system emails already use this verified sender successfully (Pay Now links, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)