### PR TITLE
ci: fix npm ci ERESOLVE across all workflows (.npmrc legacy-peer-deps)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -16,3 +16,10 @@ cache-max=0
 
 # Logging
 loglevel=warn
+
+# Peer dependency resolution
+# next-themes@0.3.0 declares a narrower react peer range than the installed
+# react, which makes a bare `npm ci` fail with ERESOLVE in CI. Resolve peers
+# leniently (matches the lockfile, which was generated this way) so every
+# workflow's install step succeeds without per-command --legacy-peer-deps flags.
+legacy-peer-deps=true


### PR DESCRIPTION
## Problem

Every PR shows red checks (TypeScript Type Check, ESLint Check, Build Check, Prepare Test Database) — but they never run the actual check. They die in **Install dependencies** with:

```
npm error peer react@"^16.8 || ^17 || ^18" from next-themes@0.3.0
npm error Fix the upstream dependency conflict, or retry with --legacy-peer-deps
```

A bare `npm ci` validates peers strictly and fails. The lockfile was generated with lenient peer resolution.

## Fix

Add `legacy-peer-deps=true` to the root **`.npmrc`** (one line). `npm ci` honors `.npmrc`, so this fixes the install step in **every** workflow at once — `pr-checks.yml` (×3), `mtn-session.yml`, `test-payment-integration.yml`, `validate-mtn-session.yml`, `api-integration-tests.yml` — instead of sprinkling `--legacy-peer-deps` onto each command (the partial approach from `60269c45`).

## Safety

`legacy-peer-deps` only *relaxes* peer resolution; it never makes a passing install fail. The production Docker build already installs cleanly, so this is a no-op for it. Verified locally: `npm config get legacy-peer-deps` → `true`.

The PR's own checks turning green is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)