### PR TITLE
chore(skills): add OpenAI and OpenRouter image generation skills + scripts

### DIFF
--- a/.claude/skills/openai-imagegen/SKILL.md
+++ b/.claude/skills/openai-imagegen/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: openai-imagegen
+description: Generate and edit images using OpenAI's gpt-image models (gpt-image-1 / gpt-image-2). Use as an alternative to the Gemini (Nano Banana) image path when the user asks for OpenAI image generation, or when comparing providers for a hero/product/social asset. Covers text-to-image, image editing, transparent backgrounds, and CircleTel brand context.
+---
+
+# OpenAI Image Generation (gpt-image)
+
+OpenAI counterpart to the Gemini-based `nb-*` / `brand-design` skills. Use when the
+user explicitly wants OpenAI, or to A/B a visual against the Gemini output.
+
+> **Provider choice**: Gemini (Nano Banana Pro) excels at photorealistic scenes and
+> reliable in-image text. gpt-image excels at instruction-following, transparent-background
+> assets (logos/stickers), and clean edits. When unsure which to use, ask the user.
+
+## Prerequisites
+
+- `OPENAI_API_KEY` in `.env.local` (already configured).
+- Helper script: `scripts/generate-image-openai.ts` (no extra npm deps — uses global `fetch`).
+- Verified working: gpt-image-1, gpt-image-1-mini, gpt-image-1.5, gpt-image-2.
+
+## Models
+
+| Model | Use for |
+|-------|---------|
+| `gpt-image-1` | Default. High quality, full feature set. |
+| `gpt-image-1-mini` | Cheaper/faster drafts and iteration. |
+| `gpt-image-1.5` | Improved quality over 1. |
+| `gpt-image-2` | Newest, highest quality (premium final assets). |
+
+## Parameters
+
+| Param | Values | Notes |
+|-------|--------|-------|
+| `size` | `1024x1024` (sq), `1536x1024` (landscape), `1024x1536` (portrait), `auto` | |
+| `quality` | `high`, `medium`, `low`, `auto` | low ≈ cheapest, use for drafts |
+| `n` | integer | number of images |
+| `background` | `opaque`, `transparent`, `auto` | transparent requires `png` or `webp` |
+| `output_format` | `png`, `jpeg`, `webp` | gpt-image always returns base64 (`b64_json`) |
+
+## CircleTel Brand Context
+
+| Element | Value |
+|---------|-------|
+| Primary | Orange `#F5831F` |
+| Secondary | Navy `#1B2A4A` |
+| Accent | White |
+| Tone | Confident, modern, South African |
+| Avoid | Stock-photo clichés, generic "tech bubbles", excessive lens flare |
+
+When generating CircleTel brand assets, reuse the prompt templates in
+`.claude/skills/nb-product-hero/SKILL.md` (Templates A–H) — they are provider-agnostic.
+Append: `colour-accurate orange #F5831F (NOT yellow or red), deep navy #1B2A4A`.
+
+## Step 1 — Gather inputs (if not provided)
+
+1. **Subject / scene** — what is the image of?
+2. **Purpose** — hero / product shot / social ad / logo / sticker?
+3. **Aspect** — square `1024x1024`, landscape `1536x1024`, portrait `1024x1536`.
+4. **Transparent background?** — yes for logos/stickers (forces png/webp).
+5. **Model** — final asset → `gpt-image-2`; quick draft → `gpt-image-1-mini`.
+
+## Step 2 — Generate
+
+```bash
+set -a && source .env.local && set +a && npx tsx scripts/generate-image-openai.ts \
+  --prompt "PASTE PROMPT HERE" \
+  --model gpt-image-1 \
+  --size 1536x1024 \
+  --quality high \
+  --out designs/circletel-hero.png
+```
+
+Transparent logo/sticker:
+
+```bash
+set -a && source .env.local && set +a && npx tsx scripts/generate-image-openai.ts \
+  --prompt "CircleTel circle-arc logo mark, flat vector, orange #F5831F" \
+  --background transparent --format png \
+  --out designs/circletel-logo.png
+```
+
+## Step 3 — Edit an existing image
+
+```bash
+set -a && source .env.local && set +a && npx tsx scripts/generate-image-openai.ts \
+  --edit designs/source.png \
+  --prompt "replace the background with a deep navy studio gradient" \
+  --out designs/edited.png
+```
+
+Multiple source images (composition): `--edit "a.png,b.png"`.
+
+## Conventions
+
+- Output goes to `designs/` (per `.claude/rules/file-organization.md`) — never project root.
+- Default output name is `designs/openai-<timestamp>.<format>` if `--out` is omitted.
+- `--n > 1` appends `-1`, `-2`, … to the filename.
+
+## Iteration Tips
+
+| If result is... | Try... |
+|-----------------|--------|
+| Wrong colours | Add "colour-accurate #F5831F orange, NOT yellow or red" |
+| Too generic | Name a place: "South African suburb / Johannesburg CBD / Cape Town coastline" |
+| Halo on transparent PNG | Add "clean cutout, no background halo or fringe" |
+| Text garbled | Keep in-image text to ≤4 words; consider the Gemini path for heavy text |

