### PR TITLE
feat(coverage): DFA fibre coverage checker with provider selector and verdict cards

### DIFF
--- a/app/admin/coverage/checker/components/CoverageMap.tsx
+++ b/app/admin/coverage/checker/components/CoverageMap.tsx
@@ -8,14 +8,20 @@ interface CoverageMapProps {
   targetLat: number;
   targetLng: number;
   targetAddress: string;
-  bnLat: number | null;
-  bnLng: number | null;
-  bnSiteName: string;
+  // Tarana mode
+  bnLat?: number | null;
+  bnLng?: number | null;
+  bnSiteName?: string;
+  // DFA mode
+  mode?: 'tarana' | 'dfa';
+  dfaCoverageType?: 'connected' | 'near-net' | 'none';
 }
 
 export default function CoverageMap({
   targetLat, targetLng, targetAddress,
   bnLat, bnLng, bnSiteName,
+  mode = 'tarana',
+  dfaCoverageType,
 }: CoverageMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<google.maps.Map | null>(null);
@@ -60,12 +66,12 @@ export default function CoverageMap({
     });
     targetMarker.addListener('click', () => targetInfo.open(map, targetMarker));
 
-    // BN marker (orange) if available
-    if (bnLat !== null && bnLng !== null) {
+    // BN marker (orange) — Tarana mode only
+    if (mode === 'tarana' && bnLat !== null && bnLat !== undefined && bnLng !== null && bnLng !== undefined) {
       const bnMarker = new google.maps.Marker({
         position: { lat: bnLat, lng: bnLng },
         map,
-        title: bnSiteName,
+        title: bnSiteName || 'Base Node',
         icon: {
           path: google.maps.SymbolPath.CIRCLE,
           scale: 12,
@@ -80,7 +86,7 @@ export default function CoverageMap({
       bounds.extend({ lat: bnLat, lng: bnLng });
 
       const bnInfo = new google.maps.InfoWindow({
-        content: `<div style="font-size:12px;font-weight:600;padding:2px 4px">📡 ${bnSiteName}</div>`,
+        content: `<div style="font-size:12px;font-weight:600;padding:2px 4px">📡 ${bnSiteName || 'Base Node'}</div>`,
       });
       bnMarker.addListener('click', () => bnInfo.open(map, bnMarker));
 
@@ -100,10 +106,32 @@ export default function CoverageMap({
           repeat: '12px',
         }],
       });
-
-      map.fitBounds(bounds, 80);
     }
-  }, [targetLat, targetLng, bnLat, bnLng, targetAddress, bnSiteName]);
+
+    // DFA mode — add a coverage zone indicator
+    if (mode === 'dfa' && dfaCoverageType && dfaCoverageType !== 'none') {
+      const dfaColor = dfaCoverageType === 'connected' ? '#10B981' : '#F59E0B';
+      // Circle overlay around target showing coverage zone
+      new google.maps.Circle({
+        map,
+        center: { lat: targetLat, lng: targetLng },
+        radius: dfaCoverageType === 'connected' ? 100 : 200,
+        fillColor: dfaColor,
+        fillOpacity: 0.15,
+        strokeColor: dfaColor,
+        strokeWeight: 2,
+        strokeOpacity: 0.6,
+      });
+
+      const dfaLabel = dfaCoverageType === 'connected' ? 'DFA Connected Zone' : 'DFA Near-Net Zone';
+      const dfaInfo = new google.maps.InfoWindow({
+        content: `<div style="font-size:12px;font-weight:600;padding:2px 4px">🔌 ${dfaLabel}</div>`,
+      });
+      targetMarker.addListener('click', () => dfaInfo.open(map, targetMarker));
+    }
+
+    map.fitBounds(bounds, 80);
+  }, [targetLat, targetLng, bnLat, bnLng, targetAddress, bnSiteName, mode, dfaCoverageType]);
 
   return (
     <SectionCard title="Coverage Map" icon={PiMapPinBold}>
@@ -113,14 +141,25 @@ export default function CoverageMap({
           <span className="w-3 h-3 rounded-full bg-blue-500 inline-block" />
           Target Address
         </span>
-        <span className="flex items-center gap-1.5">
-          <span className="w-3 h-3 rounded-full bg-orange-500 inline-block" />
-          Base Node ({bnSiteName})
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="w-6 border-t-2 border-dashed border-orange-400 inline-block" />
-          Link Path
-        </span>
+        {mode === 'dfa' ? (
+          <span className="flex items-center gap-1.5">
+            <span className={`w-3 h-3 rounded-full inline-block ${
+              dfaCoverageType === 'connected' ? 'bg-emerald-500' : 'bg-amber-500'
+            }`} />
+            DFA {dfaCoverageType === 'connected' ? 'Connected' : 'Near-Net'} Zone
+          </span>
+        ) : (
+          <>
+            <span className="flex items-center gap-1.5">
+              <span className="w-3 h-3 rounded-full bg-orange-500 inline-block" />
+              Base Node ({bnSiteName || 'Unknown'})
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-6 border-t-2 border-dashed border-orange-400 inline-block" />
+              Link Path
+            </span>
+          </>
+        )}
       </div>
     </SectionCard>
   );

--- a/app/admin/coverage/checker/components/CoverageVerdictCard.tsx
+++ b/app/admin/coverage/checker/components/CoverageVerdictCard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import type { CoveragePrediction, SignalQuality } from '@/lib/coverage/prediction/types';
+import type { CoveragePrediction, LiveNetworkStatus, SignalQuality } from '@/lib/coverage/prediction/types';
 import { StatusBadge } from '@/components/admin/shared';
+import { PiWarningCircleBold } from 'react-icons/pi';
 
 interface CoverageVerdictCardProps {
   prediction: CoveragePrediction | null;
+  liveStatus?: LiveNetworkStatus | null;
 }
 
 const QUALITY_CONFIG: Record<SignalQuality, {
@@ -44,7 +46,7 @@ function SignalBars({ filled, total = 5 }: { filled: number; total?: number }) {
   );
 }
 
-export default function CoverageVerdictCard({ prediction }: CoverageVerdictCardProps) {
+export default function CoverageVerdictCard({ prediction, liveStatus }: CoverageVerdictCardProps) {
   if (!prediction) {
     const cfg = QUALITY_CONFIG.none;
     return (
@@ -99,6 +101,36 @@ export default function CoverageVerdictCard({ prediction }: CoverageVerdictCardP
         <p className="mt-3 text-xs text-amber-700 bg-amber-100 rounded-lg px-3 py-2">
           ⚠️ Elevated installation may be required (10m+ antenna mast) for optimal signal at this location.
         </p>
+      )}
+      {/* BN offline — overrides terrain prediction */}
+      {liveStatus && !liveStatus.bnOnline && (
+        <div className="mt-3 flex items-start gap-2 bg-red-100 border border-red-300 rounded-lg px-3 py-2.5">
+          <PiWarningCircleBold className="text-red-600 mt-0.5 shrink-0 h-4 w-4" />
+          <div>
+            <p className="text-sm font-semibold text-red-800">
+              Base Station Offline — Do Not Sell
+            </p>
+            <p className="text-xs text-red-700 mt-0.5">
+              The nearest base station ({prediction.nearestBnSiteName}) is currently offline.
+              This address is not serviceable until the base station is restored.
+            </p>
+          </div>
+        </div>
+      )}
+      {/* BN online but zero connections — coverage unverified */}
+      {liveStatus && liveStatus.bnOnline && liveStatus.bnActiveConnections === 0 && prediction.signalQuality !== 'none' && (
+        <div className="mt-3 flex items-start gap-2 bg-amber-100 border border-amber-300 rounded-lg px-3 py-2.5">
+          <PiWarningCircleBold className="text-amber-600 mt-0.5 shrink-0 h-4 w-4" />
+          <div>
+            <p className="text-sm font-semibold text-amber-800">
+              Unverified Coverage — No Active Customers
+            </p>
+            <p className="text-xs text-amber-700 mt-0.5">
+              This base station is online but has zero active customer connections.
+              Coverage is unverified — a site survey is strongly recommended before selling.
+            </p>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/app/admin/coverage/checker/components/DFAInstallationEstimate.tsx
+++ b/app/admin/coverage/checker/components/DFAInstallationEstimate.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { SectionCard } from '@/components/admin/shared';
+import { PiClockBold, PiCurrencyDollarBold, PiNoteBold } from 'react-icons/pi';
+
+interface DFAInstallationEstimateProps {
+  estimate: {
+    estimatedCost: string;
+    estimatedDays: string;
+    notes: string;
+  };
+}
+
+export default function DFAInstallationEstimate({ estimate }: DFAInstallationEstimateProps) {
+  return (
+    <SectionCard title="Installation Estimate" icon={PiClockBold}>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex items-start gap-3">
+          <PiCurrencyDollarBold className="h-5 w-5 text-slate-400 mt-0.5" />
+          <div>
+            <p className="text-xs text-slate-500 mb-0.5">Estimated Cost</p>
+            <p className="text-sm font-semibold text-slate-900">{estimate.estimatedCost}</p>
+          </div>
+        </div>
+        <div className="flex items-start gap-3">
+          <PiClockBold className="h-5 w-5 text-slate-400 mt-0.5" />
+          <div>
+            <p className="text-xs text-slate-500 mb-0.5">Timeline</p>
+            <p className="text-sm font-semibold text-slate-900">{estimate.estimatedDays}</p>
+          </div>
+        </div>
+      </div>
+      <div className="mt-3 flex items-start gap-2 bg-slate-50 rounded-lg px-3 py-2">
+        <PiNoteBold className="h-4 w-4 text-slate-400 mt-0.5 shrink-0" />
+        <p className="text-xs text-slate-600">{estimate.notes}</p>
+      </div>
+    </SectionCard>
+  );
+}

--- a/app/admin/coverage/checker/components/DFAProductTiers.tsx
+++ b/app/admin/coverage/checker/components/DFAProductTiers.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { SectionCard } from '@/components/admin/shared';
+import { PiCheckCircleBold, PiPackageBold } from 'react-icons/pi';
+
+interface DFAProduct {
+  id: string;
+  name: string;
+  download_speed: number;
+  upload_speed: number;
+  price: number;
+  description?: string;
+}
+
+interface DFAProductTiersProps {
+  products: DFAProduct[];
+  recommended: DFAProduct | null;
+}
+
+function formatPrice(price: number): string {
+  return `R${price.toLocaleString()}/mo`;
+}
+
+function formatSpeed(dl: number, ul: number): string {
+  return `${dl}/${ul} Mbps`;
+}
+
+export default function DFAProductTiers({ products, recommended }: DFAProductTiersProps) {
+  if (products.length === 0) return null;
+
+  return (
+    <SectionCard title="Available BizFibreConnect Tiers" icon={PiPackageBold}>
+      <div className={`grid gap-3 ${products.length <= 2 ? 'grid-cols-2' : 'grid-cols-3'}`}>
+        {products.map(product => {
+          const isRecommended = recommended?.id === product.id;
+          return (
+            <div
+              key={product.id}
+              className={`relative rounded-lg border-2 p-3 transition-all ${
+                isRecommended
+                  ? 'border-blue-500 bg-blue-50 shadow-sm'
+                  : 'border-slate-200 bg-white'
+              }`}
+            >
+              {isRecommended && (
+                <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 text-xs bg-blue-600 text-white px-2 py-0.5 rounded-full font-semibold whitespace-nowrap">
+                  Recommended
+                </span>
+              )}
+              <p className="text-xs font-semibold text-slate-500 mb-0.5">
+                {formatSpeed(product.download_speed, product.upload_speed)}
+              </p>
+              <p className="text-sm font-bold text-slate-900 leading-tight">{product.name}</p>
+              <p className="text-sm font-semibold text-slate-700 mt-1">{formatPrice(product.price)}</p>
+              <p className="text-xs text-slate-400 mt-1.5 flex items-center gap-1">
+                <PiCheckCircleBold className="text-emerald-500" />
+                Business · Symmetrical
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </SectionCard>
+  );
+}

--- a/app/admin/coverage/checker/components/DFAVerdictCard.tsx
+++ b/app/admin/coverage/checker/components/DFAVerdictCard.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { StatusBadge } from '@/components/admin/shared';
+import { PiCheckCircleBold, PiLightningBold, PiXBold, PiBuildingBold } from 'react-icons/pi';
+
+interface DFAVerdictCardProps {
+  result: {
+    coverageType: 'connected' | 'near-net' | 'none';
+    message: string;
+    connected?: { buildingId: string; status: string; ftth: string | null; broadband: string | null; precinct: string | null; };
+    nearNet?: { distanceMeters: number; display: string; timeline: string; note: string; };
+  };
+}
+
+const CONFIG = {
+  connected: {
+    icon: PiCheckCircleBold,
+    color: 'text-emerald-500',
+    bgClass: 'bg-emerald-50 border-emerald-400',
+    badge: 'success' as const,
+    label: 'Connected — Active Fibre',
+  },
+  'near-net': {
+    icon: PiLightningBold,
+    color: 'text-amber-500',
+    bgClass: 'bg-amber-50 border-amber-400',
+    badge: 'warning' as const,
+    label: 'Near-Net — Extension Required',
+  },
+  none: {
+    icon: PiXBold,
+    color: 'text-red-500',
+    bgClass: 'bg-red-50 border-red-400',
+    badge: 'error' as const,
+    label: 'No DFA Coverage',
+  },
+};
+
+export default function DFAVerdictCard({ result }: DFAVerdictCardProps) {
+  const cfg = CONFIG[result.coverageType];
+  const Icon = cfg.icon;
+
+  return (
+    <div className={`rounded-xl border-l-4 ${cfg.bgClass} p-5`}>
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <Icon className={`h-8 w-8 ${cfg.color}`} />
+          <div>
+            <p className="text-xs font-semibold tracking-wider uppercase text-slate-500 mb-1">
+              DFA Fibre Status
+            </p>
+            <StatusBadge variant={cfg.badge} status={cfg.label} />
+          </div>
+        </div>
+        <p className="text-sm text-slate-500 max-w-md text-right">{result.message}</p>
+      </div>
+
+      {/* Connected building details */}
+      {result.coverageType === 'connected' && result.connected && (
+        <div className="mt-3 grid grid-cols-2 gap-2 text-xs bg-white/60 rounded-lg p-3">
+          <div>
+            <span className="text-slate-500">Building ID</span>
+            <p className="font-mono font-semibold text-slate-700">{result.connected.buildingId}</p>
+          </div>
+          <div>
+            <span className="text-slate-500">Status</span>
+            <p className="font-semibold text-emerald-700">{result.connected.status}</p>
+          </div>
+          {result.connected.precinct && (
+            <div>
+              <span className="text-slate-500">Precinct</span>
+              <p className="font-semibold text-slate-700">{result.connected.precinct}</p>
+            </div>
+          )}
+          {result.connected.ftth && (
+            <div>
+              <span className="text-slate-500">FTTH</span>
+              <p className="font-semibold text-slate-700">{result.connected.ftth}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Near-net details */}
+      {result.coverageType === 'near-net' && result.nearNet && (
+        <div className="mt-3 bg-amber-100/60 rounded-lg p-3 flex items-center gap-3">
+          <PiBuildingBold className="h-5 w-5 text-amber-600 shrink-0" />
+          <div>
+            <p className="text-sm font-semibold text-amber-800">
+              ~{result.nearNet.display} from nearest fibre point
+            </p>
+            <p className="text-xs text-amber-700 mt-0.5">{result.nearNet.note}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/coverage/checker/components/NetworkStatusCard.tsx
+++ b/app/admin/coverage/checker/components/NetworkStatusCard.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { LiveNetworkStatus } from '@/lib/coverage/prediction/types';
+import { SectionCard } from '@/components/admin/shared';
+import { Badge } from '@/components/ui/badge';
+import {
+  PiCheckCircleBold,
+  PiWarningCircleBold,
+  PiUsersBold,
+  PiRadioBold,
+} from 'react-icons/pi';
+
+interface NetworkStatusCardProps {
+  liveStatus: LiveNetworkStatus;
+}
+
+export default function NetworkStatusCard({ liveStatus }: NetworkStatusCardProps) {
+  const { bnOnline, bnActiveConnections, networkSummary } = liveStatus;
+
+  return (
+    <SectionCard title="Live Network Status" icon={PiRadioBold}>
+      <div className="space-y-3">
+        {/* BN Status */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-slate-600">Base Station Status</span>
+          {bnOnline ? (
+            <Badge className="bg-green-500 hover:bg-green-600 gap-1">
+              <PiCheckCircleBold className="h-3 w-3" />
+              Online
+            </Badge>
+          ) : (
+            <Badge variant="destructive" className="gap-1">
+              <PiWarningCircleBold className="h-3 w-3" />
+              Offline
+            </Badge>
+          )}
+        </div>
+
+        {/* Active Connections */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-slate-600">Active Connections</span>
+          <span className="text-sm font-semibold flex items-center gap-1">
+            <PiUsersBold className="h-3.5 w-3.5 text-slate-400" />
+            {bnActiveConnections}
+          </span>
+        </div>
+
+        {/* Network Summary */}
+        {networkSummary && (
+          <div className="border-t border-slate-100 pt-3 mt-1">
+            <p className="text-xs font-medium text-slate-500 mb-2 uppercase tracking-wider">
+              Network Overview
+            </p>
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              <div className="bg-slate-50 rounded px-2 py-1.5">
+                <span className="text-slate-500">BNs online</span>
+                <span className="float-right font-semibold">
+                  {networkSummary.onlineBNs}/{networkSummary.totalBNs}
+                </span>
+              </div>
+              <div className="bg-slate-50 rounded px-2 py-1.5">
+                <span className="text-slate-500">RNs online</span>
+                <span className="float-right font-semibold">
+                  {networkSummary.onlineRNs}/{networkSummary.totalRNs}
+                </span>
+              </div>
+            </div>
+            {networkSummary.fetchedAt && (
+              <p className="text-xs text-slate-400 mt-1.5">
+                Last synced: {new Date(networkSummary.fetchedAt).toLocaleString('en-ZA')}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </SectionCard>
+  );
+}

--- a/app/admin/coverage/checker/components/ProviderSelector.tsx
+++ b/app/admin/coverage/checker/components/ProviderSelector.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { PiRadioBold, PiBroadcastBold } from 'react-icons/pi';
+
+type ProviderType = 'tarana' | 'dfa';
+
+interface ProviderSelectorProps {
+  provider: ProviderType;
+  onChange: (p: ProviderType) => void;
+}
+
+export default function ProviderSelector({ provider, onChange }: ProviderSelectorProps) {
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-1 flex gap-1 w-fit">
+      <button
+        type="button"
+        onClick={() => onChange('tarana')}
+        className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+          provider === 'tarana'
+            ? 'bg-orange-500 text-white shadow-sm'
+            : 'text-slate-600 hover:text-slate-800 hover:bg-slate-50'
+        }`}
+      >
+        <PiRadioBold className="h-4 w-4" />
+        Tarana FWB
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange('dfa')}
+        className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+          provider === 'dfa'
+            ? 'bg-blue-600 text-white shadow-sm'
+            : 'text-slate-600 hover:text-slate-800 hover:bg-slate-50'
+        }`}
+      >
+        <PiBroadcastBold className="h-4 w-4" />
+        DFA Fibre
+      </button>
+    </div>
+  );
+}

--- a/app/admin/coverage/checker/components/SalesRecommendationCard.tsx
+++ b/app/admin/coverage/checker/components/SalesRecommendationCard.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import type { CoveragePrediction, SignalQuality } from '@/lib/coverage/prediction/types';
+import type { CoveragePrediction, LiveNetworkStatus, SignalQuality } from '@/lib/coverage/prediction/types';
 import { SectionCard } from '@/components/admin/shared';
 import { PiSparkleBold, PiCheckCircleBold, PiWarningBold, PiBuildingsBold, PiHouseBold } from 'react-icons/pi';
 
 interface SalesRecommendationCardProps {
   prediction: CoveragePrediction | null;
+  liveStatus?: LiveNetworkStatus | null;
 }
 
 // ── Product catalogue (source of truth: products/connectivity/) ──────────────
@@ -37,9 +38,19 @@ type CustomerType = 'smb' | 'residential';
 function getRecommendation(
   prediction: CoveragePrediction | null,
   customerType: CustomerType,
+  liveStatus: LiveNetworkStatus | null,
 ): { text: string; tiers: Tier[]; warning: string | null } {
   const baseTiers = customerType === 'residential' ? RESIDENTIAL_TIERS : SMB_TIERS;
   const allUnavailable = baseTiers.map(t => ({ ...t, available: false, recommended: false }));
+
+  // Gate: BN is offline — nothing can be sold regardless of signal quality
+  if (liveStatus && !liveStatus.bnOnline) {
+    return {
+      text: 'The nearest base station is currently offline. SkyFibre cannot be sold at this address until the base station is restored. Check back after the next sync or contact operations.',
+      tiers: allUnavailable,
+      warning: 'Do not create an order — installation will fail. Monitor the base station status and re-check coverage when the BN is back online.',
+    };
+  }
 
   if (!prediction || prediction.signalQuality === 'none') {
     return {
@@ -103,9 +114,9 @@ function getRecommendation(
   }
 }
 
-export default function SalesRecommendationCard({ prediction }: SalesRecommendationCardProps) {
+export default function SalesRecommendationCard({ prediction, liveStatus }: SalesRecommendationCardProps) {
   const [customerType, setCustomerType] = useState<CustomerType>('smb');
-  const { text, tiers, warning } = getRecommendation(prediction, customerType);
+  const { text, tiers, warning } = getRecommendation(prediction, customerType, liveStatus ?? null);
   const noService = !prediction || prediction.signalQuality === 'none';
 
   return (

--- a/app/admin/coverage/checker/page.tsx
+++ b/app/admin/coverage/checker/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useJsApiLoader } from '@react-google-maps/api';
-import type { CoveragePrediction } from '@/lib/coverage/prediction/types';
+import type { CoveragePrediction, LiveNetworkStatus } from '@/lib/coverage/prediction/types';
 import {
   StatCard, StatusBadge, UnderlineTabs, TabPanel,
 } from '@/components/admin/shared';
@@ -12,6 +12,11 @@ import SalesRecommendationCard from './components/SalesRecommendationCard';
 import CoverageMap from './components/CoverageMap';
 import TechnicalDetailsPanel from './components/TechnicalDetailsPanel';
 import TierEligibilityTable from './components/TierEligibilityTable';
+import NetworkStatusCard from './components/NetworkStatusCard';
+import ProviderSelector from './components/ProviderSelector';
+import DFAVerdictCard from './components/DFAVerdictCard';
+import DFAProductTiers from './components/DFAProductTiers';
+import DFAInstallationEstimate from './components/DFAInstallationEstimate';
 import RecentChecksPanel, { saveRecentCheck } from './components/RecentChecksPanel';
 import {
   PiRulerBold, PiLightningBold, PiGaugeBold, PiCheckCircleBold,
@@ -28,6 +33,7 @@ const TABS = [
 ] as const;
 
 type TabId = typeof TABS[number]['id'];
+type ProviderType = 'tarana' | 'dfa';
 
 const QUALITY_LABEL: Record<string, string> = {
   excellent: 'Excellent', good: 'Good', fair: 'Marginal', poor: 'Weak', none: 'None',
@@ -49,15 +55,35 @@ interface CheckResult {
   prediction: CoveragePrediction | null;
   baseStation: { lat: number; lng: number } | null;
   networkInfo: NetworkInfo | null;
+  liveStatus: LiveNetworkStatus | null;
   address: string;
   lat: number;
   lng: number;
 }
 
+interface DFAResult {
+  coverageType: 'connected' | 'near-net' | 'none';
+  message: string;
+  connected?: { buildingId: string; status: string; ftth: string | null; broadband: string | null; precinct: string | null; };
+  nearNet?: { distanceMeters: number; display: string; timeline: string; note: string; };
+  products: Array<{ id: string; name: string; download_speed: number; upload_speed: number; price: number; coverage_details: any; description?: string; }>;
+  recommendedProduct: any | null;
+  installationEstimate: { estimatedCost: string; estimatedDays: string; notes: string; };
+  coordinates: { lat: number; lng: number };
+  address: string;
+}
+
 export default function CoverageCheckerPage() {
+  const [provider, setProvider] = useState<ProviderType>('tarana');
+  // Tarana state
   const [result, setResult] = useState<CheckResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // DFA state
+  const [dfaResult, setDfaResult] = useState<DFAResult | null>(null);
+  const [dfaLoading, setDfaLoading] = useState(false);
+  const [dfaError, setDfaError] = useState<string | null>(null);
+  // Shared
   const [activeTab, setActiveTab] = useState<TabId>('check');
   const statsRef = useRef<HTMLDivElement>(null);
 
@@ -66,10 +92,12 @@ export default function CoverageCheckerPage() {
     libraries: MAPS_LIBRARIES,
   });
 
+  // ── Tarana check ──
   const handleCheck = useCallback(async (lat: number, lng: number, address: string) => {
     setIsLoading(true);
     setError(null);
     setResult(null);
+    setDfaResult(null);
     setActiveTab('check');
 
     try {
@@ -88,6 +116,7 @@ export default function CoverageCheckerPage() {
         prediction: CoveragePrediction | null;
         baseStation: { lat: number; lng: number } | null;
         networkInfo: NetworkInfo | null;
+        liveStatus: LiveNetworkStatus | null;
         message?: string;
       };
 
@@ -95,6 +124,7 @@ export default function CoverageCheckerPage() {
         prediction: data.prediction,
         baseStation: data.baseStation ?? null,
         networkInfo: data.networkInfo ?? null,
+        liveStatus: data.liveStatus ?? null,
         address,
         lat,
         lng,
@@ -118,14 +148,43 @@ export default function CoverageCheckerPage() {
     }
   }, []);
 
+  // ── DFA check ──
+  const handleDFACheck = useCallback(async (lat: number, lng: number, address: string) => {
+    setDfaLoading(true);
+    setDfaError(null);
+    setDfaResult(null);
+    setResult(null);
+    setActiveTab('check');
+
+    try {
+      const res = await fetch('/api/admin/coverage/dfa', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coordinates: { lat, lng }, address }),
+      });
+
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || data.message || 'DFA check failed');
+
+      setDfaResult({ ...data.data, address });
+    } catch (err) {
+      setDfaError(err instanceof Error ? err.message : 'DFA coverage check failed');
+    } finally {
+      setDfaLoading(false);
+    }
+  }, []);
+
   // Scroll stats row into view after result loads
   useEffect(() => {
-    if (result && statsRef.current) {
+    if ((result || dfaResult) && statsRef.current) {
       statsRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
-  }, [result]);
+  }, [result, dfaResult]);
 
   const prediction = result?.prediction ?? null;
+  const loading = provider === 'tarana' ? isLoading : dfaLoading;
+  const currentError = provider === 'tarana' ? error : dfaError;
+  const hasResult = provider === 'tarana' ? result !== null : dfaResult !== null;
 
   function getMcsLevel(rssi: number): number {
     if (rssi >= -65)   return 16;
@@ -166,16 +225,24 @@ export default function CoverageCheckerPage() {
               </Link>
               <div>
                 <div className="flex items-center gap-3">
-                  <h1 className="text-xl font-bold text-slate-900">Tarana Coverage Checker</h1>
+                  <h1 className="text-xl font-bold text-slate-900">Coverage Checker</h1>
                   {prediction && (
                     <StatusBadge
                       status={QUALITY_LABEL[prediction.signalQuality] ?? '—'}
                       variant={QUALITY_VARIANT[prediction.signalQuality] ?? 'neutral'}
                     />
                   )}
+                  {dfaResult && (
+                    <StatusBadge
+                      status={dfaResult.coverageType === 'connected' ? 'Connected' : dfaResult.coverageType === 'near-net' ? 'Near-Net' : 'No Coverage'}
+                      variant={dfaResult.coverageType === 'connected' ? 'success' : dfaResult.coverageType === 'near-net' ? 'warning' : 'error'}
+                    />
+                  )}
                 </div>
-                {result?.address && (
-                  <p className="text-sm text-slate-500 mt-0.5 truncate max-w-md">{result.address}</p>
+                {(result?.address || dfaResult?.address) && (
+                  <p className="text-sm text-slate-500 mt-0.5 truncate max-w-md">
+                    {result?.address || dfaResult?.address}
+                  </p>
                 )}
               </div>
             </div>
@@ -190,7 +257,7 @@ export default function CoverageCheckerPage() {
         </div>
       </div>
 
-      {/* ── Stat Cards (shown after first result) ── */}
+      {/* ── Stat Cards (Tarana only — shown after first result) ── */}
       {prediction && (
         <div ref={statsRef} className="bg-white border-b border-slate-100">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
@@ -238,9 +305,15 @@ export default function CoverageCheckerPage() {
         {/* Coverage Check Tab */}
         <TabPanel id="check" activeTab={activeTab} className="space-y-5">
 
+          {/* Provider Selector */}
+          <ProviderSelector provider={provider} onChange={(p) => { setProvider(p); setResult(null); setDfaResult(null); setError(null); setDfaError(null); }} />
+
           {/* Address input */}
           {mapsLoaded ? (
-            <AddressInput onCheck={handleCheck} isLoading={isLoading} />
+            <AddressInput
+              onCheck={provider === 'tarana' ? handleCheck : handleDFACheck}
+              isLoading={loading}
+            />
           ) : (
             <div className="bg-white rounded-xl border border-slate-200 p-6 text-sm text-slate-500 flex items-center gap-3">
               <div className="w-4 h-4 border-2 border-orange-400 border-t-transparent rounded-full animate-spin" />
@@ -249,29 +322,38 @@ export default function CoverageCheckerPage() {
           )}
 
           {/* Loading state */}
-          {isLoading && (
+          {loading && (
             <div className="bg-white rounded-xl border border-slate-200 p-8 text-center">
               <div className="w-8 h-8 border-[3px] border-orange-400 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
-              <p className="text-sm font-medium text-slate-700">Checking coverage…</p>
-              <p className="text-xs text-slate-400 mt-1">Running terrain analysis and link budget calculation</p>
+              <p className="text-sm font-medium text-slate-700">
+                {provider === 'tarana' ? 'Checking coverage…' : 'Checking DFA fibre coverage…'}
+              </p>
+              <p className="text-xs text-slate-400 mt-1">
+                {provider === 'tarana'
+                  ? 'Running terrain analysis and link budget calculation'
+                  : 'Querying DFA ArcGIS connected and near-net buildings'}
+              </p>
             </div>
           )}
 
           {/* Error state */}
-          {error && (
+          {currentError && (
             <div className="bg-red-50 border border-red-200 rounded-xl p-4 text-sm text-red-700">
-              <span className="font-semibold">Error: </span>{error}
+              <span className="font-semibold">Error: </span>{currentError}
             </div>
           )}
 
-          {/* Results */}
-          {result && !isLoading && (
+          {/* ── Tarana Results ── */}
+          {provider === 'tarana' && result && !isLoading && (
             <div className="space-y-4">
-              <CoverageVerdictCard prediction={result.prediction} />
+              <CoverageVerdictCard prediction={result.prediction} liveStatus={result.liveStatus} />
               {result.prediction && (
                 <TierEligibilityTable prediction={result.prediction} />
               )}
-              <SalesRecommendationCard prediction={result.prediction} />
+              {result.liveStatus && (
+                <NetworkStatusCard liveStatus={result.liveStatus} />
+              )}
+              <SalesRecommendationCard prediction={result.prediction} liveStatus={result.liveStatus} />
               <CoverageMap
                 targetLat={result.lat}
                 targetLng={result.lng}
@@ -283,17 +365,41 @@ export default function CoverageCheckerPage() {
             </div>
           )}
 
+          {/* ── DFA Results ── */}
+          {provider === 'dfa' && dfaResult && !dfaLoading && (
+            <div className="space-y-4">
+              <DFAVerdictCard result={dfaResult} />
+              {dfaResult.coverageType !== 'none' && dfaResult.products.length > 0 && (
+                <DFAProductTiers products={dfaResult.products} recommended={dfaResult.recommendedProduct} />
+              )}
+              {dfaResult.coverageType !== 'none' && (
+                <DFAInstallationEstimate estimate={dfaResult.installationEstimate} />
+              )}
+              <CoverageMap
+                targetLat={dfaResult.coordinates.lat}
+                targetLng={dfaResult.coordinates.lng}
+                targetAddress={dfaResult.address}
+                mode="dfa"
+                dfaCoverageType={dfaResult.coverageType}
+              />
+            </div>
+          )}
+
           {/* Empty state */}
-          {!result && !isLoading && !error && (
+          {!hasResult && !loading && !currentError && (
             <div className="bg-white rounded-xl border border-dashed border-slate-300 p-12 text-center">
-              <p className="text-sm text-slate-400">Enter an address above to check Tarana FWB coverage</p>
+              <p className="text-sm text-slate-400">
+                {provider === 'tarana'
+                  ? 'Enter an address above to check Tarana FWB coverage'
+                  : 'Enter an address above to check DFA fibre coverage'}
+              </p>
             </div>
           )}
         </TabPanel>
 
         {/* Technical Details Tab */}
         <TabPanel id="technical" activeTab={activeTab} className="space-y-5">
-          {result?.prediction ? (
+          {provider === 'tarana' && result?.prediction ? (
             <TechnicalDetailsPanel
               prediction={result.prediction}
               bnLat={result.baseStation?.lat ?? null}
@@ -302,7 +408,11 @@ export default function CoverageCheckerPage() {
             />
           ) : (
             <div className="bg-white rounded-xl border border-dashed border-slate-300 p-12 text-center">
-              <p className="text-sm text-slate-400">Run a coverage check to see technical details</p>
+              <p className="text-sm text-slate-400">
+                {provider === 'dfa'
+                  ? 'Technical details are available for Tarana FWB checks. Switch to Tarana and run a check.'
+                  : 'Run a Tarana coverage check to see technical details'}
+              </p>
             </div>
           )}
         </TabPanel>

--- a/app/api/admin/tarana/predict/route.ts
+++ b/app/api/admin/tarana/predict/route.ts
@@ -26,12 +26,32 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ prediction: null, message: 'No base stations within range' });
     }
 
-    // Fetch BN coordinates + network topology for map display and UI
+    // Fetch BN coordinates + network topology + live status for map display and UI
     const { data: bn } = await supabase
       .from('tarana_base_stations')
-      .select('lat, lng, cell_name, sector_name, market_id, site_id')
+      .select('lat, lng, cell_name, sector_name, market_id, site_id, device_status, active_connections')
       .eq('serial_number', prediction.nearestBnSerial)
       .single();
+
+    // Fetch latest device counts for network-wide context
+    const { data: deviceCounts } = await supabase
+      .from('tarana_device_counts')
+      .select('*')
+      .order('fetched_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    const liveStatus = {
+      bnOnline: (bn?.device_status ?? 0) === 1,
+      bnActiveConnections: bn?.active_connections ?? 0,
+      networkSummary: deviceCounts ? {
+        totalBNs: deviceCounts.bn_total,
+        onlineBNs: deviceCounts.bn_connected,
+        totalRNs: deviceCounts.rn_total,
+        onlineRNs: deviceCounts.rn_connected,
+        fetchedAt: deviceCounts.fetched_at,
+      } : null,
+    };
 
     return NextResponse.json({
       prediction,
@@ -43,6 +63,7 @@ export async function POST(request: NextRequest) {
         cellName: bn.cell_name ?? null,
         sectorName: bn.sector_name ?? null,
       } : null,
+      liveStatus,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/docs/plans/2026-05-25-dfa-fibre-coverage-checker.md
+++ b/docs/plans/2026-05-25-dfa-fibre-coverage-checker.md
@@ -1,0 +1,591 @@
+# DFA Fibre Coverage in Admin Checker — Implementation Plan
+
+> **For Hermes:** Implement task-by-task. Each task is self-contained and type-checkable.
+
+**Goal:** Add DFA fibre coverage checks to the admin coverage checker (`/admin/coverage/checker`) alongside the existing Tarana FWB check, so sales staff can check both wireless and fibre coverage from a single tool.
+
+**Architecture:** Add a provider selector (Tarana FWB | DFA Fibre) at the top of the checker. DFA checks reuse the existing `POST /api/admin/coverage/dfa` endpoint — no new API needed. DFA results render via new provider-specific components for verdict, product tiers, and installation estimates. The map component is extended to support DFA building markers.
+
+**Scope:** Broadband fibre only (BizFibreConnect). Dedicated fibre (DIA, layer 2) requires product catalog changes — noted as follow-up.
+
+**Files (9 total):**
+- `app/admin/coverage/checker/page.tsx` — add provider selector + DFA flow
+- `app/admin/coverage/checker/components/ProviderSelector.tsx` — new
+- `app/admin/coverage/checker/components/DFAVerdictCard.tsx` — new
+- `app/admin/coverage/checker/components/DFAProductTiers.tsx` — new
+- `app/admin/coverage/checker/components/DFAInstallationEstimate.tsx` — new
+- `app/admin/coverage/checker/components/CoverageMap.tsx` — extend for DFA
+- `app/admin/coverage/checker/components/CoverageResultPanel.tsx` — DFA branch
+- `app/admin/coverage/checker/components/AddressInput.tsx` — no changes needed
+- `app/admin/coverage/checker/components/TierEligibilityTable.tsx` — no changes
+
+---
+
+## DFA API Response Shape (for reference)
+
+`POST /api/admin/coverage/dfa` already returns:
+
+```typescript
+{
+  success: true,
+  data: {
+    provider: 'dfa',
+    coordinates: { lat, lng },
+    coverageType: 'connected' | 'near-net' | 'none',
+    message: string,
+    // If connected:
+    connected?: {
+      buildingId: string,
+      status: string,
+      ftth: string | null,
+      broadband: string | null,
+      precinct: string | null,
+    },
+    // If near-net:
+    nearNet?: {
+      distanceMeters: number,
+      display: string,          // e.g. "~85m"
+      timeline: string,          // e.g. "8–12 weeks"
+      note: string,
+    },
+    // If has coverage:
+    products: MappedProduct[],   // BizFibreConnect tiers
+    recommendedProduct: MappedProduct | null,
+    installationEstimate: {
+      estimatedCost: string,     // e.g. "R0 - R1,500"
+      estimatedDays: string,     // e.g. "5-10 business days"
+      notes: string,
+    },
+    timestamp: string,
+  }
+}
+```
+
+---
+
+### Task 1: Add provider state and selector to the checker page
+
+**Objective:** The checker page currently only runs Tarana checks. Add a `provider` state (`'tarana' | 'dfa'`) and a selector component.
+
+**File:** `app/admin/coverage/checker/page.tsx`
+
+**Step 1:** Add `ProviderType` and state:
+
+```typescript
+type ProviderType = 'tarana' | 'dfa';
+
+export default function CoverageCheckerPage() {
+  const [provider, setProvider] = useState<ProviderType>('tarana');
+  // ... existing state
+```
+
+**Step 2:** Add DFA result state alongside existing Tarana state:
+
+```typescript
+interface DFAResult {
+  coverageType: 'connected' | 'near-net' | 'none';
+  message: string;
+  connected?: { buildingId: string; status: string; ftth: string | null; broadband: string | null; precinct: string | null; };
+  nearNet?: { distanceMeters: number; display: string; timeline: string; note: string; };
+  products: Array<{ id: string; name: string; download_speed: number; upload_speed: number; price: number; coverage_details: any; description?: string; }>;
+  recommendedProduct: any | null;
+  installationEstimate: { estimatedCost: string; estimatedDays: string; notes: string; };
+  coordinates: { lat: number; lng: number };
+  address: string;
+}
+
+const [dfaResult, setDfaResult] = useState<DFAResult | null>(null);
+const [dfaLoading, setDfaLoading] = useState(false);
+const [dfaError, setDfaError] = useState<string | null>(null);
+```
+
+**Step 3:** Add the DFA fetch handler:
+
+```typescript
+const handleDFACheck = useCallback(async (lat: number, lng: number, address: string) => {
+  setDfaLoading(true);
+  setDfaError(null);
+  setDfaResult(null);
+  setActiveTab('check');
+
+  try {
+    const res = await fetch('/api/admin/coverage/dfa', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ coordinates: { lat, lng }, address }),
+    });
+
+    const data = await res.json();
+    if (!data.success) throw new Error(data.error || data.message || 'DFA check failed');
+
+    setDfaResult({ ...data.data, address });
+  } catch (err) {
+    setDfaError(err instanceof Error ? err.message : 'DFA coverage check failed');
+  } finally {
+    setDfaLoading(false);
+  }
+}, []);
+```
+
+**Step 4:** Render the provider selector and conditional flows. Replace the check flow to branch on `provider`:
+
+```typescript
+{/* Provider Selector — above AddressInput */}
+<ProviderSelector provider={provider} onChange={setProvider} />
+
+{/* AddressInput — same for both, calls the appropriate handler */}
+{mapsLoaded ? (
+  <AddressInput
+    onCheck={provider === 'tarana' ? handleCheck : handleDFACheck}
+    isLoading={provider === 'tarana' ? isLoading : dfaLoading}
+  />
+) : (
+  // loading skeleton
+)}
+```
+
+**Step 5:** After results, branch rendering:
+
+```typescript
+{/* Tarana results (existing) */}
+{provider === 'tarana' && result && !isLoading && (
+  // ... existing Tarana result components
+)}
+
+{/* DFA results (new) */}
+{provider === 'dfa' && dfaResult && !dfaLoading && (
+  <div className="space-y-4">
+    <DFAVerdictCard result={dfaResult} />
+    {dfaResult.coverageType !== 'none' && (
+      <DFAProductTiers products={dfaResult.products} recommended={dfaResult.recommendedProduct} />
+    )}
+    <DFAInstallationEstimate estimate={dfaResult.installationEstimate} />
+    <CoverageMap
+      targetLat={dfaResult.coordinates.lat}
+      targetLng={dfaResult.coordinates.lng}
+      targetAddress={dfaResult.address}
+      mode="dfa"
+      dfaCoverageType={dfaResult.coverageType}
+    />
+  </div>
+)}
+```
+
+**Step 6:** Also add DFA loading, error, and empty states paralleling the existing Tarana states.
+
+**Verify:** `npm run type-check` — expect errors only in components not yet created (Tasks 2-5).
+
+---
+
+### Task 2: Create `ProviderSelector` component
+
+**Objective:** A clean tab-like selector letting the user pick between Tarana FWB and DFA Fibre before entering an address.
+
+**File:** Create `app/admin/coverage/checker/components/ProviderSelector.tsx`
+
+```typescript
+'use client';
+
+import { PiRadioBold, PiFiberSmartRecordBold } from 'react-icons/pi';
+
+type ProviderType = 'tarana' | 'dfa';
+
+interface ProviderSelectorProps {
+  provider: ProviderType;
+  onChange: (p: ProviderType) => void;
+}
+
+export default function ProviderSelector({ provider, onChange }: ProviderSelectorProps) {
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-1 flex gap-1 w-fit">
+      <button
+        type="button"
+        onClick={() => onChange('tarana')}
+        className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+          provider === 'tarana'
+            ? 'bg-orange-500 text-white shadow-sm'
+            : 'text-slate-600 hover:text-slate-800 hover:bg-slate-50'
+        }`}
+      >
+        <PiRadioBold className="h-4 w-4" />
+        Tarana FWB
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange('dfa')}
+        className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+          provider === 'dfa'
+            ? 'bg-blue-600 text-white shadow-sm'
+            : 'text-slate-600 hover:text-slate-800 hover:bg-slate-50'
+        }`}
+      >
+        <PiFiberSmartRecordBold className="h-4 w-4" />
+        DFA Fibre
+      </button>
+    </div>
+  );
+}
+```
+
+If `PiFiberSmartRecordBold` doesn't exist in react-icons/pi, use `PiGraphBold` or `PiNetworkBold` as fallback.
+
+**Verify:** `npm run type-check`
+
+---
+
+### Task 3: Create `DFAVerdictCard` component
+
+**Objective:** Shows the DFA coverage verdict with clear visual indicators for connected, near-net, and no coverage.
+
+**File:** Create `app/admin/coverage/checker/components/DFAVerdictCard.tsx`
+
+```typescript
+'use client';
+
+import { SectionCard } from '@/components/admin/shared';
+import { StatusBadge } from '@/components/admin/shared';
+import { PiCheckCircleBold, PiLightningBold, PiXBold, PiBuildingBold } from 'react-icons/pi';
+
+interface DFAVerdictCardProps {
+  result: {
+    coverageType: 'connected' | 'near-net' | 'none';
+    message: string;
+    connected?: { buildingId: string; status: string; ftth: string | null; broadband: string | null; precinct: string | null; };
+    nearNet?: { distanceMeters: number; display: string; timeline: string; note: string; };
+  };
+}
+
+const CONFIG = {
+  connected: {
+    icon: PiCheckCircleBold,
+    color: 'text-emerald-500',
+    bgClass: 'bg-emerald-50 border-emerald-400',
+    badge: 'success' as const,
+    label: 'Connected — Active Fibre',
+  },
+  'near-net': {
+    icon: PiLightningBold,
+    color: 'text-amber-500',
+    bgClass: 'bg-amber-50 border-amber-400',
+    badge: 'warning' as const,
+    label: 'Near-Net — Extension Required',
+  },
+  none: {
+    icon: PiXBold,
+    color: 'text-red-500',
+    bgClass: 'bg-red-50 border-red-400',
+    badge: 'error' as const,
+    label: 'No DFA Coverage',
+  },
+};
+
+export default function DFAVerdictCard({ result }: DFAVerdictCardProps) {
+  const cfg = CONFIG[result.coverageType];
+  const Icon = cfg.icon;
+
+  return (
+    <div className={`rounded-xl border-l-4 ${cfg.bgClass} p-5`}>
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <Icon className={`h-8 w-8 ${cfg.color}`} />
+          <div>
+            <p className="text-xs font-semibold tracking-wider uppercase text-slate-500 mb-1">
+              DFA Fibre Status
+            </p>
+            <StatusBadge variant={cfg.badge} status={cfg.label} />
+          </div>
+        </div>
+        <p className="text-sm text-slate-500 max-w-md text-right">{result.message}</p>
+      </div>
+
+      {/* Connected building details */}
+      {result.coverageType === 'connected' && result.connected && (
+        <div className="mt-3 grid grid-cols-2 gap-2 text-xs bg-white/60 rounded-lg p-3">
+          <div>
+            <span className="text-slate-500">Building ID</span>
+            <p className="font-mono font-semibold text-slate-700">{result.connected.buildingId}</p>
+          </div>
+          <div>
+            <span className="text-slate-500">Status</span>
+            <p className="font-semibold text-emerald-700">{result.connected.status}</p>
+          </div>
+          {result.connected.precinct && (
+            <div>
+              <span className="text-slate-500">Precinct</span>
+              <p className="font-semibold text-slate-700">{result.connected.precinct}</p>
+            </div>
+          )}
+          {result.connected.ftth && (
+            <div>
+              <span className="text-slate-500">FTTH</span>
+              <p className="font-semibold text-slate-700">{result.connected.ftth}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Near-net details */}
+      {result.coverageType === 'near-net' && result.nearNet && (
+        <div className="mt-3 bg-amber-100/60 rounded-lg p-3 flex items-center gap-3">
+          <PiBuildingBold className="h-5 w-5 text-amber-600 shrink-0" />
+          <div>
+            <p className="text-sm font-semibold text-amber-800">
+              ~{result.nearNet.display} from nearest fibre point
+            </p>
+            <p className="text-xs text-amber-700 mt-0.5">{result.nearNet.note}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**Verify:** `npm run type-check`
+
+---
+
+### Task 4: Create `DFAProductTiers` component
+
+**Objective:** Shows available BizFibreConnect tiers with pricing, highlighting the recommended product.
+
+**File:** Create `app/admin/coverage/checker/components/DFAProductTiers.tsx`
+
+Reuses the tier card layout from `SalesRecommendationCard` but simplified — no customer type toggle, no signal-quality logic. Just shows all available DFA products with the recommended one highlighted.
+
+```typescript
+'use client';
+
+import { SectionCard } from '@/components/admin/shared';
+import { PiCheckCircleBold, PiPackageBold } from 'react-icons/pi';
+
+interface DFAProduct {
+  id: string;
+  name: string;
+  download_speed: number;
+  upload_speed: number;
+  price: number;
+  description?: string;
+}
+
+interface DFAProductTiersProps {
+  products: DFAProduct[];
+  recommended: DFAProduct | null;
+}
+
+function formatPrice(price: number): string {
+  return `R${price.toLocaleString()}/mo`;
+}
+
+function formatSpeed(dl: number, ul: number): string {
+  return `${dl}/${ul} Mbps`;
+}
+
+export default function DFAProductTiers({ products, recommended }: DFAProductTiersProps) {
+  if (products.length === 0) return null;
+
+  return (
+    <SectionCard title="Available BizFibreConnect Tiers" icon={PiPackageBold}>
+      <div className={`grid gap-3 ${products.length <= 2 ? 'grid-cols-2' : 'grid-cols-3'}`}>
+        {products.map(product => {
+          const isRecommended = recommended?.id === product.id;
+          return (
+            <div
+              key={product.id}
+              className={`relative rounded-lg border-2 p-3 transition-all ${
+                isRecommended
+                  ? 'border-blue-500 bg-blue-50 shadow-sm'
+                  : 'border-slate-200 bg-white'
+              }`}
+            >
+              {isRecommended && (
+                <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 text-xs bg-blue-600 text-white px-2 py-0.5 rounded-full font-semibold whitespace-nowrap">
+                  Recommended
+                </span>
+              )}
+              <p className="text-xs font-semibold text-slate-500 mb-0.5">
+                {formatSpeed(product.download_speed, product.upload_speed)}
+              </p>
+              <p className="text-sm font-bold text-slate-900 leading-tight">{product.name}</p>
+              <p className="text-sm font-semibold text-slate-700 mt-1">{formatPrice(product.price)}</p>
+              <p className="text-xs text-slate-400 mt-1.5 flex items-center gap-1">
+                <PiCheckCircleBold className="text-emerald-500" />
+                Business · Symmetrical
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </SectionCard>
+  );
+}
+```
+
+**Verify:** `npm run type-check`
+
+---
+
+### Task 5: Create `DFAInstallationEstimate` component
+
+**Objective:** Shows installation cost estimate, timeline, and notes from `dfaProductMapper.getInstallationEstimate()`.
+
+**File:** Create `app/admin/coverage/checker/components/DFAInstallationEstimate.tsx`
+
+```typescript
+'use client';
+
+import { SectionCard } from '@/components/admin/shared';
+import { PiClockBold, PiCurrencyDollarBold, PiNoteBold } from 'react-icons/pi';
+
+interface DFAInstallationEstimateProps {
+  estimate: {
+    estimatedCost: string;
+    estimatedDays: string;
+    notes: string;
+  };
+}
+
+export default function DFAInstallationEstimate({ estimate }: DFAInstallationEstimateProps) {
+  return (
+    <SectionCard title="Installation Estimate" icon={PiClockBold}>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex items-start gap-3">
+          <PiCurrencyDollarBold className="h-5 w-5 text-slate-400 mt-0.5" />
+          <div>
+            <p className="text-xs text-slate-500 mb-0.5">Estimated Cost</p>
+            <p className="text-sm font-semibold text-slate-900">{estimate.estimatedCost}</p>
+          </div>
+        </div>
+        <div className="flex items-start gap-3">
+          <PiClockBold className="h-5 w-5 text-slate-400 mt-0.5" />
+          <div>
+            <p className="text-xs text-slate-500 mb-0.5">Timeline</p>
+            <p className="text-sm font-semibold text-slate-900">{estimate.estimatedDays}</p>
+          </div>
+        </div>
+      </div>
+      <div className="mt-3 flex items-start gap-2 bg-slate-50 rounded-lg px-3 py-2">
+        <PiNoteBold className="h-4 w-4 text-slate-400 mt-0.5 shrink-0" />
+        <p className="text-xs text-slate-600">{estimate.notes}</p>
+      </div>
+    </SectionCard>
+  );
+}
+```
+
+**Verify:** `npm run type-check`
+
+---
+
+### Task 6: Extend `CoverageMap` for DFA mode
+
+**Objective:** The existing map only shows Tarana BN markers and link paths. Add a `mode` prop — when `'dfa'`, show a green building marker if connected, or a yellow near-net indicator.
+
+**File:** `app/admin/coverage/checker/components/CoverageMap.tsx`
+
+**Step 1:** Add `mode` and DFA props to interface:
+
+```typescript
+interface CoverageMapProps {
+  targetLat: number;
+  targetLng: number;
+  targetAddress: string;
+  // Tarana mode
+  bnLat?: number | null;
+  bnLng?: number | null;
+  bnSiteName?: string;
+  // DFA mode
+  mode?: 'tarana' | 'dfa';
+  dfaCoverageType?: 'connected' | 'near-net' | 'none';
+}
+```
+
+**Step 2:** At the top of the effect, after adding the target marker, branch on mode:
+
+```typescript
+// DFA mode: show building marker based on coverage type
+if (mode === 'dfa' && dfaCoverageType && dfaCoverageType !== 'none') {
+  const dfaColor = dfaCoverageType === 'connected' ? '#10B981' : '#F59E0B';
+  const dfaLabel = dfaCoverageType === 'connected' ? 'DFA Connected' : 'DFA Near-Net';
+
+  // Add a second marker at target location with DFA styling
+  // (DFA building location comes from the target itself since we're checking a point)
+  const dfaInfo = new google.maps.InfoWindow({
+    content: `<div style="font-size:12px;font-weight:600;padding:2px 4px">🔌 ${dfaLabel}</div>`,
+  });
+  // Info window opens on marker click
+}
+```
+
+For a simpler initial approach, just update the legend at the bottom to show DFA-appropriate labels instead of "Base Node" / "Link Path" when in DFA mode.
+
+**Step 3:** Update the legend:
+
+```typescript
+<div className="flex items-center gap-5 mt-3 text-xs text-slate-500">
+  <span className="flex items-center gap-1.5">
+    <span className="w-3 h-3 rounded-full bg-blue-500 inline-block" />
+    Target Address
+  </span>
+  {mode === 'dfa' ? (
+    <span className="flex items-center gap-1.5">
+      <span className="w-3 h-3 rounded-full bg-emerald-500 inline-block" />
+      DFA {dfaCoverageType === 'connected' ? 'Connected' : 'Near-Net'} Zone
+    </span>
+  ) : (
+    <>
+      <span className="flex items-center gap-1.5">
+        <span className="w-3 h-3 rounded-full bg-orange-500 inline-block" />
+        Base Node ({bnSiteName})
+      </span>
+      <span className="flex items-center gap-1.5">
+        <span className="w-6 border-t-2 border-dashed border-orange-400 inline-block" />
+        Link Path
+      </span>
+    </>
+  )}
+</div>
+```
+
+**Verify:** `npm run type-check`
+
+---
+
+### Task 7: Update `CoverageResultPanel` (if used)
+
+**Objective:** `CoverageResultPanel` is a wrapper component that renders Tarana results. Add a DFA branch or confirm it's not used by the main page (the main page renders components directly).
+
+Check whether `CoverageResultPanel` is imported by `page.tsx`. Based on the current code read, it is NOT imported — the page renders components inline. If so, skip this task.
+
+**Verify:** `grep -r "CoverageResultPanel" app/admin/coverage/checker/page.tsx` — if no match, skip.
+
+---
+
+### Task 8: Full type-check pass
+
+```bash
+npm run type-check 2>&1 | grep -E "(checker|coverage/dfa)" | head -20
+```
+
+Expected: zero output.
+
+Fix any type errors before considering the plan complete.
+
+---
+
+## Summary
+
+| # | File | Action |
+|---|---|---|
+| 1 | `app/admin/coverage/checker/page.tsx` | Add provider state + DFA fetch handler + conditional rendering |
+| 2 | `app/admin/coverage/checker/components/ProviderSelector.tsx` | Create — Tarana/DFA toggle |
+| 3 | `app/admin/coverage/checker/components/DFAVerdictCard.tsx` | Create — Connected/Near-Net/None verdict with building details |
+| 4 | `app/admin/coverage/checker/components/DFAProductTiers.tsx` | Create — BizFibreConnect tier cards |
+| 5 | `app/admin/coverage/checker/components/DFAInstallationEstimate.tsx` | Create — Cost + timeline |
+| 6 | `app/admin/coverage/checker/components/CoverageMap.tsx` | Extend — add DFA mode + legend |
+| 7 | `app/admin/coverage/checker/components/CoverageResultPanel.tsx` | Confirm skipped (not used by page) |
+| 8 | — | Type-check all changes |
+
+**No new API endpoints needed.** The existing `POST /api/admin/coverage/dfa` returns everything required.
+
+**Follow-up:** Dedicated fibre (DIA, layer 2) needs separate products in `service_packages` with `service_type: 'DedicatedFibre'` or similar, plus a dedicated-fibre mapper in the DFA provider. Out of scope for this plan — broadband only.

--- a/lib/coverage/prediction/types.ts
+++ b/lib/coverage/prediction/types.ts
@@ -60,6 +60,26 @@ export interface CoveragePrediction {
 }
 
 // ============================================================================
+// Live Network Status (from TCS Portal)
+// ============================================================================
+
+/** Operational status of the nearest base station and network-wide health */
+export interface LiveNetworkStatus {
+  /** Whether the nearest BN is currently online */
+  bnOnline: boolean;
+  /** Active customer connections on the nearest BN's site */
+  bnActiveConnections: number;
+  /** Network-wide BN/RN summary from latest sync */
+  networkSummary: {
+    totalBNs: number;
+    onlineBNs: number;
+    totalRNs: number;
+    onlineRNs: number;
+    fetchedAt: string | null;
+  } | null;
+}
+
+// ============================================================================
 // Calibration
 // ============================================================================
 


### PR DESCRIPTION
## What

Extends the admin coverage checker with DFA fibre support and a richer verdict UI:

- **New components**: `ProviderSelector`, `DFAVerdictCard`, `DFAProductTiers`, `DFAInstallationEstimate`, `NetworkStatusCard`
- **Updated**: `CoverageMap`, `CoverageVerdictCard`, `SalesRecommendationCard`, and the checker `page.tsx` to wire them together
- **API**: `app/api/admin/tarana/predict/route.ts` updates
- **Types**: `lib/coverage/prediction/types.ts`
- **Plan doc**: `docs/plans/2026-05-25-dfa-fibre-coverage-checker.md`

## Verification

- Type-check: **0 new errors vs `main`** baseline (stays at the project's 291 pre-existing baseline).
- No database migrations.
- Self-contained to the coverage-checker area; no shared-file changes outside `lib/coverage/prediction/types.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)