### PR TITLE
feat(whatsapp): Pay Now billing template fix + prod number/template scripts

### DIFF
--- a/lib/billing/whatsapp-paynow-service.ts
+++ b/lib/billing/whatsapp-paynow-service.ts
@@ -69,19 +69,6 @@ export type WhatsAppNotificationType =
   | 'payment_reminder'
   | 'debit_failed';
 
-// =============================================================================
-// SHORT URL HELPER
-// =============================================================================
-
-/**
- * Generate short payment URL for WhatsApp
- * Uses circletel.co.za/api/paynow/[ref] which redirects to full NetCash URL
- */
-function getShortPaymentUrl(transactionRef: string): string {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.circletel.co.za';
-  return `${baseUrl}/api/paynow/${transactionRef}`;
-}
-
 /**
  * Format date for WhatsApp message (e.g., "28 February 2026")
  */
@@ -217,8 +204,11 @@ export class WhatsAppPayNowService {
         };
       }
 
-      // Generate short URL for WhatsApp
-      const paymentUrl = getShortPaymentUrl(invoice.paynow_transaction_ref);
+      // WhatsApp templates use a DYNAMIC URL button with base
+      // https://www.circletel.co.za/api/paynow/{{1}} — Meta substitutes the button
+      // parameter into {{1}}, so we must pass the BARE transaction ref (not the full URL),
+      // otherwise the link doubles up.
+      const paymentUrl = invoice.paynow_transaction_ref;
       const customerName = customer.first_name || 'Customer';
 
       // Send appropriate template

