### PR TITLE
feat(blog): editorial layout redesign (minimalist orange/neutral)

### DIFF
--- a/__tests__/lib/blog/read-time.test.ts
+++ b/__tests__/lib/blog/read-time.test.ts
@@ -1,0 +1,40 @@
+import { readMinutes } from '@/lib/blog/read-time'
+
+describe('readMinutes', () => {
+  it('returns 1 for null', () => {
+    expect(readMinutes(null)).toBe(1)
+  })
+
+  it('returns 1 for empty string', () => {
+    expect(readMinutes('')).toBe(1)
+  })
+
+  it('strips HTML tags and counts words', () => {
+    const html = '<p>This is a test article with ten words in total.</p>'
+    // 10 words / 200 wpm = 0.05 → rounds to 0 → Math.max(1, 0) = 1
+    expect(readMinutes(html)).toBe(1)
+  })
+
+  it('calculates ~2 minutes for ~400 words', () => {
+    // 400 words / 200 wpm = 2 minutes
+    const words = Array(400).fill('word').join(' ')
+    const html = `<p>${words}</p>`
+    expect(readMinutes(html)).toBe(2)
+  })
+
+  it('handles multiple HTML tags', () => {
+    const html = `
+      <h1>Title</h1>
+      <p>This is a paragraph with some words.</p>
+      <p>And another paragraph with more words here.</p>
+    `
+    // 13 words / 200 = 0.065 → rounds to 0 → 1
+    expect(readMinutes(html)).toBe(1)
+  })
+
+  it('handles nested tags', () => {
+    const html = '<div><p>Some <strong>bold</strong> text here.</p></div>'
+    // 5 words / 200 = 0.025 → rounds to 0 → 1
+    expect(readMinutes(html)).toBe(1)
+  })
+})

--- a/__tests__/lib/data/cms-blog.test.ts
+++ b/__tests__/lib/data/cms-blog.test.ts
@@ -1,11 +1,20 @@
-import { getPublishedPosts, getPostBySlug, getPostSlugs } from '@/lib/data/cms-blog'
+import { getPublishedPosts, getPostBySlug, getPostSlugs, getAllCategories, getRelatedPosts } from '@/lib/data/cms-blog'
 
 const rows = [
   {
     id: 1, title: 'Hello', slug: 'hello', excerpt: 'hi',
     published_at: '2026-06-07T00:00:00Z', author_name: 'Jeffrey',
     featured_image_thumb_url: 'http://img/thumb.jpg', featured_image_alt: 'alt',
+    categories: ['how-to', 'technology'],
     content_html: '<p>body</p>', featured_image_hero_url: 'http://img/hero.jpg',
+    meta_title: null, meta_description: null,
+  },
+  {
+    id: 2, title: 'World', slug: 'world', excerpt: 'world post',
+    published_at: '2026-06-06T00:00:00Z', author_name: 'Alice',
+    featured_image_thumb_url: 'http://img/thumb2.jpg', featured_image_alt: 'alt2',
+    categories: ['technology'],
+    content_html: '<p>world body</p>', featured_image_hero_url: 'http://img/hero2.jpg',
     meta_title: null, meta_description: null,
   },
 ]
@@ -16,6 +25,9 @@ function makeClient(result: { data: any; error: any }) {
       select: () => createBuilder(),
       order: () => createBuilder(),
       eq: () => createBuilder(),
+      neq: () => createBuilder(),
+      contains: () => createBuilder(),
+      limit: (n: number) => ({ ...createBuilder(), _limit: n }),
       maybeSingle: () => Promise.resolve({ data: result.data?.[0] ?? null, error: result.error }),
       then: (onfulfilled: any, onrejected?: any) => Promise.resolve(result).then(onfulfilled, onrejected),
       catch: (onrejected: any) => Promise.resolve(result).catch(onrejected),
@@ -29,25 +41,40 @@ jest.mock('@/lib/supabase/server', () => ({ createClient: jest.fn() }))
 import { createClient } from '@/lib/supabase/server'
 
 describe('cms-blog data module', () => {
-  it('getPublishedPosts maps rows to cards', async () => {
+  it('getPublishedPosts maps rows to cards with categories', async () => {
     ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: rows, error: null }))
     const posts = await getPublishedPosts()
-    expect(posts).toHaveLength(1)
-    expect(posts[0]).toMatchObject({ slug: 'hello', authorName: 'Jeffrey', featuredImageThumbUrl: 'http://img/thumb.jpg' })
+    expect(posts).toHaveLength(2)
+    expect(posts[0]).toMatchObject({ slug: 'hello', authorName: 'Jeffrey', categories: ['how-to', 'technology'] })
   })
-  it('getPostBySlug maps a full post incl. contentHtml', async () => {
+  it('getPostBySlug maps a full post incl. contentHtml and readMinutes', async () => {
     ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: rows, error: null }))
     const post = await getPostBySlug('hello')
     expect(post).toMatchObject({ slug: 'hello', contentHtml: '<p>body</p>', featuredImageHeroUrl: 'http://img/hero.jpg' })
+    expect(post?.readMinutes).toBe(1)
   })
   it('getPostSlugs returns slug strings', async () => {
     ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: [{ slug: 'hello' }], error: null }))
     expect(await getPostSlugs()).toEqual(['hello'])
+  })
+  it('getAllCategories returns distinct categories', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: rows, error: null }))
+    const cats = await getAllCategories()
+    expect(cats).toContain('how-to')
+    expect(cats).toContain('technology')
+  })
+  it('getRelatedPosts filters by slug and category', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: [rows[1]], error: null }))
+    const related = await getRelatedPosts('hello', 'technology', 3)
+    expect(related).toHaveLength(1)
+    expect(related[0].slug).toBe('world')
   })
   it('degrades to empty/null on error', async () => {
     ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: null, error: { message: 'boom' } }))
     expect(await getPublishedPosts()).toEqual([])
     expect(await getPostBySlug('x')).toBeNull()
     expect(await getPostSlugs()).toEqual([])