--- a/.claude/skills/openrouter-imagegen/SKILL.md
+++ b/.claude/skills/openrouter-imagegen/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: openrouter-imagegen
+description: Generate images cost-effectively via OpenRouter (Seedream 4.5, FLUX.2, Recraft V4, etc.) as a cheaper alternative to OpenAI gpt-image. Use when the user wants low-cost image generation, a specific OpenRouter image model, or quality comparable to gpt-image-2 at a fraction of the price. Requires OPENROUTER_API_KEY in .env.local.
+---
+
+# OpenRouter Image Generation (cost-effective)
+
+A unified gateway to many image models. Use for the cheap-but-high-quality path,
+or to reach models only available via OpenRouter (Seedream, FLUX, Recraft, Sourceful).
+
+## Prerequisites
+
+- `OPENROUTER_API_KEY` in `.env.local` (placeholder present — paste your key from
+  https://openrouter.ai/keys). Until set, the helper exits with a clear message.
+- Helper script: `scripts/generate-image-openrouter.ts` (no extra npm deps — global `fetch`).
+
+## ⚠️ Two facts that matter
+
+1. **No Qwen image model on OpenRouter** (checked live). Qwen-Image is served via Alibaba
+   DashScope, not OpenRouter. Don't promise it here.
+2. **Gemini image models are cheaper called DIRECTLY** via `GEMINI_API_KEY` (no OpenRouter
+   markup) — use the `nb-*` skills for those. Use *this* skill for Seedream / FLUX / Recraft /
+   OpenAI gpt-5-image, which you can only reach via OpenRouter.
+
+## Cost-effective model picks (≈ per image)
+
+| Model id | ~Cost | Best for |
+|----------|-------|----------|
+| `bytedance-seed/seedream-4.5` | **~$0.03** | **Default** — best quality-per-dollar, gpt-image-2-class |
+| `recraft/recraft-v4` | ~$0.04 | UI / design / logos / **vector** output |
+| `google/gemini-2.5-flash-image` | ~$0.039 | Photoreal + in-image text (cheaper direct, though) |
+| `black-forest-labs/flux.2-pro` | ~$0.05 | Arguably highest quality |
+| `openai/gpt-5-image` | higher | OpenAI quality via one key |
+
+For reference, OpenAI `gpt-image-2` high ≈ **$0.17–0.19/img** — Seedream is ~6× cheaper.
+
+> Pricing changes — verify live: `curl "https://openrouter.ai/api/v1/models?output_modalities=image"`.
+
+## How it works (different from OpenAI!)
+
+OpenRouter generates images through the **chat-completions** endpoint with a `modalities`
+param, NOT `/images/generations`:
+
+```
+POST https://openrouter.ai/api/v1/chat/completions
+{ "model": "...", "messages": [{ "role": "user", "content": "PROMPT" }],
+  "modalities": ["image"],            // ["image","text"] for gemini/openai models
+  "image_config": { "aspect_ratio": "16:9", "image_size": "2K" } }
+```
+
+Images return as base64 data URLs in `choices[0].message.images[].image_url.url`.
+The helper handles modalities selection, parsing, and saving automatically.
+
+## Generate
+
+```bash
+set -a && source .env.local && set +a && npx tsx scripts/generate-image-openrouter.ts \
+  --prompt "PASTE PROMPT HERE" \
+  --model bytedance-seed/seedream-4.5 \
+  --aspect 16:9 \
+  --out designs/circletel-hero.png
+```
+
+Other models: `--model black-forest-labs/flux.2-pro`, `--model recraft/recraft-v4`.
+
+## Image-to-image / edit
+
+```bash
+set -a && source .env.local && set +a && npx tsx scripts/generate-image-openrouter.ts \
+  --edit designs/source.png \
+  --prompt "replace the background with a deep navy studio gradient" \
+  --out designs/edited.png
+```
+
+## Aspect ratios
+
+`1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `9:16`, `16:9`, `21:9` (model-dependent).
+gemini-3.1-flash-image-preview also supports `1:4`, `4:1`, `1:8`, `8:1`.
+
+## CircleTel brand context
+
+Orange `#F5831F`, navy `#1B2A4A`, white accent. The prompt templates in
+`.claude/skills/nb-product-hero/SKILL.md` are provider-agnostic — reuse them and append
+`colour-accurate orange #F5831F (NOT yellow or red), deep navy #1B2A4A`.
+
+## Provider cheat-sheet
+
+| Want | Use |
+|------|-----|
+| Cheapest good quality | this skill → `seedream-4.5` |
+| Best instruction-following / transparent logos | `openai-imagegen` (gpt-image) |
+| Photoreal + reliable in-image text | `nb-*` (Gemini direct) |
+| Vector / icon / logo files | this skill → `recraft/recraft-v4` |

--- a/scripts/generate-image-openai.ts
+++ b/scripts/generate-image-openai.ts
@@ -1,0 +1,106 @@
+/**
+ * OpenAI Image Generation helper (gpt-image-1 / gpt-image-2)
+ *
+ * Generates or edits images via the OpenAI Images API and saves them to disk.
+ * Companion to the `openai-imagegen` skill. Mirror of the Gemini path used by
+ * the nb-* skills, but for OpenAI's gpt-image models.
+ *
+ * Run:
+ *   set -a && source .env.local && set +a && npx tsx scripts/generate-image-openai.ts \
+ *     --prompt "a photorealistic fibre router on a navy studio backdrop" \
+ *     --out designs/router.png
+ *
+ * Flags:
+ *   --prompt   <text>   (required) the image prompt
+ *   --model    <id>     gpt-image-1 (default) | gpt-image-1-mini | gpt-image-1.5 | gpt-image-2
+ *   --size     <wxh>    1024x1024 (default) | 1536x1024 | 1024x1536 | auto
+ *   --quality  <level>  high (default) | medium | low | auto
+ *   --n        <int>    number of images (default 1)
+ *   --background <mode> opaque (default) | transparent | auto   (transparent needs png/webp)
+ *   --format   <ext>    png (default) | jpeg | webp
+ *   --edit     <path>   optional source image(s), comma-separated — switches to /images/edits
+ *   --out      <path>   output path (default designs/openai-<timestamp>.<format>)
+ */
+
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
+import { dirname } from 'path';
+
+function arg(name: string, fallback = ''): string {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.error('❌ OPENAI_API_KEY not set. Run with: set -a && source .env.local && set +a && npx tsx ...');
+    process.exit(1);
+  }
+
+  const prompt = arg('prompt');
+  if (!prompt) {
+    console.error('❌ --prompt is required');
+    process.exit(1);
+  }
+
+  const model = arg('model', 'gpt-image-1');
+  const size = arg('size', '1024x1024');
+  const quality = arg('quality', 'high');
+  const n = parseInt(arg('n', '1'), 10);
+  const background = arg('background', 'opaque');
+  const format = arg('format', 'png');
+  const editPaths = arg('edit');
+  const outBase = arg('out', `designs/openai-${Date.now()}.${format}`);
+
+  let data: Array<{ b64_json?: string }>;
+
+  if (editPaths) {
+    // Image edit (multipart). One or more source images.
+    const form = new FormData();
+    form.append('model', model);
+    form.append('prompt', prompt);
+    form.append('size', size);
+    form.append('quality', quality);
+    form.append('n', String(n));
+    for (const p of editPaths.split(',').map((s) => s.trim())) {
+      const buf = readFileSync(p);
+      const ext = p.split('.').pop() || 'png';
+      form.append('image[]', new Blob([buf], { type: `image/${ext}` }), p.split('/').pop() || 'image.png');
+    }
+    const res = await fetch('https://api.openai.com/v1/images/edits', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: form,
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(`OpenAI ${res.status}: ${JSON.stringify(json)}`);
+    data = json.data;
+  } else {
+    // Generation (JSON). gpt-image models always return b64_json.
+    const body: Record<string, unknown> = { model, prompt, size, quality, n };
+    if (background !== 'opaque') body.background = background;
+    if (format !== 'png') body.output_format = format;
+    const res = await fetch('https://api.openai.com/v1/images/generations', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(`OpenAI ${res.status}: ${JSON.stringify(json)}`);
+    data = json.data;
+  }
+
+  data.forEach((img, idx) => {
+    if (!img.b64_json) return;
+    const out = n > 1 ? outBase.replace(/(\.\w+)$/, `-${idx + 1}$1`) : outBase;
+    const dir = dirname(out);
+    if (dir && !existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(out, Buffer.from(img.b64_json, 'base64'));
+    console.log(`✅ Saved: ${out}`);
+  });
+}
+
+main().catch((err) => {
+  console.error('❌', err.message);
+  process.exit(1);
+});

--- a/scripts/generate-image-openrouter.ts
+++ b/scripts/generate-image-openrouter.ts
@@ -1,0 +1,130 @@
+/**
+ * OpenRouter Image Generation helper — cost-effective alternative to gpt-image.
+ *
+ * OpenRouter generates images via the CHAT COMPLETIONS endpoint with a `modalities`
+ * param (NOT OpenAI's /images/generations). Images come back as base64 data URLs in
+ * `choices[0].message.images[].image_url.url`. Companion to the `openrouter-imagegen` skill.
+ *
+ * Run (after adding OPENROUTER_API_KEY to .env.local):
+ *   set -a && source .env.local && set +a && npx tsx scripts/generate-image-openrouter.ts \
+ *     --prompt "a fibre router on a navy studio backdrop" --out designs/router.png
+ *
+ * Flags:
+ *   --prompt <text>    (required) the image prompt
+ *   --model  <id>      bytedance-seed/seedream-4.5 (default, ~$0.03/img)
+ *                      alternatives: black-forest-labs/flux.2-pro (~$0.05),
+ *                      recraft/recraft-v4 (~$0.04), google/gemini-2.5-flash-image (~$0.039),
+ *                      openai/gpt-5-image, openai/gpt-5-image-mini
+ *   --aspect <ratio>   1:1 (default) | 16:9 | 4:3 | 3:2 | 9:16 | 4:5 | 21:9 ...
+ *   --size   <res>     1K (default) | 2K | 4K   (only some models honour this)
+ *   --edit   <path>    optional source image(s), comma-separated (image-to-image)
+ *   --out    <path>    output path (default designs/openrouter-<timestamp>.png)
+ *
+ * Cost-effective model note: Gemini image models are cheaper called DIRECTLY via
+ * GEMINI_API_KEY (no OpenRouter markup) — use scripts nb-* / generate-hero-image.py for those.
+ * Use this helper for models you can ONLY reach via OpenRouter (Seedream, FLUX, Recraft).
+ */
+
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
+import { dirname } from 'path';
+
+function arg(name: string, fallback = ''): string {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+// Gemini/OpenAI on OpenRouter output text+image; pure image models (Flux, Seedream,
+// Recraft, Sourceful) take image-only. Deterministic rule — not model-as-policy.
+function modalitiesFor(model: string): string[] {
+  return /gemini|gpt-5|openai/i.test(model) ? ['image', 'text'] : ['image'];
+}
+
+function extFromMime(mime: string): string {
+  const m = mime.split('/')[1] || 'png';
+  return m === 'jpeg' ? 'jpg' : m;
+}
+
+async function main() {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    console.error('❌ OPENROUTER_API_KEY not set. Add it to .env.local, then run with: set -a && source .env.local && set +a && npx tsx ...');
+    process.exit(1);
+  }
+
+  const prompt = arg('prompt');
+  if (!prompt) {
+    console.error('❌ --prompt is required');
+    process.exit(1);
+  }
+
+  const model = arg('model', 'bytedance-seed/seedream-4.5');
+  const aspect = arg('aspect', '1:1');
+  const size = arg('size');
+  const editPaths = arg('edit');
+  let outBase = arg('out', `designs/openrouter-${Date.now()}.png`);
+
+  // Build user content. For image-to-image, attach source images alongside the text.
+  let content: unknown = prompt;
+  if (editPaths) {
+    const parts: unknown[] = [{ type: 'text', text: prompt }];
+    for (const p of editPaths.split(',').map((s) => s.trim())) {
+      const buf = readFileSync(p);
+      const ext = (p.split('.').pop() || 'png').replace('jpg', 'jpeg');
+      parts.push({ type: 'image_url', image_url: { url: `data:image/${ext};base64,${buf.toString('base64')}` } });
+    }
+    content = parts;
+  }
+
+  const image_config: Record<string, string> = { aspect_ratio: aspect };
+  if (size) image_config.image_size = size;
+
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://www.circletel.co.za',
+      'X-Title': 'CircleTel Image Gen',
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content }],
+      modalities: modalitiesFor(model),
+      image_config,
+    }),
+  });
+
+  const json = await res.json();
+  if (!res.ok) throw new Error(`OpenRouter ${res.status}: ${JSON.stringify(json)}`);
+
+  const message = json.choices?.[0]?.message;
+  // REST returns snake_case image_url; SDK camelCases to imageUrl — handle both.
+  const images = message?.images || [];
+  if (!images.length) {
+    throw new Error(`No images returned. Response: ${JSON.stringify(json).slice(0, 800)}`);
+  }
+
+  images.forEach((img: any, idx: number) => {
+    const url: string = img?.image_url?.url || img?.imageUrl?.url || '';
+    const match = url.match(/^data:(image\/\w+);base64,(.*)$/s);
+    if (!match) {
+      console.error(`⚠️  image ${idx + 1}: unexpected url format (${url.slice(0, 40)}...)`);
+      return;
+    }
+    // Always match the file extension to the ACTUAL returned format (models pick
+    // their own — e.g. Seedream returns JPEG even when png is requested).
+    const ext = extFromMime(match[1]);
+    let out = outBase.replace(/\.\w+$/, '');
+    out = `${out}.${ext}`;
+    if (images.length > 1) out = out.replace(/(\.\w+)$/, `-${idx + 1}$1`);
+    const dir = dirname(out);
+    if (dir && !existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(out, Buffer.from(match[2], 'base64'));
+    console.log(`✅ Saved: ${out}  (model: ${model})`);
+  });
+}
+
+main().catch((err) => {
+  console.error('❌', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds two image-generation tooling skills and their backing scripts:

- `.claude/skills/openai-imagegen/SKILL.md` + `scripts/generate-image-openai.ts` — OpenAI gpt-image generation
- `.claude/skills/openrouter-imagegen/SKILL.md` + `scripts/generate-image-openrouter.ts` — OpenRouter (cheap models, e.g. Seedream) generation

## Why

Adds OpenAI and OpenRouter as additional image-gen providers alongside the existing Gemini-based tooling. Pure developer tooling — no application code.

## Verification

- No application code; scripts live under `scripts/` (excluded from the type-check include).
- No database migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)