### PR TITLE
B2B/Unjani self-service onboarding + reusable document vetting

### DIFF
--- a/__tests__/lib/onboarding/document-requirements.test.ts
+++ b/__tests__/lib/onboarding/document-requirements.test.ts
@@ -1,0 +1,44 @@
+import { requiredDocsFor, computeVettingStatus } from '@/lib/onboarding/document-requirements';
+
+describe('requiredDocsFor', () => {
+  it('omits vat_certificate when not VAT registered', () => {
+    const types = requiredDocsFor('unjani', { vatRegistered: false, entityType: 'Private Company (Pty) Ltd' }).map(d => d.type);
+    expect(types).toContain('company_registration');
+    expect(types).toContain('bank_statement');
+    expect(types).not.toContain('vat_certificate');
+  });
+  it('includes vat_certificate when VAT registered', () => {
+    const types = requiredDocsFor('unjani', { vatRegistered: true, entityType: 'Private Company (Pty) Ltd' }).map(d => d.type);
+    expect(types).toContain('vat_certificate');
+  });
+  it('sole proprietor needs director_id (owner ID) but not company_registration', () => {
+    const types = requiredDocsFor('unjani', { vatRegistered: false, entityType: 'Sole Proprietor' }).map(d => d.type);
+    expect(types).toContain('director_id');
+    expect(types).not.toContain('company_registration');
+  });
+});
+
+describe('computeVettingStatus', () => {
+  const req = ['company_registration', 'bank_statement', 'director_id'] as const;
+  it('approved when every required doc approved', () => {
+    expect(computeVettingStatus([...req], [
+      { document_type: 'company_registration', verification_status: 'approved' },
+      { document_type: 'bank_statement', verification_status: 'approved' },
+      { document_type: 'director_id', verification_status: 'approved' },
+    ])).toBe('approved');
+  });
+  it('rejected if any required doc rejected', () => {
+    expect(computeVettingStatus([...req], [
+      { document_type: 'company_registration', verification_status: 'rejected' },
+    ])).toBe('rejected');
+  });
+  it('under_review when some approved, none rejected, not all done', () => {
+    expect(computeVettingStatus([...req], [
+      { document_type: 'company_registration', verification_status: 'approved' },
+      { document_type: 'bank_statement', verification_status: 'pending' },
+    ])).toBe('under_review');
+  });
+  it('documents_pending when nothing uploaded', () => {
+    expect(computeVettingStatus([...req], [])).toBe('documents_pending');
+  });
+});

--- a/__tests__/lib/onboarding/document-requirements.test.ts
+++ b/__tests__/lib/onboarding/document-requirements.test.ts
@@ -41,4 +41,16 @@ describe('computeVettingStatus', () => {
   it('documents_pending when nothing uploaded', () => {
     expect(computeVettingStatus([...req], [])).toBe('documents_pending');
   });
+  it('ignores rejection of a non-required document', () => {
+    expect(computeVettingStatus(['company_registration', 'bank_statement'], [
+      { document_type: 'company_registration', verification_status: 'approved' },
+      { document_type: 'bank_statement', verification_status: 'approved' },
+      { document_type: 'proof_of_address', verification_status: 'rejected' }, // not in required list
+    ])).toBe('approved');
+  });
+  it('is documents_pending when a required doc has no upload yet', () => {
+    expect(computeVettingStatus(['company_registration', 'bank_statement'], [
+      { document_type: 'company_registration', verification_status: 'approved' },
+    ])).toBe('under_review');
+  });
 });

--- a/__tests__/lib/onboarding/emandate-request.test.ts
+++ b/__tests__/lib/onboarding/emandate-request.test.ts
@@ -1,0 +1,27 @@
+import { buildEMandateRequest } from '@/lib/onboarding/emandate-request';
+
+describe('buildEMandateRequest', () => {
+  const base = {
+    accountNumber: 'CT-2026-00020',
+    paymentMethodId: 'pm-uuid',
+    submissionId: 'sub-uuid',
+    accountHolder: 'Lens Ext 10 Clinic',
+    isConsumer: false,
+    entityName: 'Lens Ext 10 (Pty) Ltd',
+    registrationNumber: '2019/123456/07',
+    mobile: '0718988722',
+    bank: 'Capitec', accountType: 'Savings', accountNumber2: '1234567890', branchCode: '470010',
+    monthlyExVat: 450, vatPct: 15, paymentDay: '1', agreementDate: '2026-07-01',
+  };
+  it('maps amount incl VAT and carries linkage in custom fields', () => {
+    const r = buildEMandateRequest(base as any);
+    expect(r.accountReference).toBe('CT-2026-00020');
+    expect(r.mandateAmount).toBeCloseTo(517.5, 2);
+    expect(r.isConsumer).toBe(false);
+    expect(r.field1).toBe('pm-uuid');
+    expect(r.field2).toBe('sub-uuid');
+    expect(r.commencementDay).toBe('1');
+    expect(r.bankDetailType).toBe(1);
+    expect(r.bankAccountType).toBe(2); // Savings -> 2
+  });
+});

--- a/__tests__/lib/onboarding/emandate-request.test.ts
+++ b/__tests__/lib/onboarding/emandate-request.test.ts
@@ -24,4 +24,13 @@ describe('buildEMandateRequest', () => {
     expect(r.bankDetailType).toBe(1);
     expect(r.bankAccountType).toBe(2); // Savings -> 2
   });
+  it('wraps commencement month from December to January', () => {
+    const r = buildEMandateRequest({ ...base, agreementDate: '2026-12-15' } as any);
+    expect(r.commencementMonth).toBe(1);
+  });
+  it('falls back to entity name as surname for a single-word account holder', () => {
+    const r = buildEMandateRequest({ ...base, accountHolder: 'Clinic' } as any);
+    expect(r.firstName).toBe('Clinic');
+    expect(r.surname).toBe(base.entityName);
+  });
 });

--- a/__tests__/lib/onboarding/onboarding-service.test.ts
+++ b/__tests__/lib/onboarding/onboarding-service.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildMagicLinkUrl } from '@/lib/onboarding/onboarding-service';
+
+describe('buildMagicLinkUrl', () => {
+  it('builds an absolute onboarding URL from base + token', () => {
+    expect(buildMagicLinkUrl('https://www.circletel.co.za', 'TOK')).toBe(
+      'https://www.circletel.co.za/onboarding/TOK'
+    );
+  });
+  it('strips a trailing slash on base', () => {
+    expect(buildMagicLinkUrl('https://www.circletel.co.za/', 'TOK')).toBe(
+      'https://www.circletel.co.za/onboarding/TOK'
+    );
+  });
+});

--- a/__tests__/lib/onboarding/prorata.test.ts
+++ b/__tests__/lib/onboarding/prorata.test.ts
@@ -1,0 +1,17 @@
+import { computeProRata } from '@/lib/onboarding/prorata';
+
+describe('computeProRata', () => {
+  it('charges full month when activation is on the billing day', () => {
+    const r = computeProRata({ monthlyExVat: 450, vatPct: 15, activationDate: '2026-07-01', billingDay: 1 });
+    expect(r.days).toBe(31);
+    expect(r.daysInMonth).toBe(31);
+    expect(r.amountInclVat).toBeCloseTo(517.5, 2);
+  });
+  it('pro-rates a mid-month activation', () => {
+    // Activation 2026-07-16, next billing day 1 Aug -> 16 days remaining in July (16..31)
+    const r = computeProRata({ monthlyExVat: 450, vatPct: 15, activationDate: '2026-07-16', billingDay: 1 });
+    expect(r.days).toBe(16);
+    expect(r.daysInMonth).toBe(31);
+    expect(r.amountInclVat).toBeCloseTo(517.5 * 16 / 31, 2);
+  });
+});

--- a/__tests__/lib/onboarding/prorata.test.ts
+++ b/__tests__/lib/onboarding/prorata.test.ts
@@ -14,4 +14,19 @@ describe('computeProRata', () => {
     expect(r.daysInMonth).toBe(31);
     expect(r.amountInclVat).toBeCloseTo(517.5 * 16 / 31, 2);
   });
+  it('charges 1 day when activated on the last day of the month', () => {
+    const r = computeProRata({ monthlyExVat: 450, vatPct: 15, activationDate: '2026-07-31', billingDay: 1 });
+    expect(r.days).toBe(1);
+    expect(r.daysInMonth).toBe(31);
+  });
+  it('handles February in a non-leap year (28 days)', () => {
+    const r = computeProRata({ monthlyExVat: 450, vatPct: 15, activationDate: '2026-02-01', billingDay: 1 });
+    expect(r.daysInMonth).toBe(28);
+    expect(r.days).toBe(28);
+  });
+  it('handles February in a leap year (29 days)', () => {
+    const r = computeProRata({ monthlyExVat: 450, vatPct: 15, activationDate: '2028-02-01', billingDay: 1 });
+    expect(r.daysInMonth).toBe(29);
+    expect(r.days).toBe(29);
+  });
 });

--- a/__tests__/lib/onboarding/token-service.test.ts
+++ b/__tests__/lib/onboarding/token-service.test.ts
@@ -1,0 +1,17 @@
+import { generateToken, hashToken } from '@/lib/onboarding/token-service';
+
+describe('token-service', () => {
+  it('generates a URL-safe token of sufficient length', () => {
+    const t = generateToken();
+    expect(t).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+  });
+  it('generates unique tokens', () => {
+    expect(generateToken()).not.toEqual(generateToken());
+  });
+  it('hashes deterministically (same input -> same hash)', () => {
+    expect(hashToken('abc')).toEqual(hashToken('abc'));
+  });
+  it('hashes differently for different input', () => {
+    expect(hashToken('abc')).not.toEqual(hashToken('abd'));
+  });
+});

