### PR TITLE
feat(whatsapp-campaign): daily sales execution cockpit (Phase 1)

### DIFF
--- a/app/admin/integrations/whatsapp-campaign/page.tsx
+++ b/app/admin/integrations/whatsapp-campaign/page.tsx
@@ -17,6 +17,12 @@ import { UnderlineTabs, TabPanel } from '@/components/admin/shared/UnderlineTabs
 import { InsightBadge } from '@/components/admin/shared/InsightBadge';
 import { ConversationThread } from '@/components/admin/whatsapp-campaign/ConversationThread';
 import type { InsightStatus, CampaignConversation } from '@/lib/integrations/zoho/desk-campaign-service';
+import {
+  enrichSalesTicket,
+  summarizeSalesQueues,
+  type SalesOpsTicket,
+  type SalesQueue,
+} from '@/lib/integrations/zoho/campaign-sales-ops';
 
 // =============================================================================
 // TYPES
@@ -43,13 +49,18 @@ interface TicketRow {
   status: string | null;
   assigned_agent: string | null;
   contact_name: string | null;
+  contact_phone: string | null;
+  contact_email: string | null;
   lead_name: string | null;
   lead_email: string | null;
   lead_phone: string | null;
   lead_address: string | null;
   insight_status: InsightStatus;
   is_signed_up: boolean;
+  order_id: string | null;
   zoho_created_at: string | null;
+  first_response_at: string | null;
+  closed_at: string | null;
   conversations: CampaignConversation[];
   conversation_count: number;
 }
