### PR TITLE
chore: add shared pre-push hook (build-config + scoped type-check)

### DIFF
--- a/.claude/rules/pre-push-hook.md
+++ b/.claude/rules/pre-push-hook.md
@@ -1,0 +1,39 @@
+# Pre-Push Hook
+
+**Trigger**: Pushing a branch, "my push was blocked", editing `.githooks/`
+**Scope**: Shared client-side pre-push validation
+
+---
+
+## What it is
+
+A tracked, shared hook at **`.githooks/pre-push`** (NOT `.git/hooks/` — that's local-only).
+Enabled via `core.hooksPath`, auto-applied on `npm install` / `npm ci` by the
+`package.json` `prepare` script: `git config core.hooksPath .githooks`.
+
+## What it checks (in order)
+
+1. **Build config** — heap ≥6144 in `vercel.json`, `cpus:1` in `next.config.js`.
+   Mirrors the `validate-build-config` job in `.github/workflows/pr-checks.yml`.
+   Catches OOM-risk config before it reaches the self-hosted runner.
+2. **Scoped type-check** — runs `npm run type-check:memory` once, blocks **only if a
+   `.ts/.tsx` file in this push has an error**. Pushes with no TS changes skip it.
+
+### Why scoped, not full-blocking
+The repo carries ~295 pre-existing type errors, so CI runs `tsc` with
+`continue-on-error`. A full blocking type-check would block every push. The hook
+ignores errors in files you didn't touch — only your own new breakage blocks.
+
+## Escape hatches
+
+| Command | Effect |
+|---------|--------|
+| `git push --no-verify` | Skip the hook entirely |
+| `SKIP_TYPECHECK=1 git push` | Keep build-config check, skip type-check |
+
+## Gotchas
+
+- **Existing clones / the runner** only pick up `core.hooksPath` after their next
+  `npm install`/`npm ci`, or run `git config core.hooksPath .githooks` manually.
+- Harmless in CI — setting `core.hooksPath` there has no effect since CI never pushes.
+- Adds ~50s to pushes that touch TS files; ~0s otherwise.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,94 @@
+#!/bin/sh
+# Shared pre-push hook (tracked in repo; enabled via core.hooksPath=.githooks).
+# Auto-wired on `npm install` / `npm ci` by the "prepare" script in package.json.
+# To enable manually:  git config core.hooksPath .githooks
+#
+#   1. Validate Vercel build config (heap/cpus) — prevents OOM crashes on the runner.
+#      Mirrors the validate-build-config job in .github/workflows/pr-checks.yml
+#   2. Type-check ONLY the .ts/.tsx files being pushed.
+#      The repo carries ~295 pre-existing type errors (CI runs tsc with
+#      continue-on-error), so a full blocking type-check is unusable. Instead we
+#      run tsc once and fail only if a file YOU are pushing has an error — bad
+#      pushes are caught before they reach the self-hosted runner, without being
+#      blocked by errors in files you never touched.
+#
+# Escape hatches:
+#   git push --no-verify       # skip this hook entirely
+#   SKIP_TYPECHECK=1 git push  # keep the build-config check, skip the type-check
+
+FAILED=0
+ZERO="0000000000000000000000000000000000000000"
+
+# ----- 1. Build config validation -----------------------------------------
+HEAP=$(grep -o 'max-old-space-size=[0-9]*' vercel.json 2>/dev/null | grep -o '[0-9]*')
+if [ -z "$HEAP" ]; then
+  echo "⚠️  WARNING: Could not find max-old-space-size in vercel.json"
+elif [ "$HEAP" -lt 6144 ]; then
+  echo "❌ vercel.json heap is ${HEAP}MB — must be ≥6144MB (Vercel OOM risk)"
+  FAILED=1
+else
+  echo "✅ vercel.json heap: ${HEAP}MB"
+fi
+
+CPUS=$(grep -E '^\s*cpus:' next.config.js 2>/dev/null | grep -o '[0-9]*')
+if [ -z "$CPUS" ]; then
+  echo "⚠️  WARNING: Could not find cpus setting in next.config.js"
+elif [ "$CPUS" -gt 1 ]; then
+  echo "❌ next.config.js cpus=${CPUS} — must be 1 (Vercel OOM risk with 2+ workers)"
+  FAILED=1
+else
+  echo "✅ next.config.js cpus: ${CPUS}"
+fi
+
+# ----- 2. Scoped type-check ------------------------------------------------
+if [ "$SKIP_TYPECHECK" = "1" ]; then
+  echo "⏭️  SKIP_TYPECHECK=1 — skipping type-check"
+else
+  # Collect .ts/.tsx files across every ref being pushed (read from stdin).
+  CHANGED=""
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    [ "$local_sha" = "$ZERO" ] && continue          # branch deletion — nothing to check
+    if [ "$remote_sha" = "$ZERO" ]; then            # new branch — compare to origin/main
+      base=$(git merge-base origin/main "$local_sha" 2>/dev/null)
+      [ -z "$base" ] && base="origin/main"
+    else
+      base="$remote_sha"
+    fi
+    files=$(git diff --name-only "$base" "$local_sha" 2>/dev/null | grep -E '\.(ts|tsx)$')
+    CHANGED="$CHANGED
+$files"
+  done
+
+  CHANGED=$(printf '%s\n' "$CHANGED" | grep -E '\.(ts|tsx)$' | sort -u)
+
+  if [ -z "$CHANGED" ]; then
+    echo "✅ No .ts/.tsx files in this push — skipping type-check"
+  else
+    N=$(printf '%s\n' "$CHANGED" | grep -c .)
+    echo "🔎 Type-checking ($N changed TS file(s) in scope)…"
+    ERRORS=$(npm run type-check:memory 2>&1 | grep -E '^[^ (]+\.(ts|tsx)\([0-9]+,[0-9]+\): error')
+
+    HITS=""
+    for f in $CHANGED; do
+      match=$(printf '%s\n' "$ERRORS" | grep -F "$f(")
+      [ -n "$match" ] && HITS="$HITS
+$match"
+    done
+
+    if [ -n "$(printf '%s' "$HITS" | tr -d '[:space:]')" ]; then
+      echo "❌ Type errors in files you're pushing:"
+      printf '%s\n' "$HITS" | grep -E 'error TS'
+      FAILED=1
+    else
+      echo "✅ No type errors in the files you're pushing"
+    fi
+  fi
+fi
+
+if [ "$FAILED" -eq 1 ]; then
+  echo ""
+  echo "Push blocked. Fix the issues above, or bypass with:  git push --no-verify"
+  exit 1
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ All detailed patterns are in `.claude/rules/`:
 | `admin-shared-components.md` | StatusBadge/StatCard/SectionCard prop interfaces — verified signatures |
 | `vercel-deployment.md` | Manual deployment trigger API, monitoring, CircleTel project IDs |
 | `invoice-pdf-patterns.md` | VAT calc (excl-VAT multiply), fetch/blob download, print:hidden, jsPDF patterns |
+| `pre-push-hook.md` | Shared `.githooks/pre-push` — build-config + scoped type-check, escape hatches |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:ci": "node --max-old-space-size=6144 ./node_modules/next/dist/bin/next build",
     "start": "next start",
     "lint": "next lint",
+    "prepare": "git config core.hooksPath .githooks || true",
     "type-check": "tsc --noEmit",
     "type-check:memory": "node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc --noEmit",
     "predeploy:check": "npm run type-check && npm run lint",


### PR DESCRIPTION
## What

Moves the pre-push hook from local `.git/hooks/` into tracked **`.githooks/`** so it is shared across all clones, and auto-enables it via a `package.json` `prepare` script (`git config core.hooksPath .githooks` on `npm install`/`npm ci`).

## The hook does two things

1. **Build-config validation** — heap ≥6144 in `vercel.json`, `cpus:1` in `next.config.js`. Mirrors the `validate-build-config` job in `pr-checks.yml`, catching OOM-risk config before it reaches the self-hosted runner.
2. **Scoped type-check** — runs `tsc` once and blocks **only if a `.ts/.tsx` file in your push has an error**.

### Why scoped, not a full blocking type-check
The repo carries ~295 pre-existing type errors (which is why CI runs `tsc` with `continue-on-error`). A naive "fail if tsc fails" hook would block every push. This one ignores errors in files you didn't touch and only stops new breakage in files you're actually pushing. Pushes with no `.ts/.tsx` changes skip type-check entirely.

### Escape hatches
- `git push --no-verify` — skip the hook entirely
- `SKIP_TYPECHECK=1 git push` — keep the build-config check, skip the type-check

## How teammates get it
`core.hooksPath` is re-applied on every `npm install`/`npm ci` via the `prepare` script. Existing clones pick it up on their next install (or `git config core.hooksPath .githooks` manually). Harmless in CI — CI never pushes.

## Verification
- `sh -n .githooks/pre-push` clean; executable (`100755`); not gitignored
- Real `git push --dry-run` fired the hook: build-config ✅, detected changed TS files, type-checked, exit 0
- Confirmed it blocks a changed file with errors and passes a clean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)