--- a/app/admin/b2b/vetting/[submissionId]/page.tsx
+++ b/app/admin/b2b/vetting/[submissionId]/page.tsx
@@ -1,0 +1,473 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  PiArrowLeftBold,
+  PiCheckCircleBold,
+  PiXCircleBold,
+  PiWarningCircleBold,
+  PiDownloadSimpleBold,
+  PiEyeBold,
+} from 'react-icons/pi';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { requiredDocsFor } from '@/lib/onboarding/document-requirements';
+
+interface SubmissionDetail {
+  id: string;
+  customer_id: string;
+  segment: string;
+  status: string;
+  document_vetting_status: string;
+  submission_data: any;
+  admin_reviewed_at: string | null;
+  admin_reviewed_by: string | null;
+  admin_notes: string | null;
+  rejection_reason: string | null;
+  submitted_at: string;
+  customers: {
+    id: string;
+    account_number: string;
+    business_name: string;
+    email: string;
+    phone: string;
+  } | null;
+  documents: Array<{
+    id: string;
+    document_type: string;
+    file_path: string;
+    verification_status: string;
+    rejection_reason: string | null;
+    verified_at: string | null;
+  }>;
+  paymentMethods: Array<{
+    id: string;
+    display_name: string;
+    mandate_status: string;
+    encrypted_details: any;
+  }>;
+  nameMatch: boolean;
+}
+
+function getVettingStatusColor(status: string) {
+  switch (status) {
+    case 'approved':
+      return 'text-green-600 bg-green-50';
+    case 'rejected':
+      return 'text-red-600 bg-red-50';
+    case 'under_review':
+      return 'text-amber-600 bg-amber-50';
+    default:
+      return 'text-gray-600 bg-gray-50';
+  }
+}
+
+function getDocStatusIcon(status: string) {
+  switch (status) {
+    case 'approved':
+      return <PiCheckCircleBold className="w-4 h-4 text-green-600" />;
+    case 'rejected':
+      return <PiXCircleBold className="w-4 h-4 text-red-600" />;
+    default:
+      return <div className="w-4 h-4 rounded-full bg-gray-300" />;
+  }
+}
+
+export default function B2BVettingDetailPage({
+  params,
+}: {
+  params: Promise<{ submissionId: string }>;
+}) {
+  const router = useRouter();
+  const [submission, setSubmission] = useState<SubmissionDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [selectedDoc, setSelectedDoc] = useState<string | null>(null);
+  const [docUrl, setDocUrl] = useState<string | null>(null);
+  const [submissionId, setSubmissionId] = useState<string>('');
+
+  // Handle async params
+  useEffect(() => {
+    params.then((p) => {
+      setSubmissionId(p.submissionId);
+    });
+  }, [params]);
+
+  // Fetch submission details
+  useEffect(() => {
+    if (!submissionId) return;
+
+    async function fetchSubmission() {
+      setLoading(true);
+      try {
+        const response = await fetch(`/api/admin/b2b/vetting/${submissionId}`, {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch submission');
+        }
+
+        const data = await response.json();
+        setSubmission(data.submission);
+      } catch (error) {
+        console.error('Error fetching submission:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchSubmission();
+  }, [submissionId]);
+
+  // Fetch signed URL for selected document
+  useEffect(() => {
+    if (!selectedDoc || !submission) return;
+
+    async function fetchDocUrl(sub: SubmissionDetail) {
+      try {
+        const doc = sub.documents.find((d) => d.id === selectedDoc);
+        if (!doc) return;
+
+        const response = await fetch(
+          `/api/admin/kyc/document-url?path=${encodeURIComponent(doc.file_path)}`,
+          {
+            headers: {
+              Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+            },
+          }
+        );
+
+        if (!response.ok) throw new Error('Failed to get document URL');
+
+        const data = await response.json();
+        setDocUrl(data.url);
+      } catch (error) {
+        console.error('Error fetching document URL:', error);
+      }
+    }
+
+    fetchDocUrl(submission);
+  }, [selectedDoc, submission]);
+
+  if (!submissionId) {
+    return <div>Loading...</div>;
+  }
+
+  if (loading) {
+    return (
+      <main className="max-w-7xl mx-auto px-4 py-8">
+        <div className="space-y-4">
+          <Skeleton className="h-12 w-1/3" />
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      </main>
+    );
+  }
+
+  if (!submission) {
+    return (
+      <main className="max-w-7xl mx-auto px-4 py-8">
+        <p className="text-red-600">Submission not found</p>
+      </main>
+    );
+  }
+
+  const step2 = submission.submission_data?.step2;
+  const requiredDocs = requiredDocsFor(submission.segment as any, {
+    vatRegistered: step2?.vat === 'Yes',
+    entityType: step2?.entityType || '',
+  });
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 py-8">
+      {/* Header */}
+      <div className="mb-6 flex items-center gap-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.back()}
+          className="gap-2"
+        >
+          <PiArrowLeftBold /> Back
+        </Button>
+        <div className="flex-1">
+          <h1 className="text-3xl font-bold">
+            {submission.customers?.business_name || 'Submission'}
+          </h1>
+          <p className="text-gray-600">
+            {submission.customers?.account_number} · {submission.segment}
+          </p>
+        </div>
+      </div>
+
+      {/* Status Banner */}
+      <Card className={`mb-6 ${getVettingStatusColor(submission.document_vetting_status)}`}>
+        <CardContent className="pt-6">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              {submission.document_vetting_status === 'approved' && (
+                <PiCheckCircleBold className="w-6 h-6" />
+              )}
+              {submission.document_vetting_status === 'rejected' && (
+                <PiXCircleBold className="w-6 h-6" />
+              )}
+              {['documents_pending', 'under_review'].includes(
+                submission.document_vetting_status
+              ) && <PiWarningCircleBold className="w-6 h-6" />}
+
+              <div>
+                <p className="font-semibold capitalize">
+                  {submission.document_vetting_status.replace(/_/g, ' ')}
+                </p>
+                {submission.admin_reviewed_at && (
+                  <p className="text-sm opacity-75">
+                    Reviewed{' '}
+                    {new Date(submission.admin_reviewed_at).toLocaleDateString()}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left Column: Documents */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Document Checklist */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Document Checklist</CardTitle>
+              <CardDescription>
+                Upload and verification status of required documents
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {requiredDocs
+                .filter((d) => d.required)
+                .map((req) => {
+                  const doc = submission.documents.find(
+                    (d) => d.document_type === req.type
+                  );
+                  return (
+                    <div
+                      key={req.type}
+                      className="flex items-start justify-between p-3 border rounded-lg"
+                    >
+                      <div className="flex-1">
+                        <p className="font-medium">{req.label}</p>
+                        {doc && (
+                          <p className="text-sm text-gray-600">
+                            {doc.verification_status === 'approved' && (
+                              <span className="text-green-600">Approved</span>
+                            )}
+                            {doc.verification_status === 'rejected' && (
+                              <span className="text-red-600">
+                                Rejected:{' '}
+                                {doc.rejection_reason && (
+                                  <span className="block text-xs mt-1">
+                                    {doc.rejection_reason}
+                                  </span>
+                                )}
+                              </span>
+                            )}
+                            {doc.verification_status === 'pending' && (
+                              <span className="text-amber-600">Pending</span>
+                            )}
+                          </p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {doc && getDocStatusIcon(doc.verification_status)}
+                        {doc && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => setSelectedDoc(doc.id)}
+                            className="gap-1"
+                          >
+                            <PiEyeBold className="w-4 h-4" />
+                            View
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+            </CardContent>
+          </Card>
+
+          {/* Document Viewer */}
+          {selectedDoc && docUrl && (
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>Document Preview</CardTitle>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => window.open(docUrl, '_blank')}
+                  className="gap-1"
+                >
+                  <PiDownloadSimpleBold className="w-4 h-4" />
+                  Open
+                </Button>
+              </CardHeader>
+              <CardContent>
+                {docUrl.toLowerCase().includes('.pdf') ? (
+                  <div className="bg-gray-100 rounded p-4 h-96">
+                    <iframe
+                      src={docUrl}
+                      className="w-full h-full rounded"
+                      title="Document preview"
+                    />
+                  </div>
+                ) : (
+                  <div className="bg-gray-100 rounded p-4 h-96 flex items-center justify-center">
+                    <img
+                      src={docUrl}
+                      alt="Document"
+                      className="max-w-full max-h-full object-contain"
+                    />
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Right Column: Details */}
+        <div className="space-y-6">
+          {/* Entity Information */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Entity Information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <p className="text-sm text-gray-600">Business Name</p>
+                <p className="font-medium">{step2?.entityName || '-'}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">Entity Type</p>
+                <p className="font-medium">{step2?.entityType || '-'}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">Registration Number</p>
+                <p className="font-mono text-sm">{step2?.regNumber || '-'}</p>
+              </div>
+              {step2?.vat === 'Yes' && (
+                <div>
+                  <p className="text-sm text-gray-600">VAT Number</p>
+                  <p className="font-mono text-sm">{step2?.vatNumber || '-'}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Banking Information */}
+          {submission.paymentMethods.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Banking Details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {submission.paymentMethods.map((pm) => {
+                  const encrypted = pm.encrypted_details || {};
+                  return (
+                    <div key={pm.id} className="space-y-2 p-3 border rounded">
+                      <div>
+                        <p className="text-sm text-gray-600">Account Holder</p>
+                        <p className="font-medium text-sm">
+                          {encrypted.account_holder_name || '-'}
+                        </p>
+                        {!submission.nameMatch && (
+                          <div className="flex gap-2 items-start mt-2 p-2 bg-amber-50 rounded">
+                            <PiWarningCircleBold className="w-4 h-4 text-amber-600 flex-shrink-0 mt-0.5" />
+                            <p className="text-xs text-amber-700">
+                              Account holder should match registered entity name
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                      <div>
+                        <p className="text-sm text-gray-600">Bank</p>
+                        <p className="font-medium text-sm">{encrypted.bank_name || '-'}</p>
+                      </div>
+                      <div>
+                        <p className="text-sm text-gray-600">Account Type</p>
+                        <p className="text-sm">{encrypted.account_type || '-'}</p>
+                      </div>
+                      <div>
+                        <p className="text-sm text-gray-600">Account Number</p>
+                        <p className="font-mono text-sm">
+                          ****{encrypted.account_number?.slice(-4) || '****'}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-sm text-gray-600">Branch Code</p>
+                        <p className="font-mono text-sm">{encrypted.branch_code || '-'}</p>
+                      </div>
+                      <div className="pt-2">
+                        <Badge
+                          variant={
+                            pm.mandate_status === 'active' ? 'default' : 'secondary'
+                          }
+                        >
+                          {pm.mandate_status}
+                        </Badge>
+                      </div>
+                    </div>
+                  );
+                })}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Contact Information */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Contact</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <p className="text-sm text-gray-600">Email</p>
+                <p className="text-sm break-all">{submission.customers?.email || '-'}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">Phone</p>
+                <p className="text-sm">{submission.customers?.phone || '-'}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Submitted Date */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Timeline</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div>
+                <p className="text-sm text-gray-600">Submitted</p>
+                <p className="text-sm">
+                  {new Date(submission.submitted_at).toLocaleString()}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/b2b/vetting/[submissionId]/page.tsx
+++ b/app/admin/b2b/vetting/[submissionId]/page.tsx
@@ -9,6 +9,9 @@ import {
   PiWarningCircleBold,
   PiDownloadSimpleBold,
   PiEyeBold,
+  PiCheckBold,
+  PiXBold,
+  PiClipboardTextBold,
 } from 'react-icons/pi';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -93,6 +96,10 @@ export default function B2BVettingDetailPage({
   const [selectedDoc, setSelectedDoc] = useState<string | null>(null);
   const [docUrl, setDocUrl] = useState<string | null>(null);
   const [submissionId, setSubmissionId] = useState<string>('');
+  const [actionInFlight, setActionInFlight] = useState<string | null>(null);
+  const [showRejectReason, setShowRejectReason] = useState<string | null>(null);
+  const [rejectReasonText, setRejectReasonText] = useState<string>('');
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // Handle async params
   useEffect(() => {
@@ -102,31 +109,33 @@ export default function B2BVettingDetailPage({
   }, [params]);
 
   // Fetch submission details
-  useEffect(() => {
+  const fetchSubmission = async () => {
     if (!submissionId) return;
 
-    async function fetchSubmission() {
-      setLoading(true);
-      try {
-        const response = await fetch(`/api/admin/b2b/vetting/${submissionId}`, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
-          },
-        });
+    setLoading(true);
+    setActionError(null);
+    try {
+      const response = await fetch(`/api/admin/b2b/vetting/${submissionId}`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+        },
+      });
 
-        if (!response.ok) {
-          throw new Error('Failed to fetch submission');
-        }
-
-        const data = await response.json();
-        setSubmission(data.submission);
-      } catch (error) {
-        console.error('Error fetching submission:', error);
-      } finally {
-        setLoading(false);
+      if (!response.ok) {
+        throw new Error('Failed to fetch submission');
       }
-    }
 
+      const data = await response.json();
+      setSubmission(data.submission);
+    } catch (error) {
+      console.error('Error fetching submission:', error);
+      setActionError('Failed to load submission');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
     fetchSubmission();
   }, [submissionId]);
 
@@ -159,6 +168,57 @@ export default function B2BVettingDetailPage({
 
     fetchDocUrl(submission);
   }, [selectedDoc, submission]);
+
+  // Handle document vetting action (approve, reject, request changes)
+  const handleDocumentAction = async (
+    documentId: string,
+    status: 'approved' | 'rejected' | 'under_review',
+    rejectionReason?: string
+  ) => {
+    if (status === 'rejected' && !rejectionReason?.trim()) {
+      setActionError('Rejection reason is required');
+      return;
+    }
+
+    const actionKey = `${documentId}-${status}`;
+    setActionInFlight(actionKey);
+    setActionError(null);
+
+    try {
+      const body: any = { documentId, status };
+      if (status === 'rejected') {
+        body.rejectionReason = rejectionReason;
+      } else if (status === 'under_review' && rejectionReason) {
+        body.notes = rejectionReason;
+      }
+
+      const response = await fetch('/api/admin/kyc/verify', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message || 'Failed to update document');
+      }
+
+      // Reset reject reason UI and re-fetch submission
+      setShowRejectReason(null);
+      setRejectReasonText('');
+      await fetchSubmission();
+    } catch (error) {
+      console.error('Error updating document:', error);
+      setActionError(
+        error instanceof Error ? error.message : 'Failed to update document'
+      );
+    } finally {
+      setActionInFlight(null);
+    }
+  };
 
   if (!submissionId) {
     return <div>Loading...</div>;
@@ -243,6 +303,15 @@ export default function B2BVettingDetailPage({
         </CardContent>
       </Card>
 
+      {/* Action Error Alert */}
+      {actionError && (
+        <Card className="mb-6 border-red-200 bg-red-50">
+          <CardContent className="pt-6">
+            <p className="text-sm text-red-700">{actionError}</p>
+          </CardContent>
+        </Card>
+      )}
+
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Left Column: Documents */}
         <div className="lg:col-span-2 space-y-6">
@@ -261,48 +330,148 @@ export default function B2BVettingDetailPage({
                   const doc = submission.documents.find(
                     (d) => d.document_type === req.type
                   );
+                  const isApproved = doc?.verification_status === 'approved';
+                  const isRejected = doc?.verification_status === 'rejected';
+                  const isPending = doc?.verification_status === 'pending';
                   return (
                     <div
                       key={req.type}
-                      className="flex items-start justify-between p-3 border rounded-lg"
+                      className="space-y-2 p-3 border rounded-lg"
                     >
-                      <div className="flex-1">
-                        <p className="font-medium">{req.label}</p>
-                        {doc && (
-                          <p className="text-sm text-gray-600">
-                            {doc.verification_status === 'approved' && (
-                              <span className="text-green-600">Approved</span>
-                            )}
-                            {doc.verification_status === 'rejected' && (
-                              <span className="text-red-600">
-                                Rejected:{' '}
-                                {doc.rejection_reason && (
-                                  <span className="block text-xs mt-1">
-                                    {doc.rejection_reason}
-                                  </span>
-                                )}
-                              </span>
-                            )}
-                            {doc.verification_status === 'pending' && (
-                              <span className="text-amber-600">Pending</span>
-                            )}
-                          </p>
-                        )}
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <p className="font-medium">{req.label}</p>
+                          {doc && (
+                            <p className="text-sm text-gray-600">
+                              {isApproved && (
+                                <span className="text-green-600">Approved</span>
+                              )}
+                              {isRejected && (
+                                <span className="text-red-600">
+                                  Rejected:{' '}
+                                  {doc.rejection_reason && (
+                                    <span className="block text-xs mt-1">
+                                      {doc.rejection_reason}
+                                    </span>
+                                  )}
+                                </span>
+                              )}
+                              {isPending && (
+                                <span className="text-amber-600">Pending</span>
+                              )}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {doc && getDocStatusIcon(doc.verification_status)}
+                          {doc && (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={() => setSelectedDoc(doc.id)}
+                              className="gap-1"
+                              disabled={actionInFlight?.startsWith(doc.id) || false}
+                            >
+                              <PiEyeBold className="w-4 h-4" />
+                              View
+                            </Button>
+                          )}
+                        </div>
                       </div>
-                      <div className="flex items-center gap-2">
-                        {doc && getDocStatusIcon(doc.verification_status)}
-                        {doc && (
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() => setSelectedDoc(doc.id)}
-                            className="gap-1"
-                          >
-                            <PiEyeBold className="w-4 h-4" />
-                            View
-                          </Button>
-                        )}
-                      </div>
+
+                      {/* Action Buttons */}
+                      {doc && (
+                        <div className="space-y-2">
+                          {showRejectReason === doc.id ? (
+                            <div className="space-y-2 pt-2 border-t">
+                              <textarea
+                                placeholder="Enter rejection reason (required)..."
+                                value={rejectReasonText}
+                                onChange={(e) => setRejectReasonText(e.target.value)}
+                                className="w-full p-2 text-sm border rounded resize-none focus:outline-none focus:ring-2 focus:ring-red-500"
+                                rows={2}
+                              />
+                              <div className="flex gap-2">
+                                <Button
+                                  size="sm"
+                                  variant="destructive"
+                                  onClick={() =>
+                                    handleDocumentAction(doc.id, 'rejected', rejectReasonText)
+                                  }
+                                  disabled={
+                                    actionInFlight === `${doc.id}-rejected` ||
+                                    !rejectReasonText.trim()
+                                  }
+                                  className="gap-1"
+                                >
+                                  <PiXBold className="w-3 h-3" />
+                                  {actionInFlight === `${doc.id}-rejected`
+                                    ? 'Rejecting...'
+                                    : 'Confirm Reject'}
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => {
+                                    setShowRejectReason(null);
+                                    setRejectReasonText('');
+                                  }}
+                                  disabled={actionInFlight === `${doc.id}-rejected`}
+                                >
+                                  Cancel
+                                </Button>
+                              </div>
+                            </div>
+                          ) : (
+                            <div className="flex flex-wrap gap-2 pt-2 border-t">
+                              {!isApproved && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() =>
+                                    handleDocumentAction(doc.id, 'approved')
+                                  }
+                                  disabled={actionInFlight === `${doc.id}-approved`}
+                                  className="gap-1 text-green-600 hover:text-green-700"
+                                >
+                                  <PiCheckBold className="w-3 h-3" />
+                                  {actionInFlight === `${doc.id}-approved`
+                                    ? 'Approving...'
+                                    : 'Approve'}
+                                </Button>
+                              )}
+                              {!isRejected && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => setShowRejectReason(doc.id)}
+                                  disabled={actionInFlight?.startsWith(doc.id) || false}
+                                  className="gap-1 text-red-600 hover:text-red-700"
+                                >
+                                  <PiXBold className="w-3 h-3" />
+                                  Reject
+                                </Button>
+                              )}
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() =>
+                                  handleDocumentAction(doc.id, 'under_review')
+                                }
+                                disabled={
+                                  actionInFlight === `${doc.id}-under_review`
+                                }
+                                className="gap-1 text-amber-600 hover:text-amber-700"
+                              >
+                                <PiClipboardTextBold className="w-3 h-3" />
+                                {actionInFlight === `${doc.id}-under_review`
+                                  ? 'Updating...'
+                                  : 'Request Changes'}
+                              </Button>
+                            </div>
+                          )}
+                        </div>
+                      )}
                     </div>
                   );
                 })}

--- a/app/admin/b2b/vetting/page.tsx
+++ b/app/admin/b2b/vetting/page.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  PiCheckCircleBold,
+  PiClockBold,
+  PiXCircleBold,
+  PiCaretRightBold,
+  PiFunnelBold,
+} from 'react-icons/pi';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface Submission {
+  id: string;
+  customer_id: string;
+  segment: string;
+  status: string;
+  document_vetting_status: string;
+  submitted_at: string;
+  customers: {
+    id: string;
+    account_number: string;
+    business_name: string;
+    onboarding_status: string;
+  } | null;
+}
+
+function getVettingBadge(status: string) {
+  const variants: Record<
+    string,
+    { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }
+  > = {
+    documents_pending: { variant: 'secondary', label: 'Documents Pending' },
+    under_review: { variant: 'secondary', label: 'Under Review' },
+    approved: { variant: 'default', label: 'Approved' },
+    rejected: { variant: 'destructive', label: 'Rejected' },
+    not_started: { variant: 'outline', label: 'Not Started' },
+  };
+  const config = variants[status] || { variant: 'outline', label: status };
+  return <Badge variant={config.variant}>{config.label}</Badge>;
+}
+
+function getStatusIcon(status: string) {
+  switch (status) {
+    case 'approved':
+      return <PiCheckCircleBold className="w-4 h-4 text-green-600" />;
+    case 'rejected':
+      return <PiXCircleBold className="w-4 h-4 text-red-600" />;
+    default:
+      return <PiClockBold className="w-4 h-4 text-amber-600" />;
+  }
+}
+
+export default function B2BVettingQueuePage() {
+  const router = useRouter();
+  const [submissions, setSubmissions] = useState<Submission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [segment, setSegment] = useState<string>('');
+
+  useEffect(() => {
+    async function fetchSubmissions() {
+      setLoading(true);
+      try {
+        const url = new URL('/api/admin/b2b/vetting', window.location.origin);
+        if (segment) {
+          url.searchParams.set('segment', segment);
+        }
+
+        const response = await fetch(url.toString(), {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch submissions');
+        }
+
+        const data = await response.json();
+        setSubmissions(data.submissions || []);
+      } catch (error) {
+        console.error('Error fetching submissions:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchSubmissions();
+  }, [segment]);
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">B2B Document Vetting Queue</h1>
+        <p className="text-gray-600">Review and approve onboarding submissions</p>
+      </div>
+
+      {/* Filters */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <PiFunnelBold /> Filters
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-4">
+            <div className="w-full max-w-xs">
+              <label className="block text-sm font-medium mb-2">Segment</label>
+              <Select value={segment} onValueChange={setSegment}>
+                <SelectTrigger>
+                  <SelectValue placeholder="All segments" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">All segments</SelectItem>
+                  <SelectItem value="unjani">Unjani</SelectItem>
+                  <SelectItem value="smb">SMB</SelectItem>
+                  <SelectItem value="edu">Education</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Queue Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Submissions</CardTitle>
+          <CardDescription>{submissions.length} total submissions</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : submissions.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              No submissions to review
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Account Number</TableHead>
+                    <TableHead>Business Name</TableHead>
+                    <TableHead>Segment</TableHead>
+                    <TableHead>Vetting Status</TableHead>
+                    <TableHead>Submitted</TableHead>
+                    <TableHead>Onboarding Status</TableHead>
+                    <TableHead className="text-right">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {submissions.map((submission) => (
+                    <TableRow key={submission.id} className="hover:bg-gray-50">
+                      <TableCell className="font-mono text-sm">
+                        {submission.customers?.account_number || '-'}
+                      </TableCell>
+                      <TableCell>{submission.customers?.business_name || '-'}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline">{submission.segment}</Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          {getStatusIcon(submission.document_vetting_status)}
+                          {getVettingBadge(submission.document_vetting_status)}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-600">
+                        {submission.submitted_at
+                          ? new Date(submission.submitted_at).toLocaleDateString()
+                          : '-'}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary">
+                          {submission.customers?.onboarding_status || '-'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() =>
+                            router.push(`/admin/b2b/vetting/${submission.id}`)
+                          }
+                        >
+                          <PiCaretRightBold className="w-4 h-4" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/api/admin/b2b/vetting/[submissionId]/route.ts
+++ b/app/api/admin/b2b/vetting/[submissionId]/route.ts
@@ -1,0 +1,101 @@
+/**
+ * B2B Onboarding Vetting Detail API
+ * Fetches a single submission with its documents and banking details
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { apiLogger } from '@/lib/logging/logger';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ submissionId: string }> }
+) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response;
+
+    const supabase = await createServerClient();
+    const { submissionId } = await context.params;
+
+    // Fetch submission with customer details
+    const { data: submission, error: subError } = await supabase
+      .from('onboarding_submissions')
+      .select(
+        `
+        id,
+        customer_id,
+        segment,
+        status,
+        document_vetting_status,
+        submission_data,
+        admin_reviewed_at,
+        admin_reviewed_by,
+        admin_notes,
+        rejection_reason,
+        submitted_at,
+        customers(id, account_number, business_name, email, phone)
+      `
+      )
+      .eq('id', submissionId)
+      .single();
+
+    if (subError || !submission) {
+      return NextResponse.json(
+        { success: false, error: 'Submission not found' },
+        { status: 404 }
+      );
+    }
+
+    // Fetch this submission's documents
+    const { data: documents, error: docsError } = await supabase
+      .from('kyc_documents')
+      .select('id, document_type, file_path, verification_status, rejection_reason, verified_at')
+      .eq('onboarding_submission_id', submissionId);
+
+    if (docsError) {
+      apiLogger.error('Failed to fetch documents', { error: docsError });
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch documents' },
+        { status: 500 }
+      );
+    }
+
+    // Fetch the customer's payment method(s) created by this submission
+    const { data: paymentMethods, error: pmError } = await supabase
+      .from('customer_payment_methods')
+      .select('id, display_name, mandate_status, encrypted_details')
+      .eq('customer_id', submission.customer_id)
+      .eq('onboarding_submission_id', submissionId);
+
+    if (pmError) {
+      apiLogger.error('Failed to fetch payment methods', { error: pmError });
+    }
+
+    // Check name match: account holder vs business_name (trimmed, lowercased)
+    const accountHolder = submission.submission_data?.step3?.accHolder ?? '';
+    const customer = Array.isArray(submission.customers)
+      ? submission.customers[0]
+      : submission.customers;
+    const businessName = customer?.business_name ?? '';
+    const nameMatch =
+      accountHolder.trim().toLowerCase() === businessName.trim().toLowerCase();
+
+    return NextResponse.json({
+      success: true,
+      submission: {
+        ...submission,
+        documents: documents || [],
+        paymentMethods: paymentMethods || [],
+        nameMatch,
+      },
+    });
+  } catch (error: unknown) {
+    apiLogger.error('API error', { error });
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/b2b/vetting/[submissionId]/route.ts
+++ b/app/api/admin/b2b/vetting/[submissionId]/route.ts
@@ -5,7 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createServerClient } from '@/lib/supabase/server';
-import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
 import { apiLogger } from '@/lib/logging/logger';
 
 export async function GET(
@@ -15,6 +15,9 @@ export async function GET(
   try {
     const authResult = await authenticateAdmin(request);
     if (!authResult.success) return authResult.response;
+
+    const perm = requirePermission(authResult.adminUser, 'kyc:verify');
+    if (perm) return perm;
 
     const supabase = await createServerClient();
     const { submissionId } = await context.params;

--- a/app/api/admin/b2b/vetting/route.ts
+++ b/app/api/admin/b2b/vetting/route.ts
@@ -1,0 +1,68 @@
+/**
+ * B2B Onboarding Vetting Queue API
+ * Lists onboarding submissions awaiting document vetting
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { apiLogger } from '@/lib/logging/logger';
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response;
+
+    const perm = requirePermission(authResult.adminUser, 'kyc:verify');
+    if (perm) return perm;
+
+    const supabase = await createServerClient();
+
+    // Get optional segment filter
+    const { searchParams } = new URL(request.url);
+    const segment = searchParams.get('segment');
+
+    // Build query
+    let query = supabase
+      .from('onboarding_submissions')
+      .select(
+        `
+        id,
+        customer_id,
+        segment,
+        status,
+        document_vetting_status,
+        submitted_at,
+        customers(id, account_number, business_name, onboarding_status)
+      `
+      )
+      .in('status', ['submitted', 'approved', 'rejected']);
+
+    if (segment) {
+      query = query.eq('segment', segment);
+    }
+
+    const { data: submissions, error } = await query.order('submitted_at', {
+      ascending: true,
+    });
+
+    if (error) {
+      apiLogger.error('Failed to fetch submissions', { error });
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch submissions' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      submissions: submissions || [],
+    });
+  } catch (error: unknown) {
+    apiLogger.error('API error', { error });
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/kyc/verify/route.ts
+++ b/app/api/admin/kyc/verify/route.ts
@@ -6,7 +6,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createServerClient } from '@/lib/supabase/server';
-import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
 import { EmailNotificationService } from '@/lib/notifications/notification-service';
 import { apiLogger } from '@/lib/logging/logger';
 import { computeVettingStatus, requiredDocsFor } from '@/lib/onboarding/document-requirements';
@@ -16,6 +16,9 @@ export async function POST(request: NextRequest) {
   try {
     const authResult = await authenticateAdmin(request);
     if (!authResult.success) return authResult.response;
+
+    const perm = requirePermission(authResult.adminUser, 'kyc:verify');
+    if (perm) return perm;
 
     // Use service role key for admin access
     const supabase = await createServerClient();
@@ -154,7 +157,7 @@ export async function POST(request: NextRequest) {
             status: submissionStatus,
             admin_reviewed_at: new Date().toISOString(),
             admin_reviewed_by: authResult.adminUser.id,
-          });
+          }).eq('id', submissionId);
 
           // Try to mark customer billing_ready if all conditions are met
           const marked = await maybeMarkBillingReady(supabase, submission.customer_id);

--- a/app/api/admin/kyc/verify/route.ts
+++ b/app/api/admin/kyc/verify/route.ts
@@ -9,6 +9,8 @@ import { createClient as createServerClient } from '@/lib/supabase/server';
 import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
 import { EmailNotificationService } from '@/lib/notifications/notification-service';
 import { apiLogger } from '@/lib/logging/logger';
+import { computeVettingStatus, requiredDocsFor } from '@/lib/onboarding/document-requirements';
+import { maybeMarkBillingReady } from '@/lib/onboarding/billing-ready';
 
 export async function POST(request: NextRequest) {
   try {
@@ -91,10 +93,83 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Update order status based on verification result
+    // Re-fetch the document to learn its scope (consumer_order_id vs onboarding_submission_id)
+    const { data: scopedDoc, error: scopeError } = await supabase
+      .from('kyc_documents')
+      .select('consumer_order_id, onboarding_submission_id')
+      .eq('id', documentId)
+      .single();
+
+    if (scopeError || !scopedDoc) {
+      apiLogger.error('Failed to re-fetch document scope', { error: scopeError });
+      return NextResponse.json(
+        { success: false, error: 'Failed to determine document scope' },
+        { status: 500 }
+      );
+    }
+
     let emailSent = false;
     let emailError: string | undefined;
 
+    // B2B SUBMISSION PATH: onboarding_submission_id is set
+    if (scopedDoc.onboarding_submission_id) {
+      const submissionId = scopedDoc.onboarding_submission_id;
+
+      // Fetch the submission to get its context (segment, submission_data)
+      const { data: submission, error: subError } = await supabase
+        .from('onboarding_submissions')
+        .select('id, customer_id, segment, submission_data, status')
+        .eq('id', submissionId)
+        .single();
+
+      if (!subError && submission) {
+        // Compute required docs based on segment + entity context
+        const step2 = submission.submission_data?.step2;
+        const required = requiredDocsFor(submission.segment as any, {
+          vatRegistered: step2?.vat === 'Yes',
+          entityType: step2?.entityType || '',
+        })
+          .filter((r) => r.required)
+          .map((r) => r.type);
+
+        // Fetch this submission's documents
+        const { data: submissionDocs, error: docsError } = await supabase
+          .from('kyc_documents')
+          .select('document_type, verification_status')
+          .eq('onboarding_submission_id', submissionId);
+
+        if (!docsError && submissionDocs) {
+          const vetting = computeVettingStatus(required, submissionDocs);
+
+          // Update the submission's vetting status and overall status
+          const submissionStatus =
+            vetting === 'approved'
+              ? 'approved'
+              : vetting === 'rejected'
+                ? 'rejected'
+                : 'submitted';
+
+          await supabase.from('onboarding_submissions').update({
+            document_vetting_status: vetting,
+            status: submissionStatus,
+            admin_reviewed_at: new Date().toISOString(),
+            admin_reviewed_by: authResult.adminUser.id,
+          });
+
+          // Try to mark customer billing_ready if all conditions are met
+          const marked = await maybeMarkBillingReady(supabase, submission.customer_id);
+
+          return NextResponse.json({
+            success: true,
+            message: `Document ${status} successfully`,
+            vetting,
+            billingReadyMarked: marked,
+          });
+        }
+      }
+    }
+
+    // CONSUMER ORDER PATH: consumer_order_id is set (original logic)
     if (status === 'approved') {
       // Check if all documents for this order are approved
       const { data: allDocs, error: docsError } = await supabase
@@ -103,9 +178,7 @@ export async function POST(request: NextRequest) {
         .eq('consumer_order_id', document.consumer_order_id);
 
       if (!docsError && allDocs) {
-        const allApproved = allDocs.every(
-          (doc) => doc.verification_status === 'approved'
-        );
+        const allApproved = allDocs.every((doc) => doc.verification_status === 'approved');
 
         if (allApproved) {
           // All documents approved, update order to kyc_approved
@@ -130,7 +203,7 @@ export async function POST(request: NextRequest) {
               }
             } catch (error: unknown) {
               apiLogger.error('Error sending KYC approval email', { error });
-              emailError = error.message;
+              emailError = (error as Error).message;
             }
           }
         }
@@ -159,7 +232,7 @@ export async function POST(request: NextRequest) {
           }
         } catch (error: unknown) {
           apiLogger.error('Error sending KYC rejection email', { error });
-          emailError = error.message;
+          emailError = (error as Error).message;
         }
       }
     }
@@ -173,7 +246,11 @@ export async function POST(request: NextRequest) {
   } catch (error: unknown) {
     apiLogger.error('API error', { error });
     return NextResponse.json(
-      { success: false, error: error.message || 'Internal server error' },
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Internal server error',
+      },
       { status: 500 }
     );
   }

--- a/app/api/admin/unjani/send-link/route.ts
+++ b/app/api/admin/unjani/send-link/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { issueToken, buildMagicLinkUrl, svc } from '@/lib/onboarding/onboarding-service';
+import { clickatellService } from '@/lib/integrations/clickatell/sms-service';
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticateAdmin(request);
+  if (!auth.success) return auth.response;
+  const perm = requirePermission(auth.adminUser, ['customers:write', 'kyc:verify']);
+  if (perm) return perm;
+
+  const { customerId, channel = 'sms' } = await request.json();
+  if (!customerId) return NextResponse.json({ success: false, error: 'customerId required' }, { status: 400 });
+
+  const supabase = svc();
+  const { data: customer } = await supabase
+    .from('customers').select('id, phone, email, business_name').eq('id', customerId).single();
+  if (!customer) return NextResponse.json({ success: false, error: 'Customer not found' }, { status: 404 });
+
+  const token = await issueToken(customerId, channel);
+  const base = process.env.NEXT_PUBLIC_APP_URL || 'https://www.circletel.co.za';
+  const url = buildMagicLinkUrl(base, token);
+
+  // Send via the chosen channel. SMS shown; swap for WhatsApp/email per project helpers.
+  if (channel === 'sms' && customer.phone) {
+    const message = `CircleTel: complete your billing setup for ${customer.business_name}: ${url} (link valid 7 days)`;
+    await clickatellService.sendSMS({ to: customer.phone, text: message });
+  }
+  await supabase.from('customers').update({ onboarding_status: 'in_progress' }).eq('id', customerId).eq('onboarding_status', 'pending');
+
+  return NextResponse.json({ success: true, url });
+}

--- a/app/api/admin/unjani/send-link/route.ts
+++ b/app/api/admin/unjani/send-link/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
 import { issueToken, buildMagicLinkUrl, svc } from '@/lib/onboarding/onboarding-service';
 import { clickatellService } from '@/lib/integrations/clickatell/sms-service';
+import { whatsAppService } from '@/lib/integrations/whatsapp/whatsapp-service';
 import { apiLogger } from '@/lib/logging/logger';
 
 export async function POST(request: NextRequest) {
@@ -22,31 +23,44 @@ export async function POST(request: NextRequest) {
   const base = process.env.NEXT_PUBLIC_APP_URL || 'https://www.circletel.co.za';
   const url = buildMagicLinkUrl(base, token);
 
-  // Send via the chosen channel and capture result
-  let smsSent = false;
-  let smsError: string | undefined;
+  // Send via the chosen channel and capture result.
+  // `sent`/`sendError` are channel-agnostic; smsSent kept for backward compatibility.
+  let sent = false;
+  let sendError: string | undefined;
 
-  if (channel === 'sms' && customer.phone) {
+  if (!customer.phone) {
+    sendError = 'Customer has no phone number';
+  } else if (channel === 'whatsapp') {
+    try {
+      const result = await whatsAppService.sendClinicOnboarding(customer.phone, {
+        clinicName: customer.business_name || 'there',
+        token,
+      });
+      sent = result.success;
+      if (!result.success) {
+        sendError = result.error;
+        apiLogger.warn('[Onboarding] WhatsApp send failed', { customerId, phone: customer.phone, error: result.error });
+      }
+    } catch (error) {
+      sendError = error instanceof Error ? error.message : 'Unknown error';
+      apiLogger.error('[Onboarding] WhatsApp send exception', { customerId, phone: customer.phone, error });
+    }
+  } else if (channel === 'sms') {
     const message = `CircleTel: complete your billing setup for ${customer.business_name}: ${url} (link valid 7 days)`;
     try {
       const result = await clickatellService.sendSMS({ to: customer.phone, text: message });
-      if (result.success) {
-        smsSent = true;
-      } else {
-        smsSent = false;
-        smsError = result.error;
+      sent = result.success;
+      if (!result.success) {
+        sendError = result.error;
         apiLogger.warn('[Onboarding] SMS send failed', { customerId, phone: customer.phone, error: result.error });
       }
     } catch (error) {
-      smsSent = false;
-      smsError = error instanceof Error ? error.message : 'Unknown error';
+      sendError = error instanceof Error ? error.message : 'Unknown error';
       apiLogger.error('[Onboarding] SMS send exception', { customerId, phone: customer.phone, error });
     }
-  } else if (channel === 'sms' && !customer.phone) {
-    smsError = 'Customer has no phone number';
   }
 
-  // Update onboarding status regardless of SMS outcome
+  // Update onboarding status regardless of send outcome
   await supabase.from('customers').update({ onboarding_status: 'in_progress' }).eq('id', customerId).eq('onboarding_status', 'pending');
 
   // Audit log for magic link issuance
@@ -54,8 +68,8 @@ export async function POST(request: NextRequest) {
     customerId,
     channel,
     issuedBy: auth.adminUser.email,
-    smsSent
+    sent,
   });
 
-  return NextResponse.json({ success: true, url, smsSent, smsError });
+  return NextResponse.json({ success: true, url, channel, sent, sendError, smsSent: sent, smsError: sendError });
 }

--- a/app/api/admin/unjani/send-link/route.ts
+++ b/app/api/admin/unjani/send-link/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
 import { issueToken, buildMagicLinkUrl, svc } from '@/lib/onboarding/onboarding-service';
 import { clickatellService } from '@/lib/integrations/clickatell/sms-service';
+import { apiLogger } from '@/lib/logging/logger';
 
 export async function POST(request: NextRequest) {
   const auth = await authenticateAdmin(request);
@@ -21,12 +22,40 @@ export async function POST(request: NextRequest) {
   const base = process.env.NEXT_PUBLIC_APP_URL || 'https://www.circletel.co.za';
   const url = buildMagicLinkUrl(base, token);
 
-  // Send via the chosen channel. SMS shown; swap for WhatsApp/email per project helpers.
+  // Send via the chosen channel and capture result
+  let smsSent = false;
+  let smsError: string | undefined;
+
   if (channel === 'sms' && customer.phone) {
     const message = `CircleTel: complete your billing setup for ${customer.business_name}: ${url} (link valid 7 days)`;
-    await clickatellService.sendSMS({ to: customer.phone, text: message });
+    try {
+      const result = await clickatellService.sendSMS({ to: customer.phone, text: message });
+      if (result.success) {
+        smsSent = true;
+      } else {
+        smsSent = false;
+        smsError = result.error;
+        apiLogger.warn('[Onboarding] SMS send failed', { customerId, phone: customer.phone, error: result.error });
+      }
+    } catch (error) {
+      smsSent = false;
+      smsError = error instanceof Error ? error.message : 'Unknown error';
+      apiLogger.error('[Onboarding] SMS send exception', { customerId, phone: customer.phone, error });
+    }
+  } else if (channel === 'sms' && !customer.phone) {
+    smsError = 'Customer has no phone number';
   }
+
+  // Update onboarding status regardless of SMS outcome
   await supabase.from('customers').update({ onboarding_status: 'in_progress' }).eq('id', customerId).eq('onboarding_status', 'pending');
 
-  return NextResponse.json({ success: true, url });
+  // Audit log for magic link issuance
+  apiLogger.info('[Onboarding] Magic link issued', {
+    customerId,
+    channel,
+    issuedBy: auth.adminUser.email,
+    smsSent
+  });
+
+  return NextResponse.json({ success: true, url, smsSent, smsError });
 }

--- a/app/api/admin/unjani/send-onboarding-batch/route.ts
+++ b/app/api/admin/unjani/send-onboarding-batch/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { issueToken, svc } from '@/lib/onboarding/onboarding-service';
+import { whatsAppService } from '@/lib/integrations/whatsapp/whatsapp-service';
+import { apiLogger } from '@/lib/logging/logger';
+
+/**
+ * Batch WhatsApp onboarding invite for Unjani clinics.
+ *
+ * For each not-yet-onboarded clinic, issue a magic-link token and send the
+ * `circletel_clinic_onboarding` WhatsApp template (from the billing WABA).
+ * The template's URL button deep-links to /onboarding/<token> (the web wizard).
+ *
+ * Body: { dryRun?: boolean, customerIds?: string[] }
+ *  - dryRun: list eligible clinics without sending.
+ *  - customerIds: restrict to specific customers (otherwise all Unjani clinics
+ *    with onboarding_status in pending/in_progress).
+ */
+export async function POST(request: NextRequest) {
+  const auth = await authenticateAdmin(request);
+  if (!auth.success) return auth.response;
+  const perm = requirePermission(auth.adminUser, ['customers:write', 'kyc:verify']);
+  if (perm) return perm;
+
+  const body = await request.json().catch(() => ({}));
+  const dryRun: boolean = !!body.dryRun;
+  const customerIds: string[] | undefined = Array.isArray(body.customerIds) ? body.customerIds : undefined;
+
+  const supabase = svc();
+
+  let query = supabase
+    .from('customers')
+    .select('id, phone, business_name, onboarding_status')
+    .in('onboarding_status', ['pending', 'in_progress']);
+
+  if (customerIds && customerIds.length > 0) {
+    query = query.in('id', customerIds);
+  } else {
+    query = query.ilike('business_name', '%unjani%');
+  }
+
+  const { data: clinics, error } = await query;
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  const eligible = (clinics || []).filter((c) => !!c.phone);
+  const noPhone = (clinics || []).filter((c) => !c.phone).map((c) => ({ id: c.id, business_name: c.business_name }));
+
+  if (dryRun) {
+    return NextResponse.json({
+      success: true,
+      dryRun: true,
+      eligibleCount: eligible.length,
+      eligible: eligible.map((c) => ({ id: c.id, business_name: c.business_name, phone: c.phone })),
+      skippedNoPhone: noPhone,
+    });
+  }
+
+  const results: Array<{ id: string; business_name: string | null; sent: boolean; error?: string }> = [];
+  let sentCount = 0;
+
+  for (const clinic of eligible) {
+    try {
+      const token = await issueToken(clinic.id, 'whatsapp');
+      const res = await whatsAppService.sendClinicOnboarding(clinic.phone!, {
+        clinicName: clinic.business_name || 'there',
+        token,
+      });
+      if (res.success) {
+        sentCount++;
+        await supabase
+          .from('customers')
+          .update({ onboarding_status: 'in_progress' })
+          .eq('id', clinic.id)
+          .eq('onboarding_status', 'pending');
+      }
+      results.push({ id: clinic.id, business_name: clinic.business_name, sent: res.success, error: res.error });
+    } catch (err) {
+      results.push({
+        id: clinic.id,
+        business_name: clinic.business_name,
+        sent: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+    // Rate-limit between sends
+    await new Promise((r) => setTimeout(r, 150));
+  }
+
+  apiLogger.info('[Onboarding] WhatsApp batch invite sent', {
+    issuedBy: auth.adminUser.email,
+    total: eligible.length,
+    sent: sentCount,
+    failed: eligible.length - sentCount,
+  });
+
+  return NextResponse.json({
+    success: true,
+    total: eligible.length,
+    sent: sentCount,
+    failed: eligible.length - sentCount,
+    skippedNoPhone: noPhone,
+    results,
+  });
+}

--- a/app/api/auth/create-customer/route.ts
+++ b/app/api/auth/create-customer/route.ts
@@ -81,12 +81,16 @@ export async function POST(request: NextRequest) {
     // mobile OTP login can't resolve which account to sign into. Reject if the
     // number is already registered to a DIFFERENT account (matched by the DB
     // partial unique index `customers_phone_unique_not_blank` as the backstop).
+    // Scope: PERSONAL accounts only. Business/clinic accounts (e.g. Unjani) may
+    // legitimately share one nurse's number across multiple clinics.
+    const accountType = account_type || 'personal';
     const normalizedPhone = (phone || '').trim();
-    if (normalizedPhone) {
+    if (normalizedPhone && accountType === 'personal') {
       const { data: phoneOwner } = await supabase
         .from('customers')
         .select('email')
         .eq('phone', normalizedPhone)
+        .eq('account_type', 'personal')
         .neq('email', email)
         .limit(1)
         .maybeSingle();

--- a/app/api/onboarding/get-clinic/route.ts
+++ b/app/api/onboarding/get-clinic/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveToken, getClinicPrefill } from '@/lib/onboarding/onboarding-service';
+
+export async function GET(request: NextRequest) {
+  const token = new URL(request.url).searchParams.get('token');
+  if (!token) return NextResponse.json({ error: 'token required' }, { status: 400 });
+  const resolved = await resolveToken(token);
+  if (!resolved) return NextResponse.json({ error: 'invalid_or_expired' }, { status: 401 });
+  const prefill = await getClinicPrefill(resolved.customerId);
+  if (!prefill) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  if (prefill.customer.onboarding_status === 'billing_ready') {
+    return NextResponse.json({ alreadyComplete: true });
+  }
+  return NextResponse.json({ ...prefill });
+}

--- a/app/api/onboarding/submit/route.ts
+++ b/app/api/onboarding/submit/route.ts
@@ -53,6 +53,26 @@ export async function POST(request: NextRequest) {
   }
   const submissionId = body.submissionId as string;
 
+  // Check idempotency: if already submitted/approved, short-circuit
+  const { data: existingSub } = await supabase
+    .from('onboarding_submissions')
+    .select('status')
+    .eq('id', submissionId)
+    .single();
+  if (existingSub?.status === 'submitted' || existingSub?.status === 'approved') {
+    const { data: c } = await supabase
+      .from('customers')
+      .select('account_number')
+      .eq('id', customerId)
+      .single();
+    return NextResponse.json({
+      success: true,
+      accountNumber: c?.account_number,
+      eMandateSent: true,
+      idempotent: true,
+    });
+  }
+
   // Require all mandatory documents present
   const required = requiredDocsFor('unjani', {
     vatRegistered: s2.data.vat === 'Yes',
@@ -76,7 +96,7 @@ export async function POST(request: NextRequest) {
   }
 
   // 1) Enrich customer
-  await supabase
+  const { error: custErr } = await supabase
     .from('customers')
     .update({
       business_name: s2.data.entityName,
@@ -94,39 +114,70 @@ export async function POST(request: NextRequest) {
       },
     })
     .eq('id', customerId);
+  if (custErr) {
+    return NextResponse.json(
+      { success: false, error: custErr.message },
+      { status: 500 }
+    );
+  }
 
   // 2) Set chosen billing day on the service
-  await supabase
+  const { error: svcErr } = await supabase
     .from('customer_services')
     .update({ billing_day: Number(s5.data.paymentDate) })
     .eq('customer_id', customerId);
+  if (svcErr) {
+    return NextResponse.json(
+      { success: false, error: svcErr.message },
+      { status: 500 }
+    );
+  }
 
   // 3) Create payment method (mandate pending, NOT verified yet)
-  const { data: pm } = await supabase
+  // Avoid duplicate payment methods on retry
+  const { data: existingPm } = await supabase
     .from('customer_payment_methods')
-    .insert({
-      customer_id: customerId,
-      onboarding_submission_id: submissionId,
-      method_type: 'debit_order',
-      display_name: `DebiCheck - ${s3.data.bank} ****${s3.data.accNumber.slice(-4)}`,
-      last_four: s3.data.accNumber.slice(-4),
-      encrypted_details: {
-        bank_name: s3.data.bank,
-        account_holder_name: s3.data.accHolder,
-        account_type: s3.data.accType,
-        account_number: s3.data.accNumber,
-        branch_code: s3.data.branchCode,
-        verified: false,
-      },
-      mandate_status: 'pending',
-      is_primary: true,
-      is_active: true,
-    })
     .select('id')
-    .single();
+    .eq('onboarding_submission_id', submissionId)
+    .maybeSingle();
+  let paymentMethodId: string;
+  if (existingPm) {
+    paymentMethodId = existingPm.id;
+  } else {
+    const { data: pm, error: pmErr } = await supabase
+      .from('customer_payment_methods')
+      .insert({
+        customer_id: customerId,
+        onboarding_submission_id: submissionId,
+        method_type: 'debit_order',
+        display_name: `DebiCheck - ${s3.data.bank} ****${s3.data.accNumber.slice(-4)}`,
+        last_four: s3.data.accNumber.slice(-4),
+        // plain object: debit-order batch + eMandate webhook read encrypted_details.verified directly
+        encrypted_details: {
+          bank_name: s3.data.bank,
+          account_holder_name: s3.data.accHolder,
+          account_type: s3.data.accType,
+          account_number: s3.data.accNumber,
+          branch_code: s3.data.branchCode,
+          verified: false,
+        },
+        mandate_status: 'pending',
+        is_primary: true,
+        is_active: true,
+      })
+      .select('id')
+      .single();
+    if (pmErr) {
+      return NextResponse.json(
+        { success: false, error: pmErr.message },
+        { status: 500 }
+      );
+    }
+    paymentMethodId = pm!.id;
+  }
 
   // 4) Finalize submission
-  await supabase
+  const { error: subErr } = await supabase
     .from('onboarding_submissions')
     .update({
       status: 'submitted',
@@ -139,6 +190,12 @@ export async function POST(request: NextRequest) {
       },
     })
     .eq('id', submissionId);
+  if (subErr) {
+    return NextResponse.json(
+      { success: false, error: subErr.message },
+      { status: 500 }
+    );
+  }
 
   // 5) Mark token used (single-use)
   await supabase
@@ -158,32 +215,39 @@ export async function POST(request: NextRequest) {
     .eq('customer_id', customerId)
     .maybeSingle();
   let fileToken: string | undefined;
+  let eMandateSent = false;
   try {
-    const req = buildEMandateRequest({
-      accountNumber: cust!.account_number,
-      paymentMethodId: pm!.id,
-      submissionId,
-      accountHolder: s3.data.accHolder,
-      isConsumer: false,
-      entityName: s2.data.entityName,
-      registrationNumber: s2.data.regNumber,
-      mobile: s1.data.phone,
-      bank: s3.data.bank,
-      accountType: s3.data.accType,
-      accountNumber2: s3.data.accNumber,
-      branchCode: s3.data.branchCode,
-      monthlyExVat: Number(svcRow?.monthly_price ?? 450),
-      vatPct: 15,
-      paymentDay: s5.data.paymentDate,
-      agreementDate: new Date().toISOString().slice(0, 10),
-    });
-    const result = await new NetCashEMandateBatchService().submitMandate(req);
-    if (result.success) {
-      fileToken = result.fileToken;
-      await supabase
-        .from('onboarding_submissions')
-        .update({ netcash_file_token: fileToken })
-        .eq('id', submissionId);
+    // Null-check: skip eMandate if account_number is missing, but don't crash
+    if (!cust?.account_number) {
+      console.warn('[Onboarding] customer account_number not found, skipping eMandate');
+    } else {
+      const req = buildEMandateRequest({
+        accountNumber: cust.account_number,
+        paymentMethodId,
+        submissionId,
+        accountHolder: s3.data.accHolder,
+        isConsumer: false,
+        entityName: s2.data.entityName,
+        registrationNumber: s2.data.regNumber,
+        mobile: s1.data.phone,
+        bank: s3.data.bank,
+        accountType: s3.data.accType,
+        accountNumber2: s3.data.accNumber,
+        branchCode: s3.data.branchCode,
+        monthlyExVat: Number(svcRow?.monthly_price ?? 450),
+        vatPct: 15,
+        paymentDay: s5.data.paymentDate,
+        agreementDate: new Date().toISOString().slice(0, 10),
+      });
+      const result = await new NetCashEMandateBatchService().submitMandate(req);
+      if (result.success) {
+        fileToken = result.fileToken;
+        eMandateSent = true;
+        await supabase
+          .from('onboarding_submissions')
+          .update({ netcash_file_token: fileToken })
+          .eq('id', submissionId);
+      }
     }
   } catch (e) {
     console.error('[Onboarding] eMandate submit error', e);
@@ -191,7 +255,7 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({
     success: true,
-    accountNumber: cust!.account_number,
-    eMandateSent: !!fileToken,
+    accountNumber: cust?.account_number,
+    eMandateSent,
   });
 }

--- a/app/api/onboarding/submit/route.ts
+++ b/app/api/onboarding/submit/route.ts
@@ -1,0 +1,197 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveToken, svc } from '@/lib/onboarding/onboarding-service';
+import { step1Schema, step2Schema, step3Schema, step5Schema } from '@/lib/onboarding/schemas';
+import { requiredDocsFor } from '@/lib/onboarding/document-requirements';
+import { buildEMandateRequest } from '@/lib/onboarding/emandate-request';
+import { NetCashEMandateBatchService } from '@/lib/payments/netcash-emandate-batch-service';
+
+export async function POST(request: NextRequest) {
+  const supabase = svc();
+  const body = await request.json();
+  const { token, mode } = body;
+  const resolved = await resolveToken(token);
+  if (!resolved) {
+    return NextResponse.json(
+      { success: false, error: 'invalid_or_expired' },
+      { status: 401 }
+    );
+  }
+  const customerId = resolved.customerId;
+
+  // DRAFT: create (or return existing) a submission so document uploads have an anchor
+  if (mode === 'draft') {
+    const { data: existing } = await supabase
+      .from('onboarding_submissions')
+      .select('id')
+      .eq('customer_id', customerId)
+      .eq('status', 'draft')
+      .maybeSingle();
+    if (existing) {
+      return NextResponse.json({ success: true, submissionId: existing.id });
+    }
+    const { data, error } = await supabase
+      .from('onboarding_submissions')
+      .insert({ customer_id: customerId, segment: 'unjani', status: 'draft' })
+      .select('id')
+      .single();
+    if (error) {
+      return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ success: true, submissionId: data.id });
+  }
+
+  // FINAL: validate all steps
+  const s1 = step1Schema.safeParse(body.step1);
+  const s2 = step2Schema.safeParse(body.step2);
+  const s3 = step3Schema.safeParse(body.step3);
+  const s5 = step5Schema.safeParse(body.step5);
+  if (!s1.success || !s2.success || !s3.success || !s5.success) {
+    return NextResponse.json(
+      { success: false, error: 'validation_failed' },
+      { status: 400 }
+    );
+  }
+  const submissionId = body.submissionId as string;
+
+  // Require all mandatory documents present
+  const required = requiredDocsFor('unjani', {
+    vatRegistered: s2.data.vat === 'Yes',
+    entityType: s2.data.entityType,
+  });
+  const { data: docs } = await supabase
+    .from('kyc_documents')
+    .select('document_type')
+    .eq('onboarding_submission_id', submissionId);
+  const have = new Set((docs ?? []).map(d => d.document_type));
+  const missing = required.filter(r => r.required && !have.has(r.type));
+  if (missing.length) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'documents_missing',
+        missing: missing.map(m => m.type),
+      },
+      { status: 400 }
+    );
+  }
+
+  // 1) Enrich customer
+  await supabase
+    .from('customers')
+    .update({
+      business_name: s2.data.entityName,
+      business_registration: s2.data.regNumber,
+      tax_number: s2.data.vat === 'Yes' ? s2.data.vatNumber : null,
+      onboarding_status: 'submitted',
+      clinic_details: {
+        clinic_name: s1.data.clinicName,
+        unjani_account: s1.data.unjaniAcc,
+        province: s1.data.province,
+        nurse_owner_name: s1.data.contact,
+        site_address: s1.data.siteAddress,
+        lat: s1.data.lat,
+        lng: s1.data.lng,
+      },
+    })
+    .eq('id', customerId);
+
+  // 2) Set chosen billing day on the service
+  await supabase
+    .from('customer_services')
+    .update({ billing_day: Number(s5.data.paymentDate) })
+    .eq('customer_id', customerId);
+
+  // 3) Create payment method (mandate pending, NOT verified yet)
+  const { data: pm } = await supabase
+    .from('customer_payment_methods')
+    .insert({
+      customer_id: customerId,
+      onboarding_submission_id: submissionId,
+      method_type: 'debit_order',
+      display_name: `DebiCheck - ${s3.data.bank} ****${s3.data.accNumber.slice(-4)}`,
+      last_four: s3.data.accNumber.slice(-4),
+      encrypted_details: {
+        bank_name: s3.data.bank,
+        account_holder_name: s3.data.accHolder,
+        account_type: s3.data.accType,
+        account_number: s3.data.accNumber,
+        branch_code: s3.data.branchCode,
+        verified: false,
+      },
+      mandate_status: 'pending',
+      is_primary: true,
+      is_active: true,
+    })
+    .select('id')
+    .single();
+
+  // 4) Finalize submission
+  await supabase
+    .from('onboarding_submissions')
+    .update({
+      status: 'submitted',
+      document_vetting_status: 'documents_pending',
+      submission_data: {
+        step1: s1.data,
+        step2: s2.data,
+        step3: { ...s3.data, accNumber: `****${s3.data.accNumber.slice(-4)}` },
+        step5: s5.data,
+      },
+    })
+    .eq('id', submissionId);
+
+  // 5) Mark token used (single-use)
+  await supabase
+    .from('onboarding_tokens')
+    .update({ used_at: new Date().toISOString() })
+    .eq('id', resolved.tokenId);
+
+  // 6) Fire NetCash eMandate (best-effort; do not fail the submission on transient errors)
+  const { data: cust } = await supabase
+    .from('customers')
+    .select('account_number')
+    .eq('id', customerId)
+    .single();
+  const { data: svcRow } = await supabase
+    .from('customer_services')
+    .select('monthly_price, activation_date')
+    .eq('customer_id', customerId)
+    .maybeSingle();
+  let fileToken: string | undefined;
+  try {
+    const req = buildEMandateRequest({
+      accountNumber: cust!.account_number,
+      paymentMethodId: pm!.id,
+      submissionId,
+      accountHolder: s3.data.accHolder,
+      isConsumer: false,
+      entityName: s2.data.entityName,
+      registrationNumber: s2.data.regNumber,
+      mobile: s1.data.phone,
+      bank: s3.data.bank,
+      accountType: s3.data.accType,
+      accountNumber2: s3.data.accNumber,
+      branchCode: s3.data.branchCode,
+      monthlyExVat: Number(svcRow?.monthly_price ?? 450),
+      vatPct: 15,
+      paymentDay: s5.data.paymentDate,
+      agreementDate: new Date().toISOString().slice(0, 10),
+    });
+    const result = await new NetCashEMandateBatchService().submitMandate(req);
+    if (result.success) {
+      fileToken = result.fileToken;
+      await supabase
+        .from('onboarding_submissions')
+        .update({ netcash_file_token: fileToken })
+        .eq('id', submissionId);
+    }
+  } catch (e) {
+    console.error('[Onboarding] eMandate submit error', e);
+  }
+
+  return NextResponse.json({
+    success: true,
+    accountNumber: cust!.account_number,
+    eMandateSent: !!fileToken,
+  });
+}

--- a/app/api/onboarding/upload-document/route.ts
+++ b/app/api/onboarding/upload-document/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveToken, svc } from '@/lib/onboarding/onboarding-service';
+import { uploadFile } from '@/lib/storage/supabase-upload';
+
+export async function POST(request: NextRequest) {
+  const supabase = svc();
+  const form = await request.formData();
+  const token = form.get('token') as string;
+  const documentType = form.get('documentType') as string;
+  const submissionId = form.get('submissionId') as string | null;
+  const file = form.get('file') as File;
+  if (!token || !documentType || !file) {
+    return NextResponse.json(
+      { success: false, error: 'token, documentType, file required' },
+      { status: 400 }
+    );
+  }
+
+  const resolved = await resolveToken(token);
+  if (!resolved) {
+    return NextResponse.json(
+      { success: false, error: 'invalid_or_expired' },
+      { status: 401 }
+    );
+  }
+
+  const { data: customer } = await supabase
+    .from('customers')
+    .select('business_name, email, phone')
+    .eq('id', resolved.customerId)
+    .single();
+
+  const up = await uploadFile(file, {
+    bucket: 'kyc-documents',
+    folder: `onboarding/${resolved.customerId}/${documentType}`,
+    maxSizeBytes: 5 * 1024 * 1024,
+    allowedTypes: ['image/jpeg', 'image/jpg', 'image/png', 'application/pdf'],
+    supabaseClient: supabase,
+  });
+  if (!up.success) {
+    return NextResponse.json({ success: false, error: up.error }, { status: 500 });
+  }
+
+  const { data: doc, error } = await supabase
+    .from('kyc_documents')
+    .insert({
+      customer_type: 'smme',
+      customer_id: resolved.customerId,
+      onboarding_submission_id: submissionId || null,
+      company_name: customer?.business_name ?? null,
+      customer_email: customer?.email ?? null,
+      customer_phone: customer?.phone ?? null,
+      document_type: documentType,
+      document_title: documentType,
+      file_name: file.name,
+      file_path: up.path,
+      file_size: file.size,
+      file_type: file.type,
+      verification_status: 'pending',
+      is_sensitive: true,
+    })
+    .select('id')
+    .single();
+  if (error) {
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true, documentId: doc.id });
+}

--- a/app/api/webhooks/netcash/emandate/route.ts
+++ b/app/api/webhooks/netcash/emandate/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { NetCashEMandateService, EMandatePostback } from '@/lib/payments/netcash-emandate-service';
 import { EmailNotificationService } from '@/lib/notifications/notification-service';
 import { AdminNotificationService } from '@/lib/notifications/admin-notifications';
+import { maybeMarkBillingReady } from '@/lib/onboarding/billing-ready';
 import { webhookLogger } from '@/lib/logging';
 
 // Vercel configuration
@@ -110,7 +111,92 @@ export async function POST(request: NextRequest) {
     }
 
     if (mandateSuccessful) {
-      // Update payment method with signed mandate details
+      // 1. Resolve customer_payment_methods: prefer field1 (paymentMethodId), fallback to field3 (account_number)
+      // field1 should be the customer_payment_methods.id; field3 is the account_number (CT-2026-XXXXX)
+      const paymentMethodIdFromField1 = parsedPostback.Field1;
+      const accountNumberFromField3 = parsedPostback.Field3;
+
+      let customerPaymentMethodId: string | null = null;
+      let resolvedCustomerId: string | null = null;
+
+      if (paymentMethodIdFromField1) {
+        // Preferred: match by payment method ID from field1
+        const { data: pm } = await supabase
+          .from('customer_payment_methods')
+          .select('id, customer_id, encrypted_details')
+          .eq('id', paymentMethodIdFromField1)
+          .eq('method_type', 'debit_order')
+          .eq('is_active', true)
+          .maybeSingle();
+        if (pm) {
+          customerPaymentMethodId = pm.id;
+          resolvedCustomerId = pm.customer_id;
+        }
+      }
+
+      // Fallback: match by account_number from field3
+      if (!customerPaymentMethodId && accountNumberFromField3) {
+        const { data: customer } = await supabase
+          .from('customers')
+          .select('id')
+          .eq('account_number', accountNumberFromField3)
+          .maybeSingle();
+
+        if (customer) {
+          const { data: pm } = await supabase
+            .from('customer_payment_methods')
+            .select('id, customer_id, encrypted_details')
+            .eq('customer_id', customer.id)
+            .eq('method_type', 'debit_order')
+            .eq('is_active', true)
+            .order('created_at', { ascending: false })
+            .limit(1)
+            .maybeSingle();
+          if (pm) {
+            customerPaymentMethodId = pm.id;
+            resolvedCustomerId = pm.customer_id;
+          }
+        }
+      }
+
+      // Update customer_payment_methods (the new table the debit-order batch reads)
+      if (customerPaymentMethodId && resolvedCustomerId) {
+        const { data: pmData } = await supabase
+          .from('customer_payment_methods')
+          .select('encrypted_details')
+          .eq('id', customerPaymentMethodId)
+          .maybeSingle();
+
+        const existingDetails = pmData?.encrypted_details ?? {};
+        const { error: cpmUpdateError } = await supabase
+          .from('customer_payment_methods')
+          .update({
+            mandate_id: parsedPostback.MandateReferenceNumber,
+            mandate_status: 'active',
+            mandate_approved_at: new Date().toISOString(),
+            // CRITICAL: set verified=true as a plain boolean; batch reads encrypted_details.verified directly
+            encrypted_details: {
+              ...existingDetails,
+              verified: true,
+            },
+          })
+          .eq('id', customerPaymentMethodId);
+
+        if (cpmUpdateError) {
+          webhookLogger.error('Error updating customer_payment_methods', { error: cpmUpdateError.message });
+        } else {
+          webhookLogger.info('customer_payment_methods updated with mandate details:', {
+            paymentMethodId: customerPaymentMethodId,
+            customerId: resolvedCustomerId,
+            mandateRef: parsedPostback.MandateReferenceNumber,
+          });
+        }
+
+        // Try to flip customer to billing_ready if docs are already approved
+        await maybeMarkBillingReady(supabase, resolvedCustomerId);
+      }
+
+      // 2. Keep legacy payment_methods table in sync (preserve existing behaviour)
       const { error: pmUpdateError } = await supabase
         .from('payment_methods')
         .update({
@@ -273,6 +359,80 @@ export async function POST(request: NextRequest) {
       }
     } else {
       // Mandate declined or failed
+      // 1. Resolve customer_payment_methods using the same logic as success branch
+      const paymentMethodIdFromField1 = parsedPostback.Field1;
+      const accountNumberFromField3 = parsedPostback.Field3;
+
+      let customerPaymentMethodId: string | null = null;
+      let customerId: string | null = null;
+
+      if (paymentMethodIdFromField1) {
+        const { data: pm } = await supabase
+          .from('customer_payment_methods')
+          .select('id, customer_id')
+          .eq('id', paymentMethodIdFromField1)
+          .eq('method_type', 'debit_order')
+          .eq('is_active', true)
+          .maybeSingle();
+        if (pm) {
+          customerPaymentMethodId = pm.id;
+          customerId = pm.customer_id;
+        }
+      }
+
+      if (!customerPaymentMethodId && accountNumberFromField3) {
+        const { data: customer } = await supabase
+          .from('customers')
+          .select('id')
+          .eq('account_number', accountNumberFromField3)
+          .maybeSingle();
+
+        if (customer) {
+          const { data: pm } = await supabase
+            .from('customer_payment_methods')
+            .select('id, customer_id')
+            .eq('customer_id', customer.id)
+            .eq('method_type', 'debit_order')
+            .eq('is_active', true)
+            .order('created_at', { ascending: false })
+            .limit(1)
+            .maybeSingle();
+          if (pm) {
+            customerPaymentMethodId = pm.id;
+            customerId = pm.customer_id;
+          }
+        }
+      }
+
+      // Update customer_payment_methods to mark mandate as failed
+      if (customerPaymentMethodId) {
+        const { error: cpmFailError } = await supabase
+          .from('customer_payment_methods')
+          .update({
+            mandate_status: 'failed',
+          })
+          .eq('id', customerPaymentMethodId);
+
+        if (cpmFailError) {
+          webhookLogger.error('Error updating customer_payment_methods on rejection', { error: cpmFailError.message });
+        }
+      }
+
+      // Mark customer onboarding as failed
+      if (customerId) {
+        const { error: custFailError } = await supabase
+          .from('customers')
+          .update({
+            onboarding_status: 'failed',
+          })
+          .eq('id', customerId);
+
+        if (custFailError) {
+          webhookLogger.error('Error updating customer onboarding_status on rejection', { error: custFailError.message });
+        }
+      }
+
+      // 2. Keep legacy payment_methods in sync
       const { error: pmFailError } = await supabase
         .from('payment_methods')
         .update({

--- a/app/api/webhooks/netcash/emandate/route.ts
+++ b/app/api/webhooks/netcash/emandate/route.ts
@@ -161,19 +161,23 @@ export async function POST(request: NextRequest) {
 
       // Update customer_payment_methods (the new table the debit-order batch reads)
       if (customerPaymentMethodId && resolvedCustomerId) {
-        const { data: pmData } = await supabase
+        // Fetch current mandate_status and encrypted_details to detect if already active (webhook redelivery)
+        const { data: pmBefore } = await supabase
           .from('customer_payment_methods')
-          .select('encrypted_details')
+          .select('mandate_status, encrypted_details')
           .eq('id', customerPaymentMethodId)
           .maybeSingle();
 
-        const existingDetails = pmData?.encrypted_details ?? {};
+        const wasAlreadyActive = pmBefore?.mandate_status === 'active' || pmBefore?.mandate_status === 'approved';
+        const existingDetails = pmBefore?.encrypted_details ?? {};
+
         const { error: cpmUpdateError } = await supabase
           .from('customer_payment_methods')
           .update({
             mandate_id: parsedPostback.MandateReferenceNumber,
             mandate_status: 'active',
             mandate_approved_at: new Date().toISOString(),
+            verified: true,
             // CRITICAL: set verified=true as a plain boolean; batch reads encrypted_details.verified directly
             encrypted_details: {
               ...existingDetails,
@@ -189,11 +193,15 @@ export async function POST(request: NextRequest) {
             paymentMethodId: customerPaymentMethodId,
             customerId: resolvedCustomerId,
             mandateRef: parsedPostback.MandateReferenceNumber,
+            wasAlreadyActive,
           });
         }
 
         // Try to flip customer to billing_ready if docs are already approved
-        await maybeMarkBillingReady(supabase, resolvedCustomerId);
+        // Only on the first activation (not on webhook redelivery)
+        if (!wasAlreadyActive && resolvedCustomerId) {
+          await maybeMarkBillingReady(supabase, resolvedCustomerId);
+        }
       }
 
       // 2. Keep legacy payment_methods table in sync (preserve existing behaviour)

--- a/app/onboarding/[token]/page.tsx
+++ b/app/onboarding/[token]/page.tsx
@@ -7,11 +7,10 @@ export default async function OnboardingPage({
 }) {
   const { token } = await params;
 
+  // <main> + background are provided by app/onboarding/layout.tsx (site chrome).
   return (
-    <main className="min-h-screen bg-gray-50">
-      <div className="max-w-3xl mx-auto px-4 py-8">
-        <OnboardingWizard token={token} />
-      </div>
-    </main>
+    <div className="container mx-auto px-4 py-10 md:py-16 max-w-3xl">
+      <OnboardingWizard token={token} />
+    </div>
   );
 }

--- a/app/onboarding/[token]/page.tsx
+++ b/app/onboarding/[token]/page.tsx
@@ -1,0 +1,17 @@
+import { OnboardingWizard } from '../components/OnboardingWizard';
+
+export default async function OnboardingPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 py-8">
+        <OnboardingWizard token={token} />
+      </div>
+    </main>
+  );
+}

--- a/app/onboarding/components/OnboardingWizard.tsx
+++ b/app/onboarding/components/OnboardingWizard.tsx
@@ -1,0 +1,292 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { step1Schema, step2Schema, step3Schema, step5Schema } from '@/lib/onboarding/schemas';
+import { useOnboardingState } from './useOnboardingState';
+import { OrderWizard } from '@/components/order/OrderWizard';
+import { Step1Clinic } from './steps/Step1Clinic';
+import { Step2Business } from './steps/Step2Business';
+import { Step3Banking } from './steps/Step3Banking';
+import { Step4Documents } from './steps/Step4Documents';
+import { Step5ServiceOrder } from './steps/Step5ServiceOrder';
+import { Step6Done } from './steps/Step6Done';
+import { Card, CardContent } from '@/components/ui/card';
+import { PiWarningCircle, PiSpinnerGap } from 'react-icons/pi';
+
+const STEPS = [
+  { number: 1, title: 'Clinic details', description: 'Confirm clinic info' },
+  { number: 2, title: 'Business', description: 'Entity & registration' },
+  { number: 3, title: 'Banking', description: 'Account details' },
+  { number: 4, title: 'Documents', description: 'Supporting docs' },
+  { number: 5, title: 'Service Order', description: 'Terms & payment date' },
+  { number: 6, title: 'Done', description: 'Complete' },
+];
+
+export interface OnboardingWizardProps {
+  token: string;
+}
+
+export function OnboardingWizard({ token }: OnboardingWizardProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [prefill, setPrefill] = useState<any>(null);
+  const [alreadyComplete, setAlreadyComplete] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [successAccountNumber, setSuccessAccountNumber] = useState<string | null>(null);
+
+  const wizard = useOnboardingState(prefill || { customer: {}, service: {} });
+  const { current, setCurrent, state, updateStep } = wizard;
+
+  // Fetch clinic details on mount
+  useEffect(() => {
+    async function fetchClinic() {
+      try {
+        const res = await fetch(`/api/onboarding/get-clinic?token=${token}`);
+        const json = await res.json();
+
+        if (res.status === 401) {
+          setError('Invalid or expired link. Please request a new one from your admin.');
+          setLoading(false);
+          return;
+        }
+
+        if (json.alreadyComplete) {
+          setAlreadyComplete(true);
+          setLoading(false);
+          return;
+        }
+
+        if (!res.ok) {
+          setError(json.error || 'Failed to load clinic details');
+          setLoading(false);
+          return;
+        }
+
+        setPrefill(json);
+
+        // Create a draft submission for document uploads
+        const submitRes = await fetch('/api/onboarding/submit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token, mode: 'draft' }),
+        });
+        const submitJson = await submitRes.json();
+        if (submitJson.success) {
+          wizard.patch('submissionId', submitJson.submissionId);
+        }
+
+        setLoading(false);
+      } catch (err) {
+        setError('Network error loading clinic details');
+        setLoading(false);
+        console.error(err);
+      }
+    }
+
+    fetchClinic();
+  }, [token]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <PiSpinnerGap className="w-6 h-6 text-circleTel-orange animate-spin" />
+        <span className="ml-2 text-gray-600">Loading...</span>
+      </div>
+    );
+  }
+
+  if (alreadyComplete) {
+    return (
+      <Card className="border-green-200 bg-green-50">
+        <CardContent className="pt-6">
+          <h2 className="text-lg font-semibold text-green-900 mb-2">
+            Already set up
+          </h2>
+          <p className="text-green-800">
+            Your clinic billing is already activated. If you need to make changes,
+            please contact support at{' '}
+            <a
+              href="https://wa.me/27824873900"
+              className="font-semibold underline"
+            >
+              082 487 3900
+            </a>
+            .
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="border-red-200 bg-red-50">
+        <CardContent className="pt-6 flex gap-3">
+          <PiWarningCircle className="w-6 h-6 text-red-600 flex-shrink-0" />
+          <div>
+            <h2 className="text-lg font-semibold text-red-900 mb-1">
+              Unable to load
+            </h2>
+            <p className="text-red-800">{error}</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Step validation
+  const s1Valid = step1Schema.safeParse(state.step1).success;
+  const s2Valid = step2Schema.safeParse(state.step2).success;
+  const s3Valid = step3Schema.safeParse(state.step3).success;
+  const s5Valid = step5Schema.safeParse(state.step5).success;
+
+  // Step 4 canGoNext: all required docs present
+  const s4RequiredDocs = require('@/lib/onboarding/document-requirements')
+    .requiredDocsFor('unjani', {
+      vatRegistered: state.step2.vat === 'Yes',
+      entityType: state.step2.entityType,
+    })
+    .filter((d: any) => d.required);
+  const s4DocsUploaded = s4RequiredDocs.every(
+    (d: any) => state.documents[d.type]
+  );
+
+  const canGoNextByStep: Record<number, boolean> = {
+    1: s1Valid,
+    2: s2Valid,
+    3: s3Valid,
+    4: s4DocsUploaded && s4RequiredDocs.length > 0,
+    5: s5Valid,
+    6: false,
+  };
+
+  const handleNext = async () => {
+    if (current === 5) {
+      // Final submit
+      setSubmitting(true);
+      try {
+        const submitRes = await fetch('/api/onboarding/submit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            token,
+            submissionId: state.submissionId,
+            step1: state.step1,
+            step2: state.step2,
+            step3: state.step3,
+            step5: state.step5,
+            mode: 'final',
+          }),
+        });
+
+        const json = await submitRes.json();
+
+        if (!json.success) {
+          setError(json.error || 'Submission failed');
+          setSubmitting(false);
+          return;
+        }
+
+        setSuccessAccountNumber(json.accountNumber);
+        setCurrent(6);
+      } catch (err) {
+        setError('Network error submitting. Please try again.');
+        console.error(err);
+      } finally {
+        setSubmitting(false);
+      }
+    } else {
+      setCurrent(current + 1);
+    }
+  };
+
+  const handlePrevious = () => {
+    setCurrent(current - 1);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Intro section with branding */}
+      <div>
+        <p className="text-sm font-semibold text-circleTel-orange uppercase tracking-widest">
+          Unjani Clinic Network · Billing setup
+        </p>
+        <h1 className="text-3xl font-bold text-gray-900 mt-1 mb-2">
+          Let's set up your clinic for billing
+        </h1>
+        <p className="text-gray-600 max-w-2xl">
+          We already hold your clinic and contact details from the Unjani network
+          record. Confirm what we have, add your business and banking details, and
+          accept your Service Order to activate billing.
+        </p>
+      </div>
+
+      {/* Wizard container */}
+      <OrderWizard
+        currentStep={current}
+        steps={STEPS}
+        canGoNext={canGoNextByStep[current]}
+        canGoPrevious={current > 1}
+        onNext={handleNext}
+        onPrevious={handlePrevious}
+        isSubmitting={submitting}
+        showNavigation={current !== 6}
+      >
+        {/* Step 1 */}
+        {current === 1 && (
+          <Step1Clinic
+            value={state.step1}
+            onChange={(vals) => updateStep('step1', vals)}
+            canGoNext={canGoNextByStep[1]}
+          />
+        )}
+
+        {/* Step 2 */}
+        {current === 2 && (
+          <Step2Business
+            value={state.step2}
+            onChange={(vals) => updateStep('step2', vals)}
+            canGoNext={canGoNextByStep[2]}
+          />
+        )}
+
+        {/* Step 3 */}
+        {current === 3 && (
+          <Step3Banking
+            value={state.step3}
+            onChange={(vals) => updateStep('step3', vals)}
+            step2EntityName={state.step2.entityName}
+            canGoNext={canGoNextByStep[3]}
+          />
+        )}
+
+        {/* Step 4 */}
+        {current === 4 && (
+          <Step4Documents
+            token={token}
+            submissionId={state.submissionId}
+            step2={state.step2}
+            documents={state.documents}
+            onChange={(docs) => wizard.patch('documents', docs)}
+            canGoNext={canGoNextByStep[4]}
+          />
+        )}
+
+        {/* Step 5 */}
+        {current === 5 && (
+          <Step5ServiceOrder
+            value={state.step5}
+            onChange={(vals) => updateStep('step5', vals)}
+            monthlyPrice={state.service?.monthly_price ?? 450}
+            activationDate={state.service?.activation_date ?? new Date().toISOString().split('T')[0]}
+            canGoNext={canGoNextByStep[5]}
+          />
+        )}
+
+        {/* Step 6 */}
+        {current === 6 && successAccountNumber && (
+          <Step6Done accountNumber={successAccountNumber} />
+        )}
+      </OrderWizard>
+    </div>
+  );
+}

--- a/app/onboarding/components/OnboardingWizard.tsx
+++ b/app/onboarding/components/OnboardingWizard.tsx
@@ -89,6 +89,17 @@ export function OnboardingWizard({ token }: OnboardingWizardProps) {
     fetchClinic();
   }, [token]);
 
+  // Step 4 canGoNext: all required docs present (memoized).
+  // MUST be declared before any early return so the hook order is stable across renders (React #310).
+  const { s4RequiredDocs, s4DocsUploaded } = useMemo(() => {
+    const requiredDocs = requiredDocsFor('unjani', {
+      vatRegistered: state.step2.vat === 'Yes',
+      entityType: state.step2.entityType || '',
+    }).filter((d) => d.required);
+    const docsUploaded = requiredDocs.every((d) => state.documents[d.type]);
+    return { s4RequiredDocs: requiredDocs, s4DocsUploaded: docsUploaded };
+  }, [state.step2.vat, state.step2.entityType, state.documents]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -142,16 +153,6 @@ export function OnboardingWizard({ token }: OnboardingWizardProps) {
   const s2Valid = step2Schema.safeParse(state.step2).success;
   const s3Valid = step3Schema.safeParse(state.step3).success;
   const s5Valid = step5Schema.safeParse(state.step5).success;
-
-  // Step 4 canGoNext: all required docs present (memoized)
-  const { s4RequiredDocs, s4DocsUploaded } = useMemo(() => {
-    const requiredDocs = requiredDocsFor('unjani', {
-      vatRegistered: state.step2.vat === 'Yes',
-      entityType: state.step2.entityType || '',
-    }).filter((d) => d.required);
-    const docsUploaded = requiredDocs.every((d) => state.documents[d.type]);
-    return { s4RequiredDocs: requiredDocs, s4DocsUploaded: docsUploaded };
-  }, [state.step2.vat, state.step2.entityType, state.documents]);
 
   const canGoNextByStep: Record<number, boolean> = {
     1: s1Valid,

--- a/app/onboarding/components/OnboardingWizard.tsx
+++ b/app/onboarding/components/OnboardingWizard.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { step1Schema, step2Schema, step3Schema, step5Schema } from '@/lib/onboarding/schemas';
+import { requiredDocsFor } from '@/lib/onboarding/document-requirements';
 import { useOnboardingState } from './useOnboardingState';
 import { OrderWizard } from '@/components/order/OrderWizard';
 import { Step1Clinic } from './steps/Step1Clinic';
@@ -70,10 +71,13 @@ export function OnboardingWizard({ token }: OnboardingWizardProps) {
           body: JSON.stringify({ token, mode: 'draft' }),
         });
         const submitJson = await submitRes.json();
-        if (submitJson.success) {
-          wizard.patch('submissionId', submitJson.submissionId);
+        if (!submitRes.ok || !submitJson.success) {
+          setError('Could not start your onboarding session. Please refresh and try again.');
+          setLoading(false);
+          return;
         }
 
+        wizard.patch('submissionId', submitJson.submissionId);
         setLoading(false);
       } catch (err) {
         setError('Network error loading clinic details');
@@ -139,16 +143,15 @@ export function OnboardingWizard({ token }: OnboardingWizardProps) {
   const s3Valid = step3Schema.safeParse(state.step3).success;
   const s5Valid = step5Schema.safeParse(state.step5).success;
 
-  // Step 4 canGoNext: all required docs present
-  const s4RequiredDocs = require('@/lib/onboarding/document-requirements')
-    .requiredDocsFor('unjani', {
+  // Step 4 canGoNext: all required docs present (memoized)
+  const { s4RequiredDocs, s4DocsUploaded } = useMemo(() => {
+    const requiredDocs = requiredDocsFor('unjani', {
       vatRegistered: state.step2.vat === 'Yes',
-      entityType: state.step2.entityType,
-    })
-    .filter((d: any) => d.required);
-  const s4DocsUploaded = s4RequiredDocs.every(
-    (d: any) => state.documents[d.type]
-  );
+      entityType: state.step2.entityType || '',
+    }).filter((d) => d.required);
+    const docsUploaded = requiredDocs.every((d) => state.documents[d.type]);
+    return { s4RequiredDocs: requiredDocs, s4DocsUploaded: docsUploaded };
+  }, [state.step2.vat, state.step2.entityType, state.documents]);
 
   const canGoNextByStep: Record<number, boolean> = {
     1: s1Valid,
@@ -276,7 +279,7 @@ export function OnboardingWizard({ token }: OnboardingWizardProps) {
           <Step5ServiceOrder
             value={state.step5}
             onChange={(vals) => updateStep('step5', vals)}
-            monthlyPrice={state.service?.monthly_price ?? 450}
+            monthlyPrice={typeof state.service?.monthly_price === 'number' ? state.service.monthly_price : 450}
             activationDate={state.service?.activation_date ?? new Date().toISOString().split('T')[0]}
             canGoNext={canGoNextByStep[5]}
           />

--- a/app/onboarding/components/OnboardingWizard.tsx
+++ b/app/onboarding/components/OnboardingWizard.tsx
@@ -214,7 +214,7 @@ export function OnboardingWizard({ token }: OnboardingWizardProps) {
         <p className="text-sm font-semibold text-circleTel-orange uppercase tracking-widest">
           Unjani Clinic Network · Billing setup
         </p>
-        <h1 className="text-3xl font-bold text-gray-900 mt-1 mb-2">
+        <h1 className="font-heading text-3xl md:text-4xl font-bold text-circleTel-navy mt-1 mb-2">
           Let's set up your clinic for billing
         </h1>
         <p className="text-gray-600 max-w-2xl">

--- a/app/onboarding/components/steps/Step1Clinic.tsx
+++ b/app/onboarding/components/steps/Step1Clinic.tsx
@@ -1,0 +1,244 @@
+'use client';
+import { useState } from 'react';
+import { step1Schema, type Step1 } from '@/lib/onboarding/schemas';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const SA_PROVINCES = [
+  'Eastern Cape',
+  'Free State',
+  'Gauteng',
+  'KwaZulu-Natal',
+  'Limpopo',
+  'Mpumalanga',
+  'Northern Cape',
+  'North West',
+  'Western Cape',
+];
+
+export interface Step1ClinicProps {
+  value: Partial<Step1>;
+  onChange: (values: Partial<Step1>) => void;
+  canGoNext: boolean;
+}
+
+export function Step1Clinic({ value, onChange, canGoNext }: Step1ClinicProps) {
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const handleFieldChange = (field: keyof Step1, val: string) => {
+    const newValue = { ...value, [field]: val };
+    onChange(newValue);
+    // Validate on change
+    const result = step1Schema.safeParse(newValue);
+    if (result.success) {
+      setErrors((e) => {
+        const newE = { ...e };
+        delete newE[field];
+        return newE;
+      });
+    }
+  };
+
+  const renderLabel = (label: string, required = false, onRecord = false) => (
+    <div className="flex items-center gap-2">
+      <span>
+        {label}
+        {required && <span className="text-red-600">*</span>}
+      </span>
+      {onRecord && (
+        <span className="text-xs font-semibold uppercase text-circleTel-orange bg-orange-50 px-2 py-1 rounded">
+          on record
+        </span>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          Confirm your clinic details
+        </h2>
+        <p className="text-gray-600">
+          These came from your Unjani network record. Check each one and correct
+          anything that's changed.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          {/* Clinic Name */}
+          <div>
+            <Label htmlFor="clinicName">
+              {renderLabel('Clinic name', true, true)}
+            </Label>
+            <Input
+              id="clinicName"
+              type="text"
+              placeholder="Unjani Clinic — Lenasia Ext 10"
+              value={value.clinicName ?? ''}
+              onChange={(e) => handleFieldChange('clinicName', e.target.value)}
+              className={errors.clinicName ? 'border-red-600' : ''}
+            />
+            {errors.clinicName && (
+              <p className="text-xs text-red-600 mt-1">{errors.clinicName}</p>
+            )}
+          </div>
+
+          {/* Unjani Account */}
+          <div>
+            <Label htmlFor="unjaniAcc">
+              {renderLabel('Unjani clinic account number', true)}
+            </Label>
+            <Input
+              id="unjaniAcc"
+              type="text"
+              placeholder="e.g. UNJ-0421"
+              value={value.unjaniAcc ?? ''}
+              onChange={(e) => handleFieldChange('unjaniAcc', e.target.value)}
+              className={errors.unjaniAcc ? 'border-red-600' : ''}
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              From the Unjani master site register.
+            </p>
+            {errors.unjaniAcc && (
+              <p className="text-xs text-red-600">{errors.unjaniAcc}</p>
+            )}
+          </div>
+
+          {/* Province */}
+          <div>
+            <Label htmlFor="province">
+              {renderLabel('Province', true, true)}
+            </Label>
+            <Select value={value.province ?? ''} onValueChange={(val) => handleFieldChange('province', val)}>
+              <SelectTrigger id="province">
+                <SelectValue placeholder="Select province" />
+              </SelectTrigger>
+              <SelectContent>
+                {SA_PROVINCES.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.province && (
+              <p className="text-xs text-red-600 mt-1">{errors.province}</p>
+            )}
+          </div>
+
+          {/* Contact (nurse-owner) */}
+          <div>
+            <Label htmlFor="contact">
+              {renderLabel('Contact (nurse-owner)', true, true)}
+            </Label>
+            <Input
+              id="contact"
+              type="text"
+              placeholder="Tsabeng Ramalope"
+              value={value.contact ?? ''}
+              onChange={(e) => handleFieldChange('contact', e.target.value)}
+              className={errors.contact ? 'border-red-600' : ''}
+            />
+            {errors.contact && (
+              <p className="text-xs text-red-600 mt-1">{errors.contact}</p>
+            )}
+          </div>
+
+          {/* Mobile */}
+          <div>
+            <Label htmlFor="phone">
+              {renderLabel('Mobile', true, true)}
+            </Label>
+            <Input
+              id="phone"
+              type="tel"
+              placeholder="071 898 8722"
+              value={value.phone ?? ''}
+              onChange={(e) => handleFieldChange('phone', e.target.value)}
+              className={errors.phone ? 'border-red-600' : ''}
+            />
+            {errors.phone && (
+              <p className="text-xs text-red-600 mt-1">{errors.phone}</p>
+            )}
+          </div>
+
+          {/* Email */}
+          <div>
+            <Label htmlFor="email">
+              {renderLabel('Email', true, true)}
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="lensext10@unjani.org"
+              value={value.email ?? ''}
+              onChange={(e) => handleFieldChange('email', e.target.value)}
+              className={errors.email ? 'border-red-600' : ''}
+            />
+            {errors.email && (
+              <p className="text-xs text-red-600 mt-1">{errors.email}</p>
+            )}
+          </div>
+
+          {/* Physical site address */}
+          <div>
+            <Label htmlFor="siteAddress">
+              {renderLabel('Physical site address', true, true)}
+            </Label>
+            <Input
+              id="siteAddress"
+              type="text"
+              placeholder="Usave, Volta Street, Lenasia Extension 10, Gauteng"
+              value={value.siteAddress ?? ''}
+              onChange={(e) => handleFieldChange('siteAddress', e.target.value)}
+              className={errors.siteAddress ? 'border-red-600' : ''}
+            />
+            {errors.siteAddress && (
+              <p className="text-xs text-red-600 mt-1">{errors.siteAddress}</p>
+            )}
+          </div>
+
+          {/* Latitude */}
+          <div>
+            <Label htmlFor="lat">
+              {renderLabel('Latitude', false)}
+            </Label>
+            <Input
+              id="lat"
+              type="text"
+              placeholder="-26.3528"
+              value={value.lat ?? ''}
+              onChange={(e) => handleFieldChange('lat', e.target.value)}
+            />
+            <p className="text-xs text-gray-500 mt-1">Confirm the clinic pin.</p>
+          </div>
+
+          {/* Longitude */}
+          <div>
+            <Label htmlFor="lng">
+              {renderLabel('Longitude', false)}
+            </Label>
+            <Input
+              id="lng"
+              type="text"
+              placeholder="27.8331"
+              value={value.lng ?? ''}
+              onChange={(e) => handleFieldChange('lng', e.target.value)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/onboarding/components/steps/Step2Business.tsx
+++ b/app/onboarding/components/steps/Step2Business.tsx
@@ -1,0 +1,199 @@
+'use client';
+import { useState } from 'react';
+import { step2Schema, type Step2 } from '@/lib/onboarding/schemas';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+
+const ENTITY_TYPES = [
+  'Private Company (Pty) Ltd',
+  'Close Corporation (CC)',
+  'Sole Proprietor',
+  'Trust',
+  'Non-profit (NPC)',
+  'Other',
+];
+
+export interface Step2BusinessProps {
+  value: Partial<Step2>;
+  onChange: (values: Partial<Step2>) => void;
+  canGoNext: boolean;
+}
+
+export function Step2Business({ value, onChange, canGoNext }: Step2BusinessProps) {
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const handleFieldChange = (field: keyof Step2, val: string) => {
+    const newValue = { ...value, [field]: val };
+    onChange(newValue);
+    // Validate on change
+    const result = step2Schema.safeParse(newValue);
+    if (result.success) {
+      setErrors((e) => {
+        const newE = { ...e };
+        delete newE[field];
+        return newE;
+      });
+    }
+  };
+
+  const isSoleProp = value.entityType === 'Sole Proprietor';
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          Your business details
+        </h2>
+        <p className="text-gray-600">
+          The legal entity that will be billed — the names must match the bank account.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          {/* Entity Name */}
+          <div>
+            <Label htmlFor="entityName">
+              Entity name<span className="text-red-600">*</span>
+            </Label>
+            <Input
+              id="entityName"
+              type="text"
+              placeholder="e.g. Lens Ext 10 (Pty) Ltd"
+              value={value.entityName ?? ''}
+              onChange={(e) => handleFieldChange('entityName', e.target.value)}
+              className={errors.entityName ? 'border-red-600' : ''}
+            />
+            {errors.entityName && (
+              <p className="text-xs text-red-600 mt-1">{errors.entityName}</p>
+            )}
+          </div>
+
+          {/* Entity Type */}
+          <div>
+            <Label htmlFor="entityType">
+              Entity type<span className="text-red-600">*</span>
+            </Label>
+            <Select
+              value={value.entityType ?? ''}
+              onValueChange={(val) => handleFieldChange('entityType', val)}
+            >
+              <SelectTrigger id="entityType">
+                <SelectValue placeholder="Select entity type" />
+              </SelectTrigger>
+              <SelectContent>
+                {ENTITY_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.entityType && (
+              <p className="text-xs text-red-600 mt-1">{errors.entityType}</p>
+            )}
+          </div>
+
+          {/* Registration Number / Owner ID */}
+          <div>
+            <Label htmlFor="regNumber">
+              {isSoleProp ? (
+                <>
+                  Owner ID number<span className="text-red-600">*</span>
+                </>
+              ) : (
+                <>
+                  Registration number<span className="text-red-600">*</span>
+                </>
+              )}
+            </Label>
+            <Input
+              id="regNumber"
+              type="text"
+              placeholder={isSoleProp ? '13-digit SA ID number' : 'CIPC registration'}
+              value={value.regNumber ?? ''}
+              onChange={(e) => handleFieldChange('regNumber', e.target.value)}
+              className={errors.regNumber ? 'border-red-600' : ''}
+            />
+            {errors.regNumber && (
+              <p className="text-xs text-red-600 mt-1">{errors.regNumber}</p>
+            )}
+          </div>
+
+          {/* VAT Registration */}
+          <div>
+            <Label>
+              VAT registered?<span className="text-red-600">*</span>
+            </Label>
+            <RadioGroup
+              value={value.vat ?? 'No'}
+              onValueChange={(val) => {
+                handleFieldChange('vat', val);
+                if (val === 'No') {
+                  handleFieldChange('vatNumber', '');
+                }
+              }}
+              className="flex gap-6 mt-2"
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="No" id="vat-no" />
+                <Label htmlFor="vat-no">No</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="Yes" id="vat-yes" />
+                <Label htmlFor="vat-yes">Yes</Label>
+              </div>
+            </RadioGroup>
+          </div>
+
+          {/* VAT Number (conditional) */}
+          {value.vat === 'Yes' && (
+            <div>
+              <Label htmlFor="vatNumber">
+                VAT number<span className="text-red-600">*</span>
+              </Label>
+              <Input
+                id="vatNumber"
+                type="text"
+                placeholder="e.g. 4123456789"
+                value={value.vatNumber ?? ''}
+                onChange={(e) => handleFieldChange('vatNumber', e.target.value)}
+                className={errors.vatNumber ? 'border-red-600' : ''}
+              />
+              {errors.vatNumber && (
+                <p className="text-xs text-red-600 mt-1">{errors.vatNumber}</p>
+              )}
+            </div>
+          )}
+
+          {/* Registration Address */}
+          <div>
+            <Label htmlFor="regAddress">
+              Registered address<span className="text-red-600">*</span>
+            </Label>
+            <Input
+              id="regAddress"
+              type="text"
+              placeholder="Street address, suburb, city"
+              value={value.regAddress ?? ''}
+              onChange={(e) => handleFieldChange('regAddress', e.target.value)}
+              className={errors.regAddress ? 'border-red-600' : ''}
+            />
+            {errors.regAddress && (
+              <p className="text-xs text-red-600 mt-1">{errors.regAddress}</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/onboarding/components/steps/Step3Banking.tsx
+++ b/app/onboarding/components/steps/Step3Banking.tsx
@@ -1,0 +1,219 @@
+'use client';
+import { useState } from 'react';
+import { step3Schema, type Step3 } from '@/lib/onboarding/schemas';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { PiWarningCircle } from 'react-icons/pi';
+
+const BANKS = [
+  'Absa',
+  'Capitec',
+  'FNB',
+  'Investec',
+  'Nedbank',
+  'Standard Bank',
+  'TymeBank',
+  'Other',
+];
+
+const ACCOUNT_TYPES = [
+  'Cheque / Current',
+  'Savings',
+  'Transmission',
+];
+
+export interface Step3BankingProps {
+  value: Partial<Step3>;
+  onChange: (values: Partial<Step3>) => void;
+  step2EntityName?: string;
+  canGoNext: boolean;
+}
+
+export function Step3Banking({
+  value,
+  onChange,
+  step2EntityName = '',
+  canGoNext,
+}: Step3BankingProps) {
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const handleFieldChange = (field: keyof Step3, val: string | boolean) => {
+    const newValue = { ...value, [field]: val };
+    onChange(newValue);
+    // Validate on change
+    const result = step3Schema.safeParse(newValue);
+    if (result.success) {
+      setErrors((e) => {
+        const newE = { ...e };
+        delete newE[field];
+        return newE;
+      });
+    }
+  };
+
+  // Check if account holder matches entity name (case-insensitive, trimmed)
+  const holderTrimmed = (value.accHolder ?? '').trim().toLowerCase();
+  const entityTrimmed = (step2EntityName ?? '').trim().toLowerCase();
+  const nameMatch = holderTrimmed.length > 0 && holderTrimmed === entityTrimmed;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          Banking details
+        </h2>
+        <p className="text-gray-600">
+          We'll set up a monthly DebiCheck debit order on your chosen payment date.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          {/* Account Holder */}
+          <div>
+            <Label htmlFor="accHolder">
+              Account holder name<span className="text-red-600">*</span>
+            </Label>
+            <Input
+              id="accHolder"
+              type="text"
+              placeholder="As it appears on your bank account"
+              value={value.accHolder ?? ''}
+              onChange={(e) => handleFieldChange('accHolder', e.target.value)}
+              className={errors.accHolder ? 'border-red-600' : ''}
+            />
+            {errors.accHolder && (
+              <p className="text-xs text-red-600 mt-1">{errors.accHolder}</p>
+            )}
+          </div>
+
+          {/* Name mismatch warning */}
+          {!nameMatch && holderTrimmed.length > 0 && entityTrimmed.length > 0 && (
+            <div className="flex gap-3 p-3 bg-yellow-50 border border-yellow-200 rounded">
+              <PiWarningCircle className="w-5 h-5 text-yellow-600 flex-shrink-0 mt-0.5" />
+              <p className="text-sm text-yellow-800">
+                <strong>Account holder should match your registered entity</strong> —
+                name mismatches are the main cause of mandate rejection.
+              </p>
+            </div>
+          )}
+
+          {/* Bank */}
+          <div>
+            <Label htmlFor="bank">
+              Bank<span className="text-red-600">*</span>
+            </Label>
+            <Select
+              value={value.bank ?? ''}
+              onValueChange={(val) => handleFieldChange('bank', val)}
+            >
+              <SelectTrigger id="bank">
+                <SelectValue placeholder="Select your bank" />
+              </SelectTrigger>
+              <SelectContent>
+                {BANKS.map((b) => (
+                  <SelectItem key={b} value={b}>
+                    {b}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.bank && (
+              <p className="text-xs text-red-600 mt-1">{errors.bank}</p>
+            )}
+          </div>
+
+          {/* Account Type */}
+          <div>
+            <Label htmlFor="accType">
+              Account type<span className="text-red-600">*</span>
+            </Label>
+            <Select
+              value={value.accType ?? ''}
+              onValueChange={(val) => handleFieldChange('accType', val)}
+            >
+              <SelectTrigger id="accType">
+                <SelectValue placeholder="Select account type" />
+              </SelectTrigger>
+              <SelectContent>
+                {ACCOUNT_TYPES.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.accType && (
+              <p className="text-xs text-red-600 mt-1">{errors.accType}</p>
+            )}
+          </div>
+
+          {/* Account Number */}
+          <div>
+            <Label htmlFor="accNumber">
+              Account number<span className="text-red-600">*</span>
+            </Label>
+            <Input
+              id="accNumber"
+              type="text"
+              placeholder="Your bank account number"
+              value={value.accNumber ?? ''}
+              onChange={(e) => handleFieldChange('accNumber', e.target.value)}
+              className={errors.accNumber ? 'border-red-600' : ''}
+            />
+            {errors.accNumber && (
+              <p className="text-xs text-red-600 mt-1">{errors.accNumber}</p>
+            )}
+          </div>
+
+          {/* Branch Code */}
+          <div>
+            <Label htmlFor="branchCode">
+              Branch code<span className="text-red-600">*</span>
+            </Label>
+            <Input
+              id="branchCode"
+              type="text"
+              placeholder="e.g. 470010"
+              value={value.branchCode ?? ''}
+              onChange={(e) => handleFieldChange('branchCode', e.target.value)}
+              className={errors.branchCode ? 'border-red-600' : ''}
+            />
+            {errors.branchCode && (
+              <p className="text-xs text-red-600 mt-1">{errors.branchCode}</p>
+            )}
+          </div>
+
+          {/* DebiCheck Consent */}
+          <div className="flex items-start gap-3 p-3 border border-gray-200 rounded bg-gray-50">
+            <Checkbox
+              id="mandate"
+              checked={value.mandate ?? false}
+              onCheckedChange={(checked) =>
+                handleFieldChange('mandate', checked as boolean)
+              }
+            />
+            <label htmlFor="mandate" className="text-sm cursor-pointer">
+              <span className="font-semibold">I authorise CircleTel</span> to set up a
+              monthly DebiCheck debit order on my account, in accordance with the
+              DebiCheck rules, and I understand this is one-time authorisation for
+              recurring debits.
+            </label>
+          </div>
+          {errors.mandate && (
+            <p className="text-xs text-red-600">{errors.mandate}</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/onboarding/components/steps/Step3Banking.tsx
+++ b/app/onboarding/components/steps/Step3Banking.tsx
@@ -32,8 +32,22 @@ const ACCOUNT_TYPES = [
 ];
 
 export interface Step3BankingProps {
-  value: Partial<Step3>;
-  onChange: (values: Partial<Step3>) => void;
+  value: {
+    accHolder?: string;
+    bank?: string;
+    accType?: string;
+    accNumber?: string;
+    branchCode?: string;
+    mandate?: boolean;
+  };
+  onChange: (values: {
+    accHolder?: string;
+    bank?: string;
+    accType?: string;
+    accNumber?: string;
+    branchCode?: string;
+    mandate?: boolean;
+  }) => void;
   step2EntityName?: string;
   canGoNext: boolean;
 }

--- a/app/onboarding/components/steps/Step4Documents.tsx
+++ b/app/onboarding/components/steps/Step4Documents.tsx
@@ -36,6 +36,20 @@ export function Step4Documents({
       return;
     }
 
+    // Client-side file validation
+    const maxSize = 5 * 1024 * 1024; // 5MB
+    const allowedTypes = ['application/pdf', 'image/jpeg', 'image/png'];
+
+    if (file.size > maxSize) {
+      setError(`File is too large. Maximum size is 5MB (${file.name} is ${(file.size / 1024 / 1024).toFixed(1)}MB).`);
+      return;
+    }
+
+    if (!allowedTypes.includes(file.type)) {
+      setError(`File type not allowed. Please upload a PDF, JPEG, or PNG file.`);
+      return;
+    }
+
     setBusy(docType);
     setError(null);
 

--- a/app/onboarding/components/steps/Step4Documents.tsx
+++ b/app/onboarding/components/steps/Step4Documents.tsx
@@ -1,0 +1,153 @@
+'use client';
+import { useState } from 'react';
+import { requiredDocsFor } from '@/lib/onboarding/document-requirements';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { PiCheckCircle, PiUploadSimple } from 'react-icons/pi';
+
+export interface Step4DocumentsProps {
+  token: string;
+  submissionId: string | null;
+  step2: any;
+  documents: Record<string, any>;
+  onChange: (docs: Record<string, any>) => void;
+  canGoNext: boolean;
+}
+
+export function Step4Documents({
+  token,
+  submissionId,
+  step2,
+  documents,
+  onChange,
+  canGoNext,
+}: Step4DocumentsProps) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const required = requiredDocsFor('unjani', {
+    vatRegistered: step2.vat === 'Yes',
+    entityType: step2.entityType,
+  }).filter((d) => d.required);
+
+  const handleFileSelect = async (docType: string, file: File) => {
+    if (!submissionId) {
+      setError('Submission ID not ready. Please refresh and try again.');
+      return;
+    }
+
+    setBusy(docType);
+    setError(null);
+
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('token', token);
+    formData.append('documentType', docType);
+    formData.append('submissionId', submissionId);
+
+    try {
+      const res = await fetch('/api/onboarding/upload-document', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const json = await res.json();
+
+      if (json.success) {
+        onChange({
+          ...documents,
+          [docType]: { documentId: json.documentId, fileName: file.name },
+        });
+      } else {
+        setError(json.error || 'Upload failed');
+      }
+    } catch (err) {
+      setError('Network error. Please try again.');
+      console.error(err);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          Supporting documents
+        </h2>
+        <p className="text-gray-600">
+          Upload the required documents to verify your company details and
+          banking.
+        </p>
+      </div>
+
+      {error && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded text-red-800 text-sm">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardContent className="pt-6 space-y-3">
+          {required.map((doc) => (
+            <div
+              key={doc.type}
+              className="flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50"
+            >
+              <div className="flex-1">
+                <p className="font-semibold text-gray-900">{doc.label}</p>
+                {documents[doc.type] ? (
+                  <p className="text-sm text-green-600 flex items-center gap-1 mt-1">
+                    <PiCheckCircle className="w-4 h-4" />
+                    Uploaded: {documents[doc.type].fileName}
+                  </p>
+                ) : (
+                  <p className="text-xs text-gray-500 mt-1">
+                    PDF, JPEG, or PNG (max 5MB)
+                  </p>
+                )}
+              </div>
+
+              <label className="ml-4 cursor-pointer">
+                <input
+                  type="file"
+                  accept="application/pdf,image/jpeg,image/png"
+                  disabled={busy === doc.type}
+                  onChange={(e) => {
+                    if (e.target.files?.[0]) {
+                      handleFileSelect(doc.type, e.target.files[0]);
+                    }
+                  }}
+                  className="sr-only"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={busy === doc.type}
+                  asChild
+                >
+                  <span className="cursor-pointer">
+                    <PiUploadSimple className="w-4 h-4 mr-1" />
+                    {busy === doc.type ? 'Uploading...' : 'Upload'}
+                  </span>
+                </Button>
+              </label>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <div className="text-sm text-gray-600">
+        <p className="font-semibold mb-2">What we need:</p>
+        <ul className="space-y-1 text-xs list-disc list-inside">
+          <li>
+            Clear, readable documents in colour (front and back for ID documents)
+          </li>
+          <li>Recent documents (bank statements dated within 3 months)</li>
+          <li>Company/director names must match your banking details</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/onboarding/components/steps/Step5ServiceOrder.tsx
+++ b/app/onboarding/components/steps/Step5ServiceOrder.tsx
@@ -1,0 +1,201 @@
+'use client';
+import { useState } from 'react';
+import { step5Schema, type Step5 } from '@/lib/onboarding/schemas';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { computeProRata } from '@/lib/onboarding/prorata';
+import { PiCaretDown, PiCaretUp } from 'react-icons/pi';
+
+export interface Step5ServiceOrderProps {
+  value: Partial<Step5>;
+  onChange: (values: Partial<Step5>) => void;
+  monthlyPrice?: number;
+  activationDate?: string;
+  canGoNext: boolean;
+}
+
+const PAYMENT_DATES = ['1', '15', '20', '25'];
+
+const SERVICE_ORDER_CLAUSES = [
+  '<b>Commencement:</b> The Service Order terms commence on the Effective Date and continue for one calendar month thereafter, automatically renewing for successive one-month periods unless either party terminates with 30 days written notice.',
+  '<b>Payment:</b> The monthly fee is due and payable in advance on the selected payment date. The first invoice is pro-rated from the Effective Date to the end of that calendar month.',
+  '<b>DebiCheck Authorisation:</b> By accepting this Service Order, you authorise CircleTel to collect the monthly fee via DebiCheck debit order on your nominated payment date, in accordance with the DebiCheck rules.',
+  '<b>Service Suspension:</b> If payment is not received by the due date, CircleTel may suspend service access without further notice.',
+  '<b>Intellectual Property:</b> All CircleTel materials, technology, and know-how remain the property of CircleTel and may not be copied or reproduced without consent.',
+  '<b>Limitation of Liability:</b> CircleTel\'s total liability under this Service Order is limited to the fees paid in the three months preceding the claim.',
+  '<b>Termination:</b> Either party may terminate this Service Order with 30 days written notice. Upon termination, all outstanding fees remain due.',
+  '<b>Governing Law:</b> This Service Order is governed by the laws of the Republic of South Africa.',
+];
+
+export function Step5ServiceOrder({
+  value,
+  onChange,
+  monthlyPrice = 450,
+  activationDate = new Date().toISOString().split('T')[0],
+  canGoNext,
+}: Step5ServiceOrderProps) {
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [showDetails, setShowDetails] = useState(false);
+
+  const paymentDate = value.paymentDate ?? '1';
+
+  const proRata = computeProRata({
+    monthlyExVat: monthlyPrice,
+    vatPct: 15,
+    activationDate,
+    billingDay: Number(paymentDate),
+  });
+
+  const handlePaymentDateChange = (date: string) => {
+    const newValue = { ...value, paymentDate: date as Step5['paymentDate'] };
+    onChange(newValue);
+    setErrors((e) => {
+      const newE = { ...e };
+      delete newE.paymentDate;
+      return newE;
+    });
+  };
+
+  const handleConsentChange = (checked: boolean) => {
+    const newValue = { ...value, soAccept: checked as any };
+    onChange(newValue);
+    setErrors((e) => {
+      const newE = { ...e };
+      delete newE.soAccept;
+      return newE;
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          Service Order
+        </h2>
+        <p className="text-gray-600">
+          Confirm your details, choose your monthly payment date, and accept the
+          Service Order terms.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6 space-y-6">
+          {/* Payment Date Selection */}
+          <div>
+            <h3 className="font-semibold text-gray-900 mb-3">
+              When should we debit your account?
+            </h3>
+            <p className="text-sm text-gray-600 mb-4">
+              Choose the day of the month (1st, 15th, 20th, or 25th)
+            </p>
+            <div className="flex flex-wrap gap-3">
+              {PAYMENT_DATES.map((date) => (
+                <button
+                  key={date}
+                  onClick={() => handlePaymentDateChange(date)}
+                  className={`px-6 py-3 rounded border-2 font-semibold transition ${
+                    paymentDate === date
+                      ? 'bg-circleTel-orange border-circleTel-orange text-white'
+                      : 'bg-white border-gray-300 text-gray-900 hover:border-circleTel-orange'
+                  }`}
+                >
+                  {date === '1' ? '1st' : date === '15' ? '15th' : date === '20' ? '20th' : '25th'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Service Order Line Item */}
+          <div className="bg-gray-50 p-4 rounded border border-gray-200">
+            <div className="flex justify-between items-start mb-3">
+              <div>
+                <p className="font-semibold text-gray-900">
+                  CircleTel ClinicConnect
+                </p>
+                <p className="text-sm text-gray-600">
+                  Managed connectivity service · Unjani clinic
+                </p>
+              </div>
+            </div>
+
+            {/* Pro-rata line */}
+            <div className="border-t pt-3 flex justify-between items-center p-3 bg-white rounded border border-circleTel-orange">
+              <div>
+                <p className="font-semibold text-gray-900">
+                  First invoice (pro-rated)
+                </p>
+                <p className="text-xs text-gray-600">
+                  {proRata.days} days of {proRata.daysInMonth} in the month
+                </p>
+              </div>
+              <p className="font-bold text-circleTel-orange text-xl">
+                R{proRata.amountInclVat.toFixed(2)}
+              </p>
+            </div>
+
+            {/* Monthly recurring */}
+            <div className="mt-3 flex justify-between items-center p-3 bg-white rounded border border-gray-200">
+              <div>
+                <p className="font-semibold text-gray-900">Monthly recurring</p>
+                <p className="text-xs text-gray-600">From the following month</p>
+              </div>
+              <div className="text-right">
+                <p className="font-bold text-gray-900">R{monthlyPrice.toFixed(2)}</p>
+                <p className="text-xs text-gray-500">ex VAT (15%)</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Service Order Terms */}
+          <div className="border rounded p-4">
+            <button
+              type="button"
+              onClick={() => setShowDetails(!showDetails)}
+              className="flex items-center justify-between w-full font-semibold text-gray-900 hover:text-circleTel-orange"
+            >
+              <span>CircleTel Service Order — Terms & Conditions</span>
+              {showDetails ? (
+                <PiCaretUp className="w-5 h-5" />
+              ) : (
+                <PiCaretDown className="w-5 h-5" />
+              )}
+            </button>
+
+            {showDetails && (
+              <div className="mt-4 space-y-3 text-sm text-gray-700">
+                {SERVICE_ORDER_CLAUSES.map((clause, idx) => (
+                  <p key={idx} dangerouslySetInnerHTML={{ __html: clause }} />
+                ))}
+                <p className="text-xs text-gray-600 mt-4 pt-4 border-t">
+                  These terms are back-to-back with the Master Service Agreement
+                  between CircleTel and Unjani Clinics NPC (the "MSA"). In the
+                  event of any conflict, the MSA prevails.
+                </p>
+              </div>
+            )}
+          </div>
+
+          {/* Acceptance Checkbox */}
+          <div className="flex items-start gap-3 p-4 border border-gray-200 rounded bg-gray-50">
+            <Checkbox
+              id="soAccept"
+              checked={value.soAccept ?? false}
+              onCheckedChange={(checked) => handleConsentChange(checked as boolean)}
+            />
+            <label htmlFor="soAccept" className="text-sm cursor-pointer flex-1">
+              <span className="font-semibold">
+                I accept the CircleTel Service Order terms above
+              </span>
+              , which are back-to-back with the Unjani Master Service Agreement,
+              and I'm authorised to do so for this entity.
+            </label>
+          </div>
+          {errors.soAccept && (
+            <p className="text-xs text-red-600">{errors.soAccept}</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/onboarding/components/steps/Step5ServiceOrder.tsx
+++ b/app/onboarding/components/steps/Step5ServiceOrder.tsx
@@ -8,8 +8,14 @@ import { computeProRata } from '@/lib/onboarding/prorata';
 import { PiCaretDown, PiCaretUp } from 'react-icons/pi';
 
 export interface Step5ServiceOrderProps {
-  value: Partial<Step5>;
-  onChange: (values: Partial<Step5>) => void;
+  value: {
+    paymentDate?: '1' | '15' | '20' | '25';
+    soAccept?: boolean;
+  };
+  onChange: (values: {
+    paymentDate?: '1' | '15' | '20' | '25';
+    soAccept?: boolean;
+  }) => void;
   monthlyPrice?: number;
   activationDate?: string;
   canGoNext: boolean;

--- a/app/onboarding/components/steps/Step6Done.tsx
+++ b/app/onboarding/components/steps/Step6Done.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { PiCheckCircleFill } from 'react-icons/pi';
+import { Card, CardContent } from '@/components/ui/card';
+
+export interface Step6DoneProps {
+  accountNumber: string;
+}
+
+export function Step6Done({ accountNumber }: Step6DoneProps) {
+  return (
+    <div className="space-y-6 text-center">
+      <div>
+        <PiCheckCircleFill className="w-16 h-16 text-green-600 mx-auto mb-4" />
+        <h2 className="text-3xl font-bold text-gray-900 mb-2">
+          Service order submitted
+        </h2>
+        <p className="text-gray-600 max-w-2xl mx-auto">
+          Your clinic billing setup is in. We've linked it to your Unjani account
+          and created your CircleTel account.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6 pb-6">
+          <div className="inline-block bg-gray-50 border-2 border-dashed border-gray-300 rounded p-6">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-2">
+              Your account number
+            </p>
+            <p className="text-3xl font-bold text-gray-900 tracking-widest">
+              {accountNumber}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="bg-gray-50 border border-gray-200 rounded p-6 text-left max-w-2xl mx-auto">
+        <h3 className="font-semibold text-gray-900 mb-3">What happens next</h3>
+        <ol className="space-y-2 text-sm text-gray-700 list-decimal list-inside">
+          <li>We validate your company and director details (CIPC) and your banking.</li>
+          <li>We set up your monthly DebiCheck debit order on your chosen payment date.</li>
+          <li>
+            We issue your CircleTel Service Order — back-to-back with the Unjani Master
+            Service Agreement — for signature.
+          </li>
+          <li>Billing runs monthly in advance from your active service date; your first
+            invoice is pro-rated.</li>
+          <li>
+            <strong>We're vetting your documents.</strong> You'll hear from us within 2
+            business days once we've checked everything.
+          </li>
+        </ol>
+      </div>
+
+      <div className="text-sm text-gray-600">
+        <p>
+          Questions?{' '}
+          <a
+            href="https://wa.me/27824873900"
+            className="font-semibold text-circleTel-orange hover:underline"
+          >
+            WhatsApp 082 487 3900
+          </a>{' '}
+          or{' '}
+          <a
+            href="mailto:contactus@circletel.co.za"
+            className="font-semibold text-circleTel-orange hover:underline"
+          >
+            contactus@circletel.co.za
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/onboarding/components/useOnboardingState.ts
+++ b/app/onboarding/components/useOnboardingState.ts
@@ -1,15 +1,30 @@
 'use client';
 import { useState } from 'react';
-import type { Step1, Step2, Step3, Step5 } from '@/lib/onboarding/schemas';
+import type { Step1, Step2 } from '@/lib/onboarding/schemas';
+
+// Working state types: allow boolean for mandate/soAccept (not just literal true)
+export interface Step3Working {
+  accHolder?: string;
+  bank?: string;
+  accType?: string;
+  accNumber?: string;
+  branchCode?: string;
+  mandate: boolean;
+}
+
+export interface Step5Working {
+  paymentDate?: '1' | '15' | '20' | '25';
+  soAccept: boolean;
+}
 
 export interface OnboardingState {
   clinic: any;
   service: any;
   step1: Partial<Step1>;
   step2: Partial<Step2>;
-  step3: Partial<Step3>;
+  step3: Step3Working;
   documents: Record<string, { documentId: string; fileName: string } | undefined>;
-  step5: Partial<Step5>;
+  step5: Step5Working;
   submissionId: string | null;
 }
 
@@ -43,12 +58,12 @@ export function useOnboardingState(prefill: { customer: any; service: any }) {
       accType: '',
       accNumber: '',
       branchCode: '',
-      mandate: false as any,
+      mandate: false,
     },
     documents: {},
     step5: {
       paymentDate: '1' as const,
-      soAccept: false as any,
+      soAccept: false,
     },
     submissionId: null,
   });

--- a/app/onboarding/components/useOnboardingState.ts
+++ b/app/onboarding/components/useOnboardingState.ts
@@ -1,0 +1,63 @@
+'use client';
+import { useState } from 'react';
+import type { Step1, Step2, Step3, Step5 } from '@/lib/onboarding/schemas';
+
+export interface OnboardingState {
+  clinic: any;
+  service: any;
+  step1: Partial<Step1>;
+  step2: Partial<Step2>;
+  step3: Partial<Step3>;
+  documents: Record<string, { documentId: string; fileName: string } | undefined>;
+  step5: Partial<Step5>;
+  submissionId: string | null;
+}
+
+export function useOnboardingState(prefill: { customer: any; service: any }) {
+  const [current, setCurrent] = useState(1);
+  const [state, setState] = useState<OnboardingState>({
+    clinic: prefill.customer,
+    service: prefill.service,
+    step1: {
+      clinicName: prefill.customer.business_name?.replace(/^Unjani Clinic — /, '') ?? '',
+      unjaniAcc: prefill.customer.clinic_details?.unjani_account ?? '',
+      province: prefill.customer.clinic_details?.province ?? '',
+      contact: prefill.customer.clinic_details?.nurse_owner_name ?? '',
+      phone: prefill.customer.phone ?? '',
+      email: prefill.customer.email ?? '',
+      siteAddress: prefill.customer.clinic_details?.site_address ?? '',
+      lat: prefill.customer.clinic_details?.lat ?? '',
+      lng: prefill.customer.clinic_details?.lng ?? '',
+    },
+    step2: {
+      entityName: prefill.customer.business_name ?? '',
+      entityType: '',
+      regNumber: prefill.customer.business_registration ?? '',
+      vat: prefill.customer.tax_number ? 'Yes' : 'No',
+      vatNumber: prefill.customer.tax_number ?? '',
+      regAddress: '',
+    },
+    step3: {
+      accHolder: '',
+      bank: '',
+      accType: '',
+      accNumber: '',
+      branchCode: '',
+      mandate: false as any,
+    },
+    documents: {},
+    step5: {
+      paymentDate: '1' as const,
+      soAccept: false as any,
+    },
+    submissionId: null,
+  });
+
+  const patch = (key: keyof OnboardingState, value: any) =>
+    setState((s) => ({ ...s, [key]: value }));
+
+  const updateStep = (stepKey: 'step1' | 'step2' | 'step3' | 'step5', values: any) =>
+    setState((s) => ({ ...s, [stepKey]: { ...s[stepKey], ...values } }));
+
+  return { current, setCurrent, state, patch, updateStep, setState };
+}

--- a/app/onboarding/layout.tsx
+++ b/app/onboarding/layout.tsx
@@ -1,0 +1,20 @@
+import { Navbar } from '@/components/layout/Navbar';
+import { Footer } from '@/components/layout/Footer';
+
+/**
+ * Onboarding shares the public site chrome (navbar + footer) so the clinic
+ * wizard looks and feels like the rest of circletel.co.za. No auth required.
+ */
+export default function OnboardingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-[#F9FAFB]">{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/docs/onboarding/UNJANI_ONBOARDING_CHEATSHEET.md
+++ b/docs/onboarding/UNJANI_ONBOARDING_CHEATSHEET.md
@@ -1,0 +1,50 @@
+# Unjani Onboarding — Desk Cheat-Sheet
+
+**Price:** R450 + VAT = **R517.50 / month / clinic** (first month pro-rated) · **Link:** valid 7 days, single-use · **Sender:** CircleTel +27 84 773 9467 ("Start setup" button)
+
+---
+
+### The process (your 5 actions)
+1. **Confirm** the clinic's WhatsApp number is correct.
+2. **Send** the onboarding link (admin tool → clinic → Send onboarding link / WhatsApp).
+3. **Guide** the nurse through the 6-step wizard (~5 min — most clinic details pre-filled).
+4. **Vet** the uploaded documents in **Admin → B2B vetting** (Approve / Reject-with-reason).
+5. **Confirm billing live** once docs approved **+** debit order active → status = **billing-ready**.
+
+> **New clinic?** Coverage check → install/activate **first**, *then* steps 1–5. (No billing before install.)
+> **Nurse with 2+ clinics?** One link & one setup **per clinic** — even on the same number. Bill is separate per clinic.
+
+---
+
+### Status — what it means / what to do
+| Status | Meaning | Do |
+|---|---|---|
+| pending | nothing sent | send the link |
+| in progress | sent, not done | follow up after a few days |
+| submitted | wizard done | vet the documents |
+| documents approved | docs OK, awaiting debit order | remind nurse to approve DebiCheck at their bank |
+| billing-ready | docs + debit order OK | done — invoices on chosen date |
+| failed | debit order rejected | fix bank details / name match, redo banking |
+
+---
+
+### Documents the nurse must upload
+CIPC company registration cert · VAT cert (only if VAT-registered) · **bank confirmation/statement** · owner/director ID · proof of business address. *(Phone photos OK — PDF/JPG/PNG, <5MB each.)*
+**#1 rejection cause:** bank **account-holder name ≠ registered clinic name** — check this first.
+
+---
+
+### Top 5 FAQs
+1. **Nurse didn't get the WhatsApp?** Check number is correct + WhatsApp-enabled → re-send (issues a fresh link). Fallback: SMS the link.
+2. **Link expired / "already used"?** Send a new one (7-day, single-use).
+3. **When are they charged?** Only after docs approved **and** debit order active (and, for new clinics, after install). First month pro-rated.
+4. **Debit order won't activate?** Nurse must approve the DebiCheck request at their bank; if rejected it's usually a name mismatch — fix banking & redo.
+5. **Bank account in nurse's own name?** Account-holder name should match the registered clinic; flag it so the mandate isn't rejected.
+
+---
+
+### Contacts
+**Customer support (nurses know this):** WhatsApp/Call **082 487 3900** · **contactus@circletel.co.za** · Mon–Fri 8am–5pm
+**Escalate technical/coverage/install or stuck mandates →** CircleTel tech team.
+
+*Full guide + WhatsApp scripts: `docs/onboarding/UNJANI_ONBOARDING_SALES_ADMIN_GUIDE.md`*

--- a/docs/onboarding/UNJANI_ONBOARDING_SALES_ADMIN_GUIDE.md
+++ b/docs/onboarding/UNJANI_ONBOARDING_SALES_ADMIN_GUIDE.md
@@ -197,4 +197,60 @@ CircleTel: WhatsApp **082 487 3900** or email **contactus@circletel.co.za** (Mon
 
 ---
 
+## 12. WhatsApp scripts (copy-paste when guiding a nurse)
+
+> These are for **you chatting one-on-one** with the nurse on WhatsApp (e.g. from the support line 082 487 3900). Keep replies in the same conversation. Replace anything in **[brackets]**. The official "Start setup" link itself is sent by the system from +27 84 773 9467 — these messages are your human follow-ups around it.
+
+**A. Heads-up before/with the link**
+```
+Hi [Nurse name] 👋 It's [Your name] from CircleTel. We're setting up your monthly billing for [Clinic name]. I'm sending you a secure WhatsApp link now — just tap the orange "Start setup" button. It takes about 5 minutes. Please have ready: your company registration (CIPC) number, VAT number (if registered), your clinic's bank details, and photos of those documents + your ID and proof of address. I'm here if you get stuck. 🙂
+```
+
+**B. "I've sent the link"**
+```
+Done ✅ You'll get a WhatsApp from CircleTel with a "Start setup" button. Tap it and follow the 6 short steps. Most of your clinic details are already filled in — just check them. Let me know once you reach the end and I'll take it from there.
+```
+
+**C. Gentle reminder (not completed yet)**
+```
+Hi [Nurse name], just checking in on the CircleTel setup for [Clinic name] 🙂 The link is still valid for [X] day(s). It only takes ~5 minutes. Reply here if anything's unclear and I'll walk you through it.
+```
+
+**D. Link expired / "it won't open"**
+```
+No problem — that link has expired or was already used. I'm sending you a fresh one now. Please tap "Start setup" within 7 days. 👍
+```
+
+**E. A document needs re-uploading**
+```
+Thanks [Nurse name]! Almost there. Your [document, e.g. bank confirmation] couldn't be approved because [reason, e.g. the account holder name must match the clinic's registered name]. Could you re-open your link and upload a corrected [document]? Everything else is approved. 🙏
+```
+
+**F. Debit-order (DebiCheck) approval reminder**
+```
+Hi [Nurse name], one last step: your bank will send you a DebiCheck request to approve the R517.50 monthly debit for [Clinic name]. Please approve it on your banking app / when prompted — billing can't activate until you do. Shout if you don't see it.
+```
+
+**G. All done — billing active**
+```
+🎉 You're all set, [Nurse name]! [Clinic name] is now set up. Your monthly fee is R517.50 (R450 + VAT), coming off on the [date]. Your first month is pro-rated. Welcome aboard — anything you need, we're on 082 487 3900.
+```
+
+**H. Nurse with more than one clinic**
+```
+Hi [Nurse name], since you also run [Second clinic], that one has its own separate setup. I'm sending a second link for [Second clinic] — please complete it too (each clinic is billed separately). Same quick steps. 🙂
+```
+
+**I. New clinic — coverage check pending**
+```
+Hi [Nurse name], for [New clinic name] we first need to confirm we can install internet at the address. Our technical team is checking coverage now. Once that's confirmed and we've installed, I'll send your billing setup link. I'll keep you posted. 👍
+```
+
+**J. Reassurance (nurse worried about giving bank details)**
+```
+Totally understand 🙂 It's the official CircleTel setup page (same as circletel.co.za). The bank details are only to set up your monthly debit order, and YOU approve it through your own bank (DebiCheck) — nothing is ever taken without your approval. You can verify us on 082 487 3900 or contactus@circletel.co.za.
+```
+
+---
+
 *Internal document. For the technical/implementation detail behind this process, see `docs/superpowers/plans/2026-06-09-unjani-b2b-onboarding.md`.*

--- a/docs/onboarding/UNJANI_ONBOARDING_SALES_ADMIN_GUIDE.md
+++ b/docs/onboarding/UNJANI_ONBOARDING_SALES_ADMIN_GUIDE.md
@@ -1,0 +1,200 @@
+# Unjani Clinic Onboarding — Sales Administrator Guide
+
+**Audience:** CircleTel internal sales administrator who helps Unjani nurses get their clinic set up for billing.
+**Purpose:** A plain-language, step-by-step playbook + FAQs so you can confidently guide a nurse through onboarding over the phone or WhatsApp.
+**Last updated:** 2026-06-09
+
+---
+
+## 1. The big picture (read this first)
+
+Every Unjani clinic pays **R450 + VAT = R517.50 per month** for CircleTel ClinicConnect (managed internet). Before we can bill a clinic, the nurse must complete a short **online setup wizard** that captures:
+
+1. Their **clinic details** (we pre-fill what we already have — they just confirm)
+2. Their **business details** (company registration + VAT)
+3. Their **banking details** + a **debit-order (DebiCheck) authorisation**
+4. **Supporting documents** (company registration certificate, etc.)
+5. Acceptance of the **Service Order terms** + choosing a monthly **payment date**
+
+The nurse does this themselves on their phone by tapping a **personal link** we send them on WhatsApp. Your job is to **send the link, guide them through it, vet their documents, and confirm when billing is live.**
+
+> **One clinic = one setup = one R450 account.** A nurse who runs more than one clinic does the setup **once per clinic** (see §6).
+
+---
+
+## 2. Two kinds of clinic — know which one you're dealing with
+
+| | **Existing clinic** (already connected) | **New clinic** (not yet installed) |
+|---|---|---|
+| Examples | The ~20 clinics already live (Alexandra, Barcelona, Lens Ext 10, …) | A brand-new site, e.g. Delmas |
+| What's needed | Just the **setup wizard** → billing starts | **Coverage check → install → THEN** the wizard/billing |
+| Billing starts | As soon as setup is done + debit order is active | Only **after the clinic is installed and activated** |
+
+**If it's a new clinic:** do **not** start billing setup until the **coverage check passes and installation is scheduled/done**. The system is built so a new clinic will not be billed until our technical team activates it — but the correct order is coverage → install → onboarding → billing.
+
+---
+
+## 3. Step-by-step: onboarding an EXISTING clinic
+
+**You will:**
+
+1. **Confirm the clinic's WhatsApp number** is correct on file (this is where the link goes).
+2. **Send the onboarding link.** From the admin tool, choose the clinic and "Send onboarding link (WhatsApp)". The nurse receives a WhatsApp from **CircleTel (+27 84 773 9467)** that says *"Hi [Clinic], let's set up your CircleTel billing"* with a **Start setup** button.
+   - The link is valid for **7 days** and is **single-use** (it's used up once they finish).
+3. **Tell the nurse what to expect:** *"Tap the orange Start setup button. It takes about 5 minutes. Have your company registration number, VAT number if you have one, your clinic's bank details, and photos of your documents ready."*
+4. **The nurse completes the 6 steps** (see §5). They tap through; most clinic details are already filled in.
+5. **They submit.** They'll see a success screen with their CircleTel account number, and a message that we're reviewing their documents.
+6. **You vet their documents** in the admin **B2B vetting queue** (`/admin/b2b/vetting`): open the clinic, view each uploaded document, and **Approve** or **Reject with a reason** (see §7).
+7. **The nurse signs the debit order.** Separately, NetCash sends the nurse a DebiCheck request to authorise the monthly debit on their banking app / via OTP. This must be **approved by the nurse** at their bank.
+8. **Billing goes live automatically** once **(a) all documents are approved AND (b) the debit order is active.** The clinic then appears as **billing-ready** and the first invoice is generated on their chosen payment date (pro-rated for the first month).
+
+**Your "done" checklist for an existing clinic:** link sent ✅ → wizard submitted ✅ → documents approved ✅ → debit order active ✅ → status shows **billing-ready** ✅.
+
+---
+
+## 4. Step-by-step: onboarding a NEW clinic (e.g. Delmas)
+
+1. **Capture the clinic's details** (clinic name, nurse name, contact number, email, physical address).
+2. **Request a coverage/feasibility check** at the clinic's address (our technical team checks Tarana / MTN coverage). **Wait for this to pass.**
+3. **Schedule and complete the installation.** The technical team installs and **activates** the service.
+4. **Only now** follow the existing-clinic steps in §3 (send link → wizard → vet docs → debit order → billing).
+
+> Until the clinic is installed and activated, it stays **dormant** in the system — no link, no billing. This is deliberate so we never bill for a service that isn't live.
+
+---
+
+## 5. What the nurse sees in the wizard (so you can guide them)
+
+The link opens a 6-step form on their phone, branded like the CircleTel website:
+
+| Step | What they do | Tips to give the nurse |
+|---|---|---|
+| **1. Clinic details** | Confirm pre-filled name, Unjani account no., province, contact, mobile, email, address | "Only change something if it's out of date." |
+| **2. Business details** | Entity name, **CIPC registration number**, VAT (Yes/No + number), registered address | Sole proprietor? The field changes to **Owner ID number** (13-digit SA ID). |
+| **3. Banking & debit order** | Account holder, bank, account type, account number, branch code, tick the **DebiCheck consent** | **Account holder name must match the clinic's registered name** — mismatches are the #1 reason debit orders get rejected. |
+| **4. Documents** | Upload: CIPC certificate, VAT certificate (if VAT-registered), bank confirmation letter/statement, owner/director ID, proof of business address | Photos from the phone camera are fine (PDF/JPG/PNG, under 5MB each). |
+| **5. Service order** | Pick a **payment date** (1st / 15th / 20th / 25th), review the R450 + VAT, read & **accept** the Service Order terms | The first month is **pro-rated** (they only pay for the days from activation to the first payment date). |
+| **6. Done** | Sees their **CircleTel account number** + "what happens next" | Reassure them we'll review documents and set up the debit order. |
+
+---
+
+## 6. Nurses who run more than one clinic
+
+Each clinic is a **separate account** with its **own link**. A nurse with two clinics (e.g. Lesedi Mmoneng runs **Barcelona** and **Delmas**) will:
+
+- Receive **two separate WhatsApp links** — even if both go to the **same phone number**.
+- Each message names its clinic ("…*Barcelona*…" / "…*Delmas*…").
+- Complete the wizard **once per clinic** (each is billed R450 separately).
+
+There is no mix-up: each link is locked to one specific clinic, so finishing one doesn't affect the other. **Just make sure they understand they must do it for each clinic.**
+
+---
+
+## 7. Document vetting — what to check (for YOU)
+
+In `/admin/b2b/vetting`, open the clinic and review each document. The account only becomes billing-ready once **all required documents are Approved**.
+
+| Document | Approve if… | Reject if… |
+|---|---|---|
+| **Company registration (CIPC)** | Legible, shows the registered entity name + reg number matching what they typed | Wrong entity, unreadable, expired/placeholder |
+| **VAT certificate** (only if VAT=Yes) | Shows the VAT number they entered | Number mismatch, not a VAT cert |
+| **Bank confirmation / statement** | Shows the **same account holder name & account number** they entered | Name/number mismatch, older than 3 months, illegible |
+| **Owner / Director ID** | Clear SA ID/passport of the owner | Cut off, unreadable |
+| **Proof of business address** | Recent (≤3 months), shows the clinic address | Too old, wrong address |
+
+- **Reject with a clear reason** — the nurse is told what to fix and can re-upload just that document.
+- **Watch the name-match warning:** if the bank account holder name ≠ the registered entity name, the debit order will likely fail. Resolve this before approving.
+
+---
+
+## 8. How to read a clinic's status
+
+| Status you'll see | Meaning | What to do |
+|---|---|---|
+| **pending** | Nothing sent yet | Send the onboarding link |
+| **in progress** | Link sent, not yet completed | Follow up if it's been a few days |
+| **submitted** | Nurse finished the wizard; awaiting your document review | Vet the documents |
+| **documents approved** | You approved all docs; waiting on the debit order | Remind the nurse to approve the DebiCheck request at their bank |
+| **billing-ready** | Docs approved **and** debit order active | Done — billing will run on the payment date |
+| **failed** | Debit order was rejected | Check bank details / name match; re-send / re-do banking step |
+
+---
+
+## 9. FAQ — Questions YOU (Sales Administrator) might have
+
+**Q: How do I know which clinic a link is for?**
+The link is locked to one clinic when we create it — you select the clinic and send. The nurse can't accidentally land on another clinic's setup.
+
+**Q: The nurse says they never got the WhatsApp.**
+Check: (1) is the number on file correct? (2) is it a WhatsApp-enabled number? (3) re-send the link (this issues a fresh one). As a fallback you can send the same link by SMS or read it to them. If WhatsApp sends are failing for everyone, the message template may still be pending Meta approval — escalate to the tech team.
+
+**Q: The link expired / "already used".**
+Links last 7 days and are single-use. Just **send a new one**.
+
+**Q: The nurse runs 3 clinics — one link or three?**
+**Three** — one per clinic. They complete the wizard for each. (See §6.)
+
+**Q: It's a brand-new clinic. Can I send the link now?**
+Not yet. New clinics need a **coverage check and installation first**. Capture their details, request the coverage check, and only send the link after install. (See §4.)
+
+**Q: When does the clinic actually get charged?**
+Only once **documents are approved AND the debit order is active** (and, for new clinics, after installation). The first invoice is pro-rated.
+
+**Q: The nurse entered their personal mobile that's also on another clinic — is that a problem?**
+No. Business/clinic accounts are allowed to share a nurse's number. Each clinic still gets its own link and its own bill.
+
+**Q: What's the price again?**
+**R450 excluding VAT = R517.50 including VAT, per month, per clinic.** First month pro-rated.
+
+**Q: A document looks wrong — what do I do?**
+Reject it with a clear reason in the vetting screen. The nurse is prompted to re-upload just that one.
+
+**Q: The debit order isn't activating.**
+The nurse must approve the DebiCheck request at their bank (app/USSD/OTP). If it was rejected, it's usually a **name mismatch** between the bank account holder and the registered clinic name — fix the banking details and re-do that step. If it's stuck pending for many days, escalate to the tech team.
+
+---
+
+## 10. FAQ — Questions the NURSE might ask (and your answers)
+
+**Q: Is this safe? Why do you need my bank details?**
+Yes. It's the secure CircleTel setup page (same look as circletel.co.za). We need your bank details to set up the monthly debit order for your R517.50 ClinicConnect fee — the same as any normal debit order. You authorise it yourself through your bank (DebiCheck), so nothing is taken without your approval.
+
+**Q: How much will I pay and when?**
+R450 + VAT = **R517.50 per month**. You choose the day it comes off (1st, 15th, 20th or 25th). Your **first month is pro-rated** — you only pay for the days from when your service started to your first payment date.
+
+**Q: How long does it take?**
+About **5 minutes**. Most of your clinic details are already filled in.
+
+**Q: What documents do I need?**
+Your **company registration certificate (CIPC)**, **VAT certificate** (only if you're VAT-registered), a **bank confirmation letter or statement**, your **ID**, and **proof of your clinic's address**. Photos from your phone are fine.
+
+**Q: My bank account is in my name, not the clinic's — is that okay?**
+Tell us — the account holder name should match your registered clinic/entity. If it doesn't match, the debit order can be rejected. We'll help you get it right.
+
+**Q: I run two clinics — do I do this twice?**
+Yes please — each clinic has its own setup and its own monthly bill. You'll get a separate WhatsApp link for each, named for that clinic.
+
+**Q: I didn't finish / my link stopped working.**
+No problem — we'll send you a fresh link.
+
+**Q: What happens after I submit?**
+We review your documents, your bank confirms the debit order with you, and then your billing is set up. We'll let you know when it's all active.
+
+**Q: Who do I contact for help?**
+CircleTel: WhatsApp **082 487 3900** or email **contactus@circletel.co.za** (Mon–Fri, 8am–5pm). Your sales administrator can also help you live.
+
+---
+
+## 11. Quick reference
+
+- **Onboarding sender (WhatsApp):** +27 84 773 9467 ("Start setup" button)
+- **Support line nurses know:** 082 487 3900 · contactus@circletel.co.za
+- **Price:** R450 ex VAT / R517.50 incl / month / clinic (first month pro-rated)
+- **Link validity:** 7 days, single-use
+- **Required docs:** CIPC cert · VAT cert (if VAT) · bank confirmation · owner/director ID · proof of address
+- **Vetting screen:** Admin → B2B vetting queue
+- **Billing starts when:** documents approved + debit order active (+ installed, for new clinics)
+
+---
+
+*Internal document. For the technical/implementation detail behind this process, see `docs/superpowers/plans/2026-06-09-unjani-b2b-onboarding.md`.*

--- a/docs/superpowers/plans/2026-06-09-unjani-b2b-onboarding.md
+++ b/docs/superpowers/plans/2026-06-09-unjani-b2b-onboarding.md
@@ -1,0 +1,1368 @@
+# Unjani / B2B Self-Service Onboarding — Implementation Plan (Critical Path, Phases 1–7)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an already-active Unjani clinic (and, reusably, any B2B customer) complete a magic-link / OTP onboarding that captures entity + banking + DebiCheck mandate + supporting documents, get its documents vetted by an admin, and become billing-ready so the existing recurring-billing engine invoices it.
+
+**Architecture:** Enrich-and-activate, not new-customer creation. All 20 clinic `customers`/`customer_services` rows already exist. The flow writes back the missing fields, inserts a `customer_payment_methods` row + `kyc_documents` rows, triggers a NetCash eMandate, and flips `customers.onboarding_status` to `billing_ready` only once documents are vetted AND the mandate is active. Document vetting reuses the existing `kyc_documents` table and admin KYC UI, generalized from order-scoped to customer/onboarding-scoped so the same backend serves all B2B segments.
+
+**Tech Stack:** Next.js 15 App Router, TypeScript, Supabase (project `agyjovdugmtopasyvlng`), Tailwind/shadcn, NetCash eMandate (SOAP BatchFileUpload), Inngest, Vitest/Jest (`*.test.ts`), Zod, react-hook-form.
+
+**Source spec:** `/root/.claude/plans/now-help-to-brainstorm-replicated-meadow.md` · **Reference UI:** `.docs/onboarding/circletel-onboarding-engine-v2_1 (1).html`
+
+---
+
+## Conventions (read once)
+
+- **Service-role Supabase client** (public/cron/webhook routes, bypasses RLS):
+  ```typescript
+  import { createClient } from '@supabase/supabase-js';
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  );
+  ```
+- **Admin routes:** `import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';` then `const r = await authenticateAdmin(request); if (!r.success) return r.response; const perm = requirePermission(r.adminUser, 'kyc:verify'); if (perm) return perm;`
+- **Migrations are NOT auto-applied by Coolify deploy.** Apply DDL via Supabase MCP `apply_migration`. Run scripts with `set -a && source .env.local && set +a && npx tsx <script>`.
+- **Type-check before every commit:** `npm run type-check:memory`.
+- **kyc_documents real columns** (verified): `customer_type`, `consumer_order_id`, `business_quote_id`, `customer_name/email/phone`, `company_name`, `document_type`, `document_title`, `file_name`, `file_path`, `file_size`, `file_type`, `verification_status`, `verified_by/at`, `verification_notes`, `rejection_reason`, `is_sensitive`, `encrypted`, `expiry_date`, `metadata`. (The legacy `app/api/kyc/upload/route.ts` writes `order_id/storage_path/storage_url` which do NOT exist — do not copy it; use the columns above.)
+
+---
+
+## Task 1: Database migration (schema foundation)
+
+**Files:**
+- Create: `supabase/migrations/20260609120000_unjani_b2b_onboarding.sql`
+
+- [ ] **Step 1: Write the migration SQL**
+
+```sql
+-- Onboarding state on existing customers (Unjani clinics live in `customers`)
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS onboarding_status text
+  DEFAULT 'pending'
+  CHECK (onboarding_status IN ('pending','in_progress','submitted','billing_ready','failed'));
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS onboarding_completed_at timestamptz;
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS clinic_details jsonb DEFAULT '{}'::jsonb;
+
+-- Magic-link tokens (store only the hash; single-use; 7-day expiry)
+CREATE TABLE IF NOT EXISTS onboarding_tokens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_id uuid NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+  token_hash text NOT NULL UNIQUE,
+  expires_at timestamptz NOT NULL,
+  used_at timestamptz,
+  sent_via text,
+  sent_at timestamptz,
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_onboarding_tokens_customer ON onboarding_tokens(customer_id);
+
+-- Submission audit + per-account document-vetting rollup
+CREATE TABLE IF NOT EXISTS onboarding_submissions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_id uuid NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+  segment text NOT NULL DEFAULT 'unjani',
+  submission_data jsonb NOT NULL DEFAULT '{}'::jsonb,
+  netcash_file_token text,
+  status text NOT NULL DEFAULT 'submitted'
+    CHECK (status IN ('draft','submitted','approved','rejected')),
+  document_vetting_status text NOT NULL DEFAULT 'documents_pending'
+    CHECK (document_vetting_status IN ('not_started','documents_pending','under_review','approved','rejected','expired')),
+  admin_reviewed_at timestamptz,
+  admin_reviewed_by uuid,
+  admin_notes text,
+  rejection_reason text,
+  submitted_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_onboarding_submissions_customer ON onboarding_submissions(customer_id);
+CREATE INDEX IF NOT EXISTS idx_onboarding_submissions_vetting ON onboarding_submissions(document_vetting_status);
+
+-- Generalize kyc_documents so docs can attach to a customer-scoped onboarding (all B2B)
+ALTER TABLE kyc_documents ADD COLUMN IF NOT EXISTS customer_id uuid REFERENCES customers(id);
+ALTER TABLE kyc_documents ADD COLUMN IF NOT EXISTS onboarding_submission_id uuid REFERENCES onboarding_submissions(id);
+CREATE INDEX IF NOT EXISTS idx_kyc_documents_onboarding_submission ON kyc_documents(onboarding_submission_id);
+CREATE INDEX IF NOT EXISTS idx_kyc_documents_customer ON kyc_documents(customer_id);
+
+-- Link a payment method back to the onboarding submission that created it
+ALTER TABLE customer_payment_methods ADD COLUMN IF NOT EXISTS onboarding_submission_id uuid REFERENCES onboarding_submissions(id);
+```
+
+- [ ] **Step 2: Apply via MCP**
+
+Use Supabase MCP `apply_migration` with name `unjani_b2b_onboarding` and the SQL above.
+
+- [ ] **Step 3: Verify**
+
+Run (MCP `execute_sql`):
+```sql
+SELECT column_name FROM information_schema.columns WHERE table_name='customers' AND column_name IN ('onboarding_status','onboarding_completed_at','clinic_details');
+SELECT to_regclass('public.onboarding_tokens'), to_regclass('public.onboarding_submissions');
+SELECT column_name FROM information_schema.columns WHERE table_name='kyc_documents' AND column_name IN ('customer_id','onboarding_submission_id');
+```
+Expected: 3 customer cols, both tables non-null, both kyc cols present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260609120000_unjani_b2b_onboarding.sql
+git commit -m "feat(onboarding): schema for B2B onboarding tokens, submissions, doc vetting"
+```
+
+---
+
+## Task 2: Token service (pure logic, TDD)
+
+**Files:**
+- Create: `lib/onboarding/token-service.ts`
+- Test: `lib/onboarding/__tests__/token-service.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// lib/onboarding/__tests__/token-service.test.ts
+import { describe, it, expect } from 'vitest';
+import { generateToken, hashToken } from '../token-service';
+
+describe('token-service', () => {
+  it('generates a URL-safe token of sufficient length', () => {
+    const t = generateToken();
+    expect(t).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+  });
+  it('generates unique tokens', () => {
+    expect(generateToken()).not.toEqual(generateToken());
+  });
+  it('hashes deterministically (same input -> same hash)', () => {
+    expect(hashToken('abc')).toEqual(hashToken('abc'));
+  });
+  it('hashes differently for different input', () => {
+    expect(hashToken('abc')).not.toEqual(hashToken('abd'));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npx vitest run lib/onboarding/__tests__/token-service.test.ts`
+Expected: FAIL — cannot find module `../token-service`.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// lib/onboarding/token-service.ts
+import crypto from 'crypto';
+
+/** Generate a 32-byte cryptographically-random URL-safe token (the plaintext sent in the link). */
+export function generateToken(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/** SHA-256 hex hash. Only the hash is stored in onboarding_tokens.token_hash. */
+export function hashToken(plain: string): string {
+  return crypto.createHash('sha256').update(plain).digest('hex');
+}
+
+export const TOKEN_TTL_DAYS = 7;
+
+/** Expiry timestamp `TOKEN_TTL_DAYS` from `from` (ISO string). */
+export function tokenExpiry(from: Date = new Date()): string {
+  return new Date(from.getTime() + TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run lib/onboarding/__tests__/token-service.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/onboarding/token-service.ts lib/onboarding/__tests__/token-service.test.ts
+git commit -m "feat(onboarding): magic-link token generation + hashing"
+```
+
+---
+
+## Task 3: Document-requirements config + vetting rollup (pure logic, TDD)
+
+**Files:**
+- Create: `lib/onboarding/document-requirements.ts`
+- Test: `lib/onboarding/__tests__/document-requirements.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// lib/onboarding/__tests__/document-requirements.test.ts
+import { describe, it, expect } from 'vitest';
+import { requiredDocsFor, computeVettingStatus } from '../document-requirements';
+
+describe('requiredDocsFor', () => {
+  it('omits vat_certificate when not VAT registered', () => {
+    const types = requiredDocsFor('unjani', { vatRegistered: false, entityType: 'Private Company (Pty) Ltd' }).map(d => d.type);
+    expect(types).toContain('company_registration');
+    expect(types).toContain('bank_statement');
+    expect(types).not.toContain('vat_certificate');
+  });
+  it('includes vat_certificate when VAT registered', () => {
+    const types = requiredDocsFor('unjani', { vatRegistered: true, entityType: 'Private Company (Pty) Ltd' }).map(d => d.type);
+    expect(types).toContain('vat_certificate');
+  });
+  it('sole proprietor needs director_id (owner ID) but not company_registration', () => {
+    const types = requiredDocsFor('unjani', { vatRegistered: false, entityType: 'Sole Proprietor' }).map(d => d.type);
+    expect(types).toContain('director_id');
+    expect(types).not.toContain('company_registration');
+  });
+});
+
+describe('computeVettingStatus', () => {
+  const req = ['company_registration', 'bank_statement', 'director_id'] as const;
+  it('approved when every required doc approved', () => {
+    expect(computeVettingStatus([...req], [
+      { document_type: 'company_registration', verification_status: 'approved' },
+      { document_type: 'bank_statement', verification_status: 'approved' },
+      { document_type: 'director_id', verification_status: 'approved' },
+    ])).toBe('approved');
+  });
+  it('rejected if any required doc rejected', () => {
+    expect(computeVettingStatus([...req], [
+      { document_type: 'company_registration', verification_status: 'rejected' },
+    ])).toBe('rejected');
+  });
+  it('under_review when some approved, none rejected, not all done', () => {
+    expect(computeVettingStatus([...req], [
+      { document_type: 'company_registration', verification_status: 'approved' },
+      { document_type: 'bank_statement', verification_status: 'pending' },
+    ])).toBe('under_review');
+  });
+  it('documents_pending when nothing uploaded', () => {
+    expect(computeVettingStatus([...req], [])).toBe('documents_pending');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npx vitest run lib/onboarding/__tests__/document-requirements.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// lib/onboarding/document-requirements.ts
+// kyc_document_type enum values: id_document, proof_of_address, bank_statement,
+// company_registration, tax_certificate, vat_certificate, director_id, shareholder_agreement, other
+export type KycDocType =
+  | 'id_document' | 'proof_of_address' | 'bank_statement' | 'company_registration'
+  | 'tax_certificate' | 'vat_certificate' | 'director_id' | 'shareholder_agreement' | 'other';
+
+export type B2BSegment = 'unjani' | 'smb' | 'edu';
+
+export interface DocRequirement {
+  type: KycDocType;
+  label: string;
+  required: boolean;
+}
+
+export interface EntityContext {
+  vatRegistered: boolean;
+  entityType: string; // matches wizard step-2 entityType options
+}
+
+/** Required supporting documents for a B2B segment, given the entity context. */
+export function requiredDocsFor(_segment: B2BSegment, ctx: EntityContext): DocRequirement[] {
+  const isSoleProp = ctx.entityType === 'Sole Proprietor';
+  const docs: DocRequirement[] = [];
+  if (isSoleProp) {
+    docs.push({ type: 'director_id', label: 'Owner ID document', required: true });
+  } else {
+    docs.push({ type: 'company_registration', label: 'CIPC registration certificate', required: true });
+    docs.push({ type: 'director_id', label: 'Director / owner ID', required: true });
+  }
+  docs.push({ type: 'bank_statement', label: 'Bank confirmation letter or statement', required: true });
+  docs.push({ type: 'proof_of_address', label: 'Proof of business address', required: true });
+  if (ctx.vatRegistered) {
+    docs.push({ type: 'vat_certificate', label: 'VAT registration certificate', required: true });
+  }
+  return docs;
+}
+
+export type VettingStatus = 'not_started' | 'documents_pending' | 'under_review' | 'approved' | 'rejected' | 'expired';
+
+interface DocStatusRow { document_type: string; verification_status: string }
+
+/** Roll up per-document statuses into the account-level vetting status. */
+export function computeVettingStatus(requiredTypes: string[], docs: DocStatusRow[]): VettingStatus {
+  if (docs.length === 0) return 'documents_pending';
+  if (docs.some(d => d.verification_status === 'rejected')) return 'rejected';
+  const statusByType = new Map(docs.map(d => [d.document_type, d.verification_status]));
+  const allApproved = requiredTypes.every(t => statusByType.get(t) === 'approved');
+  if (allApproved) return 'approved';
+  return 'under_review';
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run lib/onboarding/__tests__/document-requirements.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/onboarding/document-requirements.ts lib/onboarding/__tests__/document-requirements.test.ts
+git commit -m "feat(onboarding): document-requirements config + vetting rollup"
+```
+
+---
+
+## Task 4: Pro-rata + eMandate request builder (pure logic, TDD)
+
+**Files:**
+- Create: `lib/onboarding/prorata.ts`
+- Create: `lib/onboarding/emandate-request.ts`
+- Test: `lib/onboarding/__tests__/prorata.test.ts`
+- Test: `lib/onboarding/__tests__/emandate-request.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// lib/onboarding/__tests__/prorata.test.ts
+import { describe, it, expect } from 'vitest';
+import { computeProRata } from '../prorata';
+
+describe('computeProRata', () => {
+  it('charges full month when activation is on the billing day', () => {
+    const r = computeProRata({ monthlyExVat: 450, vatPct: 15, activationDate: '2026-07-01', billingDay: 1 });
+    expect(r.days).toBe(31);
+    expect(r.daysInMonth).toBe(31);
+    expect(r.amountInclVat).toBeCloseTo(517.5, 2);
+  });
+  it('pro-rates a mid-month activation', () => {
+    // Activation 2026-07-16, next billing day 1 Aug -> 16 days remaining in July (16..31)
+    const r = computeProRata({ monthlyExVat: 450, vatPct: 15, activationDate: '2026-07-16', billingDay: 1 });
+    expect(r.days).toBe(16);
+    expect(r.daysInMonth).toBe(31);
+    expect(r.amountInclVat).toBeCloseTo(517.5 * 16 / 31, 2);
+  });
+});
+```
+
+```typescript
+// lib/onboarding/__tests__/emandate-request.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildEMandateRequest } from '../emandate-request';
+
+describe('buildEMandateRequest', () => {
+  const base = {
+    accountNumber: 'CT-2026-00020',
+    paymentMethodId: 'pm-uuid',
+    submissionId: 'sub-uuid',
+    accountHolder: 'Lens Ext 10 Clinic',
+    isConsumer: false,
+    entityName: 'Lens Ext 10 (Pty) Ltd',
+    registrationNumber: '2019/123456/07',
+    mobile: '0718988722',
+    bank: 'Capitec', accountType: 'Savings', accountNumber2: '1234567890', branchCode: '470010',
+    monthlyExVat: 450, vatPct: 15, paymentDay: '1', agreementDate: '2026-07-01',
+  };
+  it('maps amount incl VAT and carries linkage in custom fields', () => {
+    const r = buildEMandateRequest(base as any);
+    expect(r.accountReference).toBe('CT-2026-00020');
+    expect(r.mandateAmount).toBeCloseTo(517.5, 2);
+    expect(r.isConsumer).toBe(false);
+    expect(r.field1).toBe('pm-uuid');
+    expect(r.field2).toBe('sub-uuid');
+    expect(r.commencementDay).toBe('1');
+    expect(r.bankDetailType).toBe(1);
+    expect(r.bankAccountType).toBe(2); // Savings -> 2
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npx vitest run lib/onboarding/__tests__/prorata.test.ts lib/onboarding/__tests__/emandate-request.test.ts`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Implement prorata**
+
+```typescript
+// lib/onboarding/prorata.ts
+export interface ProRataInput {
+  monthlyExVat: number;
+  vatPct: number;
+  activationDate: string; // YYYY-MM-DD
+  billingDay: number;     // 1..28
+}
+export interface ProRataResult {
+  days: number;
+  daysInMonth: number;
+  amountExVat: number;
+  amountInclVat: number;
+}
+
+/**
+ * First-invoice pro-rata: days from activation (inclusive) to the end of the
+ * activation month, charged as a fraction of that month. Recurring months are full.
+ */
+export function computeProRata(input: ProRataInput): ProRataResult {
+  const act = new Date(input.activationDate + 'T00:00:00Z');
+  const year = act.getUTCFullYear();
+  const month = act.getUTCMonth();
+  const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  const actDay = act.getUTCDate();
+  const days = daysInMonth - actDay + 1; // inclusive of activation day
+  const inclFull = input.monthlyExVat * (1 + input.vatPct / 100);
+  const amountInclVat = inclFull * days / daysInMonth;
+  const amountExVat = input.monthlyExVat * days / daysInMonth;
+  return { days, daysInMonth, amountExVat, amountInclVat };
+}
+```
+
+- [ ] **Step 4: Implement emandate-request**
+
+```typescript
+// lib/onboarding/emandate-request.ts
+import type { EMandateBatchRequest } from '@/lib/payments/netcash-emandate-batch-service';
+
+export interface EMandateBuildInput {
+  accountNumber: string;       // -> accountReference + field3
+  paymentMethodId: string;     // -> field1
+  submissionId: string;        // -> field2
+  accountHolder: string;
+  isConsumer: boolean;
+  entityName: string;
+  registrationNumber?: string;
+  mobile: string;
+  bank: string;
+  accountType: string;         // 'Cheque / Current' | 'Savings' | 'Transmission'
+  accountNumber2: string;      // bank account number
+  branchCode: string;
+  monthlyExVat: number;
+  vatPct: number;
+  paymentDay: string;          // '1' | '15' | '20' | '25'
+  agreementDate: string;       // YYYY-MM-DD (service activation / acceptance date)
+}
+
+/** Map onboarding submission data to a NetCash EMandateBatchRequest. */
+export function buildEMandateRequest(i: EMandateBuildInput): EMandateBatchRequest {
+  const amountInclVat = Number((i.monthlyExVat * (1 + i.vatPct / 100)).toFixed(2));
+  const agreement = new Date(i.agreementDate + 'T00:00:00Z');
+  // Commencement month = the month the first debit should run (next month after agreement)
+  const commencementMonth = ((agreement.getUTCMonth() + 1) % 12) + 1;
+  const [first = '', ...rest] = i.accountHolder.trim().split(/\s+/);
+  return {
+    accountReference: i.accountNumber.substring(0, 22),
+    mandateName: i.accountHolder.substring(0, 50),
+    isConsumer: i.isConsumer,
+    firstName: first,
+    surname: rest.join(' ') || i.entityName.substring(0, 50),
+    mobileNumber: i.mobile,
+    mandateAmount: amountInclVat,
+    debitFrequency: 1, // monthly
+    commencementMonth,
+    commencementDay: i.paymentDay,
+    agreementDate: agreement,
+    agreementReference: `CT-UNJ-${i.accountNumber}`.substring(0, 50),
+    sendMandate: true,
+    tradingName: i.isConsumer ? undefined : i.entityName.substring(0, 50),
+    registrationNumber: i.isConsumer ? undefined : i.registrationNumber,
+    registeredName: i.isConsumer ? undefined : i.entityName.substring(0, 50),
+    bankDetailType: 1,
+    bankAccountName: i.accountHolder.substring(0, 50),
+    bankAccountType: i.accountType.toLowerCase().startsWith('savings') ? 2 : 1,
+    branchCode: i.branchCode,
+    bankAccountNumber: i.accountNumber2,
+    field1: i.paymentMethodId,
+    field2: i.submissionId,
+    field3: i.accountNumber,
+  };
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `npx vitest run lib/onboarding/__tests__/prorata.test.ts lib/onboarding/__tests__/emandate-request.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/onboarding/prorata.ts lib/onboarding/emandate-request.ts lib/onboarding/__tests__/prorata.test.ts lib/onboarding/__tests__/emandate-request.test.ts
+git commit -m "feat(onboarding): pro-rata calc + NetCash eMandate request builder"
+```
+
+> **Note:** `buildEMandateRequest` uses NetCash custom fields `field1/field2/field3` to carry `paymentMethodId/submissionId/accountNumber`. Before relying on these in the webhook (Task 8 of the spec / Task 9 below), confirm NetCash echoes custom fields back on the mandate postback. If it does NOT, the webhook must match on `agreementReference`/`accountReference` (`CT-UNJ-<account_number>`) instead — both are present, so this is a safe fallback.
+
+---
+
+## Task 5: Onboarding access — token issue + verify + clinic pre-fill
+
+**Files:**
+- Create: `lib/onboarding/onboarding-service.ts` (shared server helpers)
+- Create: `app/api/admin/unjani/send-link/route.ts`
+- Create: `app/api/onboarding/get-clinic/route.ts`
+- Test: `lib/onboarding/__tests__/onboarding-service.test.ts`
+
+- [ ] **Step 1: Write failing test for the link builder helper**
+
+```typescript
+// lib/onboarding/__tests__/onboarding-service.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildMagicLinkUrl } from '../onboarding-service';
+
+describe('buildMagicLinkUrl', () => {
+  it('builds an absolute onboarding URL from base + token', () => {
+    expect(buildMagicLinkUrl('https://www.circletel.co.za', 'TOK')).toBe(
+      'https://www.circletel.co.za/onboarding/TOK'
+    );
+  });
+  it('strips a trailing slash on base', () => {
+    expect(buildMagicLinkUrl('https://www.circletel.co.za/', 'TOK')).toBe(
+      'https://www.circletel.co.za/onboarding/TOK'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npx vitest run lib/onboarding/__tests__/onboarding-service.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement onboarding-service**
+
+```typescript
+// lib/onboarding/onboarding-service.ts
+import { createClient } from '@supabase/supabase-js';
+import { generateToken, hashToken, tokenExpiry } from './token-service';
+
+export function svc() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  );
+}
+
+export function buildMagicLinkUrl(base: string, token: string): string {
+  return `${base.replace(/\/+$/, '')}/onboarding/${token}`;
+}
+
+/** Issue a fresh single-use token for a customer; returns the plaintext token. */
+export async function issueToken(customerId: string, sentVia: string): Promise<string> {
+  const supabase = svc();
+  const token = generateToken();
+  const { error } = await supabase.from('onboarding_tokens').insert({
+    customer_id: customerId,
+    token_hash: hashToken(token),
+    expires_at: tokenExpiry(),
+    sent_via: sentVia,
+    sent_at: new Date().toISOString(),
+  });
+  if (error) throw new Error(`Failed to issue token: ${error.message}`);
+  return token;
+}
+
+/** Resolve a plaintext token to a customer id, enforcing expiry + single use. */
+export async function resolveToken(token: string): Promise<{ customerId: string; tokenId: string } | null> {
+  const supabase = svc();
+  const { data, error } = await supabase
+    .from('onboarding_tokens')
+    .select('id, customer_id, expires_at, used_at')
+    .eq('token_hash', hashToken(token))
+    .maybeSingle();
+  if (error || !data) return null;
+  if (data.used_at) return null;
+  if (new Date(data.expires_at).getTime() < Date.now()) return null;
+  return { customerId: data.customer_id, tokenId: data.id };
+}
+
+/** Pre-fill payload for the wizard from the existing customer record. */
+export async function getClinicPrefill(customerId: string) {
+  const supabase = svc();
+  const { data: c, error } = await supabase
+    .from('customers')
+    .select('id, account_number, business_name, business_registration, tax_number, email, phone, onboarding_status, clinic_details')
+    .eq('id', customerId)
+    .single();
+  if (error || !c) return null;
+  const { data: svcRow } = await supabase
+    .from('customer_services')
+    .select('monthly_price, billing_day, activation_date')
+    .eq('customer_id', customerId)
+    .limit(1)
+    .maybeSingle();
+  return { customer: c, service: svcRow };
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run lib/onboarding/__tests__/onboarding-service.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Implement admin send-link route**
+
+```typescript
+// app/api/admin/unjani/send-link/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { issueToken, buildMagicLinkUrl } from '@/lib/onboarding/onboarding-service';
+import { sendSms } from '@/lib/integrations/clickatell/sms-service'; // verify path; see Step 6
+import { svc } from '@/lib/onboarding/onboarding-service';
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticateAdmin(request);
+  if (!auth.success) return auth.response;
+  const perm = requirePermission(auth.adminUser, ['customers:write', 'kyc:verify']);
+  if (perm) return perm;
+
+  const { customerId, channel = 'sms' } = await request.json();
+  if (!customerId) return NextResponse.json({ success: false, error: 'customerId required' }, { status: 400 });
+
+  const supabase = svc();
+  const { data: customer } = await supabase
+    .from('customers').select('id, phone, email, business_name').eq('id', customerId).single();
+  if (!customer) return NextResponse.json({ success: false, error: 'Customer not found' }, { status: 404 });
+
+  const token = await issueToken(customerId, channel);
+  const base = process.env.NEXT_PUBLIC_APP_URL || 'https://www.circletel.co.za';
+  const url = buildMagicLinkUrl(base, token);
+
+  // Send via the chosen channel. SMS shown; swap for WhatsApp/email per project helpers.
+  if (channel === 'sms' && customer.phone) {
+    await sendSms(customer.phone, `CircleTel: complete your billing setup for ${customer.business_name}: ${url} (link valid 7 days)`);
+  }
+  await supabase.from('customers').update({ onboarding_status: 'in_progress' }).eq('id', customerId).eq('onboarding_status', 'pending');
+
+  return NextResponse.json({ success: true, url });
+}
+```
+
+- [ ] **Step 6: Confirm the SMS helper export**
+
+Run: `grep -rn "export" lib/integrations/clickatell/*.ts | grep -i "sms\|send" | head`
+If the export name differs (e.g. `ClickatellService.send`), update the import in Step 5 accordingly. Do not invent — use the real export.
+
+- [ ] **Step 7: Implement public get-clinic route (token-scoped)**
+
+```typescript
+// app/api/onboarding/get-clinic/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveToken, getClinicPrefill } from '@/lib/onboarding/onboarding-service';
+
+export async function GET(request: NextRequest) {
+  const token = new URL(request.url).searchParams.get('token');
+  if (!token) return NextResponse.json({ error: 'token required' }, { status: 400 });
+  const resolved = await resolveToken(token);
+  if (!resolved) return NextResponse.json({ error: 'invalid_or_expired' }, { status: 401 });
+  const prefill = await getClinicPrefill(resolved.customerId);
+  if (!prefill) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  if (prefill.customer.onboarding_status === 'billing_ready') {
+    return NextResponse.json({ alreadyComplete: true });
+  }
+  return NextResponse.json({ ...prefill });
+}
+```
+
+- [ ] **Step 8: Type-check + commit**
+
+```bash
+npm run type-check:memory
+git add lib/onboarding/onboarding-service.ts lib/onboarding/__tests__/onboarding-service.test.ts app/api/admin/unjani/send-link/route.ts app/api/onboarding/get-clinic/route.ts
+git commit -m "feat(onboarding): token issue/resolve, admin send-link, clinic pre-fill API"
+```
+
+---
+
+## Task 6: Wizard UI (magic-link landing + 6 steps)
+
+> Reuse `components/order/OrderWizard.tsx` for the stepper/nav (props: `currentStep`, `steps:{number,title,description}[]`, `onNext`, `onPrevious`, `canGoNext`, `isSubmitting`, `currentStep===steps.length` shows "Complete Order"). Field sets come verbatim from the reference HTML's `unjani` profile. Brand classes already exist (`bg-circleTel-orange`).
+
+**Files:**
+- Create: `app/onboarding/[token]/page.tsx` (server: nothing secret; renders client wizard)
+- Create: `app/onboarding/components/OnboardingWizard.tsx` (client orchestrator)
+- Create: `app/onboarding/components/useOnboardingState.ts` (client state hook)
+- Create: `app/onboarding/components/steps/Step1Clinic.tsx`, `Step2Business.tsx`, `Step3Banking.tsx`, `Step4Documents.tsx`, `Step5ServiceOrder.tsx`, `Step6Done.tsx`
+- Create: `lib/onboarding/schemas.ts` (Zod per step)
+
+- [ ] **Step 1: Zod schemas (one per step)**
+
+```typescript
+// lib/onboarding/schemas.ts
+import { z } from 'zod';
+
+export const step1Schema = z.object({
+  clinicName: z.string().min(3),
+  unjaniAcc: z.string().min(2),
+  province: z.string().min(2),
+  contact: z.string().min(2),
+  phone: z.string().min(9),
+  email: z.string().email(),
+  siteAddress: z.string().min(5),
+  lat: z.string().optional(),
+  lng: z.string().optional(),
+});
+
+export const step2Schema = z.object({
+  entityName: z.string().min(2),
+  entityType: z.string().min(2),
+  regNumber: z.string().min(4),         // CIPC reg OR owner ID (sole prop)
+  vat: z.enum(['No', 'Yes']),
+  vatNumber: z.string().optional(),
+  regAddress: z.string().min(5),
+}).refine(v => v.vat === 'No' || (v.vatNumber && v.vatNumber.length >= 9), {
+  message: 'VAT number required when VAT registered', path: ['vatNumber'],
+});
+
+export const step3Schema = z.object({
+  accHolder: z.string().min(2),
+  bank: z.string().min(2),
+  accType: z.string().min(2),
+  accNumber: z.string().min(6),
+  branchCode: z.string().min(5),
+  mandate: z.literal(true),             // DebiCheck consent checkbox
+});
+
+export const step5Schema = z.object({
+  paymentDate: z.enum(['1', '15', '20', '25']),
+  soAccept: z.literal(true),
+});
+
+export type Step1 = z.infer<typeof step1Schema>;
+export type Step2 = z.infer<typeof step2Schema>;
+export type Step3 = z.infer<typeof step3Schema>;
+export type Step5 = z.infer<typeof step5Schema>;
+```
+
+- [ ] **Step 2: State hook**
+
+```typescript
+// app/onboarding/components/useOnboardingState.ts
+'use client';
+import { useState } from 'react';
+
+export interface OnboardingState {
+  clinic: any; service: any;            // from get-clinic
+  step1: any; step2: any; step3: any;
+  documents: Record<string, { documentId: string; fileName: string } | undefined>;
+  step5: { paymentDate: '1'|'15'|'20'|'25'; soAccept: boolean };
+}
+
+export function useOnboardingState(prefill: { customer: any; service: any }) {
+  const [current, setCurrent] = useState(1);
+  const [state, setState] = useState<OnboardingState>({
+    clinic: prefill.customer,
+    service: prefill.service,
+    step1: {
+      clinicName: prefill.customer.business_name?.replace('Unjani Clinic - ', '') ?? '',
+      unjaniAcc: prefill.customer.clinic_details?.unjani_account ?? '',
+      province: prefill.customer.clinic_details?.province ?? '',
+      contact: prefill.customer.clinic_details?.nurse_owner_name ?? '',
+      phone: prefill.customer.phone ?? '',
+      email: prefill.customer.email ?? '',
+      siteAddress: prefill.customer.clinic_details?.site_address ?? '',
+      lat: '', lng: '',
+    },
+    step2: { entityName: prefill.customer.business_name ?? '', entityType: '', regNumber: '', vat: 'No', vatNumber: '', regAddress: '' },
+    step3: { accHolder: '', bank: '', accType: '', accNumber: '', branchCode: '', mandate: false },
+    documents: {},
+    step5: { paymentDate: '1', soAccept: false },
+  });
+  const patch = (key: keyof OnboardingState, value: any) => setState(s => ({ ...s, [key]: value }));
+  return { current, setCurrent, state, patch, setState };
+}
+```
+
+- [ ] **Step 3: Step components**
+
+Build `Step1Clinic`, `Step2Business`, `Step3Banking`, `Step5ServiceOrder` as controlled forms rendering the exact fields from `lib/onboarding/schemas.ts` (and the reference HTML's `unjani` profile), each calling `onChange(patchedValues)` up to the orchestrator. Specifics:
+- **Step1:** pre-filled inputs with an "on record" badge; lat/lng optional.
+- **Step2:** when `entityType === 'Sole Proprietor'`, relabel `regNumber` to "Owner ID number" (13-digit) per reference. Show `vatNumber` only when `vat==='Yes'`.
+- **Step3:** `bank` select (`Absa, Capitec, FNB, Investec, Nedbank, Standard Bank, TymeBank, Other`), `accType` select (`Cheque / Current, Savings, Transmission`), DebiCheck consent checkbox. Show an inline warning if `accHolder` differs from `step2.entityName` (case-insensitive, trimmed): "Account holder should match your registered entity — name mismatches are the main cause of mandate rejection."
+- **Step4Documents:** see Step 4 below.
+- **Step5ServiceOrder:** payment-date pills (`1/15/20/25`), order line "CircleTel ClinicConnect — R450 ex / R517.50 incl", live pro-rata from `computeProRata({monthlyExVat: service.monthly_price, vatPct:15, activationDate: service.activation_date, billingDay: Number(paymentDate)})`, collapsible Service Order T&Cs (clauses verbatim from reference), accept checkbox.
+- **Step6Done:** success tick + `clinic.account_number` + "what happens next" list + "we're vetting your documents".
+
+Each form validates with its Zod schema on Next; `canGoNext` is the schema's `safeParse(...).success`.
+
+- [ ] **Step 4: Documents step (reuse upload pattern)**
+
+```tsx
+// app/onboarding/components/steps/Step4Documents.tsx
+'use client';
+import { useState } from 'react';
+import { requiredDocsFor } from '@/lib/onboarding/document-requirements';
+
+export function Step4Documents({ token, submissionId, step2, documents, onChange }: {
+  token: string; submissionId: string | null; step2: any;
+  documents: Record<string, any>; onChange: (docs: Record<string, any>) => void;
+}) {
+  const required = requiredDocsFor('unjani', { vatRegistered: step2.vat === 'Yes', entityType: step2.entityType });
+  const [busy, setBusy] = useState<string | null>(null);
+
+  async function upload(docType: string, file: File) {
+    setBusy(docType);
+    const fd = new FormData();
+    fd.append('file', file);
+    fd.append('token', token);
+    fd.append('documentType', docType);
+    const res = await fetch('/api/onboarding/upload-document', { method: 'POST', body: fd });
+    const json = await res.json();
+    setBusy(null);
+    if (json.success) onChange({ ...documents, [docType]: { documentId: json.documentId, fileName: file.name } });
+    else alert(json.error || 'Upload failed');
+  }
+
+  return (
+    <div className="space-y-4">
+      {required.map(d => (
+        <div key={d.type} className="flex items-center justify-between border rounded-lg p-4">
+          <div>
+            <p className="font-semibold">{d.label}{d.required && <span className="text-red-600"> *</span>}</p>
+            {documents[d.type] && <p className="text-sm text-green-600">Uploaded: {documents[d.type].fileName}</p>}
+          </div>
+          <input type="file" accept="application/pdf,image/jpeg,image/png" disabled={busy===d.type}
+            onChange={e => e.target.files?.[0] && upload(d.type, e.target.files[0])} />
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+`canGoNext` for Step 4 = every `required.filter(r=>r.required)` type present in `documents`.
+
+- [ ] **Step 5: Orchestrator + landing page**
+
+`OnboardingWizard.tsx` (client): fetch `/api/onboarding/get-clinic?token=...` on mount; if `alreadyComplete` show "already set up"; else render `OrderWizard` with 6 steps and the active step component; on final "Complete Order" POST `/api/onboarding/submit` (Task 7) and advance to Step6Done with the returned account number. **Documents must attach to a submission** — call submit at the END so the submission exists, but documents upload in Step 4 BEFORE submit. Resolve this ordering by creating a `draft` submission when the wizard loads (POST `/api/onboarding/submit` with `{mode:'draft'}` returns `submissionId`), then uploads reference that `submissionId`, then final submit updates it to `submitted`. The orchestrator stores `submissionId` in state.
+
+`app/onboarding/[token]/page.tsx`:
+```tsx
+import { OnboardingWizard } from '../components/OnboardingWizard';
+export default async function Page({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  return <main className="max-w-3xl mx-auto px-4 py-8"><OnboardingWizard token={token} /></main>;
+}
+```
+
+- [ ] **Step 6: Type-check + commit**
+
+```bash
+npm run type-check:memory
+git add app/onboarding lib/onboarding/schemas.ts
+git commit -m "feat(onboarding): 6-step clinic wizard (magic-link landing + steps)"
+```
+
+---
+
+## Task 7: Submit API + document upload (write-back + create payment method + create kyc_documents + fire eMandate)
+
+**Files:**
+- Create: `app/api/onboarding/submit/route.ts`
+- Create: `app/api/onboarding/upload-document/route.ts`
+
+- [ ] **Step 1: Implement upload-document (token-scoped, onboarding submission)**
+
+```typescript
+// app/api/onboarding/upload-document/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveToken, svc } from '@/lib/onboarding/onboarding-service';
+import { uploadFile } from '@/lib/storage/supabase-upload';
+
+export async function POST(request: NextRequest) {
+  const supabase = svc();
+  const form = await request.formData();
+  const token = form.get('token') as string;
+  const documentType = form.get('documentType') as string;
+  const submissionId = form.get('submissionId') as string | null;
+  const file = form.get('file') as File;
+  if (!token || !documentType || !file) return NextResponse.json({ success: false, error: 'token, documentType, file required' }, { status: 400 });
+
+  const resolved = await resolveToken(token);
+  if (!resolved) return NextResponse.json({ success: false, error: 'invalid_or_expired' }, { status: 401 });
+
+  const { data: customer } = await supabase
+    .from('customers').select('business_name, email, phone').eq('id', resolved.customerId).single();
+
+  const up = await uploadFile(file, {
+    bucket: 'kyc-documents',
+    folder: `onboarding/${resolved.customerId}/${documentType}`,
+    maxSizeBytes: 5 * 1024 * 1024,
+    allowedTypes: ['image/jpeg', 'image/jpg', 'image/png', 'application/pdf'],
+    supabaseClient: supabase,
+  });
+  if (!up.success) return NextResponse.json({ success: false, error: up.error }, { status: 500 });
+
+  const { data: doc, error } = await supabase.from('kyc_documents').insert({
+    customer_type: 'business',
+    customer_id: resolved.customerId,
+    onboarding_submission_id: submissionId || null,
+    company_name: customer?.business_name ?? null,
+    customer_email: customer?.email ?? null,
+    customer_phone: customer?.phone ?? null,
+    document_type: documentType,
+    file_name: file.name,
+    file_path: up.path,
+    file_size: file.size,
+    file_type: file.type,
+    verification_status: 'pending',
+    is_sensitive: true,
+  }).select('id').single();
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+
+  return NextResponse.json({ success: true, documentId: doc.id });
+}
+```
+> If `customer_type` enum rejects `'business'`, run `SELECT enum_range(NULL::kyc_customer_type);` and use the correct label.
+
+- [ ] **Step 2: Implement submit (draft + final modes)**
+
+```typescript
+// app/api/onboarding/submit/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveToken, svc } from '@/lib/onboarding/onboarding-service';
+import { step1Schema, step2Schema, step3Schema, step5Schema } from '@/lib/onboarding/schemas';
+import { requiredDocsFor } from '@/lib/onboarding/document-requirements';
+import { buildEMandateRequest } from '@/lib/onboarding/emandate-request';
+import { NetCashEMandateBatchService } from '@/lib/payments/netcash-emandate-batch-service';
+
+export async function POST(request: NextRequest) {
+  const supabase = svc();
+  const body = await request.json();
+  const { token, mode } = body;
+  const resolved = await resolveToken(token);
+  if (!resolved) return NextResponse.json({ success: false, error: 'invalid_or_expired' }, { status: 401 });
+  const customerId = resolved.customerId;
+
+  // DRAFT: create (or return existing) a submission so document uploads have an anchor
+  if (mode === 'draft') {
+    const { data: existing } = await supabase.from('onboarding_submissions')
+      .select('id').eq('customer_id', customerId).eq('status', 'submitted').maybeSingle();
+    if (existing) return NextResponse.json({ success: true, submissionId: existing.id });
+    const { data, error } = await supabase.from('onboarding_submissions')
+      .insert({ customer_id: customerId, segment: 'unjani', status: 'draft' }).select('id').single();
+    if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+    return NextResponse.json({ success: true, submissionId: data.id });
+  }
+
+  // FINAL: validate all steps
+  const s1 = step1Schema.safeParse(body.step1);
+  const s2 = step2Schema.safeParse(body.step2);
+  const s3 = step3Schema.safeParse(body.step3);
+  const s5 = step5Schema.safeParse(body.step5);
+  if (!s1.success || !s2.success || !s3.success || !s5.success) {
+    return NextResponse.json({ success: false, error: 'validation_failed' }, { status: 400 });
+  }
+  const submissionId = body.submissionId as string;
+
+  // Require all mandatory documents present
+  const required = requiredDocsFor('unjani', { vatRegistered: s2.data.vat === 'Yes', entityType: s2.data.entityType });
+  const { data: docs } = await supabase.from('kyc_documents')
+    .select('document_type').eq('onboarding_submission_id', submissionId);
+  const have = new Set((docs ?? []).map(d => d.document_type));
+  const missing = required.filter(r => r.required && !have.has(r.type));
+  if (missing.length) return NextResponse.json({ success: false, error: 'documents_missing', missing: missing.map(m => m.type) }, { status: 400 });
+
+  // 1) Enrich customer
+  await supabase.from('customers').update({
+    business_name: s2.data.entityName,
+    business_registration: s2.data.regNumber,
+    tax_number: s2.data.vat === 'Yes' ? s2.data.vatNumber : null,
+    onboarding_status: 'submitted',
+    clinic_details: {
+      clinic_name: s1.data.clinicName, unjani_account: s1.data.unjaniAcc, province: s1.data.province,
+      nurse_owner_name: s1.data.contact, site_address: s1.data.siteAddress, lat: s1.data.lat, lng: s1.data.lng,
+    },
+  }).eq('id', customerId);
+
+  // 2) Set chosen billing day on the service
+  await supabase.from('customer_services').update({ billing_day: Number(s5.data.paymentDate) }).eq('customer_id', customerId);
+
+  // 3) Create payment method (mandate pending, NOT verified yet)
+  const { data: pm } = await supabase.from('customer_payment_methods').insert({
+    customer_id: customerId,
+    onboarding_submission_id: submissionId,
+    method_type: 'debit_order',
+    display_name: `DebiCheck - ${s3.data.bank} ****${s3.data.accNumber.slice(-4)}`,
+    last_four: s3.data.accNumber.slice(-4),
+    encrypted_details: {
+      bank_name: s3.data.bank, account_holder_name: s3.data.accHolder, account_type: s3.data.accType,
+      account_number: s3.data.accNumber, branch_code: s3.data.branchCode, verified: false,
+    },
+    mandate_status: 'pending', is_primary: true, is_active: true,
+  }).select('id').single();
+
+  // 4) Finalize submission
+  await supabase.from('onboarding_submissions').update({
+    status: 'submitted', document_vetting_status: 'documents_pending',
+    submission_data: { step1: s1.data, step2: s2.data, step3: { ...s3.data, accNumber: `****${s3.data.accNumber.slice(-4)}` }, step5: s5.data },
+  }).eq('id', submissionId);
+
+  // 5) Mark token used (single-use)
+  await supabase.from('onboarding_tokens').update({ used_at: new Date().toISOString() }).eq('id', resolved.tokenId);
+
+  // 6) Fire NetCash eMandate (best-effort; do not fail the submission on transient errors)
+  const { data: cust } = await supabase.from('customers').select('account_number').eq('id', customerId).single();
+  const { data: svcRow } = await supabase.from('customer_services').select('monthly_price, activation_date').eq('customer_id', customerId).maybeSingle();
+  let fileToken: string | undefined;
+  try {
+    const req = buildEMandateRequest({
+      accountNumber: cust!.account_number, paymentMethodId: pm!.id, submissionId,
+      accountHolder: s3.data.accHolder, isConsumer: false, entityName: s2.data.entityName,
+      registrationNumber: s2.data.regNumber, mobile: s1.data.phone, bank: s3.data.bank,
+      accountType: s3.data.accType, accountNumber2: s3.data.accNumber, branchCode: s3.data.branchCode,
+      monthlyExVat: Number(svcRow?.monthly_price ?? 450), vatPct: 15, paymentDay: s5.data.paymentDate,
+      agreementDate: new Date().toISOString().slice(0, 10),
+    });
+    const result = await new NetCashEMandateBatchService().submitMandate(req);
+    if (result.success) {
+      fileToken = result.fileToken;
+      await supabase.from('onboarding_submissions').update({ netcash_file_token: fileToken }).eq('id', submissionId);
+    }
+  } catch (e) {
+    console.error('[Onboarding] eMandate submit error', e);
+  }
+
+  return NextResponse.json({ success: true, accountNumber: cust!.account_number, eMandateSent: !!fileToken });
+}
+```
+
+- [ ] **Step 3: Manual verification (one clinic, end to end up to submit)**
+
+Issue a token for `CT-2026-00020` (MCP `execute_sql` to read its `customers.id`, then call send-link or insert a token via the service). Open `/onboarding/<token>`, complete all steps with a test PDF per required doc. Then verify:
+```sql
+SELECT onboarding_status, business_registration, tax_number FROM customers WHERE account_number='CT-2026-00020';
+SELECT mandate_status, is_primary, encrypted_details->>'verified' FROM customer_payment_methods WHERE customer_id=(SELECT id FROM customers WHERE account_number='CT-2026-00020');
+SELECT status, document_vetting_status, netcash_file_token FROM onboarding_submissions WHERE customer_id=(SELECT id FROM customers WHERE account_number='CT-2026-00020');
+SELECT document_type, verification_status FROM kyc_documents WHERE customer_id=(SELECT id FROM customers WHERE account_number='CT-2026-00020');
+```
+Expected: customer `submitted` + reg/vat filled; payment method `pending`, `verified=false`; submission `submitted`/`documents_pending`; one `pending` kyc_documents row per required type.
+
+- [ ] **Step 4: Type-check + commit**
+
+```bash
+npm run type-check:memory
+git add app/api/onboarding/submit/route.ts app/api/onboarding/upload-document/route.ts
+git commit -m "feat(onboarding): submit write-back + document upload + eMandate trigger"
+```
+
+---
+
+## Task 8: Generalize the admin vetting backend + B2B vetting queue
+
+**Files:**
+- Modify: `app/api/admin/kyc/verify/route.ts`
+- Create: `app/api/admin/b2b/vetting/route.ts` (queue list)
+- Create: `app/api/admin/b2b/vetting/[submissionId]/route.ts` (detail)
+- Create: `app/admin/b2b/vetting/page.tsx` (queue UI)
+- Create: `app/admin/b2b/vetting/[submissionId]/page.tsx` (detail UI)
+
+- [ ] **Step 1: Generalize the verify route rollup**
+
+The existing route updates document status then, for consumer orders, checks "all approved → `consumer_orders.status='kyc_approved'`". Add a branch: when the document carries an `onboarding_submission_id`, roll up via `computeVettingStatus` over that submission's required docs instead. Replace the post-update block (after the `kyc_documents` update succeeds) with:
+
+```typescript
+import { computeVettingStatus, requiredDocsFor } from '@/lib/onboarding/document-requirements';
+// ...after the kyc_documents update...
+
+// Re-fetch the document to learn its scope
+const { data: scope } = await supabase
+  .from('kyc_documents')
+  .select('consumer_order_id, onboarding_submission_id')
+  .eq('id', documentId).single();
+
+if (scope?.onboarding_submission_id) {
+  // B2B onboarding rollup
+  const submissionId = scope.onboarding_submission_id;
+  const { data: sub } = await supabase
+    .from('onboarding_submissions')
+    .select('id, customer_id, segment, submission_data')
+    .eq('id', submissionId).single();
+  const { data: subDocs } = await supabase
+    .from('kyc_documents')
+    .select('document_type, verification_status')
+    .eq('onboarding_submission_id', submissionId);
+  const sd = (sub?.submission_data ?? {}) as any;
+  const required = requiredDocsFor(sub?.segment ?? 'unjani', {
+    vatRegistered: sd?.step2?.vat === 'Yes',
+    entityType: sd?.step2?.entityType ?? '',
+  }).filter(r => r.required).map(r => r.type);
+  const vetting = computeVettingStatus(required, subDocs ?? []);
+  await supabase.from('onboarding_submissions').update({
+    document_vetting_status: vetting,
+    status: vetting === 'approved' ? 'approved' : vetting === 'rejected' ? 'rejected' : 'submitted',
+    admin_reviewed_at: new Date().toISOString(),
+    admin_reviewed_by: authResult.adminUser.id,
+  }).eq('id', submissionId);
+  // Attempt to flip billing-ready (only succeeds if mandate already active)
+  await maybeMarkBillingReady(supabase, sub!.customer_id);
+  return NextResponse.json({ success: true, vetting });
+}
+
+// else: existing consumer_orders path (unchanged)
+```
+
+Add a shared helper used by both this route and the webhook (Task 9):
+
+```typescript
+// lib/onboarding/billing-ready.ts
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** Set customers.onboarding_status='billing_ready' iff docs approved AND mandate active+verified. */
+export async function maybeMarkBillingReady(supabase: SupabaseClient, customerId: string): Promise<boolean> {
+  const { data: sub } = await supabase.from('onboarding_submissions')
+    .select('document_vetting_status').eq('customer_id', customerId)
+    .order('submitted_at', { ascending: false }).limit(1).maybeSingle();
+  const { data: pm } = await supabase.from('customer_payment_methods')
+    .select('mandate_status, encrypted_details').eq('customer_id', customerId)
+    .eq('is_active', true).eq('method_type', 'debit_order').maybeSingle();
+  const docsOk = sub?.document_vetting_status === 'approved';
+  const mandateOk = (pm?.mandate_status === 'active' || pm?.mandate_status === 'approved')
+    && (pm?.encrypted_details?.verified === true || pm?.encrypted_details?.verified === 'true');
+  if (docsOk && mandateOk) {
+    await supabase.from('customers').update({
+      onboarding_status: 'billing_ready', onboarding_completed_at: new Date().toISOString(),
+    }).eq('id', customerId);
+    return true;
+  }
+  return false;
+}
+```
+Import `maybeMarkBillingReady` into the verify route. (Note the existing route names its auth result `authResult` — reuse `authResult.adminUser.id`.)
+
+- [ ] **Step 2: Queue list route**
+
+```typescript
+// app/api/admin/b2b/vetting/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: NextRequest) {
+  const auth = await authenticateAdmin(request);
+  if (!auth.success) return auth.response;
+  const perm = requirePermission(auth.adminUser, 'kyc:verify');
+  if (perm) return perm;
+  const supabase = await createClient();
+  const segment = new URL(request.url).searchParams.get('segment');
+  let q = supabase.from('onboarding_submissions')
+    .select('id, customer_id, segment, status, document_vetting_status, submitted_at, customer:customers(account_number, business_name, onboarding_status)')
+    .in('status', ['submitted', 'approved', 'rejected'])
+    .order('submitted_at', { ascending: true });
+  if (segment) q = q.eq('segment', segment);
+  const { data, error } = await q;
+  if (error) return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  return NextResponse.json({ success: true, submissions: data ?? [] });
+}
+```
+
+- [ ] **Step 3: Detail route (documents + entity + banking + name-match)**
+
+```typescript
+// app/api/admin/b2b/vetting/[submissionId]/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ submissionId: string }> }) {
+  const auth = await authenticateAdmin(request);
+  if (!auth.success) return auth.response;
+  const perm = requirePermission(auth.adminUser, 'kyc:verify');
+  if (perm) return perm;
+  const { submissionId } = await ctx.params;
+  const supabase = await createClient();
+  const { data: sub } = await supabase.from('onboarding_submissions')
+    .select('*, customer:customers(account_number, business_name, business_registration, tax_number, onboarding_status)')
+    .eq('id', submissionId).single();
+  const { data: documents } = await supabase.from('kyc_documents')
+    .select('id, document_type, file_name, file_path, verification_status, rejection_reason, verified_at')
+    .eq('onboarding_submission_id', submissionId);
+  const { data: pm } = await supabase.from('customer_payment_methods')
+    .select('display_name, last_four, mandate_status, encrypted_details')
+    .eq('onboarding_submission_id', submissionId).maybeSingle();
+  // name-match flag (account holder vs entity)
+  const holder = (pm?.encrypted_details?.account_holder_name ?? '').trim().toLowerCase();
+  const entity = (sub?.customer?.business_name ?? '').trim().toLowerCase();
+  const nameMatch = holder.length > 0 && holder === entity;
+  return NextResponse.json({ success: true, submission: sub, documents: documents ?? [], paymentMethod: pm, nameMatch });
+}
+```
+
+- [ ] **Step 4: Queue + detail UI**
+
+`app/admin/b2b/vetting/page.tsx`: table of submissions (Account #, Business, Segment, `document_vetting_status` via `components/compliance/KYCStatusBadge.tsx`, doc count, mandate, days waiting), each row links to detail. Use existing admin layout + `StatCard`/`StatusBadge` (props: `StatusBadge` uses `status=`; `StatCard` `icon` is a ReactNode — pass `icon={<PiXxx />}`).
+
+`app/admin/b2b/vetting/[submissionId]/page.tsx`: render the document checklist; per doc, a "View" button calling existing `app/api/admin/kyc/document-url/route.ts` to get a signed URL (reuse `components/admin/kyc/DocumentViewer.tsx`), plus **Approve** / **Reject (reason)** buttons POSTing to `app/api/admin/kyc/verify` with `{ documentId, status, rejectionReason }`. Show read-only entity (reg/VAT) and masked banking with the `nameMatch` warning. Bottom: a status banner reflecting `document_vetting_status`; once `approved` and mandate active, the customer auto-flips to `billing_ready` (no extra button needed because `verify` calls `maybeMarkBillingReady`). Add a "Request changes" control that POSTs `verify` with `status:'under_review'`/reject to set a doc back to re-upload.
+
+- [ ] **Step 5: Manual verification**
+
+In the queue, open the `CT-2026-00020` submission, view each doc, approve all required. Then:
+```sql
+SELECT document_vetting_status, status FROM onboarding_submissions WHERE customer_id=(SELECT id FROM customers WHERE account_number='CT-2026-00020');
+SELECT onboarding_status FROM customers WHERE account_number='CT-2026-00020';
+```
+Expected: submission `approved`; customer still `submitted` (mandate not yet active — flips after Task 9).
+
+- [ ] **Step 6: Type-check + commit**
+
+```bash
+npm run type-check:memory
+git add app/api/admin/kyc/verify/route.ts lib/onboarding/billing-ready.ts app/api/admin/b2b app/admin/b2b
+git commit -m "feat(vetting): generalize KYC verify to onboarding submissions + B2B vetting queue/detail"
+```
+
+---
+
+## Task 9: eMandate webhook fix (mandate active → verified → billing-ready)
+
+**Files:**
+- Locate + Modify: the NetCash eMandate postback handler (spec names `lib/payment/netcash-webhook-processor.ts`)
+- Possibly Modify: the eMandate webhook route under `app/api/`
+
+- [ ] **Step 1: Locate the handler**
+
+Run:
+```bash
+grep -rln "mandate" app/api lib/payment lib/payments lib/integrations | grep -i "webhook\|postback\|notify" 
+grep -rln "payment_methods\b" lib/payment lib/payments app/api | head
+```
+Identify the route that receives NetCash mandate postbacks and the function that currently writes `payment_methods`. Read it before editing.
+
+- [ ] **Step 2: On mandate signed/active, write `customer_payment_methods` (the table the batch reads) + set `verified`**
+
+In the handler's "mandate approved/active" branch, resolve the payment method. Prefer the custom field `field1` (the `customer_payment_methods.id`) if NetCash echoes it; otherwise match by account reference (`field3`/`accountReference` = `customers.account_number`). Then:
+
+```typescript
+import { maybeMarkBillingReady } from '@/lib/onboarding/billing-ready';
+
+// resolve paymentMethodId (by field1) OR customerId (by account_number from field3/accountReference)
+const { data: pm } = await supabase
+  .from('customer_payment_methods')
+  .select('id, customer_id, encrypted_details')
+  .eq(paymentMethodId ? 'id' : 'customer_id', paymentMethodId ?? customerIdFromAccountRef)
+  .eq('method_type', 'debit_order').eq('is_active', true)
+  .order('created_at', { ascending: false }).limit(1).maybeSingle();
+
+if (pm) {
+  await supabase.from('customer_payment_methods').update({
+    mandate_id: netcashMandateRef,
+    mandate_status: 'active',
+    mandate_approved_at: new Date().toISOString(),
+    encrypted_details: { ...(pm.encrypted_details ?? {}), verified: true }, // batch requires verified===true
+  }).eq('id', pm.id);
+
+  // Keep legacy payment_methods in sync for back-compat (existing behaviour stays)
+  // ...existing payment_methods upsert...
+
+  // Flip to billing_ready iff docs already vetted-approved
+  await maybeMarkBillingReady(supabase, pm.customer_id);
+}
+```
+
+On rejection: set `customer_payment_methods.mandate_status='failed'` and `customers.onboarding_status='failed'`, and notify (reuse existing notification service).
+
+- [ ] **Step 3: Verify with a simulated postback**
+
+If the test account still does not deliver postbacks (known blocker), simulate by directly setting the mandate active and calling the helper path. Run via a tsx script or MCP `execute_sql`:
+```sql
+UPDATE customer_payment_methods
+SET mandate_status='active', mandate_approved_at=now(),
+    encrypted_details = jsonb_set(coalesce(encrypted_details,'{}'::jsonb),'{verified}','true')
+WHERE customer_id=(SELECT id FROM customers WHERE account_number='CT-2026-00020');
+```
+Then trigger the billing-ready check (call the webhook handler or run a one-off tsx invoking `maybeMarkBillingReady`). Verify:
+```sql
+SELECT onboarding_status, onboarding_completed_at FROM customers WHERE account_number='CT-2026-00020';
+```
+Expected: `billing_ready` (because docs were approved in Task 8).
+
+- [ ] **Step 4: Commit**
+
+```bash
+npm run type-check:memory
+git add <located webhook files> lib/onboarding/billing-ready.ts
+git commit -m "fix(emandate): write customer_payment_methods + verified flag on mandate active, flip billing-ready"
+```
+
+---
+
+## Task 10: Billing gate + pro-rata first invoice + collection method
+
+**Files:**
+- Modify: `lib/billing/monthly-invoice-generator.ts` (eligibility query + first-invoice amount + payment_collection_method)
+
+- [ ] **Step 1: Gate eligibility on billing-ready (inner join)**
+
+In `getServicesDueForBilling` change the customer join to `!inner` and add the filter so only vetted+mandated clinics bill:
+
+```typescript
+// in the .select(...) string, change:
+//   customer:customers( ... )
+// to:
+//   customer:customers!inner( id, first_name, last_name, email, phone, account_number, onboarding_status )
+// then after .eq('billing_day', billingDay) add:
+      .eq('customers.onboarding_status', 'billing_ready');
+```
+Update the `ServiceToBill` type / mapping to include `customer.onboarding_status` (it is read-only here; no other change).
+
+- [ ] **Step 2: Pro-rata the FIRST invoice and set collection method**
+
+In `processServiceBilling` (where the invoice amount + insert are built), use `last_invoice_date === null` to pick pro-rata vs full, and always set `payment_collection_method='debit_order'`:
+
+```typescript
+import { computeProRata } from '@/lib/onboarding/prorata';
+// when building the invoice amounts:
+const isFirst = service.last_invoice_date === null;
+let subtotalExVat = service.monthly_price;
+if (isFirst && service.activation_date) {
+  subtotalExVat = computeProRata({
+    monthlyExVat: service.monthly_price, vatPct: 15,
+    activationDate: service.activation_date, billingDay: service.billing_day,
+  }).amountExVat;
+}
+const taxAmount = Number((subtotalExVat * 0.15).toFixed(2));
+const totalAmount = Number((subtotalExVat + taxAmount).toFixed(2));
+// include in the customer_invoices insert payload:
+//   subtotal: subtotalExVat, tax_amount: taxAmount, total_amount: totalAmount,
+//   amount_due: totalAmount, amount_paid: 0,
+//   payment_collection_method: 'debit_order',
+```
+Add `activation_date` to the `getServicesDueForBilling` select and to the `ServiceToBill` type if not already present (it is selected as part of `customer_services`; add `activation_date` to the column list).
+
+- [ ] **Step 3: Verify (dry run)**
+
+Run a dry-run generation for `billing_day=1` against the billing-ready clinic only. Use the existing cron/generator entry with `dryRun: true` (e.g. a tsx script calling `new MonthlyInvoiceGenerator().generateMonthlyInvoices({ billingDay: 1, dryRun: true })`). Confirm: only `CT-2026-00020` (billing_ready) is selected; other 19 clinics (`submitted`/`pending`) are excluded; the computed first invoice is pro-rata and carries `payment_collection_method='debit_order'`.
+
+Then confirm the debit-order batch would pick it up (it already filters `payment_collection_method in ('debit_order','Debit Order')` AND requires `customer_payment_methods.encrypted_details.verified===true` + `mandate_status active/approved` — all satisfied after Task 9).
+
+- [ ] **Step 4: Type-check + commit**
+
+```bash
+npm run type-check:memory
+git add lib/billing/monthly-invoice-generator.ts
+git commit -m "feat(billing): gate invoicing on billing_ready + pro-rata first invoice + debit_order collection"
+```
+
+---
+
+## End-to-end verification (whole critical path)
+
+1. `git pull` clean; migration applied (Task 1 verify queries pass).
+2. Admin issues a magic link to `CT-2026-00020`; open `/onboarding/<token>` → fields pre-filled; `alreadyComplete` is false.
+3. Complete all 6 steps incl. a PDF per required document; submit succeeds; Step 6 shows the account number.
+4. DB shows: customer `submitted` + reg/VAT filled; `customer_payment_methods` `pending`+`verified=false`; submission `submitted`/`documents_pending`; one `pending` kyc_documents row per required type; `netcash_file_token` set (or eMandate flagged not-sent if blocker active).
+5. Admin vetting queue lists the clinic; view each doc via signed URL; reject one → it returns to re-upload and submission stays `submitted`; re-upload + approve all → submission `approved`.
+6. Mandate becomes active (real postback or simulated SQL in Task 9) → `customer_payment_methods` `active`+`verified=true` → customer `billing_ready`.
+7. Dry-run `generateMonthlyInvoices({billingDay:1, dryRun:true})` → only `billing_ready` clinic selected, pro-rata first invoice, `payment_collection_method='debit_order'`.
+8. `npm run type-check:memory` clean; all phase tests pass: `npx vitest run lib/onboarding/__tests__`.
+
+---
+
+## Self-review notes (carry into execution)
+
+- **NetCash postback blocker** (test account not delivering eMandate postbacks) gates Task 9 step 3 and the live half of Task 10. Resolve on a working account or use the documented SQL simulation to prove the chain; do not claim live collection until a real postback flips `verified=true`.
+- **Custom-field echo**: confirm NetCash returns `field1/field2/field3` on the postback; the webhook (Task 9) has an account-reference fallback if not.
+- **`customer_type` enum**: verify the `'business'` label exists before relying on it (Task 7 step 1 note).
+- **Reusability**: nothing above is Unjani-specific except `segment:'unjani'` defaults and copy. `requiredDocsFor`, the vetting rollup, the generalized verify route, and the `app/admin/b2b/vetting` queue serve any segment — a future SMB/EduConnect onboarding sets `segment` and reuses all of it.

--- a/lib/billing/monthly-invoice-generator.ts
+++ b/lib/billing/monthly-invoice-generator.ts
@@ -507,7 +507,7 @@ export class MonthlyInvoiceGenerator {
     const vatRate = 15.0;
 
     // Always compute full-month amounts from the existing function on the unchanged price.
-    const { subtotal: fullSubtotal, vatAmount: fullVat, totalAmount: fullTotal } = computeVatInclusiveAmounts(service.monthly_price);
+    const { subtotal: fullSubtotal, vatAmount: fullVat } = computeVatInclusiveAmounts(service.monthly_price);
 
     // Pro-rata first invoice: detect via last_invoice_date === null and apply fraction
     // Only use computeProRata to get days/daysInMonth; ignore its amount fields (VAT base is already set above).

--- a/lib/billing/monthly-invoice-generator.ts
+++ b/lib/billing/monthly-invoice-generator.ts
@@ -23,6 +23,7 @@ import { createClient } from '@/lib/supabase/server';
 import { syncInvoiceToZohoBilling } from '@/lib/integrations/zoho/invoice-sync-service';
 import { computeVatInclusiveAmounts, formatInvoiceNumber, nextInvoiceSequence } from './invoice-amounts';
 import { processPayNowForInvoice } from '@/lib/billing/paynow-billing-service';
+import { computeProRata } from '@/lib/onboarding/prorata';
 import { billingLogger } from '@/lib/logging';
 
 // =============================================================================
@@ -42,6 +43,7 @@ export interface ServiceToBill {
   billing_day: number;
   last_invoice_date: string | null;
   status: string;
+  activation_date: string | null;
   customer: {
     id: string;
     first_name: string | null;
@@ -49,6 +51,7 @@ export interface ServiceToBill {
     email: string | null;
     phone: string | null;
     account_number: string | null;
+    onboarding_status: string | null;
   } | null;
   package: {
     id: string;
@@ -255,6 +258,7 @@ export class MonthlyInvoiceGenerator {
         monthly_price,
         billing_day,
         last_invoice_date,
+        activation_date,
         status,
         customer:customers(
           id,
@@ -262,7 +266,8 @@ export class MonthlyInvoiceGenerator {
           last_name,
           email,
           phone,
-          account_number
+          account_number,
+          onboarding_status
         ),
         package:service_packages(
           id,
@@ -288,7 +293,7 @@ export class MonthlyInvoiceGenerator {
     }
 
     // Transform data - handle Supabase joins returning arrays
-    return (services || []).map((service) => ({
+    const transformed = (services || []).map((service) => ({
       ...service,
       customer: Array.isArray(service.customer)
         ? service.customer[0]
@@ -297,6 +302,27 @@ export class MonthlyInvoiceGenerator {
         ? service.package[0]
         : service.package,
     })) as ServiceToBill[];
+
+    // GATE: Exclude customers in onboarding flow unless they are billing_ready.
+    // Legacy customers (no onboarding_submission) continue to bill normally.
+    const customerIds = transformed.map(s => s.customer_id);
+    if (customerIds.length > 0) {
+      const { data: onboardingByCustomer } = await supabase
+        .from('onboarding_submissions')
+        .select('customer_id')
+        .in('customer_id', customerIds);
+      const inOnboardingSet = new Set((onboardingByCustomer || []).map(row => row.customer_id));
+
+      return transformed.filter(service => {
+        const inOnboarding = inOnboardingSet.has(service.customer_id);
+        // If NOT in onboarding: bill (legacy customer)
+        if (!inOnboarding) return true;
+        // If in onboarding: bill only if billing_ready
+        return service.customer?.onboarding_status === 'billing_ready';
+      });
+    }
+
+    return transformed;
   }
 
   /**
@@ -479,7 +505,31 @@ export class MonthlyInvoiceGenerator {
     // Amounts — consumer monthly_price is VAT-INCLUSIVE (gross); back VAT out so total === price.
     // Matches every existing paid invoice (e.g. R899 -> net 781.74 + VAT 117.26 = 899).
     const vatRate = 15.0;
-    const { subtotal, vatAmount, totalAmount } = computeVatInclusiveAmounts(service.monthly_price);
+
+    // Pro-rata first invoice: detect via last_invoice_date === null and apply fraction
+    const isFirstInvoice = service.last_invoice_date === null;
+    let monthlyPrice = service.monthly_price;
+    if (isFirstInvoice && service.activation_date) {
+      const prorata = computeProRata({
+        monthlyExVat: service.monthly_price, // Pass as-is; computeProRata treats it as VAT-exclusive (business rule says 450 ex)
+        vatPct: 15,
+        activationDate: service.activation_date,
+        billingDay: service.billing_day,
+      });
+      // Apply pro-rata fraction to the monthly price
+      // prorata.days / prorata.daysInMonth gives the fraction of the month to charge
+      monthlyPrice = prorata.amountInclVat;
+      billingLogger.info('MonthlyInvoice: Pro-rata first invoice', {
+        serviceId: service.id,
+        activationDate: service.activation_date,
+        days: prorata.days,
+        daysInMonth: prorata.daysInMonth,
+        monthlyPrice: service.monthly_price,
+        prorataPrice: monthlyPrice,
+      });
+    }
+
+    const { subtotal, vatAmount, totalAmount } = computeVatInclusiveAmounts(monthlyPrice);
 
     // Generate INV-YYYY-NNNNN — customer_invoices has NO DB sequence/trigger for invoice_number
     // (the legacy sequence was dropped in the baseline squash), so the app must supply it.
@@ -508,27 +558,39 @@ export class MonthlyInvoiceGenerator {
       },
     ];
 
+    // Determine collection method: onboarding customers use debit_order, others default to existing behavior
+    let paymentCollectionMethod: string | null = null;
+    if (service.customer?.onboarding_status === 'billing_ready') {
+      paymentCollectionMethod = 'debit_order';
+    }
+
     // Insert invoice (invoice_number generated above — no DB trigger exists for customer_invoices)
+    const invoicePayload: Record<string, any> = {
+      invoice_number: invoiceNumber,
+      customer_id: service.customer_id,
+      service_id: service.id,
+      invoice_date: invoiceDate,
+      due_date: dueDate,
+      period_start: periodStart,
+      period_end: periodEnd,
+      subtotal,
+      vat_rate: vatRate,
+      tax_amount: vatAmount,
+      total_amount: totalAmount,
+      amount_due: totalAmount, // new invoice: full amount owed (NOT NULL column)
+      amount_paid: 0,
+      line_items: lineItems,
+      invoice_type: 'recurring',
+      status: 'sent', // valid_invoice_status CHECK allows draft|sent|paid|partial|overdue|cancelled|voided ('unpaid' is invalid)
+    };
+
+    if (paymentCollectionMethod) {
+      invoicePayload.payment_collection_method = paymentCollectionMethod;
+    }
+
     const { data: invoice, error } = await supabase
       .from('customer_invoices')
-      .insert({
-        invoice_number: invoiceNumber,
-        customer_id: service.customer_id,
-        service_id: service.id,
-        invoice_date: invoiceDate,
-        due_date: dueDate,
-        period_start: periodStart,
-        period_end: periodEnd,
-        subtotal,
-        vat_rate: vatRate,
-        tax_amount: vatAmount,
-        total_amount: totalAmount,
-        amount_due: totalAmount, // new invoice: full amount owed (NOT NULL column)
-        amount_paid: 0,
-        line_items: lineItems,
-        invoice_type: 'recurring',
-        status: 'sent', // valid_invoice_status CHECK allows draft|sent|paid|partial|overdue|cancelled|voided ('unpaid' is invalid)
-      })
+      .insert(invoicePayload)
       .select('id, invoice_number')
       .single();
 

--- a/lib/billing/monthly-invoice-generator.ts
+++ b/lib/billing/monthly-invoice-generator.ts
@@ -506,30 +506,34 @@ export class MonthlyInvoiceGenerator {
     // Matches every existing paid invoice (e.g. R899 -> net 781.74 + VAT 117.26 = 899).
     const vatRate = 15.0;
 
+    // Always compute full-month amounts from the existing function on the unchanged price.
+    const { subtotal: fullSubtotal, vatAmount: fullVat, totalAmount: fullTotal } = computeVatInclusiveAmounts(service.monthly_price);
+
     // Pro-rata first invoice: detect via last_invoice_date === null and apply fraction
+    // Only use computeProRata to get days/daysInMonth; ignore its amount fields (VAT base is already set above).
     const isFirstInvoice = service.last_invoice_date === null;
-    let monthlyPrice = service.monthly_price;
+    let fraction = 1;
     if (isFirstInvoice && service.activation_date) {
-      const prorata = computeProRata({
-        monthlyExVat: service.monthly_price, // Pass as-is; computeProRata treats it as VAT-exclusive (business rule says 450 ex)
+      const pr = computeProRata({
+        monthlyExVat: service.monthly_price, // only days/daysInMonth are used; VAT treatment irrelevant here
         vatPct: 15,
         activationDate: service.activation_date,
         billingDay: service.billing_day,
       });
-      // Apply pro-rata fraction to the monthly price
-      // prorata.days / prorata.daysInMonth gives the fraction of the month to charge
-      monthlyPrice = prorata.amountInclVat;
+      fraction = pr.days / pr.daysInMonth;
       billingLogger.info('MonthlyInvoice: Pro-rata first invoice', {
         serviceId: service.id,
         activationDate: service.activation_date,
-        days: prorata.days,
-        daysInMonth: prorata.daysInMonth,
-        monthlyPrice: service.monthly_price,
-        prorataPrice: monthlyPrice,
+        days: pr.days,
+        daysInMonth: pr.daysInMonth,
+        fraction,
       });
     }
 
-    const { subtotal, vatAmount, totalAmount } = computeVatInclusiveAmounts(monthlyPrice);
+    const round2 = (n: number) => Math.round(n * 100) / 100;
+    const subtotal = round2(fullSubtotal * fraction);
+    const vatAmount = round2(fullVat * fraction);
+    const totalAmount = round2(subtotal + vatAmount);
 
     // Generate INV-YYYY-NNNNN — customer_invoices has NO DB sequence/trigger for invoice_number
     // (the legacy sequence was dropped in the baseline squash), so the app must supply it.

--- a/lib/integrations/whatsapp/types.ts
+++ b/lib/integrations/whatsapp/types.ts
@@ -88,7 +88,8 @@ export type CircleTelTemplate =
   | 'circletel_payment_reminder'
   | 'circletel_debit_failed'
   | 'circletel_payment_received'
-  | 'circletel_service_activated';
+  | 'circletel_service_activated'
+  | 'circletel_clinic_onboarding';
 
 /**
  * Template parameter mappings for CircleTel templates
@@ -127,6 +128,11 @@ export interface ServiceActivatedParams {
   customerName: string;       // {{1}} - Customer first name
   serviceName: string;        // {{2}} - Package name
   accountNumber: string;      // {{3}} - Account number
+}
+
+export interface ClinicOnboardingParams {
+  clinicName: string;         // {{1}} - Clinic / contact name (body)
+  token: string;              // URL button param: https://www.circletel.co.za/onboarding/{{1}}
 }
 
 // Union type for all template params

--- a/lib/integrations/whatsapp/whatsapp-service.ts
+++ b/lib/integrations/whatsapp/whatsapp-service.ts
@@ -22,6 +22,7 @@ import type {
   DebitFailedParams,
   PaymentReceivedParams,
   ServiceActivatedParams,
+  ClinicOnboardingParams,
 } from './types';
 
 // =============================================================================
@@ -339,6 +340,39 @@ export class WhatsAppService {
     ];
 
     return this.sendTemplate(to, 'circletel_service_activated', components);
+  }
+
+  // ===========================================================================
+  // CLINIC ONBOARDING TEMPLATE
+  // ===========================================================================
+
+  /**
+   * Send clinic onboarding invitation (magic-link to the web wizard)
+   * Template: circletel_clinic_onboarding
+   *
+   * Structure:
+   * - Body: Hi {{1}}, let's set up your CircleTel ClinicConnect billing...
+   * - Button: Start setup -> https://www.circletel.co.za/onboarding/{{1}} (token)
+   */
+  async sendClinicOnboarding(
+    to: string,
+    params: ClinicOnboardingParams
+  ): Promise<WhatsAppSendResult> {
+    const components: SendTemplateRequest['template']['components'] = [
+      {
+        type: 'body',
+        parameters: [{ type: 'text', text: params.clinicName }],
+      },
+      // Button URL parameter — the magic-link token substituted into the template URL
+      {
+        type: 'button',
+        sub_type: 'url',
+        index: 0,
+        parameters: [{ type: 'text', text: params.token }],
+      },
+    ];
+
+    return this.sendTemplate(to, 'circletel_clinic_onboarding', components);
   }
 
   // ===========================================================================

--- a/lib/onboarding/billing-ready.ts
+++ b/lib/onboarding/billing-ready.ts
@@ -30,12 +30,13 @@ export async function maybeMarkBillingReady(
   // Docs must be approved
   if (submission.document_vetting_status !== 'approved') return false;
 
-  // Mandate must exist, be verified, and be active
+  // Mandate must exist, be verified, be active, and is_active must be true
   const { data: mandate, error: manError } = await supabase
     .from('customer_payment_methods')
     .select('mandate_status, encrypted_details')
     .eq('customer_id', customerId)
     .eq('method_type', 'debit_order')
+    .eq('is_active', true)
     .maybeSingle();
 
   if (manError || !mandate) return false;

--- a/lib/onboarding/billing-ready.ts
+++ b/lib/onboarding/billing-ready.ts
@@ -1,0 +1,66 @@
+/**
+ * Billing-ready status computation
+ * Sets customers.onboarding_status = 'billing_ready' when docs approved AND mandate verified+active
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Check if an onboarding submission's documents are approved and the
+ * associated mandate is verified and active, then mark the customer billing_ready.
+ *
+ * Returns true if status was flipped to billing_ready, false otherwise.
+ * Safe to call repeatedly — idempotent.
+ */
+export async function maybeMarkBillingReady(
+  supabase: SupabaseClient,
+  customerId: string
+): Promise<boolean> {
+  // Get the latest submission for this customer
+  const { data: submission, error: subError } = await supabase
+    .from('onboarding_submissions')
+    .select('id, document_vetting_status')
+    .eq('customer_id', customerId)
+    .order('submitted_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (subError || !submission) return false;
+
+  // Docs must be approved
+  if (submission.document_vetting_status !== 'approved') return false;
+
+  // Mandate must exist, be verified, and be active
+  const { data: mandate, error: manError } = await supabase
+    .from('customer_payment_methods')
+    .select('mandate_status, encrypted_details')
+    .eq('customer_id', customerId)
+    .eq('method_type', 'debit_order')
+    .maybeSingle();
+
+  if (manError || !mandate) return false;
+
+  const mandateActive = mandate.mandate_status === 'active' || mandate.mandate_status === 'approved';
+  const verified =
+    mandate.encrypted_details?.verified === true ||
+    mandate.encrypted_details?.verified === 'true';
+
+  if (!mandateActive || !verified) return false;
+
+  // All conditions met: mark customer billing_ready
+  const now = new Date().toISOString();
+  const { error: updateError } = await supabase
+    .from('customers')
+    .update({
+      onboarding_status: 'billing_ready',
+      onboarding_completed_at: now,
+    })
+    .eq('id', customerId);
+
+  if (updateError) {
+    console.error('[Billing Ready] Failed to update customer:', updateError);
+    return false;
+  }
+
+  return true;
+}

--- a/lib/onboarding/document-requirements.ts
+++ b/lib/onboarding/document-requirements.ts
@@ -42,8 +42,9 @@ interface DocStatusRow { document_type: string; verification_status: string }
 /** Roll up per-document statuses into the account-level vetting status. */
 export function computeVettingStatus(requiredTypes: string[], docs: DocStatusRow[]): VettingStatus {
   if (docs.length === 0) return 'documents_pending';
-  if (docs.some(d => d.verification_status === 'rejected')) return 'rejected';
+  const requiredSet = new Set(requiredTypes);
   const statusByType = new Map(docs.map(d => [d.document_type, d.verification_status]));
+  if (requiredTypes.some(t => statusByType.get(t) === 'rejected')) return 'rejected';
   const allApproved = requiredTypes.every(t => statusByType.get(t) === 'approved');
   if (allApproved) return 'approved';
   return 'under_review';

--- a/lib/onboarding/document-requirements.ts
+++ b/lib/onboarding/document-requirements.ts
@@ -1,0 +1,50 @@
+// kyc_document_type enum values: id_document, proof_of_address, bank_statement,
+// company_registration, tax_certificate, vat_certificate, director_id, shareholder_agreement, other
+export type KycDocType =
+  | 'id_document' | 'proof_of_address' | 'bank_statement' | 'company_registration'
+  | 'tax_certificate' | 'vat_certificate' | 'director_id' | 'shareholder_agreement' | 'other';
+
+export type B2BSegment = 'unjani' | 'smb' | 'edu';
+
+export interface DocRequirement {
+  type: KycDocType;
+  label: string;
+  required: boolean;
+}
+
+export interface EntityContext {
+  vatRegistered: boolean;
+  entityType: string; // matches wizard step-2 entityType options
+}
+
+/** Required supporting documents for a B2B segment, given the entity context. */
+export function requiredDocsFor(_segment: B2BSegment, ctx: EntityContext): DocRequirement[] {
+  const isSoleProp = ctx.entityType === 'Sole Proprietor';
+  const docs: DocRequirement[] = [];
+  if (isSoleProp) {
+    docs.push({ type: 'director_id', label: 'Owner ID document', required: true });
+  } else {
+    docs.push({ type: 'company_registration', label: 'CIPC registration certificate', required: true });
+    docs.push({ type: 'director_id', label: 'Director / owner ID', required: true });
+  }
+  docs.push({ type: 'bank_statement', label: 'Bank confirmation letter or statement', required: true });
+  docs.push({ type: 'proof_of_address', label: 'Proof of business address', required: true });
+  if (ctx.vatRegistered) {
+    docs.push({ type: 'vat_certificate', label: 'VAT registration certificate', required: true });
+  }
+  return docs;
+}
+
+export type VettingStatus = 'not_started' | 'documents_pending' | 'under_review' | 'approved' | 'rejected' | 'expired';
+
+interface DocStatusRow { document_type: string; verification_status: string }
+
+/** Roll up per-document statuses into the account-level vetting status. */
+export function computeVettingStatus(requiredTypes: string[], docs: DocStatusRow[]): VettingStatus {
+  if (docs.length === 0) return 'documents_pending';
+  if (docs.some(d => d.verification_status === 'rejected')) return 'rejected';
+  const statusByType = new Map(docs.map(d => [d.document_type, d.verification_status]));
+  const allApproved = requiredTypes.every(t => statusByType.get(t) === 'approved');
+  if (allApproved) return 'approved';
+  return 'under_review';
+}

--- a/lib/onboarding/emandate-request.ts
+++ b/lib/onboarding/emandate-request.ts
@@ -1,0 +1,55 @@
+import type { EMandateBatchRequest } from '@/lib/payments/netcash-emandate-batch-service';
+
+export interface EMandateBuildInput {
+  accountNumber: string;       // -> accountReference + field3
+  paymentMethodId: string;     // -> field1
+  submissionId: string;        // -> field2
+  accountHolder: string;
+  isConsumer: boolean;
+  entityName: string;
+  registrationNumber?: string;
+  mobile: string;
+  bank: string;
+  accountType: string;         // 'Cheque / Current' | 'Savings' | 'Transmission'
+  accountNumber2: string;      // bank account number
+  branchCode: string;
+  monthlyExVat: number;
+  vatPct: number;
+  paymentDay: string;          // '1' | '15' | '20' | '25'
+  agreementDate: string;       // YYYY-MM-DD (service activation / acceptance date)
+}
+
+/** Map onboarding submission data to a NetCash EMandateBatchRequest. */
+export function buildEMandateRequest(i: EMandateBuildInput): EMandateBatchRequest {
+  const amountInclVat = Number((i.monthlyExVat * (1 + i.vatPct / 100)).toFixed(2));
+  const agreement = new Date(i.agreementDate + 'T00:00:00Z');
+  // Commencement month = the month the first debit should run (next month after agreement)
+  const commencementMonth = ((agreement.getUTCMonth() + 1) % 12) + 1;
+  const [first = '', ...rest] = i.accountHolder.trim().split(/\s+/);
+  return {
+    accountReference: i.accountNumber.substring(0, 22),
+    mandateName: i.accountHolder.substring(0, 50),
+    isConsumer: i.isConsumer,
+    firstName: first,
+    surname: rest.join(' ') || i.entityName.substring(0, 50),
+    mobileNumber: i.mobile,
+    mandateAmount: amountInclVat,
+    debitFrequency: 1, // monthly
+    commencementMonth,
+    commencementDay: i.paymentDay,
+    agreementDate: agreement,
+    agreementReference: `CT-UNJ-${i.accountNumber}`.substring(0, 50),
+    sendMandate: true,
+    tradingName: i.isConsumer ? undefined : i.entityName.substring(0, 50),
+    registrationNumber: i.isConsumer ? undefined : i.registrationNumber,
+    registeredName: i.isConsumer ? undefined : i.entityName.substring(0, 50),
+    bankDetailType: 1,
+    bankAccountName: i.accountHolder.substring(0, 50),
+    bankAccountType: i.accountType.toLowerCase().startsWith('savings') ? 2 : 1,
+    branchCode: i.branchCode,
+    bankAccountNumber: i.accountNumber2,
+    field1: i.paymentMethodId,
+    field2: i.submissionId,
+    field3: i.accountNumber,
+  };
+}

--- a/lib/onboarding/onboarding-service.ts
+++ b/lib/onboarding/onboarding-service.ts
@@ -1,0 +1,61 @@
+import { createClient } from '@supabase/supabase-js';
+import { generateToken, hashToken, tokenExpiry } from './token-service';
+
+export function svc() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  );
+}
+
+export function buildMagicLinkUrl(base: string, token: string): string {
+  return `${base.replace(/\/+$/, '')}/onboarding/${token}`;
+}
+
+/** Issue a fresh single-use token for a customer; returns the plaintext token. */
+export async function issueToken(customerId: string, sentVia: string): Promise<string> {
+  const supabase = svc();
+  const token = generateToken();
+  const { error } = await supabase.from('onboarding_tokens').insert({
+    customer_id: customerId,
+    token_hash: hashToken(token),
+    expires_at: tokenExpiry(),
+    sent_via: sentVia,
+    sent_at: new Date().toISOString(),
+  });
+  if (error) throw new Error(`Failed to issue token: ${error.message}`);
+  return token;
+}
+
+/** Resolve a plaintext token to a customer id, enforcing expiry + single use. */
+export async function resolveToken(token: string): Promise<{ customerId: string; tokenId: string } | null> {
+  const supabase = svc();
+  const { data, error } = await supabase
+    .from('onboarding_tokens')
+    .select('id, customer_id, expires_at, used_at')
+    .eq('token_hash', hashToken(token))
+    .maybeSingle();
+  if (error || !data) return null;
+  if (data.used_at) return null;
+  if (new Date(data.expires_at).getTime() < Date.now()) return null;
+  return { customerId: data.customer_id, tokenId: data.id };
+}
+
+/** Pre-fill payload for the wizard from the existing customer record. */
+export async function getClinicPrefill(customerId: string) {
+  const supabase = svc();
+  const { data: c, error } = await supabase
+    .from('customers')
+    .select('id, account_number, business_name, business_registration, tax_number, email, phone, onboarding_status, clinic_details')
+    .eq('id', customerId)
+    .single();
+  if (error || !c) return null;
+  const { data: svcRow } = await supabase
+    .from('customer_services')
+    .select('monthly_price, billing_day, activation_date')
+    .eq('customer_id', customerId)
+    .limit(1)
+    .maybeSingle();
+  return { customer: c, service: svcRow };
+}

--- a/lib/onboarding/prorata.ts
+++ b/lib/onboarding/prorata.ts
@@ -1,0 +1,29 @@
+export interface ProRataInput {
+  monthlyExVat: number;
+  vatPct: number;
+  activationDate: string; // YYYY-MM-DD
+  billingDay: number;     // 1..28
+}
+export interface ProRataResult {
+  days: number;
+  daysInMonth: number;
+  amountExVat: number;
+  amountInclVat: number;
+}
+
+/**
+ * First-invoice pro-rata: days from activation (inclusive) to the end of the
+ * activation month, charged as a fraction of that month. Recurring months are full.
+ */
+export function computeProRata(input: ProRataInput): ProRataResult {
+  const act = new Date(input.activationDate + 'T00:00:00Z');
+  const year = act.getUTCFullYear();
+  const month = act.getUTCMonth();
+  const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  const actDay = act.getUTCDate();
+  const days = daysInMonth - actDay + 1; // inclusive of activation day
+  const inclFull = input.monthlyExVat * (1 + input.vatPct / 100);
+  const amountInclVat = inclFull * days / daysInMonth;
+  const amountExVat = input.monthlyExVat * days / daysInMonth;
+  return { days, daysInMonth, amountExVat, amountInclVat };
+}

--- a/lib/onboarding/schemas.ts
+++ b/lib/onboarding/schemas.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+export const step1Schema = z.object({
+  clinicName: z.string().min(3),
+  unjaniAcc: z.string().min(2),
+  province: z.string().min(2),
+  contact: z.string().min(2),
+  phone: z.string().min(9),
+  email: z.string().email(),
+  siteAddress: z.string().min(5),
+  lat: z.string().optional(),
+  lng: z.string().optional(),
+});
+
+export const step2Schema = z.object({
+  entityName: z.string().min(2),
+  entityType: z.string().min(2),
+  regNumber: z.string().min(4), // CIPC reg OR owner ID (sole prop)
+  vat: z.enum(['No', 'Yes']),
+  vatNumber: z.string().optional(),
+  regAddress: z.string().min(5),
+}).refine(v => v.vat === 'No' || (v.vatNumber && v.vatNumber.length >= 9), {
+  message: 'VAT number required when VAT registered', path: ['vatNumber'],
+});
+
+export const step3Schema = z.object({
+  accHolder: z.string().min(2),
+  bank: z.string().min(2),
+  accType: z.string().min(2),
+  accNumber: z.string().min(6),
+  branchCode: z.string().min(5),
+  mandate: z.literal(true), // DebiCheck consent checkbox
+});
+
+export const step5Schema = z.object({
+  paymentDate: z.enum(['1', '15', '20', '25']),
+  soAccept: z.literal(true),
+});
+
+export type Step1 = z.infer<typeof step1Schema>;
+export type Step2 = z.infer<typeof step2Schema>;
+export type Step3 = z.infer<typeof step3Schema>;
+export type Step5 = z.infer<typeof step5Schema>;

--- a/lib/onboarding/token-service.ts
+++ b/lib/onboarding/token-service.ts
@@ -1,0 +1,18 @@
+import crypto from 'crypto';
+
+/** Generate a 32-byte cryptographically-random URL-safe token (the plaintext sent in the link). */
+export function generateToken(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/** SHA-256 hex hash. Only the hash is stored in onboarding_tokens.token_hash. */
+export function hashToken(plain: string): string {
+  return crypto.createHash('sha256').update(plain).digest('hex');
+}
+
+export const TOKEN_TTL_DAYS = 7;
+
+/** Expiry timestamp `TOKEN_TTL_DAYS` from `from` (ISO string). */
+export function tokenExpiry(from: Date = new Date()): string {
+  return new Date(from.getTime() + TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+}

--- a/scripts/create-onboarding-template.ts
+++ b/scripts/create-onboarding-template.ts
@@ -1,0 +1,50 @@
+/**
+ * Submit the CircleTel clinic-onboarding WhatsApp template to the PROD WABA.
+ * Body var ORDER must match lib/integrations/whatsapp/whatsapp-service.ts
+ * sendClinicOnboarding(): body {{1}} = clinicName; URL button {{1}} = magic-link token.
+ *
+ * Run: set -a && source .env.local && set +a && npx tsx scripts/create-onboarding-template.ts
+ */
+
+const GRAPH = 'https://graph.facebook.com/v21.0'
+const TOKEN = process.env.WHATSAPP_ACCESS_TOKEN || ''
+const WABA = process.env.WHATSAPP_BUSINESS_ACCOUNT_ID || ''
+const ONBOARD_URL = 'https://www.circletel.co.za/onboarding/{{1}}'
+const ONBOARD_EXAMPLE = 'https://www.circletel.co.za/onboarding/9UND2s3z-test'
+const FOOTER = { type: 'FOOTER', text: 'CircleTel SA (Pty) Ltd' }
+
+const template = {
+  // sendClinicOnboarding -> body [clinicName]; button[0] dynamic URL = token
+  name: 'circletel_clinic_onboarding',
+  language: 'en_ZA',
+  category: 'UTILITY',
+  components: [
+    {
+      type: 'BODY',
+      text: "Hi {{1}}, let's set up your CircleTel ClinicConnect billing. Tap the button below to confirm your clinic details, add your banking and documents, and activate your account. It only takes a few minutes, and the link is valid for 7 days.",
+      example: { body_text: [['Unjani Clinic - Lens ext 10']] },
+    },
+    FOOTER,
+    {
+      type: 'BUTTONS',
+      buttons: [{ type: 'URL', text: 'Start setup', url: ONBOARD_URL, example: [ONBOARD_EXAMPLE] }],
+    },
+  ],
+}
+
+async function main() {
+  if (!TOKEN || !WABA) {
+    console.error('❌ WHATSAPP_ACCESS_TOKEN / WHATSAPP_BUSINESS_ACCOUNT_ID not set. Did you source .env.local?')
+    process.exit(1)
+  }
+  console.log(`Submitting '${template.name}' to WABA ${WABA}…`)
+  const res = await fetch(`${GRAPH}/${WABA}/message_templates`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+    body: JSON.stringify(template),
+  })
+  const json = await res.json().catch(() => ({}))
+  console.log(`${template.name}: ${res.ok ? '✅ submitted (PENDING Meta review ~24h)' : '❌'} ${JSON.stringify(json)}`)
+}
+
+main()

--- a/supabase/migrations/20260609120000_unjani_b2b_onboarding.sql
+++ b/supabase/migrations/20260609120000_unjani_b2b_onboarding.sql
@@ -1,0 +1,51 @@
+-- B2B / Unjani self-service onboarding: tokens, submissions, document vetting.
+-- Additive + idempotent. Safe to run multiple times.
+
+-- Onboarding state on existing customers (Unjani clinics live in `customers`)
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS onboarding_status text
+  DEFAULT 'pending'
+  CHECK (onboarding_status IN ('pending','in_progress','submitted','billing_ready','failed'));
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS onboarding_completed_at timestamptz;
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS clinic_details jsonb DEFAULT '{}'::jsonb;
+
+-- Magic-link tokens (store only the hash; single-use; 7-day expiry)
+CREATE TABLE IF NOT EXISTS onboarding_tokens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_id uuid NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+  token_hash text NOT NULL UNIQUE,
+  expires_at timestamptz NOT NULL,
+  used_at timestamptz,
+  sent_via text,
+  sent_at timestamptz,
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_onboarding_tokens_customer ON onboarding_tokens(customer_id);
+
+-- Submission audit + per-account document-vetting rollup
+CREATE TABLE IF NOT EXISTS onboarding_submissions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_id uuid NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+  segment text NOT NULL DEFAULT 'unjani',
+  submission_data jsonb NOT NULL DEFAULT '{}'::jsonb,
+  netcash_file_token text,
+  status text NOT NULL DEFAULT 'submitted'
+    CHECK (status IN ('draft','submitted','approved','rejected')),
+  document_vetting_status text NOT NULL DEFAULT 'documents_pending'
+    CHECK (document_vetting_status IN ('not_started','documents_pending','under_review','approved','rejected','expired')),
+  admin_reviewed_at timestamptz,
+  admin_reviewed_by uuid,
+  admin_notes text,
+  rejection_reason text,
+  submitted_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_onboarding_submissions_customer ON onboarding_submissions(customer_id);
+CREATE INDEX IF NOT EXISTS idx_onboarding_submissions_vetting ON onboarding_submissions(document_vetting_status);
+
+-- Generalize kyc_documents so docs can attach to a customer-scoped onboarding (all B2B)
+ALTER TABLE kyc_documents ADD COLUMN IF NOT EXISTS customer_id uuid REFERENCES customers(id);
+ALTER TABLE kyc_documents ADD COLUMN IF NOT EXISTS onboarding_submission_id uuid REFERENCES onboarding_submissions(id);
+CREATE INDEX IF NOT EXISTS idx_kyc_documents_onboarding_submission ON kyc_documents(onboarding_submission_id);
+CREATE INDEX IF NOT EXISTS idx_kyc_documents_customer ON kyc_documents(customer_id);
+
+-- Link a payment method back to the onboarding submission that created it
+ALTER TABLE customer_payment_methods ADD COLUMN IF NOT EXISTS onboarding_submission_id uuid REFERENCES onboarding_submissions(id);

--- a/supabase/migrations/20260609160000_scope_phone_dedupe_to_personal.sql
+++ b/supabase/migrations/20260609160000_scope_phone_dedupe_to_personal.sql
@@ -1,0 +1,10 @@
+-- Scope the duplicate-phone protection to PERSONAL accounts only.
+-- Business/clinic accounts (e.g. Unjani) legitimately share one nurse's number
+-- across multiple clinics, so the global one-number-one-account rule must not
+-- apply to them. Consumer dedupe (mobile OTP login resolution) is preserved.
+
+DROP INDEX IF EXISTS customers_phone_unique_not_blank;
+
+CREATE UNIQUE INDEX customers_phone_unique_not_blank
+  ON public.customers USING btree (phone)
+  WHERE ((phone)::text <> ''::text AND (account_type)::text = 'personal'::text);


### PR DESCRIPTION
## Summary

Self-service onboarding for the 20 already-active Unjani clinics (reusable for any B2B segment). A magic-link/OTP wizard enriches each clinic's existing `customers`/`customer_services` record with entity + banking + supporting documents, captures a DebiCheck eMandate, and — once an admin vets the documents **and** the mandate goes active — flips the clinic to `billing_ready` so the existing monthly-invoice engine bills it (pro-rata first invoice, collected by debit order).

Built as a 10-task critical path; every task went through implementation + spec-compliance review + code-quality review (issues fixed inline).

### What's included
- **Schema** (`supabase/migrations/20260609120000_unjani_b2b_onboarding.sql`, already applied): `customers.onboarding_status/onboarding_completed_at/clinic_details`, `onboarding_tokens`, `onboarding_submissions` (+ `document_vetting_status`), generalized `kyc_documents` (`customer_id`, `onboarding_submission_id`), `customer_payment_methods.onboarding_submission_id`. Additive + idempotent.
- **Customer flow**: 6-step wizard at `/onboarding/[token]` (+ public clinic-pick/OTP), `lib/onboarding/*` (token service, document requirements + vetting rollup, pro-rata, eMandate request builder), `app/api/onboarding/{get-clinic,submit,upload-document}`, admin `send-link`.
- **Reusable vetting backend**: generalized `app/api/admin/kyc/verify` (consumer path preserved) + `app/admin/b2b/vetting` queue & detail (per-document approve/reject/request-changes), `lib/onboarding/billing-ready.ts`.
- **Mandate → billing**: `app/api/webhooks/netcash/emandate` sets mandate active + `encrypted_details.verified=true` and flips billing-ready (redelivery-safe); `MonthlyInvoiceGenerator` gates onboarding customers on `billing_ready` (legacy customers unaffected) + pro-rata first invoice + `payment_collection_method='debit_order'`.

### Tests
- 143 unit tests pass across `__tests__/lib/onboarding` + `__tests__/lib/billing` (token, document-requirements/vetting rollup, pro-rata incl. leap/month-boundary, eMandate mapping). Pre-push scoped type-check: no errors in the 32 changed TS files.

## Known follow-ups (not blocking, flagged during review)
- **NetCash eMandate postback** must be confirmed delivering on a working account before live collection (test account previously blocked). Until then the chain stalls at `mandate_status='pending'`.
- **Unjani VAT semantics**: the generator treats `monthly_price` as VAT-*inclusive* (R450→R450), but the business rule is R450 *ex-VAT* → R517.50. This is a pre-existing data/spec conflict left for a deliberate decision; pro-rata is consistent (first month == recurring base).
- **Bank details in `customer_payment_methods.encrypted_details`** are stored as a plain object (the debit-order batch + webhook read `.verified` directly); encrypting needs a coordinated scheme change across writer/webhook/reader.

## Test Plan
- [ ] Apply already done on prod DB; confirm migration present in any other env
- [ ] Admin issues a magic link to a test clinic; complete all 6 steps incl. document upload
- [ ] Vet documents in `/admin/b2b/vetting`; approve all required → submission `approved`
- [ ] Simulate mandate-active postback → customer `billing_ready`
- [ ] Dry-run monthly invoice generation → only billing-ready clinic billed, pro-rata, `debit_order`
- [ ] Confirm legacy (non-onboarding) customers still bill normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)