### PR TITLE
feat(blog): CMS-authored blog on the public site (/blog)

### DIFF
--- a/__tests__/lib/data/cms-blog.test.ts
+++ b/__tests__/lib/data/cms-blog.test.ts
@@ -1,0 +1,53 @@
+import { getPublishedPosts, getPostBySlug, getPostSlugs } from '@/lib/data/cms-blog'
+
+const rows = [
+  {
+    id: 1, title: 'Hello', slug: 'hello', excerpt: 'hi',
+    published_at: '2026-06-07T00:00:00Z', author_name: 'Jeffrey',
+    featured_image_thumb_url: 'http://img/thumb.jpg', featured_image_alt: 'alt',
+    content_html: '<p>body</p>', featured_image_hero_url: 'http://img/hero.jpg',
+    meta_title: null, meta_description: null,
+  },
+]
+
+function makeClient(result: { data: any; error: any }) {
+  const createBuilder = () => {
+    const builder: any = {
+      select: () => createBuilder(),
+      order: () => createBuilder(),
+      eq: () => createBuilder(),
+      maybeSingle: () => Promise.resolve({ data: result.data?.[0] ?? null, error: result.error }),
+      then: (onfulfilled: any, onrejected?: any) => Promise.resolve(result).then(onfulfilled, onrejected),
+      catch: (onrejected: any) => Promise.resolve(result).catch(onrejected),
+    }
+    return builder
+  }
+  return { from: () => createBuilder() }
+}
+
+jest.mock('@/lib/supabase/server', () => ({ createClient: jest.fn() }))
+import { createClient } from '@/lib/supabase/server'
+
+describe('cms-blog data module', () => {
+  it('getPublishedPosts maps rows to cards', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: rows, error: null }))
+    const posts = await getPublishedPosts()
+    expect(posts).toHaveLength(1)
+    expect(posts[0]).toMatchObject({ slug: 'hello', authorName: 'Jeffrey', featuredImageThumbUrl: 'http://img/thumb.jpg' })
+  })
+  it('getPostBySlug maps a full post incl. contentHtml', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: rows, error: null }))
+    const post = await getPostBySlug('hello')
+    expect(post).toMatchObject({ slug: 'hello', contentHtml: '<p>body</p>', featuredImageHeroUrl: 'http://img/hero.jpg' })
+  })
+  it('getPostSlugs returns slug strings', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: [{ slug: 'hello' }], error: null }))
+    expect(await getPostSlugs()).toEqual(['hello'])
+  })
+  it('degrades to empty/null on error', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: null, error: { message: 'boom' } }))
+    expect(await getPublishedPosts()).toEqual([])
+    expect(await getPostBySlug('x')).toBeNull()
+    expect(await getPostSlugs()).toEqual([])
+  })
+})

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { getPostBySlug, getPostSlugs } from '@/lib/data/cms-blog'
+
+export const revalidate = 300
+
+type Params = { params: Promise<{ slug: string }> }
+
+export async function generateStaticParams() {
+  const slugs = await getPostSlugs()
+  return slugs.map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { slug } = await params
+  const post = await getPostBySlug(slug)
+  if (!post) return { title: 'Post not found | CircleTel' }
+  const description = post.metaDescription ?? post.excerpt ?? undefined
+  return {
+    title: `${post.metaTitle ?? post.title} | CircleTel`,
+    description,
+    openGraph: {
+      title: post.metaTitle ?? post.title,
+      description,
+      images: post.featuredImageHeroUrl ? [{ url: post.featuredImageHeroUrl }] : undefined,
+      type: 'article',
+    },
+  }
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString('en-ZA', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+export default async function BlogPostPage({ params }: Params) {
+  const { slug } = await params
+  const post = await getPostBySlug(slug)
+  if (!post) notFound()
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-12">
+      <h1 className="text-3xl font-bold text-[#1B2A4A]">{post.title}</h1>
+      <p className="text-sm text-gray-400 mt-2">{[post.authorName, formatDate(post.publishedAt)].filter(Boolean).join(' · ')}</p>
+      {post.featuredImageHeroUrl && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={post.featuredImageHeroUrl} alt={post.featuredImageAlt ?? post.title} className="w-full rounded-lg mt-6 object-cover" />
+      )}
+      {post.contentHtml ? (
+        <div className="prose max-w-none mt-8" dangerouslySetInnerHTML={{ __html: post.contentHtml }} />
+      ) : (
+        post.excerpt && <p className="mt-8 text-gray-700">{post.excerpt}</p>
+      )}
+    </main>
+  )
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { getPublishedPosts } from '@/lib/data/cms-blog'
+
+export const revalidate = 300
+
+export const metadata: Metadata = {
+  title: 'Blog | CircleTel',
+  description: 'News, guides and updates from CircleTel.',
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString('en-ZA', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+export default async function BlogIndexPage() {
+  const posts = await getPublishedPosts()
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-12">
+      <h1 className="text-3xl font-bold text-[#1B2A4A] mb-8">Blog</h1>
+      {posts.length === 0 ? (
+        <p className="text-gray-500">No posts yet. Check back soon.</p>
+      ) : (
+        <div className="grid gap-8 sm:grid-cols-2">
+          {posts.map((p) => (
+            <Link key={p.id} href={`/blog/${p.slug}`} className="group block rounded-lg border border-gray-200 overflow-hidden hover:shadow-md transition">
+              {p.featuredImageThumbUrl && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={p.featuredImageThumbUrl} alt={p.featuredImageAlt ?? p.title} className="w-full h-44 object-cover" />
+              )}
+              <div className="p-4">
+                <h2 className="font-semibold text-lg text-[#1B2A4A] group-hover:text-[#F5831F] transition">{p.title}</h2>
+                {p.excerpt && <p className="text-sm text-gray-600 mt-2 line-clamp-3">{p.excerpt}</p>}
+                <p className="text-xs text-gray-400 mt-3">{[p.authorName, formatDate(p.publishedAt)].filter(Boolean).join(' · ')}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/components/navigation/NavigationData.ts
+++ b/components/navigation/NavigationData.ts
@@ -165,6 +165,12 @@ export const aboutItems: NavigationItem[] = [];
 // Note: "/resources" overview link is added via prependItems in NavigationMenu.tsx
 export const resourcesItems: NavigationItem[] = [
   {
+    name: "Blog",
+    href: "/blog",
+    icon: PiBookOpenBold,
+    description: "News, guides and updates from CircleTel"
+  },
+  {
     name: "Client Forms",
     href: "/forms",
     icon: PiClipboardTextBold,

--- a/lib/data/cms-blog.ts
+++ b/lib/data/cms-blog.ts
@@ -1,0 +1,87 @@
+import { createClient } from '@/lib/supabase/server'
+
+export interface BlogPostCard {
+  id: number
+  title: string
+  slug: string
+  excerpt: string | null
+  publishedAt: string | null
+  authorName: string | null
+  featuredImageThumbUrl: string | null
+  featuredImageAlt: string | null
+}
+
+export interface BlogPost extends BlogPostCard {
+  contentHtml: string | null
+  featuredImageHeroUrl: string | null
+  metaTitle: string | null
+  metaDescription: string | null
+}
+
+const CARD_COLS =
+  'id,title,slug,excerpt,published_at,author_name,featured_image_thumb_url,featured_image_alt'
+const FULL_COLS =
+  CARD_COLS + ',content_html,featured_image_hero_url,meta_title,meta_description'
+
+function mapCard(r: any): BlogPostCard {
+  return {
+    id: r.id,
+    title: r.title,
+    slug: r.slug,
+    excerpt: r.excerpt ?? null,
+    publishedAt: r.published_at ?? null,
+    authorName: r.author_name ?? null,
+    featuredImageThumbUrl: r.featured_image_thumb_url ?? null,
+    featuredImageAlt: r.featured_image_alt ?? null,
+  }
+}
+
+function mapFull(r: any): BlogPost {
+  return {
+    ...mapCard(r),
+    contentHtml: r.content_html ?? null,
+    featuredImageHeroUrl: r.featured_image_hero_url ?? null,
+    metaTitle: r.meta_title ?? null,
+    metaDescription: r.meta_description ?? null,
+  }
+}
+
+export async function getPublishedPosts(): Promise<BlogPostCard[]> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('cms_blog_posts')
+      .select(CARD_COLS)
+      .order('published_at', { ascending: false })
+    if (error || !data) return []
+    return data.map(mapCard)
+  } catch {
+    return []
+  }
+}
+
+export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('cms_blog_posts')
+      .select(FULL_COLS)
+      .eq('slug', slug)
+      .maybeSingle()
+    if (error || !data) return null
+    return mapFull(data)
+  } catch {
+    return null
+  }
+}
+
+export async function getPostSlugs(): Promise<string[]> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase.from('cms_blog_posts').select('slug').order('published_at', { ascending: false })
+    if (error || !data) return []
+    return data.map((r: any) => r.slug as string)
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
## What this adds

Public-facing **blog** rendered from content authored in the standalone Payload CMS (`cms.circletel.co.za`), at `/blog` and `/blog/[slug]`. First slice of the "CMS drives public marketing content" capability.

**The monolith does NOT import Payload.** It reads published posts from a read-only Supabase view (`public.cms_blog_posts`) via the existing service-role client.

## Changes
- `lib/data/cms-blog.ts` — typed read layer over the `cms_blog_posts` view (`getPublishedPosts`, `getPostBySlug`, `getPostSlugs`); graceful `[]`/`null` fallbacks.
- `app/blog/page.tsx` — blog index (ISR 300s).
- `app/blog/[slug]/page.tsx` — single post (ISR 300s, `generateStaticParams`, SEO/OG, renders `contentHtml`).
- `components/navigation/NavigationData.ts` — adds "Blog" link.
- `__tests__/lib/data/cms-blog.test.ts` — 4 unit tests (mocked Supabase), all passing.

## Already shipped on the CMS side (separate `circletel-cms` repo)
- `contentHtml` field + Lexical→HTML `beforeChange` hook (so the public build needs no rich-text renderer).
- Media → Supabase Storage (S3 adapter), verified persisting + serving public URLs.
- `public.cms_blog_posts` view (DB migration).

## How content flows
Author publishes in the CMS → image to Supabase Storage, `contentHtml` generated → `public.cms_blog_posts` view → public ISR pages (≤5 min) render it.

## Risk
- Additive only; no existing routes/data changed. Product pages remain on static `lib/data/products`.
- No new Payload deps in the monolith build.

## Verification
- `npx jest __tests__/lib/data/cms-blog.test.ts` → 4/4 pass.
- `npm run type-check:memory` → no blog-related errors.
- CMS media upload verified end-to-end (Supabase public URL fetchable).

Spec: `docs/superpowers/specs/2026-06-07-cms-blog-public-rendering-design.md`
Plan: `docs/superpowers/plans/2026-06-07-cms-blog-public-rendering.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
