### PR TITLE
fix(inngest): cap concurrency at Hobby limit (5) to unblock cron registration

### DIFF
--- a/lib/inngest/functions/invoice-notification.ts
+++ b/lib/inngest/functions/invoice-notification.ts
@@ -73,7 +73,7 @@ export const invoiceNotificationFunction = inngest.createFunction(
     id: 'invoice-notification',
     name: 'Invoice Notification (Email + SMS)',
     retries: 3,
-    concurrency: { limit: 10 },
+    concurrency: { limit: 5 }, // Inngest Hobby plan max = 5; any value >5 makes the ENTIRE app sync fail (no crons register)
   },
   { event: 'billing/invoice.generated' },
   async ({ event, step }) => {


### PR DESCRIPTION
## Root cause
Billing/reconciliation Inngest crons (billing-day, debit-orders, paynow-reconciliation, eft-reconciliation, …) never fire in prod. Diagnosed via `PUT /api/inngest` (manual sync), which returns **HTTP 400**:

> The function 'Invoice Notification (Email + SMS)' has higher concurrency limits (10) than your plan limit of 5 — `"modified": false`

Inngest's app sync is **atomic**: one function over a plan limit rejects the **entire** registration, so every function/cron added since the last good sync stays unregistered. (Tarana still runs because it was registered in an earlier successful sync.)

## Fix
`invoice-notification.ts`: `concurrency: { limit: 10 }` → `{ limit: 5 }` (Hobby plan max). One line.

## After deploy
Re-sync the app (`PUT https://www.circletel.co.za/api/inngest`) — Coolify has no Vercel-style auto-sync. Once the sync returns `modified: true`, all crons register and begin firing on schedule.

## Note
This re-enables automated invoicing (`billing-day`, billing_day=1 → next run 1 Jul). Unjani clinics must be onboarded + repriced (R450→R517.50) before then, or they'd be auto-billed at the wrong price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)