### PR TITLE
ci: move zero-coupling CI jobs to Ubicloud runners

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
   # Job 1: Prepare test database
   prepare-test-db:
     name: Prepare Test Database
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 15
 
     steps:
@@ -101,7 +101,7 @@ jobs:
   # Job 2: Run authenticated API tests
   api-tests:
     name: Admin Quote API Tests
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     needs: prepare-test-db
     timeout-minutes: 15
 
@@ -192,7 +192,7 @@ jobs:
   # Job 3: Type check after API changes
   type-check:
     name: TypeScript Validation
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     needs: api-tests
     timeout-minutes: 15
 
@@ -216,7 +216,7 @@ jobs:
   # Job 4: Security validation
   security-check:
     name: Security Validation
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     needs: api-tests
     timeout-minutes: 15
 
@@ -252,7 +252,7 @@ jobs:
   # Job 5: Report results
   report:
     name: Test Report
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     needs: [api-tests, type-check, security-check]
     if: always()
     timeout-minutes: 15

--- a/.github/workflows/mtn-session.yml
+++ b/.github/workflows/mtn-session.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   validate:
     name: Validate MTN Session
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 10
     outputs:
       valid: ${{ steps.validate.outputs.valid }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   validate-dockerfile:
     name: Validate Dockerfile Build Config
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 5
 
     steps:
@@ -51,7 +51,7 @@ jobs:
 
   type-check:
     name: TypeScript Type Check
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 10
     continue-on-error: true  # Don't block automation on type errors
 
@@ -73,7 +73,7 @@ jobs:
 
   lint:
     name: ESLint Check
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 10
     continue-on-error: true  # Don't block automation on lint errors
 

--- a/.github/workflows/test-payment-integration.yml
+++ b/.github/workflows/test-payment-integration.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   test:
     name: Run Payment Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 15
 
     strategy:
@@ -90,7 +90,7 @@ jobs:
 
   quality-gates:
     name: Quality Gates
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     needs: test
     timeout-minutes: 15
 
@@ -127,7 +127,7 @@ jobs:
 
   security:
     name: Security Scan
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/validate-mtn-session.yml
+++ b/.github/workflows/validate-mtn-session.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   validate-session:
     name: Validate MTN SSO Session
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Roll zero-coupling CI jobs onto Ubicloud

Moves the `ubuntu-latest` CI **test/check** jobs to Ubicloud managed runners (`ubicloud-standard-2`, 2 vCPU/8 GB — parity with `ubuntu-latest`), after the Ubicloud integration was proven green on the type-check trial (PR #525).

Clean branch off latest `main` (the original rollout attempt got tangled with concurrent local git work, so this supersedes it).

### Moved (13 jobs)
- **pr-checks:** Validate Dockerfile, TypeScript Type Check, ESLint
- **test-payment-integration:** Payment Integration Tests (matrix 18.x/20.x), Quality Gates, Security Scan
- **api-integration-tests:** all 5 jobs
- **mtn-session:** Validate
- **validate-mtn-session**

### Deliberately NOT moved
- **pr-checks `Build Check`** — runs heavy `build:ci` with a 10-min timeout + only 2 of ~10 secrets, so it never completes; moving wastes free-tier minutes. Left on `ubuntu-latest` pending a separate decision.
- **deploy.yml / deploy-staging.yml / mtn Refresh** — `self-hosted` (runner IS the prod VPS; off-box needs a GHCR handoff). See `docs/plans/2026-06-08_staging-image-promotion.md`.
- **claude / claude-code-review / auto-merge / staging-deployment** — AI/automation, not CI compute.

### Notes
- Supersedes the trial PR #525 (which moved only type-check) — #525 can be closed.
- Ubicloud free tier 1,250 min/mo; ~1,800 CI min/mo → modest overage at \$0.004/min (~\$2-3/mo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)