### PR TITLE
fix(payments): NetCash Pay Now link uses p4 (Rands) not Amount (cents) — fixes R0.00

### DIFF
--- a/__tests__/lib/payments/netcash-paynow-link.test.ts
+++ b/__tests__/lib/payments/netcash-paynow-link.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression guard for the NetCash Pay Now LINK format.
+ *
+ * The hosted paynow.aspx GET link must carry the amount as `p4` in RANDS. A prior bug encoded the
+ * server-to-server form fields (`Amount` in cents) into the GET querystring, so the hosted page
+ * rendered R0.00 (NetCash ignores `Amount` on a GET link). These tests lock the correct format in.
+ */
+
+import { netcashService } from '@/lib/payments/netcash-service';
+
+const baseFormData: any = {
+  m1: '65251ca3-svc',
+  m2: '6940844b-pci',
+  m3: 'circletel-nextjs',
+  m4: 'CT-ref-1',
+  m5: 'inv-uuid-1',
+  m6: 'INV-2026-00099',
+  m9: 'Customer',
+  p2: 'return-url',
+  p3: 'CircleTel - INV-2026-00099',
+  Budget: 'N',
+  CardPayment: 'Y',
+  EFTPayment: 'Y',
+  TestMode: '0',
+  Amount: '89900', // cents
+};
+
+describe('NetCash Pay Now link (generatePaymentUrl)', () => {
+  it('emits the amount as p4 in RANDS, never Amount in cents', () => {
+    const url = netcashService.generatePaymentUrl(baseFormData);
+    expect(url).toContain('p4=899.00'); // 89900 cents -> R899.00
+    expect(url).not.toMatch(/[?&]Amount=/); // the cents form-field must never appear on a GET link
+  });
+
+  it('uses m5 as the p2 reference so postback reconciliation matches paynow_transaction_ref', () => {
+    const url = netcashService.generatePaymentUrl(baseFormData);
+    expect(url).toContain('p2=inv-uuid-1');
+  });
+
+  it('converts cents to Rands correctly (41907 -> 419.07)', () => {
+    const url = netcashService.generatePaymentUrl({ ...baseFormData, Amount: '41907' });
+    expect(url).toContain('p4=419.07');
+  });
+
+  it('points at the NetCash hosted Pay Now page', () => {
+    const url = netcashService.generatePaymentUrl(baseFormData);
+    expect(url).toContain('paynow.netcash.co.za/site/paynow.aspx');
+  });
+});

--- a/lib/payments/netcash-service.ts
+++ b/lib/payments/netcash-service.ts
@@ -103,11 +103,32 @@ export class NetcashPaymentService {
   }
 
   /**
-   * Generate payment URL with form data
-   * Returns the full URL to redirect customer to for payment
+   * Generate a hosted Pay Now LINK (GET) to redirect/email/SMS the customer to.
+   *
+   * IMPORTANT: NetCash's hosted paynow.aspx page reads the amount from `p4` in RANDS for GET
+   * links. The `Amount`-in-cents + m-field set on NetcashPaymentFormData is the *form-POST*
+   * shape; encoding it straight into a GET querystring makes the page render R0.00 (the page
+   * ignores `Amount`). So build the correct GET-link params here (p4 in Rands).
+   *
+   * `p2` carries the reference NetCash echoes back on the postback; we use `m5` (the invoice id)
+   * which is also what we persist as `paynow_transaction_ref`, so reconciliation stays consistent.
    */
   generatePaymentUrl(formData: NetcashPaymentFormData): string {
-    const params = new URLSearchParams(formData as any);
+    const amountInRands = (parseInt(formData.Amount, 10) / 100).toFixed(2);
+    const params = new URLSearchParams({
+      m1: formData.m1,                    // Service key
+      m2: formData.m2,                    // PCI Vault key
+      p2: formData.m5,                    // Reference (= invoice id) echoed back for reconciliation
+      p3: formData.p3,                    // Description (bank statement narrative)
+      p4: amountInRands,                  // Amount in RANDS (NOT cents) — fixes the R0.00 bug
+      Budget: formData.Budget || 'N',
+      m4: formData.m4,                    // Extra 1: CT- transaction ref
+      m6: formData.m6,                    // Extra 3: invoice number
+      m9: process.env.NETCASH_RETURN_URL    // Success/return URL (robust fallback base)
+        || `${process.env.NEXT_PUBLIC_BASE_URL || 'https://www.circletel.co.za'}/api/payments/netcash/redirect`,
+      m10: process.env.NETCASH_CANCEL_URL
+        || `${process.env.NEXT_PUBLIC_BASE_URL || 'https://www.circletel.co.za'}/payment/cancelled`,
+    });
     return `${this.paymentUrl}?${params.toString()}`;
   }
 


### PR DESCRIPTION
## Problem
The automated/admin per-invoice Pay Now path (`PayNowBillingService` → `netcash-service.generatePaymentUrl`) built the hosted **GET link** out of the server-to-server **form-POST** fields (`Amount` in cents + `m3='circletel-nextjs'`). NetCash's hosted `paynow.aspx` ignores `Amount` on a GET link (it reads **`p4` in Rands**), so the page rendered **R0.00** — customers literally could not pay.

Verified live: the two affected links showed R0.00; after a DB hot-fix to the `p4` format they correctly show R899.00 / R419.07.

## Fix
`generatePaymentUrl` now emits the correct hosted-link params:
- **`p4` = amount in Rands** (converted from the cents `Amount`) — fixes R0.00
- **`p2` = `m5`** (invoice id) — the reference NetCash echoes back, so `paynow_transaction_ref` reconciliation is unchanged
- robust `m9`/`m10` return/cancel URLs with a hardcoded base fallback

`generatePaymentFormData` (cents/m-field set) is **untouched** — it's correct for the server-to-server form POST.

## Scope / blast radius
Only **2 invoices** ever received broken links (INV-2026-00009 Shaun, INV-2026-00011 Ashwyn) — both already hot-fixed in the database. Every historical paid invoice used the correct `p4` script format.

## Tests
Adds `__tests__/lib/payments/netcash-paynow-link.test.ts` (jest) asserting generated links contain `p4=` (Rands) and never `&Amount=` (cents), plus cents→Rands conversion and `p2=m5`. All 4 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)