### PR TITLE
fix(auth): prevent duplicate phone numbers across customer accounts

### DIFF
--- a/app/api/auth/create-customer/route.ts
+++ b/app/api/auth/create-customer/route.ts
@@ -77,6 +77,33 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Dedupe-on-signup: a phone number must map to a single account, otherwise
+    // mobile OTP login can't resolve which account to sign into. Reject if the
+    // number is already registered to a DIFFERENT account (matched by the DB
+    // partial unique index `customers_phone_unique_not_blank` as the backstop).
+    const normalizedPhone = (phone || '').trim();
+    if (normalizedPhone) {
+      const { data: phoneOwner } = await supabase
+        .from('customers')
+        .select('email')
+        .eq('phone', normalizedPhone)
+        .neq('email', email)
+        .limit(1)
+        .maybeSingle();
+
+      if (phoneOwner) {
+        apiLogger.warn('[Create Customer] Phone already registered to another account', { email });
+        return NextResponse.json(
+          {
+            success: false,
+            error: 'This phone number is already registered to another account. Please use a different number or sign in.',
+            code: 'PHONE_TAKEN',
+          },
+          { status: 409 }
+        );
+      }
+    }
+
     // Insert customer record using service role with ON CONFLICT handling
     // If email already exists, update the record instead of failing
     const { data: customer, error: customerError } = await supabase
@@ -86,7 +113,7 @@ export async function POST(request: NextRequest) {
         first_name: finalFirstName,
         last_name: finalLastName,
         email,
-        phone: phone || '', // Use empty string if phone not provided (OAuth users)
+        phone: normalizedPhone, // '' if not provided (OAuth users)
         account_type: account_type || 'personal',
         email_verified: false,
         status: 'active',

--- a/lib/auth/customer-auth-service.ts
+++ b/lib/auth/customer-auth-service.ts
@@ -193,6 +193,17 @@ export class CustomerAuthService {
         const errorMsg = lastError || customerResult?.error || 'Unknown error';
         console.error('Failed to create customer record:', errorMsg);
 
+        // Phone already registered to another account — surface the friendly
+        // message as-is instead of the generic "profile setup failed" wrapper.
+        if (customerResult?.code === 'PHONE_TAKEN') {
+          return {
+            user: null,
+            customer: null,
+            session: null,
+            error: customerResult.error || 'This phone number is already registered to another account.',
+          };
+        }
+
         // If it's a duplicate key error, this is actually OK - the customer record exists
         // This can happen during retry scenarios or rate limiting
         if (errorMsg?.includes('duplicate key') || errorMsg?.includes('already exists')) {

--- a/supabase/migrations/20260606000000_customers_phone_unique.sql
+++ b/supabase/migrations/20260606000000_customers_phone_unique.sql
@@ -1,0 +1,13 @@
+-- Prevent the same phone number from being attached to more than one customer
+-- account. This is the hard backstop behind the app-level check in
+-- app/api/auth/create-customer/route.ts (PHONE_TAKEN).
+--
+-- `customers.phone` is NOT NULL and uses '' as the "no phone" sentinel (OAuth
+-- users, cleared numbers), so a plain UNIQUE(phone) is not possible. A partial
+-- unique index allows any number of blank phones but guarantees that every
+-- real number maps to exactly one account.
+--
+-- Existing duplicates were resolved before applying this index.
+CREATE UNIQUE INDEX IF NOT EXISTS customers_phone_unique_not_blank
+  ON public.customers (phone)
+  WHERE phone <> '';


### PR DESCRIPTION
## Why
A phone number attached to multiple `customers` rows makes mobile OTP login non-deterministic — the login route can't tell which account to sign into (returns `409`). This is the root prevention behind the manual dedupe done for `0737288016` and `0747106459`.

## Changes (two layers)
1. **App-level dedupe-on-signup** — `POST /api/auth/create-customer` now rejects a signup whose phone is already registered to a **different** account with a friendly `409 { code: 'PHONE_TAKEN' }`; `CustomerAuthService.signUp` surfaces that message cleanly. The same account keeping its own number is allowed (matched by email).
2. **DB backstop** — migration `20260606000000_customers_phone_unique.sql`: partial unique index `customers_phone_unique_not_blank` = `UNIQUE (phone) WHERE phone <> ''`. `phone` is `NOT NULL` with `''` as the "no phone" sentinel (OAuth users / cleared numbers), so the index permits many blanks but guarantees real numbers are unique — even against races and admin/manual inserts.

## Data prep (already done on prod)
All pre-existing duplicates resolved: `0737288016` kept only on `jeffrey.de.wee@circletel.co.za`; `0747106459` kept only on `takalanim@circletel.co.za`. Verified zero non-blank duplicates remain, so the index applies cleanly.

## Verification
- `create-customer` → `409 PHONE_TAKEN` for a number owned by another account.
- `create-customer` → `200` when the same account keeps its own number (no false positive).

## Deploy note
The migration is **not auto-applied** by deploy — it will be applied to prod via the Supabase MCP **after** this merges & deploys, so the friendly app-level `409` ships before the hard DB constraint.

> Follow-up (not in this PR): phone **normalization** (e.g. E.164) so `0xx` and `+27xx` variants can't both exist — the index/check match exact strings today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)