### PR TITLE
fix(compliance,billing): customer document upload + admin review, VAT display fix

### DIFF
--- a/app/admin/compliance/documents/page.tsx
+++ b/app/admin/compliance/documents/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+/**
+ * Admin compliance document review queue.
+ * Cross-customer list of FICA/RICA documents uploaded via the self-service customer portal.
+ */
+
+import { CustomerComplianceDocuments } from '@/components/admin/compliance/CustomerComplianceDocuments';
+
+export default function ComplianceDocumentReviewPage() {
+  return (
+    <div className="min-h-screen bg-slate-50 p-6">
+      <div className="max-w-6xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Compliance Document Reviews</h1>
+          <p className="text-gray-600 mt-1">
+            FICA/RICA documents uploaded by customers through the self-service portal. Review, then
+            approve or reject.
+          </p>
+        </div>
+        <CustomerComplianceDocuments defaultStatus="pending" showCustomer title="Documents" />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/customers/[id]/page.tsx
+++ b/app/admin/customers/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { PiArrowLeftBold, PiChatBold, PiCheckCircleBold, PiCreditCardBold, PiMagnifyingGlassBold, PiPlusBold, PiShoppingCartBold, PiUserBold, PiWifiHighBold, PiXBold } from 'react-icons/pi';
+import { PiArrowLeftBold, PiChatBold, PiCheckCircleBold, PiCreditCardBold, PiFileTextBold, PiMagnifyingGlassBold, PiPlusBold, PiShoppingCartBold, PiUserBold, PiWifiHighBold, PiXBold } from 'react-icons/pi';
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
@@ -24,6 +24,7 @@ import Link from 'next/link';
 import { CustomerRadiusSection } from '@/components/admin/interstellio';
 import { PPPoECredentialsSection } from '@/components/admin/pppoe';
 import { CustomerBillingTab } from '@/components/admin/customers/CustomerBillingTab';
+import { CustomerComplianceDocuments } from '@/components/admin/compliance/CustomerComplianceDocuments';
 
 interface Customer {
   id: string;
@@ -369,7 +370,19 @@ export default function CustomerDetailPage() {
             <PiChatBold className="w-4 h-4 mr-2" />
             Tickets
           </TabsTrigger>
+          <TabsTrigger
+            value="documents"
+            className="rounded-none border-b-2 border-transparent data-[state=active]:border-circleTel-orange data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 py-3"
+          >
+            <PiFileTextBold className="w-4 h-4 mr-2" />
+            Documents
+          </TabsTrigger>
         </TabsList>
+
+        {/* Documents Tab */}
+        <TabsContent value="documents" className="mt-0">
+          <CustomerComplianceDocuments customerId={customerId} title="FICA / RICA Documents" />
+        </TabsContent>
 
         {/* Overview Tab */}
         <TabsContent value="overview" className="mt-0">

--- a/app/api/admin/compliance/documents/route.ts
+++ b/app/api/admin/compliance/documents/route.ts
@@ -1,0 +1,158 @@
+/**
+ * Admin Compliance Documents API
+ * Lists FICA/RICA documents customers uploaded via the self-service portal, and lets an
+ * admin/compliance officer approve or reject them.
+ *
+ * Files live in the private `kyc-documents` bucket — use GET /api/admin/kyc/document-url?path={file_path}
+ * to obtain a short-lived signed URL for viewing.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { apiLogger } from '@/lib/logging/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/compliance/documents?customerId=&orderId=&status=
+ * Returns compliance documents (optionally filtered) enriched with customer + order info.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response;
+
+    // Service role — admin reads across all customers (bypasses RLS).
+    const supabase = await createClient();
+
+    const { searchParams } = new URL(request.url);
+    const customerId = searchParams.get('customerId');
+    const orderId = searchParams.get('orderId');
+    const status = searchParams.get('status');
+
+    let query = supabase
+      .from('compliance_documents')
+      .select('*')
+      .order('uploaded_at', { ascending: false });
+
+    if (customerId) query = query.eq('customer_id', customerId);
+    if (orderId) query = query.eq('order_id', orderId);
+    if (status) query = query.eq('status', status);
+
+    const { data: documents, error } = await query;
+
+    if (error) {
+      apiLogger.error('[Admin Compliance] List query failed', { error: error.message });
+      return NextResponse.json({ success: false, error: 'Failed to fetch documents' }, { status: 500 });
+    }
+
+    const docs = documents || [];
+
+    // compliance_documents.customer_id has no FK to customers, so enrich via batched lookups.
+    const customerIds = Array.from(new Set(docs.map((d) => d.customer_id).filter(Boolean)));
+    const orderIds = Array.from(new Set(docs.map((d) => d.order_id).filter(Boolean)));
+
+    const [{ data: customers }, { data: orders }] = await Promise.all([
+      customerIds.length
+        ? supabase
+            .from('customers')
+            .select('id, first_name, last_name, email, phone, account_number')
+            .in('id', customerIds)
+        : Promise.resolve({ data: [] as any[] }),
+      orderIds.length
+        ? supabase.from('consumer_orders').select('id, order_number, package_name').in('id', orderIds)
+        : Promise.resolve({ data: [] as any[] }),
+    ]);
+
+    const customerById = new Map((customers || []).map((c) => [c.id, c]));
+    const orderById = new Map((orders || []).map((o) => [o.id, o]));
+
+    const enriched = docs.map((d) => {
+      const c = customerById.get(d.customer_id);
+      const o = orderById.get(d.order_id);
+      return {
+        ...d,
+        customer: c
+          ? {
+              id: c.id,
+              name: [c.first_name, c.last_name].filter(Boolean).join(' ').trim() || c.email,
+              email: c.email,
+              phone: c.phone,
+              account_number: c.account_number,
+            }
+          : null,
+        order: o ? { id: o.id, order_number: o.order_number, package_name: o.package_name } : null,
+      };
+    });
+
+    return NextResponse.json({ success: true, documents: enriched, count: enriched.length });
+  } catch (error) {
+    apiLogger.error('[Admin Compliance] GET error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/admin/compliance/documents
+ * Body: { documentId, status: 'approved' | 'rejected' | 'pending', rejection_reason? }
+ */
+export async function PATCH(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response;
+    const { adminUser } = authResult;
+
+    const body = await request.json();
+    const { documentId, status, rejection_reason } = body as {
+      documentId?: string;
+      status?: string;
+      rejection_reason?: string;
+    };
+
+    if (!documentId || !status) {
+      return NextResponse.json({ success: false, error: 'documentId and status are required' }, { status: 400 });
+    }
+    if (!['approved', 'rejected', 'pending'].includes(status)) {
+      return NextResponse.json(
+        { success: false, error: "status must be 'approved', 'rejected' or 'pending'" },
+        { status: 400 }
+      );
+    }
+    if (status === 'rejected' && !rejection_reason) {
+      return NextResponse.json(
+        { success: false, error: 'rejection_reason is required when rejecting a document' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await createClient();
+
+    const { data: updated, error } = await supabase
+      .from('compliance_documents')
+      .update({
+        status,
+        rejection_reason: status === 'rejected' ? rejection_reason : null,
+        reviewed_at: new Date().toISOString(),
+        reviewed_by: adminUser.id,
+      })
+      .eq('id', documentId)
+      .select()
+      .single();
+
+    if (error) {
+      apiLogger.error('[Admin Compliance] Update failed', { error: error.message, documentId });
+      return NextResponse.json({ success: false, error: 'Failed to update document' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, document: updated });
+  } catch (error) {
+    apiLogger.error('[Admin Compliance] PATCH error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/compliance/upload/route.ts
+++ b/app/api/compliance/upload/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { createClientWithSession } from '@/lib/supabase/server'
 import type { FICADocumentType, RICADocumentType } from '@/lib/types/fica-rica'
 import { apiLogger } from '@/lib/logging'
 
@@ -30,7 +30,7 @@ interface UploadRequestBody {
  */
 export async function POST(request: NextRequest) {
   try {
-    const supabase = await createClient()
+    const supabase = await createClientWithSession()
 
     // Check authentication
     const {
@@ -105,19 +105,10 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Update order status to kyc_submitted if this is the first document
-    const { data: existingDocs } = await supabase
-      .from('compliance_documents')
-      .select('id')
-      .eq('order_id', body.orderId)
-
-    if (existingDocs && existingDocs.length === 1) {
-      // First document uploaded - update order status
-      await supabase
-        .from('consumer_orders')
-        .update({ status: 'kyc_submitted' })
-        .eq('id', body.orderId)
-    }
+    // Note: we intentionally do NOT mutate consumer_orders.status here. Orders may be in any
+    // pre-active state (e.g. payment_method_pending) when documents are uploaded, and the order
+    // status state-machine (trigger_validate_order_status_transition) rejects an arbitrary jump
+    // to 'kyc_submitted'. Document review/approval drives compliance state separately.
 
     return NextResponse.json({
       success: true,
@@ -139,7 +130,7 @@ export async function POST(request: NextRequest) {
  */
 export async function GET(request: NextRequest) {
   try {
-    const supabase = await createClient()
+    const supabase = await createClientWithSession()
 
     // Check authentication
     const {
@@ -225,7 +216,7 @@ export async function GET(request: NextRequest) {
  */
 export async function DELETE(request: NextRequest) {
   try {
-    const supabase = await createClient()
+    const supabase = await createClientWithSession()
 
     // Check authentication
     const {

--- a/app/dashboard/compliance/page.tsx
+++ b/app/dashboard/compliance/page.tsx
@@ -66,12 +66,33 @@ export default function CompliancePage() {
         return
       }
 
-      // Get user's most recent order that needs KYC
+      // Resolve the customer record for this auth user. consumer_orders.customer_id stores
+      // customers.id (NOT the auth user id), so bridge via customers.auth_user_id.
+      const { data: customer, error: customerError } = await supabase
+        .from('customers')
+        .select('id')
+        .eq('auth_user_id', user.id)
+        .single()
+
+      if (customerError || !customer) {
+        setError('No customer profile found for your account.')
+        setLoading(false)
+        return
+      }
+
+      // Get the customer's most recent order still needing documents
+      // (any pre-active, non-cancelled state — not just the KYC states).
       const { data: orderData, error: orderError } = await supabase
         .from('consumer_orders')
         .select('*')
-        .eq('customer_id', user.id)
-        .in('status', ['kyc_pending', 'kyc_submitted', 'kyc_rejected'])
+        .eq('customer_id', customer.id)
+        .in('status', [
+          'pending', 'payment_pending', 'payment_received',
+          'kyc_pending', 'kyc_approved', 'kyc_rejected',
+          'payment_method_pending', 'payment_method_registered',
+          'credit_check_pending', 'credit_check_approved', 'credit_check_rejected',
+          'installation_scheduled', 'installation_in_progress',
+        ])
         .order('created_at', { ascending: false })
         .limit(1)
         .single()

--- a/app/order/confirmation/[orderId]/page.tsx
+++ b/app/order/confirmation/[orderId]/page.tsx
@@ -33,6 +33,23 @@ export default async function OrderConfirmationPage({ params }: Props) {
     .select('*')
     .eq('order_id', orderId);
 
+  // Monthly cost for display, INCLUSIVE of 15% VAT.
+  // consumer_orders.package_price has an inconsistent VAT basis across historical orders
+  // (some ex-VAT, some incl), so derive the figure from the catalog price (service_packages.price
+  // is consistently ex-VAT) and add VAT. Fall back to the stored package_price only if the
+  // catalog row is unavailable.
+  let monthlyCostInclVat = order.package_price ? Number(order.package_price) : 0;
+  if (order.service_package_id) {
+    const { data: pkg } = await supabase
+      .from('service_packages')
+      .select('price')
+      .eq('id', order.service_package_id)
+      .single();
+    if (pkg?.price != null) {
+      monthlyCostInclVat = Math.round(Number(pkg.price) * 1.15 * 100) / 100;
+    }
+  }
+
   const kycStatus = order.kyc_verification_status || 'pending';
   const hasKycDocuments = kycDocuments && kycDocuments.length > 0;
 
@@ -224,9 +241,9 @@ export default async function OrderConfirmationPage({ params }: Props) {
                   <span className="font-medium text-gray-900">{order.package_name || 'N/A'}</span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-gray-600">Monthly Cost:</span>
+                  <span className="text-gray-600">Monthly Cost (incl. VAT):</span>
                   <span className="font-medium text-gray-900">
-                    R{order.monthly_price ? Number(order.monthly_price).toFixed(2) : '0.00'}
+                    R{monthlyCostInclVat.toFixed(2)}
                   </span>
                 </div>
                 {order.once_off_price && Number(order.once_off_price) > 0 && (

--- a/components/admin/compliance/CustomerComplianceDocuments.tsx
+++ b/components/admin/compliance/CustomerComplianceDocuments.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+/**
+ * Admin view of customer-uploaded FICA/RICA compliance documents.
+ * Used both as a tab on the customer detail page (pass `customerId`) and as a cross-customer
+ * review queue (omit `customerId`, set `defaultStatus="pending"`, `showCustomer`).
+ *
+ * Files live in the private `kyc-documents` bucket; "View" fetches a short-lived signed URL
+ * from /api/admin/kyc/document-url. List/approve/reject go through /api/admin/compliance/documents.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PiCheckBold, PiEyeBold, PiFileTextBold, PiXBold } from 'react-icons/pi';
+
+interface ComplianceDoc {
+  id: string;
+  category: string;
+  document_type: string;
+  file_name: string;
+  file_path: string;
+  status: string;
+  uploaded_at: string;
+  rejection_reason?: string | null;
+  customer?: { id: string; name: string; email: string; account_number?: string } | null;
+  order?: { id: string; order_number: string; package_name?: string } | null;
+}
+
+interface Props {
+  customerId?: string;
+  defaultStatus?: string;
+  showCustomer?: boolean;
+  title?: string;
+}
+
+export function CustomerComplianceDocuments({
+  customerId,
+  defaultStatus = '',
+  showCustomer = false,
+  title,
+}: Props) {
+  const [docs, setDocs] = useState<ComplianceDoc[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState(defaultStatus);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (customerId) params.set('customerId', customerId);
+      if (statusFilter) params.set('status', statusFilter);
+      const res = await fetch(`/api/admin/compliance/documents?${params.toString()}`);
+      const data = await res.json();
+      if (!res.ok || !data.success) throw new Error(data.error || 'Failed to load documents');
+      setDocs(data.documents || []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load documents');
+    } finally {
+      setLoading(false);
+    }
+  }, [customerId, statusFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function view(path: string) {
+    try {
+      const res = await fetch(`/api/admin/kyc/document-url?path=${encodeURIComponent(path)}`);
+      const data = await res.json();
+      if (!res.ok || !data.success) throw new Error(data.error || 'Failed to get document URL');
+      window.open(data.url, '_blank', 'noopener,noreferrer');
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to open document');
+    }
+  }
+
+  async function review(id: string, status: 'approved' | 'rejected') {
+    let rejection_reason: string | undefined;
+    if (status === 'rejected') {
+      const r = window.prompt('Reason for rejection (shown to the customer):');
+      if (!r) return;
+      rejection_reason = r;
+    }
+    setBusyId(id);
+    try {
+      const res = await fetch('/api/admin/compliance/documents', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ documentId: id, status, rejection_reason }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) throw new Error(data.error || 'Update failed');
+      await load();
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Update failed');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const badgeClass = (s: string) =>
+    s === 'approved'
+      ? 'bg-green-100 text-green-800'
+      : s === 'rejected'
+        ? 'bg-red-100 text-red-800'
+        : 'bg-yellow-100 text-yellow-800';
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle>{title || 'Compliance Documents'}</CardTitle>
+        <div className="flex items-center gap-2">
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="border rounded-md px-2 py-1 text-sm"
+          >
+            <option value="">All statuses</option>
+            <option value="pending">Pending</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
+          </select>
+          <Button variant="outline" size="sm" onClick={load}>
+            Refresh
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p className="text-sm text-gray-500">Loading…</p>
+        ) : error ? (
+          <p className="text-sm text-red-600">{error}</p>
+        ) : docs.length === 0 ? (
+          <p className="text-sm text-gray-500">No documents uploaded.</p>
+        ) : (
+          <div className="space-y-3">
+            {docs.map((d) => (
+              <div key={d.id} className="flex items-center justify-between gap-4 p-3 border rounded-lg">
+                <div className="flex items-center gap-3 min-w-0">
+                  <PiFileTextBold className="w-5 h-5 text-gray-400 shrink-0" />
+                  <div className="min-w-0">
+                    <p className="font-medium text-sm truncate">{d.file_name}</p>
+                    <p className="text-xs text-gray-500">
+                      <span className="uppercase">{d.category}</span> ·{' '}
+                      {d.document_type.replace(/_/g, ' ')}
+                      {d.order?.order_number ? ` · ${d.order.order_number}` : ''}
+                    </p>
+                    {showCustomer && d.customer && (
+                      <p className="text-xs text-gray-600">
+                        {d.customer.name} · {d.customer.email}
+                        {d.customer.account_number ? ` · ${d.customer.account_number}` : ''}
+                      </p>
+                    )}
+                    {d.status === 'rejected' && d.rejection_reason && (
+                      <p className="text-xs text-red-600 mt-0.5">Reason: {d.rejection_reason}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className={`px-2.5 py-1 text-xs font-medium rounded-full ${badgeClass(d.status)}`}>
+                    {d.status.charAt(0).toUpperCase() + d.status.slice(1)}
+                  </span>
+                  <Button variant="outline" size="sm" onClick={() => view(d.file_path)}>
+                    <PiEyeBold className="w-4 h-4 mr-1" />
+                    View
+                  </Button>
+                  {d.status !== 'approved' && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={busyId === d.id}
+                      onClick={() => review(d.id, 'approved')}
+                      className="text-green-700 border-green-300 hover:bg-green-50"
+                      title="Approve"
+                    >
+                      <PiCheckBold className="w-4 h-4" />
+                    </Button>
+                  )}
+                  {d.status !== 'rejected' && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={busyId === d.id}
+                      onClick={() => review(d.id, 'rejected')}
+                      className="text-red-700 border-red-300 hover:bg-red-50"
+                      title="Reject"
+                    >
+                      <PiXBold className="w-4 h-4" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -262,6 +262,12 @@ const navigationSections: NavSection[] = [
         icon: PiShieldCheckBold,
         description: 'View KYB subject KYC status and risk'
       },
+      {
+        name: 'Document Reviews',
+        href: '/admin/compliance/documents',
+        icon: PiFileTextBold,
+        description: 'FICA/RICA documents uploaded via the customer portal'
+      },
     ]
   },
   {

--- a/supabase/migrations/20260604120000_fix_compliance_documents_rls_customer_mapping.sql
+++ b/supabase/migrations/20260604120000_fix_compliance_documents_rls_customer_mapping.sql
@@ -1,0 +1,25 @@
+-- Consumer compliance-document RLS was keyed on `customer_id = auth.uid()`, but compliance_documents.customer_id
+-- stores customers.id (NOT the auth user id). That mismatch meant no customer could ever read/insert their own
+-- docs (0 rows ever uploaded). Remap the customer policies through customers.auth_user_id -> customers.id.
+-- Admin policies (compliance_documents_admin_select/update) are unchanged.
+
+DROP POLICY IF EXISTS compliance_documents_select_own ON public.compliance_documents;
+CREATE POLICY compliance_documents_select_own ON public.compliance_documents
+  FOR SELECT TO authenticated
+  USING (customer_id IN (SELECT id FROM public.customers WHERE auth_user_id = auth.uid()));
+
+DROP POLICY IF EXISTS compliance_documents_insert_own ON public.compliance_documents;
+CREATE POLICY compliance_documents_insert_own ON public.compliance_documents
+  FOR INSERT TO authenticated
+  WITH CHECK (customer_id IN (SELECT id FROM public.customers WHERE auth_user_id = auth.uid()));
+
+DROP POLICY IF EXISTS compliance_documents_update_own ON public.compliance_documents;
+CREATE POLICY compliance_documents_update_own ON public.compliance_documents
+  FOR UPDATE TO authenticated
+  USING (customer_id IN (SELECT id FROM public.customers WHERE auth_user_id = auth.uid()) AND status = 'pending')
+  WITH CHECK (customer_id IN (SELECT id FROM public.customers WHERE auth_user_id = auth.uid()) AND status = 'pending');
+
+DROP POLICY IF EXISTS compliance_documents_delete_own ON public.compliance_documents;
+CREATE POLICY compliance_documents_delete_own ON public.compliance_documents
+  FOR DELETE TO authenticated
+  USING (customer_id IN (SELECT id FROM public.customers WHERE auth_user_id = auth.uid()) AND status = 'pending');

--- a/supabase/migrations/20260604120100_kyc_documents_storage_policies.sql
+++ b/supabase/migrations/20260604120100_kyc_documents_storage_policies.sql
@@ -1,0 +1,39 @@
+-- The private `kyc-documents` bucket had NO RLS policies on storage.objects, so browser-side uploads from the
+-- customer portal were always denied. Files are stored under `{customers.id}/{order_id}/{category}/{type}/{file}`,
+-- so scope authenticated access to the first path segment matching the user's own customers.id. Admins read all.
+-- Service-role (server) access bypasses RLS and is unaffected.
+
+DROP POLICY IF EXISTS kyc_docs_customer_insert ON storage.objects;
+CREATE POLICY kyc_docs_customer_insert ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'kyc-documents'
+    AND (storage.foldername(name))[1] IN (SELECT id::text FROM public.customers WHERE auth_user_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS kyc_docs_customer_select ON storage.objects;
+CREATE POLICY kyc_docs_customer_select ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'kyc-documents'
+    AND (storage.foldername(name))[1] IN (SELECT id::text FROM public.customers WHERE auth_user_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS kyc_docs_customer_delete ON storage.objects;
+CREATE POLICY kyc_docs_customer_delete ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'kyc-documents'
+    AND (storage.foldername(name))[1] IN (SELECT id::text FROM public.customers WHERE auth_user_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS kyc_docs_admin_select ON storage.objects;
+CREATE POLICY kyc_docs_admin_select ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'kyc-documents'
+    AND EXISTS (
+      SELECT 1 FROM public.admin_users
+      WHERE id = auth.uid() AND role = ANY (ARRAY['super_admin','admin','compliance_officer'])
+    )
+  );


### PR DESCRIPTION
## Summary
Repairs the (previously non-functional) self-service FICA/RICA document upload flow, adds admin document review, and fixes a VAT display bug. Customer-relevant for getting orders to a billable state.

### ① VAT display
- Order-confirmation page showed **R0.00** (read a non-existent `monthly_price` column) → now derives monthly cost **incl-VAT** from the catalog price.

### ③ Document upload (was broken — 0 uploads ever)
- `compliance_documents` RLS remapped `auth.uid()` → `customers.id` (migration)
- `kyc-documents` storage policies added — own-folder upload/read + admin read (migration)
- Upload API: `createClient()`+`getUser()` (always 401) → `createClientWithSession()`
- Dashboard page: resolve customer via `auth_user_id`; valid `order_status` filter incl `payment_method_pending`
- Removed invalid auto status-bump to `kyc_submitted`
- **Admin**: `GET/PATCH /api/admin/compliance/documents`, shared `CustomerComplianceDocuments` component, review queue `/admin/compliance/documents` (+ Sidebar link), Documents tab on `/admin/customers/[id]`; viewing via existing signed-URL route.

## DB migrations
Both migrations are **already applied to the production database** (RLS + storage policies). This PR carries the matching migration files + code.

## Deferred (Phase 2, not in this PR)
Full VAT price-data normalization of `consumer_orders.package_price` / `customer_services.monthly_price` — it changes live billing amounts (incl. Unjani R450→R517.50) and must be done deliberately with the Unjani onboarding (by 12 Jun 2026).

## Verification
- All 8 touched files type-clean (pre-existing repo errors unrelated).
- RLS/flow verified end-to-end for a real customer (auth id → customers.id → order found → insert allowed → storage folder matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)