### PR TITLE
chore(gitignore): exclude local artifacts and sensitive operational data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,12 @@ graphify-out/
 .claude/mem/
 .factory/
 .env.staging
+
+# Local-only artifacts & sensitive operational data (not for git)
+.docs/
+.understand-anything/
+.claude-workflows/
+mockups/
+app/prototype/
+.design/ctel CI/
+.design/image copy 2.png


### PR DESCRIPTION
## What

Adds `.gitignore` entries to exclude local-only artifacts and **sensitive operational data** from version control.

## Why

While cleaning up an accumulated working tree, several untracked paths were found that must never be committed — most importantly `.docs/`, which contains customer KYC ID documents and Pay Now card-transaction reports (CSV/XLS). None of these are currently gitignored, so they were one `git add` away from leaking to the remote.

## Excluded paths

| Path | Reason |
|------|--------|
| `.docs/` | 🔴 Sensitive: KYC IDs, customer payment/card-transaction reports, screenshots |
| `.understand-anything/` | Knowledge-graph tool state (regenerable) |
| `.claude-workflows/` | Workflow output |
| `mockups/` | Binary design mockups + HTML |
| `app/prototype/` | Throwaway HTML prototypes |
| `.design/ctel CI/`, `.design/image copy 2.png` | Binary brand assets |

## Notes

- Config-only change (1 file). No code, no type-check impact.
- Recommended to merge first so the guardrail is in place before other branches land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)