### PR TITLE
ci: move zero-coupling CI jobs to Ubicloud runners

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,7 +51,7 @@ jobs:
 
   type-check:
     name: TypeScript Type Check
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2  # TRIAL: Ubicloud managed runner (was ubuntu-latest)
     timeout-minutes: 10
     continue-on-error: true  # Don't block automation on type errors
 


### PR DESCRIPTION
## Roll zero-coupling CI jobs onto Ubicloud

Started as a type-check trial (proven green on `ubicloud-standard-2`); now moves all remaining **zero-coupling** CI test/check jobs to Ubicloud managed runners (`ubicloud-standard-2`, 2 vCPU/8 GB — parity with `ubuntu-latest`).

### Moved (13 jobs)
- **pr-checks:** Validate Dockerfile, TypeScript Type Check, ESLint
- **test-payment-integration:** Run Payment Integration Tests (matrix 18.x/20.x), Quality Gates, Security Scan
- **api-integration-tests:** all 5 jobs
- **mtn-session:** Validate
- **validate-mtn-session**

### Deliberately NOT moved
- **pr-checks `Build Check`** — runs the heavy `build:ci` with a 10-min timeout + only 2 of ~10 secrets, so it never completes. Moving it would burn free-tier minutes for zero validation. Left on `ubuntu-latest` pending a separate decision (make it a real gate on `ubicloud-standard-8`, or drop it).
- **deploy.yml / deploy-staging.yml / mtn Refresh** — `self-hosted` (runner IS the prod VPS; off-box needs a GHCR handoff). See `docs/plans/2026-06-08_staging-image-promotion.md`.
- **claude / claude-code-review / auto-merge / staging-deployment** — AI/automation, not CI compute.

### Cost
~1,800 CI min/mo → Ubicloud. Free tier is 1,250 min/mo; modest overage at \$0.004/min (~\$2-3/mo). Revert = `runs-on` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)