### PR TITLE
fix(auth): make mobile OTP login create a real session

### DIFF
--- a/app/api/otp/login/route.ts
+++ b/app/api/otp/login/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { otpService } from '@/lib/integrations/clickatell/otp-service';
+import { createClient } from '@/lib/supabase/server';
+import { apiLogger } from '@/lib/logging/logger';
+
+/**
+ * Mobile OTP login — session bridge.
+ *
+ * Clickatell delivers + verifies the SMS OTP, but it cannot create a Supabase
+ * session on its own. This route runs server-side with the service role:
+ *   1. Verifies (and consumes) the Clickatell OTP exactly once.
+ *   2. Resolves the auth-linked customer for the phone number.
+ *   3. Mints a Supabase magic-link token for that customer's email and returns
+ *      its `token_hash`, which the browser exchanges via `verifyOtp` to obtain
+ *      a real session (same localStorage session the password login produces).
+ *
+ * The OTP is verified ONLY here — the client must not pre-verify it, otherwise
+ * the single-use code is consumed and this call fails with "No OTP found".
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { phone, otp } = body;
+
+    if (!phone || !otp) {
+      return NextResponse.json(
+        { success: false, error: 'Phone number and OTP are required' },
+        { status: 400 }
+      );
+    }
+
+    // 1. Verify + consume the Clickatell OTP (single source of verification)
+    const verify = await otpService.verifyOTP(phone, otp);
+    if (!verify.success) {
+      return NextResponse.json(
+        { success: false, error: verify.error || 'Invalid or expired OTP' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await createClient(); // service role
+
+    // Record phone verification (non-blocking, mirrors the old verify route)
+    supabase
+      .from('customers')
+      .update({ phone_verified_at: new Date().toISOString() })
+      .eq('phone', phone)
+      .then(({ error }) => {
+        if (error) apiLogger.error('[OTP Login] phone_verified_at update failed', { error });
+      });
+
+    // 2. Resolve the auth-linked customer for this phone. Phone is NOT unique in
+    //    `customers`, so we only consider rows with an auth user and refuse to
+    //    guess when more than one matches.
+    const { data: customers, error: custErr } = await supabase
+      .from('customers')
+      .select('email, auth_user_id, created_at')
+      .eq('phone', phone)
+      .not('auth_user_id', 'is', null)
+      .order('created_at', { ascending: false });
+
+    if (custErr) {
+      apiLogger.error('[OTP Login] customer lookup failed', { error: custErr });
+      return NextResponse.json(
+        { success: false, error: 'Could not sign you in. Please try again.' },
+        { status: 500 }
+      );
+    }
+
+    const linked = (customers ?? []).filter((c) => c.email);
+
+    if (linked.length === 0) {
+      return NextResponse.json(
+        { success: false, error: 'No account found with this phone number. Please create an account first.' },
+        { status: 404 }
+      );
+    }
+
+    if (linked.length > 1) {
+      // Safety: never guess which account to sign into.
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'This number is linked to multiple accounts. Please sign in with your email and password.',
+        },
+        { status: 409 }
+      );
+    }
+
+    const email = linked[0].email as string;
+
+    // 3. Mint a magic-link token for that email; the browser exchanges its hash.
+    const { data: linkData, error: linkErr } = await supabase.auth.admin.generateLink({
+      type: 'magiclink',
+      email,
+    });
+
+    const tokenHash = linkData?.properties?.hashed_token;
+    if (linkErr || !tokenHash) {
+      apiLogger.error('[OTP Login] generateLink failed', { error: linkErr });
+      return NextResponse.json(
+        { success: false, error: 'Could not start your session. Please try again.' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true, tokenHash, email });
+  } catch (error) {
+    apiLogger.error('[OTP Login] route error', { error });
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Login failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/auth/verify-otp/page.tsx
+++ b/app/auth/verify-otp/page.tsx
@@ -6,13 +6,12 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
-import { useCustomerAuth } from '@/components/providers/CustomerAuthProvider';
+import { createClient } from '@/lib/supabase/client';
 import Link from 'next/link';
 
 export default function VerifyOTPLoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { signInWithOtp } = useCustomerAuth();
   const phone = searchParams.get('phone') || '';
   const redirectPath = searchParams.get('redirect') || '/dashboard';
 
@@ -51,7 +50,9 @@ export default function VerifyOTPLoginPage() {
     setIsVerifying(true);
 
     try {
-      const response = await fetch('/api/otp/verify', {
+      // Single call: server verifies the Clickatell OTP (once) and returns a
+      // Supabase magic-link token hash to establish the session.
+      const response = await fetch('/api/otp/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phone, otp }),
@@ -59,24 +60,29 @@ export default function VerifyOTPLoginPage() {
 
       const result = await response.json();
 
-      if (result.success) {
-        // If OTP is valid, sign in the user
-        if (signInWithOtp) {
-          const signInResult = await signInWithOtp(phone, otp);
-
-          if (signInResult.error) {
-            toast.error(signInResult.error);
-            setIsVerifying(false);
-            return;
-          }
-        }
-
-        toast.success('Successfully signed in!');
-        // Redirect to intended page or dashboard
-        router.push(redirectPath);
-      } else {
+      if (!result.success || !result.tokenHash) {
         toast.error(result.error || 'Invalid verification code');
+        setIsVerifying(false);
+        return;
       }
+
+      // Exchange the token hash for a real session (stored like password login).
+      const supabase = createClient();
+      const { error: sessionError } = await supabase.auth.verifyOtp({
+        token_hash: result.tokenHash,
+        type: 'magiclink',
+      });
+
+      if (sessionError) {
+        console.error('Error establishing session:', sessionError);
+        toast.error('Could not sign you in. Please try again.');
+        setIsVerifying(false);
+        return;
+      }
+
+      toast.success('Successfully signed in!');
+      // Redirect to intended page or dashboard
+      router.push(redirectPath);
     } catch (error) {
       console.error('Error verifying OTP:', error);
       toast.error('Failed to verify code. Please try again.');


### PR DESCRIPTION
## Problem

Mobile OTP login on `/auth/login` → `/auth/verify-otp` verified the SMS code (Clickatell) but **never logged the user in** — no Supabase session was created. Reported in production with two `400`s from `/api/otp/verify`.

### Root cause (verified against the DB)
The `otp_verifications` rows for the tested phone were `verified=true, attempts=0` — i.e. the OTP **verified fine**. The failure was downstream:

1. **Double-verify.** The verify-otp page called `/api/otp/verify` (success, consumed the single-use code), then `signInWithOtp()` called `/api/otp/verify` **again** → the already-consumed record no longer matched `verified=false` → `400 "No OTP found"` (the console 400s).
2. **No session bridge.** `signInWithOtp()` then called `supabase.auth.signInWithOtp({phone})`, which the code's own fallback admits isn't configured, and which only *sends* an OTP — it never mints a session.

This feature was never completed; it is **not** a regression from the auth-layout work (`customer-auth-service.ts` was untouched by #509).

## Fix (keep Clickatell SMS, bridge to a real Supabase session)

- **New `POST /api/otp/login`** (service role): verifies + consumes the Clickatell OTP **once**, resolves the auth-linked customer for the phone, mints a Supabase **magic-link** token, returns its `token_hash`.
- **`verify-otp` page**: single call to `/api/otp/login`, then browser `verifyOtp({ token_hash, type: 'magiclink' })` → establishes the session (same localStorage session the password login uses). Removes the double-verify and the dead `signInWithOtp` path.

### Phone is not unique in `customers`
The route only considers auth-linked rows and **never guesses**:
- `0` → `404` "no account"
- exactly `1` → sign in
- `>1` → `409` "this number is linked to multiple accounts, sign in with email"

## Verification
- Bridge proven: `admin.generateLink({type:'magiclink'})` → browser `verifyOtp({token_hash})` returns a real session for the correct user.
- Route (dev server): single-account phone → `success + token_hash`; multi-account → `409`; wrong/expired/consumed → `400`.

> ⚠️ Note: the developer's own test number `0737288016` is linked to **3** auth accounts, so it will hit the `409` path — testing the happy path needs a single-account number (or dedupe those accounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)