+    expect(await getAllCategories()).toEqual([])
+    expect(await getRelatedPosts('x', 'tech')).toEqual([])
   })
 })

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,6 +1,14 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { getPostBySlug, getPostSlugs } from '@/lib/data/cms-blog'
+import { getPostBySlug, getPostSlugs, getRelatedPosts, primaryCategory } from '@/lib/data/cms-blog'
+import { Breadcrumb } from '@/components/blog/Breadcrumb'
+import { ShareButtons } from '@/components/blog/ShareButtons'
+import { SalesCtaCard } from '@/components/blog/SalesCtaCard'
+import { NewsletterSignup } from '@/components/blog/NewsletterSignup'
+import { RelatedPosts } from '@/components/blog/RelatedPosts'
+import { SalesCtaBanner } from '@/components/blog/SalesCtaBanner'
+import { ArticleJsonLd } from '@/components/blog/ArticleJsonLd'
+import { categoryLabel } from '@/lib/blog/categories'
 
 export const revalidate = 300
 
@@ -38,19 +46,150 @@ export default async function BlogPostPage({ params }: Params) {
   const post = await getPostBySlug(slug)
   if (!post) notFound()
 
+  const primaryCat = primaryCategory(post.categories)
+  const relatedPosts = await getRelatedPosts(slug, primaryCat, 4)
+
+  const postUrl = `https://www.circletel.co.za/blog/${slug}`
+
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
-      <h1 className="text-3xl font-bold text-[#1B2A4A]">{post.title}</h1>
-      <p className="text-sm text-gray-400 mt-2">{[post.authorName, formatDate(post.publishedAt)].filter(Boolean).join(' · ')}</p>
-      {post.featuredImageHeroUrl && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={post.featuredImageHeroUrl} alt={post.featuredImageAlt ?? post.title} className="w-full rounded-lg mt-6 object-cover" />
-      )}
-      {post.contentHtml ? (
-        <div className="prose max-w-none mt-8" dangerouslySetInnerHTML={{ __html: post.contentHtml }} />
-      ) : (
-        post.excerpt && <p className="mt-8 text-gray-700">{post.excerpt}</p>
-      )}
-    </main>
+    <>
+      <ArticleJsonLd post={post} url={postUrl} />
+
+      <article className="mx-auto max-w-6xl px-4 py-12">
+        {/* Breadcrumb */}
+        <Breadcrumb
+          items={[
+            { label: 'Home', href: '/' },
+            { label: 'Blog', href: '/blog' },
+            ...(primaryCat ? [{ label: categoryLabel(primaryCat), href: `/blog?category=${encodeURIComponent(primaryCat)}` }] : []),
+            { label: post.title },
+          ]}
+        />
+
+        {/* Main content grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          {/* Left column: article content */}
+          <div className="lg:col-span-2">
+            {/* Eyebrow category pill */}
+            {primaryCat && (
+              <div className="mb-4 inline-block">
+                <span className="px-3 py-1 bg-[#F5831F] text-white text-xs font-semibold rounded-full">
+                  {categoryLabel(primaryCat)}
+                </span>
+              </div>
+            )}
+
+            {/* H1 */}
+            <h1 className="text-4xl font-bold text-neutral-900 mb-4 font-heading leading-tight">
+              {post.title}
+            </h1>
+
+            {/* Meta row */}
+            <div className="flex items-center gap-2 text-sm text-neutral-500 mb-6 pb-6 border-b border-neutral-200">
+              {post.authorName && <span>{post.authorName}</span>}
+              {post.authorName && formatDate(post.publishedAt) && <span>·</span>}
+              {formatDate(post.publishedAt) && <span>{formatDate(post.publishedAt)}</span>}
+              {post.readMinutes && (
+                <>
+                  <span>·</span>
+                  <span>{post.readMinutes} min read</span>
+                </>
+              )}
+            </div>
+
+            {/* Hero image */}
+            {post.featuredImageHeroUrl && (
+              <div className="mb-8 overflow-hidden rounded-lg">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={post.featuredImageHeroUrl}
+                  alt={post.featuredImageAlt ?? post.title}
+                  className="w-full h-auto object-cover"
+                />
+              </div>
+            )}
+
+            {/* Body prose */}
+            {post.contentHtml && (
+              <div
+                className="prose prose-neutral max-w-none mb-12
+                  prose-a:text-[#F5831F] prose-a:no-underline hover:prose-a:underline
+                  prose-headings:text-neutral-900 prose-headings:font-heading prose-headings:font-bold
+                  prose-h2:text-2xl prose-h3:text-xl
+                  prose-img:rounded-lg prose-img:my-6
+                  prose-strong:text-neutral-900
+                  prose-blockquote:border-l-[#F5831F] prose-blockquote:italic
+                "
+                dangerouslySetInnerHTML={{ __html: post.contentHtml }}
+              />
+            )}
+
+            {/* Author byline */}
+            {post.authorName && (
+              <div className="py-6 border-y border-neutral-200 mb-12">
+                <p className="text-sm text-neutral-600">
+                  <span className="font-semibold">{post.authorName}</span> is the author of this article.
+                </p>
+              </div>
+            )}
+
+            {/* Related posts grid at bottom of article */}
+            {relatedPosts.length > 0 && (
+              <RelatedPosts posts={relatedPosts.slice(0, 3)} title="Read More" />
+            )}
+          </div>
+
+          {/* Right column: sticky sidebar */}
+          <aside className="lg:col-span-1">
+            <div className="space-y-6 lg:sticky lg:top-24">
+              {/* Share buttons */}
+              <ShareButtons url={postUrl} title={post.title} />
+
+              {/* Sales CTA card */}
+              <SalesCtaCard />
+
+              {/* Newsletter signup */}
+              <NewsletterSignup />
+
+              {/* Sidebar related posts */}
+              {relatedPosts.length > 0 && (
+                <div className="space-y-3">
+                  <h3 className="text-sm font-semibold text-neutral-900">Recent Posts</h3>
+                  <div className="space-y-3">
+                    {relatedPosts.slice(0, 4).map((relPost) => (
+                      <a
+                        key={relPost.id}
+                        href={`/blog/${relPost.slug}`}
+                        className="flex gap-3 group"
+                      >
+                        {relPost.featuredImageThumbUrl && (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={relPost.featuredImageThumbUrl}
+                            alt={relPost.featuredImageAlt ?? relPost.title}
+                            className="w-16 h-16 object-cover rounded-lg flex-shrink-0 group-hover:opacity-80 transition"
+                          />
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <h4 className="text-xs font-semibold text-neutral-900 group-hover:text-[#F5831F] transition line-clamp-2">
+                            {relPost.title}
+                          </h4>
+                          <p className="text-xs text-neutral-500 mt-1">
+                            {formatDate(relPost.publishedAt)}
+                          </p>
+                        </div>
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </aside>
+        </div>
+
+        {/* Bottom sales CTA banner */}
+        <SalesCtaBanner />
+      </article>
+    </>
   )
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,43 +1,64 @@
-import Link from 'next/link'
 import type { Metadata } from 'next'
-import { getPublishedPosts } from '@/lib/data/cms-blog'
+import { getPublishedPosts, getAllCategories } from '@/lib/data/cms-blog'
+import { CategoryPills } from '@/components/blog/CategoryPills'
+import { PostCard } from '@/components/blog/PostCard'
 
 export const revalidate = 300
 
 export const metadata: Metadata = {
   title: 'Blog | CircleTel',
-  description: 'News, guides and updates from CircleTel.',
+  description: 'Reviews, guides and connectivity news from CircleTel.',
 }
 
-function formatDate(iso: string | null): string {
-  if (!iso) return ''
-  return new Date(iso).toLocaleDateString('en-ZA', { year: 'numeric', month: 'long', day: 'numeric' })
+interface BlogIndexPageProps {
+  searchParams: Promise<{ category?: string }>
 }
 
-export default async function BlogIndexPage() {
-  const posts = await getPublishedPosts()
+export default async function BlogIndexPage({ searchParams }: BlogIndexPageProps) {
+  const { category } = await searchParams
+  const [posts, categories] = await Promise.all([
+    getPublishedPosts({ category }),
+    getAllCategories(),
+  ])
 
   return (
-    <main className="mx-auto max-w-5xl px-4 py-12">
-      <h1 className="text-3xl font-bold text-[#1B2A4A] mb-8">Blog</h1>
+    <main className="mx-auto max-w-6xl px-4 py-12">
+      {/* Header band */}
+      <div className="mb-12">
+        <h1 className="text-4xl font-bold text-neutral-900 mb-2 font-heading">
+          CircleTel Blog
+        </h1>
+        <p className="text-lg text-neutral-500 mb-6">
+          Reviews, guides and connectivity news
+        </p>
+        {/* Orange accent rule */}
+        <div className="w-12 h-1 bg-[#F5831F] rounded-full" />
+      </div>
+
+      {/* Category pills */}
+      <CategoryPills categories={categories} active={category} />
+
+      {/* Featured hero + grid */}
       {posts.length === 0 ? (
-        <p className="text-gray-500">No posts yet. Check back soon.</p>
-      ) : (
-        <div className="grid gap-8 sm:grid-cols-2">
-          {posts.map((p) => (
-            <Link key={p.id} href={`/blog/${p.slug}`} className="group block rounded-lg border border-gray-200 overflow-hidden hover:shadow-md transition">
-              {p.featuredImageThumbUrl && (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={p.featuredImageThumbUrl} alt={p.featuredImageAlt ?? p.title} className="w-full h-44 object-cover" />
-              )}
-              <div className="p-4">
-                <h2 className="font-semibold text-lg text-[#1B2A4A] group-hover:text-[#F5831F] transition">{p.title}</h2>
-                {p.excerpt && <p className="text-sm text-gray-600 mt-2 line-clamp-3">{p.excerpt}</p>}
-                <p className="text-xs text-gray-400 mt-3">{[p.authorName, formatDate(p.publishedAt)].filter(Boolean).join(' · ')}</p>
-              </div>
-            </Link>
-          ))}
+        <div className="py-12 text-center">
+          <p className="text-neutral-500">No posts yet. Check back soon.</p>
         </div>
+      ) : (
+        <>
+          {/* Featured post (first one) */}
+          {posts.length > 0 && (
+            <PostCard post={posts[0]} variant="featured" />
+          )}
+
+          {/* Remaining posts grid */}
+          {posts.length > 1 && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {posts.slice(1).map((post) => (
+                <PostCard key={post.id} post={post} />
+              ))}
+            </div>
+          )}
+        </>
       )}
     </main>
   )

--- a/components/blog/ArticleJsonLd.tsx
+++ b/components/blog/ArticleJsonLd.tsx
@@ -1,0 +1,40 @@
+import { BlogPost } from '@/lib/data/cms-blog'
+
+interface ArticleJsonLdProps {
+  post: BlogPost
+  url: string
+}
+
+export function ArticleJsonLd({ post, url }: ArticleJsonLdProps) {
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: post.title,
+    description: post.excerpt || post.metaDescription,
+    image: post.featuredImageHeroUrl ? [post.featuredImageHeroUrl] : undefined,
+    datePublished: post.publishedAt,
+    dateModified: post.publishedAt,
+    author: {
+      '@type': 'Person',
+      name: post.authorName || 'CircleTel',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'CircleTel',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://www.circletel.co.za/images/circletel-logo-2026.png',
+        width: 250,
+        height: 60,
+      },
+    },
+    url,
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  )
+}

--- a/components/blog/Breadcrumb.tsx
+++ b/components/blog/Breadcrumb.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+export interface BreadcrumbItem {
+  label: string
+  href?: string
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[]
+}
+
+export function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center text-sm text-neutral-500 mb-6">
+      {items.map((item, idx) => (
+        <div key={idx} className="flex items-center">
+          {idx > 0 && <span className="mx-2">/</span>}
+          {item.href ? (
+            <Link href={item.href} className="hover:text-neutral-700 transition">
+              {item.label}
+            </Link>
+          ) : (
+            <span className="text-neutral-700">{item.label}</span>
+          )}
+        </div>
+      ))}
+    </nav>
+  )
+}

--- a/components/blog/CategoryPills.tsx
+++ b/components/blog/CategoryPills.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+import { categoryLabel } from '@/lib/blog/categories'
+
+interface CategoryPillsProps {
+  categories: string[]
+  active?: string
+}
+
+export function CategoryPills({ categories, active }: CategoryPillsProps) {
+  return (
+    <div className="flex flex-wrap gap-3 mb-8">
+      {/* "All" pill */}
+      <Link
+        href="/blog"
+        className={`px-4 py-2 rounded-lg text-sm font-medium transition ${
+          !active
+            ? 'bg-[#F5831F] text-white'
+            : 'border border-neutral-200 text-neutral-700 hover:text-[#F5831F] hover:border-[#F5831F]'
+        }`}
+      >
+        All
+      </Link>
+
+      {/* Category pills */}
+      {categories.map((cat) => (
+        <Link
+          key={cat}
+          href={`/blog?category=${encodeURIComponent(cat)}`}
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition ${
+            active === cat
+              ? 'bg-[#F5831F] text-white'
+              : 'border border-neutral-200 text-neutral-700 hover:text-[#F5831F] hover:border-[#F5831F]'
+          }`}
+        >
+          {categoryLabel(cat)}
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/components/blog/NewsletterSignup.tsx
+++ b/components/blog/NewsletterSignup.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState } from 'react'
+
+export function NewsletterSignup() {
+  const [status, setStatus] = useState<'idle' | 'success'>('idle')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setStatus('success')
+    setTimeout(() => setStatus('idle'), 3000)
+  }
+
+  return (
+    <div className="p-6 bg-neutral-50 rounded-lg border border-neutral-200">
+      <h3 className="text-sm font-semibold text-neutral-900 mb-2">Stay Updated</h3>
+      <p className="text-xs text-neutral-500 mb-4">Get fresh articles delivered to your inbox.</p>
+
+      {status === 'success' ? (
+        <div className="p-3 bg-green-50 border border-green-200 rounded text-sm text-green-700">
+          Thanks for your interest! Coming soon.
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="email"
+            placeholder="you@example.com"
+            className="w-full px-3 py-2 border border-neutral-200 rounded-lg text-sm placeholder-neutral-400 focus:outline-none focus:border-[#F5831F]"
+            required
+          />
+          <button
+            type="submit"
+            className="w-full px-4 py-2 bg-[#F5831F] text-white text-sm font-semibold rounded-lg hover:bg-[#E87A1E] transition"
+          >
+            Subscribe
+          </button>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link'
+import { BlogPostCard } from '@/lib/data/cms-blog'
+import { categoryLabel } from '@/lib/blog/categories'
+
+interface PostCardProps {
+  post: BlogPostCard
+  variant?: 'default' | 'featured'
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString('en-ZA', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+export function PostCard({ post, variant = 'default' }: PostCardProps) {
+  if (variant === 'featured') {
+    return (
+      <article className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12 border border-neutral-200 rounded-lg overflow-hidden hover:border-neutral-300 transition">
+        {/* Image */}
+        {post.featuredImageThumbUrl && (
+          <div className="aspect-video overflow-hidden">
+            <img
+              src={post.featuredImageThumbUrl}
+              alt={post.featuredImageAlt ?? post.title}
+              className="w-full h-full object-cover"
+            />
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="flex flex-col justify-center p-6">
+          {/* Category pill */}
+          {post.categories.length > 0 && (
+            <div className="inline-flex w-fit mb-3">
+              <span className="px-3 py-1 bg-[#F5831F] text-white text-xs font-semibold rounded-full">
+                {categoryLabel(post.categories[0])}
+              </span>
+            </div>
+          )}
+
+          {/* Title */}
+          <Link href={`/blog/${post.slug}`}>
+            <h2 className="text-2xl font-bold text-neutral-900 hover:text-[#F5831F] transition mb-3 line-clamp-3">
+              {post.title}
+            </h2>
+          </Link>
+
+          {/* Excerpt */}
+          {post.excerpt && (
+            <p className="text-neutral-600 line-clamp-3 mb-4">{post.excerpt}</p>
+          )}
+
+          {/* Meta */}
+          <div className="flex items-center gap-1 text-sm text-neutral-500">
+            {post.authorName && <span>{post.authorName}</span>}
+            {post.authorName && formatDate(post.publishedAt) && <span>·</span>}
+            {formatDate(post.publishedAt) && <span>{formatDate(post.publishedAt)}</span>}
+          </div>
+        </div>
+      </article>
+    )
+  }
+
+  // Default variant
+  return (
+    <article className="group block border border-neutral-200 rounded-lg overflow-hidden hover:border-neutral-300 hover:shadow-md transition">
+      {/* Image */}
+      {post.featuredImageThumbUrl && (
+        <div className="aspect-video overflow-hidden bg-neutral-100">
+          <img
+            src={post.featuredImageThumbUrl}
+            alt={post.featuredImageAlt ?? post.title}
+            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+          />
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="p-5">
+        {/* Category tag */}
+        {post.categories.length > 0 && (
+          <div className="mb-3 inline-block">
+            <span className="px-2.5 py-1 bg-[#F5831F] text-white text-xs font-semibold rounded-full">
+              {categoryLabel(post.categories[0])}
+            </span>
+          </div>
+        )}
+
+        {/* Title */}
+        <Link href={`/blog/${post.slug}`}>
+          <h3 className="text-lg font-bold text-neutral-900 group-hover:text-[#F5831F] transition mb-2 line-clamp-2">
+            {post.title}
+          </h3>
+        </Link>
+
+        {/* Excerpt */}
+        {post.excerpt && (
+          <p className="text-sm text-neutral-600 mb-4 line-clamp-3">
+            {post.excerpt}
+          </p>
+        )}
+
+        {/* Meta */}
+        <div className="flex items-center gap-1 text-xs text-neutral-500">
+          {post.authorName && <span>{post.authorName}</span>}
+          {post.authorName && formatDate(post.publishedAt) && <span>·</span>}
+          {formatDate(post.publishedAt) && <span>{formatDate(post.publishedAt)}</span>}
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/components/blog/RelatedPosts.tsx
+++ b/components/blog/RelatedPosts.tsx
@@ -1,0 +1,22 @@
+import { BlogPostCard } from '@/lib/data/cms-blog'
+import { PostCard } from './PostCard'
+
+interface RelatedPostsProps {
+  posts: BlogPostCard[]
+  title?: string
+}
+
+export function RelatedPosts({ posts, title = 'Related Posts' }: RelatedPostsProps) {
+  if (posts.length === 0) return null
+
+  return (
+    <section className="mt-12">
+      <h2 className="text-2xl font-bold text-neutral-900 mb-6">{title}</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {posts.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/blog/SalesCtaBanner.tsx
+++ b/components/blog/SalesCtaBanner.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export function SalesCtaBanner() {
+  return (
+    <section className="mt-12 py-8 px-6 bg-[#1B2A4A] rounded-lg text-center">
+      <h2 className="text-2xl font-bold text-white mb-3">Ready to get connected?</h2>
+      <p className="text-neutral-300 mb-6 max-w-md mx-auto">
+        Explore our internet plans and check your coverage today.
+      </p>
+      <Link
+        href="/"
+        className="inline-block px-6 py-3 bg-[#F5831F] text-white font-semibold rounded-lg hover:bg-[#E87A1E] transition"
+      >
+        Check your coverage
+      </Link>
+    </section>
+  )
+}

--- a/components/blog/SalesCtaCard.tsx
+++ b/components/blog/SalesCtaCard.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+export function SalesCtaCard() {
+  return (
+    <div className="p-6 border border-neutral-200 rounded-lg bg-white space-y-4">
+      <div>
+        <h3 className="text-base font-bold text-neutral-900 mb-2">Get connected</h3>
+        <p className="text-sm text-neutral-600">
+          Ready to upgrade your internet? Check your coverage and find the perfect plan.
+        </p>
+      </div>
+
+      <Link
+        href="/"
+        className="block px-4 py-2.5 bg-[#F5831F] text-white text-sm font-semibold rounded-lg hover:bg-[#E87A1E] transition text-center"
+      >
+        Check your coverage
+      </Link>
+
+      <Link
+        href="/packages"
+        className="block px-4 py-2.5 border border-neutral-200 text-neutral-700 text-sm font-medium rounded-lg hover:border-[#F5831F] hover:text-[#F5831F] transition text-center"
+      >
+        View packages
+      </Link>
+    </div>
+  )
+}

--- a/components/blog/ShareButtons.tsx
+++ b/components/blog/ShareButtons.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState } from 'react'
+import { FiX } from 'react-icons/fi'
+
+interface ShareButtonsProps {
+  url: string
+  title: string
+}
+
+export function ShareButtons({ url, title }: ShareButtonsProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Silent fallback
+    }
+  }
+
+  const xShareUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`
+  const linkedInShareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`
+  const whatsappShareUrl = `https://wa.me/?text=${encodeURIComponent(`${title} ${url}`)}`
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold text-neutral-900">Share</h3>
+      <div className="flex gap-2">
+        {/* X (Twitter) */}
+        <a
+          href={xShareUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center w-10 h-10 rounded-lg border border-neutral-200 text-neutral-700 hover:text-[#F5831F] hover:border-[#F5831F] transition"
+          aria-label="Share on X"
+        >
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.6l-5.165-6.75-5.868 6.75h-3.308l7.732-8.835L2.882 2.25h6.6l4.75 6.285 5.312-6.285zM17.55 19.5h1.828L5.566 3.75H3.66l13.89 15.75z" />
+          </svg>
+        </a>
+
+        {/* LinkedIn */}
+        <a
+          href={linkedInShareUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center w-10 h-10 rounded-lg border border-neutral-200 text-neutral-700 hover:text-[#F5831F] hover:border-[#F5831F] transition"
+          aria-label="Share on LinkedIn"
+        >
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.475-2.236-1.667-2.236-.91 0-1.385.613-1.605 1.205-.082.2-.103.48-.103.758v5.842h-3.554s.047-9.474 0-10.452h3.554v1.481c.458-.708 1.28-1.717 3.11-1.717 2.27 0 3.97 1.483 3.97 4.667v5.021zM5.337 8.855c-1.144 0-1.915-.758-1.915-1.71 0-.957.769-1.71 1.96-1.71 1.19 0 1.916.753 1.938 1.71 0 .952-.748 1.71-1.983 1.71zm1.582 11.597H3.73V9.963h3.189v10.489zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z" />
+          </svg>
+        </a>
+
+        {/* WhatsApp */}
+        <a
+          href={whatsappShareUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center w-10 h-10 rounded-lg border border-neutral-200 text-neutral-700 hover:text-[#F5831F] hover:border-[#F5831F] transition"
+          aria-label="Share on WhatsApp"
+        >
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.67-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.076 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421-7.403h-.004a9.87 9.87 0 00-4.946 1.288l-.355.192-3.674-.964.984 3.6-.235.374a9.847 9.847 0 001.438 5.645l.192.303 3.003.711-.024.339c.589 2.959 3.434 5.210 6.514 5.21h.006c3.479 0 6.426-2.703 6.8-6.215l.036-.335 3.172.667-.239-.375a9.9 9.9 0 00-1.4-3.627l-.213-.304-.823-3.073 3.624-1.084-.365-.294a9.874 9.874 0 00-3.8-1.238l-.38-.047c-1.552-.134-3.066.279-4.514 1.22l-.283.188z" />
+          </svg>
+        </a>
+
+        {/* Copy Link */}
+        <button
+          onClick={handleCopyLink}
+          className="flex items-center justify-center w-10 h-10 rounded-lg border border-neutral-200 text-neutral-700 hover:text-[#F5831F] hover:border-[#F5831F] transition"
+          title={copied ? 'Copied!' : 'Copy link'}
+        >
+          {copied ? (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          ) : (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/docs/superpowers/specs/2026-06-07-blog-layout-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-07-blog-layout-redesign-design.md
@@ -1,0 +1,117 @@
+# Blog Layout Redesign — Design Spec
+
+**Date:** 2026-06-07
+**Status:** Approved (design)
+**Builds on:** `2026-06-07-cms-blog-public-rendering-design.md` (the working CMS-driven blog at `/blog`)
+
+## Goal
+
+Upgrade the public blog from the minimal placeholder layout to a polished **editorial layout**
+optimised for the blog's purposes: **reviews, organic SEO, how-to/info guides, and driving sales.**
+Reference layouts studied: BusinessTech, TechCentral (both classic editorial article + sidebar),
+PCMag (review-specific blocks — deferred to a later slice).
+
+## Brand / Visual Direction (user-approved)
+
+Minimalist, neutral-forward — **orange is the accent, grey/neutrals carry the page, navy is rare.**
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| **Accent (orange)** | `#F5831F` | Primary CTAs, links, category pills, active/hover states, rules under headings |
+| **Neutral scale** | Tailwind `neutral-*` (logo grey `#737373` = `neutral-500`) | Body text (`neutral-800`), meta/secondary (`neutral-500`), borders (`neutral-200`), subtle section bg (`neutral-50`) |
+| **Navy** | `#1B2A4A` | **Sparingly** — at most one accent (e.g. the footer CTA band). NOT for headlines/body. |
+| **Background** | `#FFFFFF` (+ `neutral-50` sections) | |
+| **Fonts** | Manrope (headings), Inter (body) — already in the app | |
+
+Principles: generous whitespace, thin `neutral-200` borders (not heavy shadows), `rounded-lg`,
+subtle hover (border→`neutral-300` / slight lift), orange used intentionally not everywhere.
+
+## Scope
+
+In: redesign `/blog` (index) and `/blog/[slug]` (post); reusable `components/blog/*`; data-layer
+additions (categories, read-time, related posts); JSON-LD `Article` SEO; sales CTAs; newsletter
+**placeholder**; **simple link-based** category navigation.
+
+Out (next slices): PCMag-style review blocks (verdict/rating/PROS-CONS — needs Payload custom
+blocks); functional newsletter backend; comments; full-text search; tag archive pages.
+
+## `/blog` — Magazine Index
+
+- **Header band**: H1 "CircleTel Blog" (Manrope, neutral-900) + tagline "Reviews, guides and
+  connectivity news" (neutral-500). Thin orange rule accent.
+- **Category pills**: `All · Reviews · Guides · News · Deals` — links to `/blog?category=<slug>`
+  (server-rendered filter via searchParams). Active pill = orange bg/white; others = neutral
+  outline. Driven by the categories present in the CMS.
+- **Featured hero** (when ≥1 post): newest post as a large 2-col card — image left, right =
+  category pill, large title, excerpt, author · date · read-time.
+- **Card grid**: remaining posts, responsive `sm:2 / lg:3` columns. Card = image (16:9, object-cover),
+  category tag, title (Manrope, hover→orange), excerpt (`line-clamp-3`), meta row (author · date ·
+  read-time). Thin border, hover lift.
+- **Empty state**: friendly "No posts yet" (kept).
+- SEO: single H1, semantic `<article>` cards, descriptive metadata.
+
+## `/blog/[slug]` — Editorial Article
+
+Container `max-w-6xl`; **two-column on `lg`** (article `~2fr` + sticky sidebar `~1fr`); single column on mobile.
+
+- **Breadcrumb**: Home › Blog › [Category] › Title (`neutral-500`, current = neutral-700). SEO + nav.
+- **Eyebrow**: category pill (orange).
+- **H1**: Manrope, `neutral-900`, large.
+- **Meta row**: author · formatted date · read-time (`neutral-500`, small).
+- **Hero image**: full container width, `rounded-lg`.
+- **Body**: `.prose` (typography plugin) with brand tweaks — links orange, `prose-headings` Manrope/
+  neutral-900, `prose-img` rounded. Renders `contentHtml`.
+- **Sticky sidebar** (`lg:` only, `position: sticky; top: 6rem`):
+  1. **Share** — X, LinkedIn, WhatsApp, Copy-link (neutral icons, orange hover).
+  2. **Sales CTA card** — "Check your coverage" → `/` (coverage checker) + secondary "View packages"
+     → `/packages`. Orange primary button. **Drives sales.**
+  3. **Newsletter** — email input + Subscribe button (placeholder: posts nowhere yet / disabled
+     submit with a "coming soon" note). Styled, ready to wire later.
+  4. **Related/Recent posts** — up to 4, title + thumb.
+- **Bottom of article**:
+  - **Inline sales-CTA banner** — full-width, `neutral-50` (or the single navy accent) with orange
+    button: "Ready to get connected? Check your coverage." → `/`.
+  - **Related posts grid** — 3 recent (prefer same category), reuse the card component.
+  - **Author byline** — name + small note.
+- **SEO**: JSON-LD `Article` (`headline`, `image`, `datePublished`, `dateModified`, `author`,
+  `publisher` w/ CircleTel logo) via a `<script type="application/ld+json">`; existing OG/Twitter
+  metadata retained.
+
+## Data-layer changes (`lib/data/cms-blog.ts` + view)
+
+- **Categories**: extend `public.cms_blog_posts` to expose `categories text[]` via
+  `array_agg(c.value)` joined from `payload.blog_posts_categories` (grouped by post). Map to
+  `categories: string[]` (+ a `primaryCategory` = first). Cards/eyebrow/breadcrumb/filter use it.
+- **Read-time**: compute in the data module from `content_html` — strip tags, word count / 200 wpm,
+  `Math.max(1, round)`. Add `readMinutes: number` to `BlogPostCard`/`BlogPost`. No view change.
+- **`getRelatedPosts(slug, category, limit=3)`**: published posts excluding `slug`, prefer same
+  category, fallback recent. (Single query on the view + filter.)
+- **`getPublishedPosts({ category? })`**: optional category filter for the index.
+
+## Components → `components/blog/`
+
+- `PostCard.tsx` — card (variant: `default` | `featured`).
+- `CategoryPills.tsx` — filter pills.
+- `Breadcrumb.tsx` — article breadcrumb.
+- `ShareButtons.tsx` — client component (copy-link uses `navigator.clipboard`).
+- `NewsletterSignup.tsx` — placeholder form.
+- `SalesCtaCard.tsx` + `SalesCtaBanner.tsx` — coverage/packages CTAs.
+- `RelatedPosts.tsx` — related grid/list.
+- `ArticleJsonLd.tsx` — JSON-LD script.
+- `lib/blog/read-time.ts` — read-time util (unit-tested).
+
+## Testing
+- Unit: `read-time.ts` (word count → minutes, min 1); `cms-blog.ts` additions (category mapping,
+  related filter) with mocked Supabase.
+- Visual: Playwright screenshot of `/blog` + a seeded post page (desktop + mobile) before deploy.
+
+## Error handling
+- All data fns keep graceful `[]`/`null` fallbacks. Missing category → no eyebrow/pill. Missing image
+  → text-only card. Empty related → section hidden.
+
+## Sequencing
+1. DB: extend view with `categories`.
+2. Data module: categories + readMinutes + related + category filter (+ tests).
+3. Components in `components/blog/`.
+4. Rewrite the two routes using the components + JSON-LD.
+5. Seed a couple of posts, Playwright screenshots (desktop+mobile), review, then PR → main.

--- a/lib/blog/categories.ts
+++ b/lib/blog/categories.ts
@@ -1,0 +1,27 @@
+/**
+ * Category label mappings for blog posts.
+ * Maps slug → display label.
+ */
+export const CATEGORY_LABELS: Record<string, string> = {
+  'product-updates': 'Product Updates',
+  'how-to': 'How-To Guides',
+  'industry': 'Industry Insights',
+  'case-studies': 'Case Studies',
+  'company-news': 'Company News',
+  'technology': 'Technology',
+}
+
+/**
+ * Get the display label for a category slug.
+ * Falls back to title-cased slug if not in the label map.
+ */
+export function categoryLabel(slug: string): string {
+  if (slug in CATEGORY_LABELS) {
+    return CATEGORY_LABELS[slug]
+  }
+  // Fallback: title-case the slug
+  return slug
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}

--- a/lib/blog/read-time.ts
+++ b/lib/blog/read-time.ts
@@ -1,0 +1,19 @@
+/**
+ * Calculate reading time in minutes for a given HTML string.
+ * Strips HTML tags, counts words, and divides by 200 WPM.
+ * Minimum 1 minute.
+ */
+export function readMinutes(html: string | null): number {
+  if (!html) return 1
+
+  // Strip HTML tags
+  const text = html.replace(/<[^>]*>/g, '')
+
+  // Count words (simple split on whitespace)
+  const words = text.trim().split(/\s+/).filter(Boolean).length
+
+  // Average reading speed: 200 words per minute
+  const minutes = Math.round(words / 200)
+
+  return Math.max(1, minutes)
+}

--- a/lib/data/cms-blog.ts
+++ b/lib/data/cms-blog.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { readMinutes } from '@/lib/blog/read-time'
 
 export interface BlogPostCard {
   id: number
@@ -9,6 +10,7 @@ export interface BlogPostCard {
   authorName: string | null
   featuredImageThumbUrl: string | null
   featuredImageAlt: string | null
+  categories: string[]
 }
 
 export interface BlogPost extends BlogPostCard {
@@ -16,10 +18,15 @@ export interface BlogPost extends BlogPostCard {
   featuredImageHeroUrl: string | null
   metaTitle: string | null
   metaDescription: string | null
+  readMinutes: number
+}
+
+export function primaryCategory(categories: string[]): string | null {
+  return categories.length > 0 ? categories[0] : null
 }
 
 const CARD_COLS =
-  'id,title,slug,excerpt,published_at,author_name,featured_image_thumb_url,featured_image_alt'
+  'id,title,slug,excerpt,published_at,author_name,featured_image_thumb_url,featured_image_alt,categories'
 const FULL_COLS =
   CARD_COLS + ',content_html,featured_image_hero_url,meta_title,meta_description'
 
@@ -33,6 +40,7 @@ function mapCard(r: any): BlogPostCard {
     authorName: r.author_name ?? null,
     featuredImageThumbUrl: r.featured_image_thumb_url ?? null,
     featuredImageAlt: r.featured_image_alt ?? null,
+    categories: Array.isArray(r.categories) ? r.categories : [],
   }
 }
 
@@ -43,16 +51,23 @@ function mapFull(r: any): BlogPost {
     featuredImageHeroUrl: r.featured_image_hero_url ?? null,
     metaTitle: r.meta_title ?? null,
     metaDescription: r.meta_description ?? null,
+    readMinutes: readMinutes(r.content_html ?? null),
   }
 }
 
-export async function getPublishedPosts(): Promise<BlogPostCard[]> {
+export async function getPublishedPosts(opts?: { category?: string }): Promise<BlogPostCard[]> {
   try {
     const supabase = await createClient()
-    const { data, error } = await supabase
+    let query = supabase
       .from('cms_blog_posts')
       .select(CARD_COLS)
       .order('published_at', { ascending: false })
+
+    if (opts?.category) {
+      query = query.contains('categories', [opts.category])
+    }
+
+    const { data, error } = await query
     if (error || !data) return []
     return data.map(mapCard)
   } catch {
@@ -81,6 +96,66 @@ export async function getPostSlugs(): Promise<string[]> {
     const { data, error } = await supabase.from('cms_blog_posts').select('slug').order('published_at', { ascending: false })
     if (error || !data) return []
     return data.map((r: any) => r.slug as string)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Get all distinct categories across published posts.
+ */
+export async function getAllCategories(): Promise<string[]> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('cms_blog_posts')
+      .select('categories')
+      .order('published_at', { ascending: false })
+
+    if (error || !data) return []
+
+    // Flatten categories arrays and get unique values
+    const allCategories = new Set<string>()
+    for (const row of data) {
+      if (Array.isArray(row.categories)) {
+        for (const cat of row.categories) {
+          allCategories.add(cat)
+        }
+      }
+    }
+
+    return Array.from(allCategories).sort()
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Get related posts for a given slug and optional category.
+ * Excludes the original post, prefers same category, falls back to recent.
+ */
+export async function getRelatedPosts(
+  slug: string,
+  category: string | null,
+  limit = 3
+): Promise<BlogPostCard[]> {
+  try {
+    const supabase = await createClient()
+    let query = supabase
+      .from('cms_blog_posts')
+      .select(CARD_COLS)
+      .neq('slug', slug)
+      .order('published_at', { ascending: false })
+
+    // If we have a category, prefer posts in that category
+    if (category) {
+      query = query.contains('categories', [category])
+    }
+
+    const { data, error } = await query.limit(limit)
+
+    if (error || !data) return []
+    return data.map(mapCard)
   } catch {
     return []
   }


### PR DESCRIPTION
## What this does
Redesigns the public blog (`/blog`, `/blog/[slug]`) from the minimal placeholder into a polished **editorial layout** for reviews, SEO, guides, and driving sales.

**Brand direction (approved):** minimalist — orange `#F5831F` accent, Tailwind neutral greys (logo grey `#737373`), navy `#1B2A4A` used sparingly (bottom CTA banner only).

## Index `/blog`
- Header + tagline + orange rule; **dynamic category pills** (from categories present on published posts).
- Featured hero card + responsive card grid; read-time, author, date.

## Article `/blog/[slug]`
- Breadcrumb, category eyebrow, Manrope H1, meta (author · date · read-time), hero image.
- Two-column: `.prose` body + **sticky sidebar** (share · sales CTA "Check your coverage" · newsletter placeholder · recent posts).
- Author byline, related-posts grid, navy sales CTA banner.
- **JSON-LD `Article`** structured data for SEO.

## Data / infra
- `public.cms_blog_posts` view extended with `categories text[]` (migration already applied).
- `lib/data/cms-blog.ts`: categories, read-time, `getAllCategories`, `getRelatedPosts`, category filter.
- New `lib/blog/{read-time,categories}.ts` + 9 `components/blog/*`.
- No Payload deps added to the monolith build.

## Verification
- Jest: **12/12 pass** (read-time + data module). Type-check: no blog-file errors.
- Playwright screenshots verified desktop + mobile.

## Deferred (next slice)
PCMag-style review blocks (verdict/rating/pros-cons) via Payload custom blocks; functional newsletter backend.

Spec: `docs/superpowers/specs/2026-06-07-blog-layout-redesign-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