--- a/lib/integrations/whatsapp/whatsapp-service.ts
+++ b/lib/integrations/whatsapp/whatsapp-service.ts
@@ -85,7 +85,7 @@ export class WhatsAppService {
     to: string,
     templateName: CircleTelTemplate,
     components: SendTemplateRequest['template']['components'] = [],
-    languageCode = 'en_US'
+    languageCode = 'en_ZA' // CircleTel templates are created in English (ZAF) — must match the template's language
   ): Promise<WhatsAppSendResult> {
     const config = this.getConfig();
 

--- a/scripts/check-whatsapp-prod-number.ts
+++ b/scripts/check-whatsapp-prod-number.ts
@@ -1,0 +1,63 @@
+/**
+ * Read-only diagnostic for wiring 084 773 9467 as the production WhatsApp sender.
+ * Checks whether the current WHATSAPP_ACCESS_TOKEN can see the new phone number
+ * and what templates exist on the new WABA. Sends NOTHING.
+ *
+ * Run: set -a && source .env.local && set +a && npx tsx scripts/check-whatsapp-prod-number.ts
+ */
+
+const GRAPH = 'https://graph.facebook.com/v21.0'
+const TOKEN = process.env.WHATSAPP_ACCESS_TOKEN || ''
+const PROD_PHONE_ID = '1198404656682736' // +27 84 773 9467
+const PROD_WABA_ID = '2030687664240306'
+
+async function get(url: string) {
+  const res = await fetch(url)
+  const json = await res.json().catch(() => ({}))
+  return { ok: res.ok, status: res.status, json }
+}
+
+async function main() {
+  if (!TOKEN) {
+    console.error('❌ WHATSAPP_ACCESS_TOKEN not set. Run with: set -a && source .env.local && set +a && npx tsx ...')
+    process.exit(1)
+  }
+
+  console.log('=== 1. Token access (debug_token) ===')
+  const dbg = await get(`${GRAPH}/debug_token?input_token=${TOKEN}&access_token=${TOKEN}`)
+  if (dbg.ok) {
+    const d = dbg.json.data || {}
+    console.log('  type:', d.type, '| valid:', d.is_valid, '| expires:', d.expires_at === 0 ? 'never' : d.expires_at)
+    console.log('  scopes:', (d.scopes || []).join(', '))
+  } else {
+    console.log('  ⚠️', dbg.status, JSON.stringify(dbg.json.error || dbg.json))
+  }
+
+  console.log('\n=== 2. Can token read the PROD phone number (084 773 9467)? ===')
+  const phone = await get(`${GRAPH}/${PROD_PHONE_ID}?fields=display_phone_number,verified_name,quality_rating,code_verification_status,platform_type,throughput&access_token=${TOKEN}`)
+  if (phone.ok) {
+    console.log('  ✅', JSON.stringify(phone.json))
+  } else {
+    console.log('  ❌', phone.status, JSON.stringify(phone.json.error || phone.json))
+    console.log('     → token likely lacks asset access to this WABA (expect #131005 on send).')
+  }
+
+  console.log('\n=== 3. Templates on the PROD WABA ===')
+  const tpl = await get(`${GRAPH}/${PROD_WABA_ID}/message_templates?fields=name,status,language,category&limit=50&access_token=${TOKEN}`)
+  if (tpl.ok) {
+    const list = tpl.json.data || []
+    if (!list.length) {
+      console.log('  ⚠️ No templates on this WABA — circletel_invoice_payment must be re-created & approved here.')
+    } else {
+      for (const t of list) console.log(`  - ${t.name} [${t.language}] ${t.status} (${t.category})`)
+    }
+  } else {
+    console.log('  ❌', tpl.status, JSON.stringify(tpl.json.error || tpl.json))
+  }
+
+  console.log('\n=== 4. WABA subscribed apps (webhook wiring) ===')
+  const subs = await get(`${GRAPH}/${PROD_WABA_ID}/subscribed_apps?access_token=${TOKEN}`)
+  console.log(subs.ok ? `  ${JSON.stringify(subs.json.data || [])}` : `  ❌ ${subs.status} ${JSON.stringify(subs.json.error || subs.json)}`)
+}
+
+main()

--- a/scripts/create-whatsapp-templates.ts
+++ b/scripts/create-whatsapp-templates.ts
@@ -1,0 +1,88 @@
+/**
+ * Submit the 3 remaining CircleTel WhatsApp message templates to the PROD WABA.
+ * Body variable ORDER must match lib/integrations/whatsapp/whatsapp-service.ts
+ * (positional {{1}}.. == the order params are pushed into bodyParams).
+ *
+ * Run: set -a && source .env.local && set +a && npx tsx scripts/create-whatsapp-templates.ts
+ */
+
+const GRAPH = 'https://graph.facebook.com/v21.0'
+const TOKEN = process.env.WHATSAPP_ACCESS_TOKEN || ''
+const WABA = process.env.WHATSAPP_BUSINESS_ACCOUNT_ID || ''
+const PAYNOW = 'https://www.circletel.co.za/api/paynow/{{1}}'
+const PAYNOW_EXAMPLE = 'https://www.circletel.co.za/api/paynow/09de69d1-test'
+const FOOTER = { type: 'FOOTER', text: 'CircleTel SA (Pty) Ltd' }
+
+const templates = [
+  {
+    // sendPaymentReminder -> [invoiceNumber, amount, daysOverdue]
+    name: 'circletel_payment_reminder',
+    language: 'en_ZA',
+    category: 'UTILITY',
+    components: [
+      {
+        type: 'BODY',
+        text: 'Hi there, a friendly reminder that your CircleTel invoice {{1}} for R{{2}} is now {{3}} days overdue. Please tap the button below to settle it securely, or reply to this message if you need help.',
+        example: { body_text: [['INV-2026-00011', '419.07', '5']] },
+      },
+      FOOTER,
+      {
+        type: 'BUTTONS',
+        buttons: [{ type: 'URL', text: 'Pay Now', url: PAYNOW, example: [PAYNOW_EXAMPLE] }],
+      },
+    ],
+  },
+  {
+    // sendDebitFailed -> [customerName, invoiceNumber, amount]; button[0] dynamic, button[1] static
+    name: 'circletel_debit_failed',
+    language: 'en_ZA',
+    category: 'UTILITY',
+    components: [
+      {
+        type: 'BODY',
+        text: 'Hi {{1}}, we were unable to collect payment for your CircleTel invoice {{2}} of R{{3}} via debit order. Please tap Pay Now to settle it securely, or update your payment details below.',
+        example: { body_text: [['Ashwyn', 'INV-2026-00011', '419.07']] },
+      },
+      FOOTER,
+      {
+        type: 'BUTTONS',
+        buttons: [
+          { type: 'URL', text: 'Pay Now', url: PAYNOW, example: [PAYNOW_EXAMPLE] },
+          { type: 'URL', text: 'Update Payment', url: 'https://www.circletel.co.za/dashboard/billing' },
+        ],
+      },
+    ],
+  },
+  {
+    // sendPaymentReceived -> [customerName, invoiceNumber, amount, paymentDate]; no button
+    name: 'circletel_payment_received',
+    language: 'en_ZA',
+    category: 'UTILITY',
+    components: [
+      {
+        type: 'BODY',
+        text: 'Hi {{1}}, thank you! Your payment for invoice {{2}} of R{{3}} was received on {{4}}. Your CircleTel account is now up to date.',
+        example: { body_text: [['Ashwyn', 'INV-2026-00011', '419.07', '10 June 2026']] },
+      },
+      FOOTER,
+    ],
+  },
+]
+
+async function main() {
+  if (!TOKEN || !WABA) {
+    console.error('❌ WHATSAPP_ACCESS_TOKEN / WHATSAPP_BUSINESS_ACCOUNT_ID not set. Did you source .env.local?')
+    process.exit(1)
+  }
+  for (const tpl of templates) {
+    const res = await fetch(`${GRAPH}/${WABA}/message_templates`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify(tpl),
+    })
+    const json = await res.json().catch(() => ({}))
+    console.log(`${tpl.name}: ${res.ok ? '✅' : '❌'} ${JSON.stringify(json)}`)
+  }
+}
+
+main()


### PR DESCRIPTION
## What

- `lib/billing/whatsapp-paynow-service.ts` — fixes the Pay Now payment link sent in WhatsApp billing templates: pass the **bare** `paynow_transaction_ref` (not the full short URL). Removes the now-unused `getShortPaymentUrl` helper.
- `lib/integrations/whatsapp/whatsapp-service.ts` — minor accompanying adjustment.
- `scripts/check-whatsapp-prod-number.ts` — diagnostic for the production WhatsApp number / WABA / template state.
- `scripts/create-whatsapp-templates.ts` — creates the billing templates on the production WABA.

## Why

The approved WhatsApp templates use a **dynamic URL button** with base `https://www.circletel.co.za/api/paynow/{{1}}`. Meta substitutes the button parameter into `{{1}}`, so the service must pass the **bare transaction ref** — passing the full URL doubled up the link and broke the button.

## Verification

- Type-check: **0 new errors vs `main`** baseline.
- No database migrations.
- Scripts live under `scripts/` (excluded from the type-check include) and are operational/diagnostic tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)