@@ -72,25 +83,55 @@ function formatDuration(ms: number | null): string {
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 
-function exportToCsv(tickets: TicketRow[]) {
-  const headers = ['Ticket #', 'Name', 'Email', 'Phone', 'Address', 'Insight', 'Signed Up', 'Agent', 'Created'];
-  const rows = tickets.map((t) => [
-    t.ticket_number ?? '',
-    t.lead_name ?? t.contact_name ?? '',
-    t.lead_email ?? '',
-    t.lead_phone ?? '',
-    t.lead_address ?? '',
-    t.insight_status,
-    t.is_signed_up ? 'Yes' : 'No',
-    t.assigned_agent ?? 'Unassigned',
-    t.zoho_created_at ? new Date(t.zoho_created_at).toLocaleDateString('en-ZA') : '',
+function csvEscape(value: string | number | null | undefined): string {
+  return `"${String(value ?? '').replace(/"/g, '""')}"`;
+}
+
+function exportToCsv(tickets: SalesOpsTicket[]) {
+  const headers = [
+    'Queue',
+    'SLA Status',
+    'Ticket #',
+    'Name',
+    'Phone',
+    'Email',
+    'Address',
+    'Insight',
+    'Signed Up',
+    'Order ID',
+    'Agent',
+    'Lead Age',
+    'First Response',
+    'Created',
+    'Messages',
+  ];
+
+  const rows = tickets.map((ticket) => [
+    getQueueLabel(ticket.sales_queue),
+    ticket.sla_status,
+    ticket.ticket_number ?? '',
+    ticket.display_name,
+    ticket.display_phone ?? '',
+    ticket.display_email ?? '',
+    ticket.lead_address ?? '',
+    ticket.insight_status,
+    ticket.is_signed_up ? 'Yes' : 'No',
+    ticket.order_id ?? '',
+    ticket.assigned_agent ?? 'Unassigned',
+    formatAge(ticket.lead_age_ms),
+    ticket.first_response_ms === null ? '' : formatDuration(ticket.first_response_ms),
+    ticket.zoho_created_at ? new Date(ticket.zoho_created_at).toLocaleString('en-ZA') : '',
+    ticket.conversation_count,
   ]);
-  const csv = [headers, ...rows].map((r) => r.map((v) => `"${v}"`).join(',')).join('\n');
+
+  const csv = [headers, ...rows]
+    .map((row) => row.map(csvEscape).join(','))
+    .join('\n');
   const blob = new Blob([csv], { type: 'text/csv' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `whatsapp-campaign-leads-${new Date().toISOString().slice(0, 10)}.csv`;
+  a.download = `whatsapp-campaign-sales-queue-${new Date().toISOString().slice(0, 10)}.csv`;
   a.click();
   URL.revokeObjectURL(url);
 }
@@ -111,12 +152,36 @@ const PIPELINE_ORDER: InsightStatus[] = [
   'no_coverage', 'awaiting_agent', 'unresponsive', 'closed_resolved',
 ];
 
+const SALES_QUEUE_TABS: Array<{ id: SalesQueue | 'all'; label: string }> = [
+  { id: 'all', label: 'All Active' },
+  { id: 'sla_risk', label: 'SLA Risk' },
+  { id: 'needs_agent', label: 'Needs Agent' },
+  { id: 'ready_to_sell', label: 'Ready to Sell' },
+  { id: 'waiting_on_customer', label: 'Waiting on Customer' },
+  { id: 'coverage_issue', label: 'Coverage Issue' },
+  { id: 'unresponsive', label: 'Unresponsive' },
+  { id: 'converted', label: 'Converted' },
+];
+
+function formatAge(ms: number | null): string {
+  if (ms === null) return 'N/A';
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  if (h >= 24) return `${Math.floor(h / 24)}d ${h % 24}h`;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function getQueueLabel(queue: SalesQueue): string {
+  return SALES_QUEUE_TABS.find((tab) => tab.id === queue)?.label ?? queue;
+}
+
 export default function WhatsAppCampaignPage() {
   const [data, setData] = useState<ReportData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState('overview');
   const [expandedTicket, setExpandedTicket] = useState<string | null>(null);
+  const [activeQueue, setActiveQueue] = useState<SalesQueue | 'all'>('all');
 
   const fetchData = useCallback(async (live = false) => {
     setLoading(true);
@@ -148,13 +213,38 @@ export default function WhatsAppCampaignPage() {
   const snap = data?.snapshot;
   const tickets = data?.tickets ?? [];
 
+  // Enrich tickets with sales ops data
+  const enrichedTickets = tickets
+    .map((ticket) => enrichSalesTicket(ticket))
+    .sort((a, b) => {
+      const queueRank: Record<SalesQueue, number> = {
+        sla_risk: 0,
+        needs_agent: 1,
+        ready_to_sell: 2,
+        waiting_on_customer: 3,
+        coverage_issue: 4,
+        unresponsive: 5,
+        converted: 6,
+      };
+      const rankDiff = queueRank[a.sales_queue] - queueRank[b.sales_queue];
+      if (rankDiff !== 0) return rankDiff;
+      return (b.lead_age_ms ?? 0) - (a.lead_age_ms ?? 0);
+    });
+
+  const queueCounts = summarizeSalesQueues(enrichedTickets);
+
+  const activeSalesTickets =
+    activeQueue === 'all'
+      ? enrichedTickets.filter((ticket) => ticket.sales_queue !== 'converted')
+      : enrichedTickets.filter((ticket) => ticket.sales_queue === activeQueue);
+
   // Derived agent rows
   const agentRows = snap
     ? Object.entries(snap.agent_breakdown).map(([agent, count]) => ({
         agent,
         count,
-        signUps: tickets.filter((t) => t.assigned_agent === agent && t.is_signed_up).length,
-        closed: tickets.filter((t) => t.assigned_agent === agent && t.status === 'Closed').length,
+        signUps: enrichedTickets.filter((t) => t.assigned_agent === agent && t.is_signed_up).length,
+        closed: enrichedTickets.filter((t) => t.assigned_agent === agent && t.status === 'Closed').length,
       }))
     : [];
 
@@ -199,27 +289,36 @@ export default function WhatsAppCampaignPage() {
         {/* Stat Cards */}
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
           <StatCard
-            label="Total Leads"
-            value={snap?.cumulative_leads ?? '—'}
-            subtitle={snap ? `${snap.new_leads_today} yesterday` : undefined}
+            label="Needs Agent"
+            value={queueCounts.needs_agent}
+            subtitle={`${queueCounts.sla_risk} SLA risk`}
             icon={<PiUsersBold />}
+            onClick={() => setActiveQueue('needs_agent')}
+            isActive={activeQueue === 'needs_agent'}
           />
           <StatCard
-            label="Conversions"
-            value={snap?.conversions_today ?? '—'}
-            subtitle={snap ? `${snap.conversion_rate.toFixed(1)}% rate` : undefined}
-            icon={<PiCheckCircleBold />}
-          />
-          <StatCard
-            label="Open Tickets"
-            value={snap?.open_tickets ?? '—'}
-            subtitle={snap?.unassigned_tickets ? `${snap.unassigned_tickets} unassigned ⚠` : undefined}
-            icon={<PiChartBarBold />}
-          />
-          <StatCard
-            label="Avg. Response"
-            value={formatDuration(snap?.avg_first_response_ms ?? null)}
+            label="SLA Risk"
+            value={queueCounts.sla_risk}
+            subtitle="No response after 2h"
             icon={<PiClockBold />}
+            onClick={() => setActiveQueue('sla_risk')}
+            isActive={activeQueue === 'sla_risk'}
+          />
+          <StatCard
+            label="Ready to Sell"
+            value={queueCounts.ready_to_sell}
+            subtitle="Details collected, no order"
+            icon={<PiChartBarBold />}
+            onClick={() => setActiveQueue('ready_to_sell')}
+            isActive={activeQueue === 'ready_to_sell'}
+          />
+          <StatCard
+            label="Converted"
+            value={queueCounts.converted}
+            subtitle={snap ? `${snap.conversions_today} yesterday` : undefined}
+            icon={<PiCheckCircleBold />}
+            onClick={() => setActiveQueue('converted')}
+            isActive={activeQueue === 'converted'}
           />
         </div>
 
@@ -228,6 +327,99 @@ export default function WhatsAppCampaignPage() {
 
         {/* Overview Tab */}
         <TabPanel id="overview" activeTab={activeTab}>
+          <SectionCard
+            title="Daily Sales Queue"
+            icon={PiWhatsappLogoBold}
+            action={
+              <button
+                onClick={() => exportToCsv(activeSalesTickets)}
+                className="flex items-center gap-1.5 text-sm text-slate-600 hover:text-slate-900"
+              >
+                <PiDownloadBold /> Export Queue
+              </button>
+            }
+          >
+            <div className="flex flex-wrap gap-2 mb-4">
+              {SALES_QUEUE_TABS.map((tab) => {
+                const count = tab.id === 'all'
+                  ? enrichedTickets.filter((ticket) => ticket.sales_queue !== 'converted').length
+                  : queueCounts[tab.id];
+                return (
+                  <button
+                    key={tab.id}
+                    onClick={() => setActiveQueue(tab.id)}
+                    className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                      activeQueue === tab.id
+                        ? 'border-circleTel-orange bg-orange-50 text-circleTel-orange'
+                        : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50'
+                    }`}
+                  >
+                    {tab.label} <span className="ml-1 text-xs opacity-70">{count}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-slate-500 border-b border-slate-200">
+                    <th className="pb-2 pr-4">Lead</th>
+                    <th className="pb-2 pr-4">Queue</th>
+                    <th className="pb-2 pr-4">Age</th>
+                    <th className="pb-2 pr-4">Response</th>
+                    <th className="pb-2 pr-4">Agent</th>
+                    <th className="pb-2 pr-4">Address</th>
+                    <th className="pb-2">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {activeSalesTickets.map((ticket) => (
+                    <tr key={ticket.ticket_id} className="hover:bg-slate-50">
+                      <td className="py-3 pr-4">
+                        <p className="font-medium text-slate-900">{ticket.display_name}</p>
+                        <p className="text-xs text-slate-500">
+                          {ticket.display_phone ?? ticket.display_email ?? 'No contact captured'} · #{ticket.ticket_number ?? 'N/A'}
+                        </p>
+                      </td>
+                      <td className="py-3 pr-4">
+                        <span className="text-xs font-semibold text-slate-700">{getQueueLabel(ticket.sales_queue)}</span>
+                      </td>
+                      <td className="py-3 pr-4 text-slate-600">{formatAge(ticket.lead_age_ms)}</td>
+                      <td className="py-3 pr-4 text-slate-600">
+                        {ticket.first_response_ms === null ? ticket.sla_status : formatDuration(ticket.first_response_ms)}
+                      </td>
+                      <td className="py-3 pr-4 text-slate-600">{ticket.assigned_agent ?? 'Unassigned'}</td>
+                      <td className="py-3 pr-4 text-slate-600 max-w-[240px] truncate">
+                        {ticket.lead_address ?? 'No address captured'}
+                      </td>
+                      <td className="py-3">
+                        <div className="flex items-center gap-2">
+                          {ticket.display_phone && (
+                            <button
+                              onClick={() => navigator.clipboard.writeText(ticket.display_phone ?? '')}
+                              className="text-xs font-medium text-slate-600 hover:text-slate-900"
+                            >
+                              Copy Phone
+                            </button>
+                          )}
+                          {ticket.order_id && (
+                            <a
+                              href={`/admin/orders/${ticket.order_id}`}
+                              className="text-xs font-medium text-circleTel-orange hover:underline"
+                            >
+                              Open Order
+                            </a>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </SectionCard>
+
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             {/* Pipeline Breakdown */}
             <SectionCard title="Lead Pipeline (All Time)" icon={PiChartBarBold}>
@@ -255,7 +447,7 @@ export default function WhatsAppCampaignPage() {
             {/* Recent Tickets */}
             <SectionCard title="Recent Tickets" icon={PiWhatsappLogoBold}>
               <div className="space-y-2 max-h-96 overflow-y-auto">
-                {tickets.slice(0, 20).map((t) => (
+                {enrichedTickets.slice(0, 20).map((t) => (
                   <div
                     key={t.ticket_id}
                     className="flex items-center justify-between py-2 border-b border-slate-100 last:border-0"
@@ -281,7 +473,7 @@ export default function WhatsAppCampaignPage() {
             icon={PiUsersBold}
             action={
               <button
-                onClick={() => exportToCsv(tickets)}
+                onClick={() => exportToCsv(enrichedTickets)}
                 className="flex items-center gap-1.5 text-sm text-slate-600 hover:text-slate-900"
               >
                 <PiDownloadBold /> Export CSV
@@ -302,7 +494,7 @@ export default function WhatsAppCampaignPage() {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-100">
-                  {tickets.map((t) => (
+                  {enrichedTickets.map((t) => (
                     <tr key={t.ticket_id} className="hover:bg-slate-50">
                       <td className="py-2 pr-4 font-medium text-slate-900">
                         {t.lead_name ?? t.contact_name ?? '—'}
@@ -364,7 +556,7 @@ export default function WhatsAppCampaignPage() {
         <TabPanel id="conversations" activeTab={activeTab}>
           <SectionCard title="Conversation Threads" icon={PiWhatsappLogoBold}>
             <div className="space-y-3">
-              {tickets.map((t) => (
+              {enrichedTickets.map((t) => (
                 <div key={t.ticket_id} className="border border-slate-200 rounded-xl overflow-hidden">
                   <button
                     onClick={() =>

--- a/app/api/admin/whatsapp-campaign/report/route.ts
+++ b/app/api/admin/whatsapp-campaign/report/route.ts
@@ -16,6 +16,7 @@ import {
   createCampaignZohoDeskService,
   ConversationIntelligence,
 } from '@/lib/integrations/zoho/desk-campaign-service';
+import { mapLiveCampaignTicketToSnapshot } from '@/lib/integrations/zoho/campaign-sales-ops';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -42,13 +43,29 @@ export async function GET(request: NextRequest) {
         const ci = new ConversationIntelligence(conversations, ticket.status);
         const profile = ci.extractLeadProfile();
         const insightStatus = ci.deriveInsightStatus({ isSigned_up: false });
-        return { ticket, conversations, profile, insightStatus };
+
+        return mapLiveCampaignTicketToSnapshot({
+          ticket,
+          conversations,
+          profile,
+          insightStatus,
+          isSignedUp: false,
+          orderId: null,
+        });
       })
     );
 
     const tickets = ticketData
-      .filter((r) => r.status === 'fulfilled')
-      .map((r) => (r as PromiseFulfilledResult<{ ticket: typeof allTickets[number]; conversations: Awaited<ReturnType<typeof campaignService.fetchConversations>>; profile: ReturnType<InstanceType<typeof ConversationIntelligence>['extractLeadProfile']>; insightStatus: ReturnType<InstanceType<typeof ConversationIntelligence>['deriveInsightStatus']> }>).value);
+      .filter(
+        (result): result is PromiseFulfilledResult<ReturnType<typeof mapLiveCampaignTicketToSnapshot>> =>
+          result.status === 'fulfilled'
+      )
+      .map((result) => result.value)
+      .sort((a, b) => {
+        const aTime = a.zoho_created_at ? new Date(a.zoho_created_at).getTime() : 0;
+        const bTime = b.zoho_created_at ? new Date(b.zoho_created_at).getTime() : 0;
+        return bTime - aTime;
+      });
 
     return NextResponse.json({
       snapshot: null,

--- a/lib/integrations/zoho/__tests__/campaign-sales-ops.test.ts
+++ b/lib/integrations/zoho/__tests__/campaign-sales-ops.test.ts
@@ -1,0 +1,157 @@
+import {
+  deriveSalesQueue,
+  deriveSlaStatus,
+  enrichSalesTicket,
+  mapLiveCampaignTicketToSnapshot,
+  summarizeSalesQueues,
+  type SalesOpsTicketInput,
+} from '../campaign-sales-ops';
+import type { CampaignConversation, CampaignTicket, LeadProfile } from '../desk-campaign-service';
+
+const NOW = new Date('2026-06-06T10:00:00.000Z');
+
+function ticket(overrides: Partial<SalesOpsTicketInput> = {}): SalesOpsTicketInput {
+  return {
+    ticket_id: 'ticket-1',
+    ticket_number: '123',
+    subject: 'Hello! Can I get more info on this?',
+    status: 'Open',
+    assigned_agent: null,
+    contact_name: null,
+    contact_phone: null,
+    contact_email: null,
+    lead_name: null,
+    lead_email: null,
+    lead_phone: null,
+    lead_address: null,
+    insight_status: 'awaiting_agent',
+    is_signed_up: false,
+    order_id: null,
+    zoho_created_at: '2026-06-06T08:00:00.000Z',
+    first_response_at: null,
+    closed_at: null,
+    conversations: [
+      {
+        id: 'conv-1',
+        author: 'Lead',
+        direction: 'in',
+        content: 'I need internet',
+        timestamp: '2026-06-06T08:00:00.000Z',
+        channel: 'whatsapp',
+      },
+    ],
+    conversation_count: 1,
+    ...overrides,
+  };
+}
+
+describe('campaign sales ops helpers', () => {
+  it('puts unresponded leads older than two hours into SLA risk', () => {
+    const row = ticket({ zoho_created_at: '2026-06-06T07:45:00.000Z' });
+    expect(deriveSlaStatus(row, NOW)).toBe('breached');
+    expect(deriveSalesQueue(row, NOW)).toBe('sla_risk');
+  });
+
+  it('puts fresh unresponded inbound leads into needs agent', () => {
+    const row = ticket({ zoho_created_at: '2026-06-06T09:15:00.000Z' });
+    expect(deriveSlaStatus(row, NOW)).toBe('ok');
+    expect(deriveSalesQueue(row, NOW)).toBe('needs_agent');
+  });
+
+  it('puts leads between 90 and 120 minutes without response into at-risk SLA', () => {
+    const row = ticket({ zoho_created_at: '2026-06-06T08:20:00.000Z' });
+    expect(deriveSlaStatus(row, NOW)).toBe('at_risk');
+    expect(deriveSalesQueue(row, NOW)).toBe('needs_agent');
+  });
+
+  it('puts completed leads with contact details into ready to sell', () => {
+    const row = ticket({
+      insight_status: 'completed',
+      first_response_at: '2026-06-06T08:10:00.000Z',
+      lead_phone: '0831234567',
+      lead_address: '15 Milner Road, Vaalview',
+      conversation_count: 5,
+    });
+    expect(deriveSalesQueue(row, NOW)).toBe('ready_to_sell');
+  });
+
+  it('keeps no coverage and signed-up states ahead of operational queues', () => {
+    expect(deriveSalesQueue(ticket({ insight_status: 'no_coverage' }), NOW)).toBe('coverage_issue');
+    expect(deriveSalesQueue(ticket({ is_signed_up: true, insight_status: 'no_coverage' }), NOW)).toBe('converted');
+  });
+
+  it('normalizes live Zoho tickets into the same flattened shape as snapshot rows', () => {
+    const zohoTicket: CampaignTicket = {
+      id: 'z-ticket',
+      ticketNumber: '456',
+      subject: 'I want to know more',
+      status: 'Open',
+      assigneeName: 'Tamsyn',
+      contactName: 'Zoho Contact',
+      contactPhone: '0821112222',
+      contactEmail: 'lead@example.com',
+      createdTime: '2026-06-06T07:00:00.000Z',
+      closedTime: null,
+      tags: [],
+    };
+    const conversations: CampaignConversation[] = [
+      {
+        id: 'msg-1',
+        author: 'Lead',
+        direction: 'in',
+        content: 'My address is 1 Main Road',
+        timestamp: '2026-06-06T07:00:00.000Z',
+        channel: 'whatsapp',
+      },
+    ];
+    const profile: LeadProfile = {
+      name: 'Lead Name',
+      phone: '0831234567',
+      email: 'lead.profile@example.com',
+      address: '1 Main Road, Vaalview',
+    };
+
+    expect(mapLiveCampaignTicketToSnapshot({
+      ticket: zohoTicket,
+      conversations,
+      profile,
+      insightStatus: 'awaiting_agent',
+      isSignedUp: false,
+      orderId: null,
+    })).toEqual({
+      ticket_id: 'z-ticket',
+      ticket_number: '456',
+      subject: 'I want to know more',
+      status: 'Open',
+      assigned_agent: 'Tamsyn',
+      contact_name: 'Zoho Contact',
+      contact_phone: '0821112222',
+      contact_email: 'lead@example.com',
+      lead_name: 'Lead Name',
+      lead_email: 'lead.profile@example.com',
+      lead_phone: '0831234567',
+      lead_address: '1 Main Road, Vaalview',
+      insight_status: 'awaiting_agent',
+      is_signed_up: false,
+      order_id: null,
+      zoho_created_at: '2026-06-06T07:00:00.000Z',
+      first_response_at: null,
+      closed_at: null,
+      conversations,
+      conversation_count: 1,
+    });
+  });
+
+  it('summarizes queue counts from enriched tickets', () => {
+    const rows = [
+      enrichSalesTicket(ticket({ zoho_created_at: '2026-06-06T09:30:00.000Z' }), NOW),
+      enrichSalesTicket(ticket({ ticket_id: 'ticket-2', insight_status: 'no_coverage' }), NOW),
+      enrichSalesTicket(ticket({ ticket_id: 'ticket-3', is_signed_up: true }), NOW),
+    ];
+    expect(summarizeSalesQueues(rows)).toMatchObject({
+      needs_agent: 1,
+      coverage_issue: 1,
+      converted: 1,
+    });
+  });
+});

--- a/lib/integrations/zoho/campaign-sales-ops.ts
+++ b/lib/integrations/zoho/campaign-sales-ops.ts
@@ -1,0 +1,209 @@
+import type {
+  CampaignConversation,
+  CampaignTicket,
+  InsightStatus,
+  LeadProfile,
+} from './desk-campaign-service';
+
+export type SalesQueue =
+  | 'needs_agent'
+  | 'sla_risk'
+  | 'ready_to_sell'
+  | 'waiting_on_customer'
+  | 'coverage_issue'
+  | 'unresponsive'
+  | 'converted';
+
+export type SlaStatus = 'breached' | 'at_risk' | 'ok' | 'responded' | 'closed';
+
+export interface SalesOpsTicketInput {
+  ticket_id: string;
+  ticket_number: string | null;
+  subject: string | null;
+  status: string | null;
+  assigned_agent: string | null;
+  contact_name: string | null;
+  contact_phone: string | null;
+  contact_email: string | null;
+  lead_name: string | null;
+  lead_email: string | null;
+  lead_phone: string | null;
+  lead_address: string | null;
+  insight_status: InsightStatus;
+  is_signed_up: boolean;
+  order_id: string | null;
+  zoho_created_at: string | null;
+  first_response_at: string | null;
+  closed_at: string | null;
+  conversations: CampaignConversation[];
+  conversation_count: number;
+}
+
+export interface SalesOpsTicket extends SalesOpsTicketInput {
+  sales_queue: SalesQueue;
+  sla_status: SlaStatus;
+  display_name: string;
+  display_phone: string | null;
+  display_email: string | null;
+  lead_age_ms: number | null;
+  first_response_ms: number | null;
+  last_inbound_at: string | null;
+  last_outbound_at: string | null;
+}
+
+export interface LiveCampaignTicketParams {
+  ticket: CampaignTicket;
+  conversations: CampaignConversation[];
+  profile: LeadProfile;
+  insightStatus: InsightStatus;
+  isSignedUp: boolean;
+  orderId: string | null;
+}
+
+const SLA_BREACH_MS = 2 * 60 * 60 * 1000;
+const SLA_AT_RISK_MS = 90 * 60 * 1000;
+
+function timestampMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function getLastInboundAt(conversations: CampaignConversation[]): string | null {
+  return conversations.filter((c) => c.direction === 'in').at(-1)?.timestamp ?? null;
+}
+
+export function getLastOutboundAt(conversations: CampaignConversation[]): string | null {
+  return conversations.filter((c) => c.direction === 'out').at(-1)?.timestamp ?? null;
+}
+
+export function getLeadAgeMs(row: SalesOpsTicketInput, now = new Date()): number | null {
+  const createdMs = timestampMs(row.zoho_created_at);
+  if (createdMs === null) return null;
+  return Math.max(0, now.getTime() - createdMs);
+}
+
+export function getFirstResponseMs(row: SalesOpsTicketInput): number | null {
+  const createdMs = timestampMs(row.zoho_created_at);
+  const responseMs = timestampMs(row.first_response_at);
+  if (createdMs === null || responseMs === null) return null;
+  return Math.max(0, responseMs - createdMs);
+}
+
+export function getDisplayName(row: SalesOpsTicketInput): string {
+  return row.lead_name || row.contact_name || 'Unknown lead';
+}
+
+export function getDisplayPhone(row: SalesOpsTicketInput): string | null {
+  return row.lead_phone || row.contact_phone || null;
+}
+
+export function getDisplayEmail(row: SalesOpsTicketInput): string | null {
+  return row.lead_email || row.contact_email || null;
+}
+
+export function hasInbound(row: SalesOpsTicketInput): boolean {
+  return row.conversations.some((conversation) => conversation.direction === 'in');
+}
+
+export function deriveSlaStatus(row: SalesOpsTicketInput, now = new Date()): SlaStatus {
+  if (row.status === 'Closed') return 'closed';
+  if (row.first_response_at) return 'responded';
+
+  const ageMs = getLeadAgeMs(row, now);
+  if (ageMs === null) return 'ok';
+  if (ageMs >= SLA_BREACH_MS) return 'breached';
+  if (ageMs >= SLA_AT_RISK_MS) return 'at_risk';
+  return 'ok';
+}
+
+export function deriveSalesQueue(row: SalesOpsTicketInput, now = new Date()): SalesQueue {
+  if (row.is_signed_up || row.order_id) return 'converted';
+  if (row.insight_status === 'no_coverage') return 'coverage_issue';
+  if (row.insight_status === 'unresponsive') return 'unresponsive';
+
+  const slaStatus = deriveSlaStatus(row, now);
+  const inboundExists = hasInbound(row);
+
+  if (!row.first_response_at && inboundExists && slaStatus === 'breached') return 'sla_risk';
+  if (!row.first_response_at && inboundExists) return 'needs_agent';
+
+  const hasUsableContact = Boolean(getDisplayPhone(row) || getDisplayEmail(row));
+  const hasAddress = Boolean(row.lead_address);
+  if (
+    (row.insight_status === 'completed' || row.insight_status === 'in_progress') &&
+    (hasUsableContact || hasAddress)
+  ) {
+    return 'ready_to_sell';
+  }
+
+  if (row.insight_status === 'awaiting_details') return 'waiting_on_customer';
+  return 'needs_agent';
+}
+
+export function enrichSalesTicket(row: SalesOpsTicketInput, now = new Date()): SalesOpsTicket {
+  return {
+    ...row,
+    sales_queue: deriveSalesQueue(row, now),
+    sla_status: deriveSlaStatus(row, now),
+    display_name: getDisplayName(row),
+    display_phone: getDisplayPhone(row),
+    display_email: getDisplayEmail(row),
+    lead_age_ms: getLeadAgeMs(row, now),
+    first_response_ms: getFirstResponseMs(row),
+    last_inbound_at: getLastInboundAt(row.conversations),
+    last_outbound_at: getLastOutboundAt(row.conversations),
+  };
+}
+
+export function summarizeSalesQueues(rows: SalesOpsTicket[]): Record<SalesQueue, number> {
+  return rows.reduce<Record<SalesQueue, number>>(
+    (summary, row) => {
+      summary[row.sales_queue] += 1;
+      return summary;
+    },
+    {
+      needs_agent: 0,
+      sla_risk: 0,
+      ready_to_sell: 0,
+      waiting_on_customer: 0,
+      coverage_issue: 0,
+      unresponsive: 0,
+      converted: 0,
+    }
+  );
+}
+
+export function mapLiveCampaignTicketToSnapshot({
+  ticket,
+  conversations,
+  profile,
+  insightStatus,
+  isSignedUp,
+  orderId,
+}: LiveCampaignTicketParams): SalesOpsTicketInput {
+  const firstOutbound = conversations.find((conversation) => conversation.direction === 'out');
+
+  return {
+    ticket_id: ticket.id,
+    ticket_number: ticket.ticketNumber ?? null,
+    subject: ticket.subject ?? null,
+    status: ticket.status ?? null,
+    assigned_agent: ticket.assigneeName ?? 'Unassigned',
+    contact_name: ticket.contactName ?? null,
+    contact_phone: ticket.contactPhone ?? null,
+    contact_email: ticket.contactEmail ?? null,
+    lead_name: profile.name ?? null,
+    lead_email: profile.email ?? null,
+    lead_phone: profile.phone ?? null,
+    lead_address: profile.address ?? null,
+    insight_status: insightStatus,
+    is_signed_up: isSignedUp,
+    order_id: orderId,
+    zoho_created_at: ticket.createdTime ?? null,
+    first_response_at: firstOutbound?.timestamp ?? null,
+    closed_at: ticket.closedTime ?? null,
+    conversations,
+    conversation_count: conversations.length,
+  };
+}


### PR DESCRIPTION
## Summary

Turns `/admin/integrations/whatsapp-campaign` from a passive campaign report into a **daily sales execution cockpit** (Phase 1 of the plan). No DB migration — Phase 1 derives sales queues, SLA state, lead age, and action labels from existing `campaign_ticket_snapshots` fields via pure TypeScript helpers.

### Changes (4 files)
- **NEW** `lib/integrations/zoho/campaign-sales-ops.ts` — pure-TS helpers: `deriveSalesQueue`, `deriveSlaStatus`, `enrichSalesTicket`, `mapLiveCampaignTicketToSnapshot`, `summarizeSalesQueues` (+ display/age helpers).
- **NEW** `lib/integrations/zoho/__tests__/campaign-sales-ops.test.ts` — 7 unit tests.
- **MOD** `app/api/admin/whatsapp-campaign/report/route.ts` — live (`?live=true`) mode now normalizes Zoho tickets into the **same flattened row shape** as the cached Supabase path (fixes blank rows in live mode).
- **MOD** `app/admin/integrations/whatsapp-campaign/page.tsx` — queue tabs, queue-focused stat cards, a "Daily Sales Queue" table with row actions, enriched Leads/Conversations tabs, and an action-oriented CSV export.

### Verification
- ✅ `19/19` Jest tests pass (`campaign-sales-ops` + `desk-campaign-service`, no regression)
- ✅ `tsc --noEmit` clean on all 4 files
- ✅ Real Next.js route compile clean (page 200, API 401 — auth working, no 500)
- ✅ **Deployed to staging** and serving (`staging.circletel.co.za` + the campaign route)

### Deferred to Phase 2 (by design — plan gates reporting until real-data feedback)
- `awaiting_details` + breached-SLA ordering, `first_response_at` = first-outbound proxy, and closed-but-unconverted ticket handling. Captured for the Phase 2 plan + `20260606120000_campaign_sales_reporting_columns.sql` migration.

Plan: `docs/superpowers/plans/2026-06-06-whatsapp-campaign-sales-cockpit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)