### PR TITLE
Onboarding Step 1: Wi-Fi-led copy + Google Places address + admin location + docs

### DIFF
--- a/app/admin/b2b/vetting/[submissionId]/page.tsx
+++ b/app/admin/b2b/vetting/[submissionId]/page.tsx
@@ -43,6 +43,12 @@ interface SubmissionDetail {
     business_name: string;
     email: string;
     phone: string;
+    clinic_details?: {
+      site_address?: string;
+      lat?: string | number;
+      lng?: string | number;
+      [key: string]: any;
+    };
   } | null;
   documents: Array<{
     id: string;
@@ -620,6 +626,41 @@ export default function B2BVettingDetailPage({
               </div>
             </CardContent>
           </Card>
+
+          {/* Clinic Location */}
+          {submission.customers?.clinic_details && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Clinic Location</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {submission.customers.clinic_details.site_address && (
+                  <div>
+                    <p className="text-sm text-gray-600">Address</p>
+                    <p className="text-sm">{submission.customers.clinic_details.site_address}</p>
+                  </div>
+                )}
+                {submission.customers.clinic_details.lat && submission.customers.clinic_details.lng && (
+                  <>
+                    <div>
+                      <p className="text-sm text-gray-600">Coordinates</p>
+                      <p className="text-sm font-mono">
+                        {submission.customers.clinic_details.lat}, {submission.customers.clinic_details.lng}
+                      </p>
+                    </div>
+                    <a
+                      href={`https://www.google.com/maps?q=${submission.customers.clinic_details.lat},${submission.customers.clinic_details.lng}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-circleTel-orange hover:underline"
+                    >
+                      View on Google Maps
+                    </a>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
           {/* Submitted Date */}
           <Card>

--- a/app/api/admin/b2b/vetting/[submissionId]/route.ts
+++ b/app/api/admin/b2b/vetting/[submissionId]/route.ts
@@ -38,7 +38,7 @@ export async function GET(
         admin_notes,
         rejection_reason,
         submitted_at,
-        customers(id, account_number, business_name, email, phone)
+        customers(id, account_number, business_name, email, phone, clinic_details)
       `
       )
       .eq('id', submissionId)

--- a/app/api/onboarding/submit/route.ts
+++ b/app/api/onboarding/submit/route.ts
@@ -105,7 +105,6 @@ export async function POST(request: NextRequest) {
       onboarding_status: 'submitted',
       clinic_details: {
         clinic_name: s1.data.clinicName,
-        unjani_account: s1.data.unjaniAcc,
         province: s1.data.province,
         nurse_owner_name: s1.data.contact,
         site_address: s1.data.siteAddress,

--- a/app/onboarding/components/OnboardingWizard.tsx
+++ b/app/onboarding/components/OnboardingWizard.tsx
@@ -117,7 +117,7 @@ export function OnboardingWizard({ token }: OnboardingWizardProps) {
             Already set up
           </h2>
           <p className="text-green-800">
-            Your clinic billing is already activated. If you need to make changes,
+            Your clinic is already set up. If you need to make changes,
             please contact support at{' '}
             <a
               href="https://wa.me/27824873900"

--- a/app/onboarding/components/OnboardingWizard.tsx
+++ b/app/onboarding/components/OnboardingWizard.tsx
@@ -212,15 +212,15 @@ export function OnboardingWizard({ token }: OnboardingWizardProps) {
       {/* Intro section with branding */}
       <div>
         <p className="text-sm font-semibold text-circleTel-orange uppercase tracking-widest">
-          Unjani Clinic Network · Billing setup
+          Unjani Clinic Network · Clinic onboarding
         </p>
         <h1 className="font-heading text-3xl md:text-4xl font-bold text-circleTel-navy mt-1 mb-2">
-          Let's set up your clinic for billing
+          Get your clinic connected — free Wi-Fi for your patients
         </h1>
         <p className="text-gray-600 max-w-2xl">
-          We already hold your clinic and contact details from the Unjani network
-          record. Confirm what we have, add your business and banking details, and
-          accept your Service Order to activate billing.
+          Welcome! Let's set up your clinic with CircleTel ClinicConnect — reliable
+          internet for the clinic and free Wi-Fi for the patients who visit you.
+          Confirm the details below and complete a few quick steps to get activated.
         </p>
       </div>
 

--- a/app/onboarding/components/steps/Step1Clinic.tsx
+++ b/app/onboarding/components/steps/Step1Clinic.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { AddressAutocomplete } from '@/components/coverage/AddressAutocomplete';
 import {
   Select,
   SelectContent,
@@ -48,19 +49,6 @@ export function Step1Clinic({ value, onChange, canGoNext }: Step1ClinicProps) {
     }
   };
 
-  const renderLabel = (label: string, required = false, onRecord = false) => (
-    <div className="flex items-center gap-2">
-      <span>
-        {label}
-        {required && <span className="text-red-600">*</span>}
-      </span>
-      {onRecord && (
-        <span className="text-xs font-semibold uppercase text-circleTel-orange bg-orange-50 px-2 py-1 rounded">
-          on record
-        </span>
-      )}
-    </div>
-  );
 
   return (
     <div className="space-y-6">
@@ -79,7 +67,8 @@ export function Step1Clinic({ value, onChange, canGoNext }: Step1ClinicProps) {
           {/* Clinic Name */}
           <div>
             <Label htmlFor="clinicName">
-              {renderLabel('Clinic name', true, true)}
+              Clinic name
+              <span className="text-red-600">*</span>
             </Label>
             <Input
               id="clinicName"
@@ -94,31 +83,11 @@ export function Step1Clinic({ value, onChange, canGoNext }: Step1ClinicProps) {
             )}
           </div>
 
-          {/* Unjani Account */}
-          <div>
-            <Label htmlFor="unjaniAcc">
-              {renderLabel('Unjani clinic account number', true)}
-            </Label>
-            <Input
-              id="unjaniAcc"
-              type="text"
-              placeholder="e.g. UNJ-0421"
-              value={value.unjaniAcc ?? ''}
-              onChange={(e) => handleFieldChange('unjaniAcc', e.target.value)}
-              className={errors.unjaniAcc ? 'border-red-600' : ''}
-            />
-            <p className="text-xs text-gray-500 mt-1">
-              From the Unjani master site register.
-            </p>
-            {errors.unjaniAcc && (
-              <p className="text-xs text-red-600">{errors.unjaniAcc}</p>
-            )}
-          </div>
-
           {/* Province */}
           <div>
             <Label htmlFor="province">
-              {renderLabel('Province', true, true)}
+              Province
+              <span className="text-red-600">*</span>
             </Label>
             <Select value={value.province ?? ''} onValueChange={(val) => handleFieldChange('province', val)}>
               <SelectTrigger id="province">
@@ -140,7 +109,8 @@ export function Step1Clinic({ value, onChange, canGoNext }: Step1ClinicProps) {
           {/* Contact (nurse-owner) */}
           <div>
             <Label htmlFor="contact">
-              {renderLabel('Contact (nurse-owner)', true, true)}
+              Contact (nurse-owner)
+              <span className="text-red-600">*</span>
             </Label>
             <Input
               id="contact"
@@ -158,7 +128,8 @@ export function Step1Clinic({ value, onChange, canGoNext }: Step1ClinicProps) {
           {/* Mobile */}
           <div>
             <Label htmlFor="phone">
-              {renderLabel('Mobile', true, true)}
+              Mobile
+              <span className="text-red-600">*</span>
             </Label>
             <Input
               id="phone"
@@ -176,7 +147,8 @@ export function Step1Clinic({ value, onChange, canGoNext }: Step1ClinicProps) {
           {/* Email */}
           <div>
             <Label htmlFor="email">
-              {renderLabel('Email', true, true)}
+              Email
+              <span className="text-red-600">*</span>
             </Label>
             <Input
               id="email"
@@ -191,51 +163,39 @@ export function Step1Clinic({ value, onChange, canGoNext }: Step1ClinicProps) {
             )}
           </div>
 
-          {/* Physical site address */}
+          {/* Physical site address - Google Places Autocomplete */}
           <div>
             <Label htmlFor="siteAddress">
-              {renderLabel('Physical site address', true, true)}
+              Physical site address
+              <span className="text-red-600">*</span>
             </Label>
-            <Input
-              id="siteAddress"
-              type="text"
-              placeholder="Usave, Volta Street, Lenasia Extension 10, Gauteng"
+            <AddressAutocomplete
               value={value.siteAddress ?? ''}
-              onChange={(e) => handleFieldChange('siteAddress', e.target.value)}
-              className={errors.siteAddress ? 'border-red-600' : ''}
+              variant="form"
+              placeholder="Start typing your clinic name or address…"
+              onLocationSelect={(data) => {
+                const newValue = {
+                  ...value,
+                  siteAddress: data.address,
+                  lat: data.latitude != null ? String(data.latitude) : (value.lat ?? ''),
+                  lng: data.longitude != null ? String(data.longitude) : (value.lng ?? ''),
+                  province: data.province || value.province,
+                };
+                onChange(newValue);
+                // Validate on change
+                const result = step1Schema.safeParse(newValue);
+                if (result.success) {
+                  setErrors((e) => {
+                    const newE = { ...e };
+                    delete newE.siteAddress;
+                    return newE;
+                  });
+                }
+              }}
             />
             {errors.siteAddress && (
               <p className="text-xs text-red-600 mt-1">{errors.siteAddress}</p>
             )}
-          </div>
-
-          {/* Latitude */}
-          <div>
-            <Label htmlFor="lat">
-              {renderLabel('Latitude', false)}
-            </Label>
-            <Input
-              id="lat"
-              type="text"
-              placeholder="-26.3528"
-              value={value.lat ?? ''}
-              onChange={(e) => handleFieldChange('lat', e.target.value)}
-            />
-            <p className="text-xs text-gray-500 mt-1">Confirm the clinic pin.</p>
-          </div>
-
-          {/* Longitude */}
-          <div>
-            <Label htmlFor="lng">
-              {renderLabel('Longitude', false)}
-            </Label>
-            <Input
-              id="lng"
-              type="text"
-              placeholder="27.8331"
-              value={value.lng ?? ''}
-              onChange={(e) => handleFieldChange('lng', e.target.value)}
-            />
           </div>
         </CardContent>
       </Card>

--- a/app/onboarding/components/useOnboardingState.ts
+++ b/app/onboarding/components/useOnboardingState.ts
@@ -35,7 +35,6 @@ export function useOnboardingState(prefill: { customer: any; service: any }) {
     service: prefill.service,
     step1: {
       clinicName: prefill.customer.business_name?.replace(/^Unjani Clinic — /, '') ?? '',
-      unjaniAcc: prefill.customer.clinic_details?.unjani_account ?? '',
       province: prefill.customer.clinic_details?.province ?? '',
       contact: prefill.customer.clinic_details?.nurse_owner_name ?? '',
       phone: prefill.customer.phone ?? '',

--- a/docs/onboarding/UNJANI_ONBOARDING_CHEATSHEET.md
+++ b/docs/onboarding/UNJANI_ONBOARDING_CHEATSHEET.md
@@ -6,7 +6,7 @@
 
 ### The process (your 5 actions)
 1. **Confirm** the clinic's WhatsApp number is correct.
-2. **Send** the onboarding link (admin tool → clinic → Send onboarding link / WhatsApp).
+2. **Send** the onboarding invite (today: request from the CircleTel team; soon: admin-panel button). WhatsApp goes to the clinic from +27 84 773 9467.
 3. **Guide** the nurse through the 6-step wizard (~5 min — most clinic details pre-filled).
 4. **Vet** the uploaded documents in **Admin → B2B vetting** (Approve / Reject-with-reason).
 5. **Confirm billing live** once docs approved **+** debit order active → status = **billing-ready**.

--- a/docs/onboarding/UNJANI_ONBOARDING_SALES_ADMIN_GUIDE.md
+++ b/docs/onboarding/UNJANI_ONBOARDING_SALES_ADMIN_GUIDE.md
@@ -4,6 +4,8 @@
 **Purpose:** A plain-language, step-by-step playbook + FAQs so you can confidently guide a nurse through onboarding over the phone or WhatsApp.
 **Last updated:** 2026-06-09
 
+> **Tooling status (read me):** The onboarding wizard, the WhatsApp invite template, and the document-vetting screen (`/admin/b2b/vetting`) are **live**. A self-serve "Send onboarding link" **button for sales admins is still being built** — until it ships, the CircleTel team triggers the WhatsApp invite (single clinic or the whole batch) on request. You can already do the **document vetting** yourself in the admin vetting queue. This note will be removed once the send button is live.
+
 ---
 
 ## 1. The big picture (read this first)
@@ -39,7 +41,7 @@ The nurse does this themselves on their phone by tapping a **personal link** we 
 **You will:**
 
 1. **Confirm the clinic's WhatsApp number** is correct on file (this is where the link goes).
-2. **Send the onboarding link.** From the admin tool, choose the clinic and "Send onboarding link (WhatsApp)". The nurse receives a WhatsApp from **CircleTel (+27 84 773 9467)** that says *"Hi [Clinic], let's set up your CircleTel billing"* with a **Start setup** button.
+2. **Send the onboarding link.** Trigger the onboarding invite for the clinic *(today: request it from the CircleTel team; soon: a "Send onboarding link" button in the admin panel)*. The nurse receives a WhatsApp from **CircleTel (+27 84 773 9467)** that says *"Hi [Clinic], let's set up your CircleTel billing"* with a **Start setup** button.
    - The link is valid for **7 days** and is **single-use** (it's used up once they finish).
 3. **Tell the nurse what to expect:** *"Tap the orange Start setup button. It takes about 5 minutes. Have your company registration number, VAT number if you have one, your clinic's bank details, and photos of your documents ready."*
 4. **The nurse completes the 6 steps** (see §5). They tap through; most clinic details are already filled in.

--- a/lib/onboarding/schemas.ts
+++ b/lib/onboarding/schemas.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 export const step1Schema = z.object({
   clinicName: z.string().min(3),
-  unjaniAcc: z.string().min(2),
   province: z.string().min(2),
   contact: z.string().min(2),
   phone: z.string().min(9),


### PR DESCRIPTION
## Summary
Follow-up to PR #527 (onboarding). Refines the clinic onboarding Step 1 and ships the sales-admin docs.

- **Copy:** Step-1 now leads with onboarding + **free patient Wi-Fi** (billing de-emphasised); softened the "already set up" message.
- **Removed:** "on record" badges; the "Unjani clinic account number" field (nurse won't know it — account number shown after completion); the Latitude/Longitude inputs.
- **Address:** Physical site address now uses **Google Places Autocomplete** (reuses `components/coverage/AddressAutocomplete`), auto-capturing lat/lng on selection.
- **Admin:** the B2B vetting detail page now shows the captured **clinic location** (address + lat/lng + Google Maps link) for the sales administrator.
- **Docs:** sales-admin guide + one-page cheat-sheet + copy-paste WhatsApp scripts; corrected the "send link" tooling status.

## Test plan
- [ ] Open a clinic onboarding link on prod → Step 1 shows new copy, no badges/account-no/lat-lng inputs, address autocomplete works (type "Unjani Clinic Delmas").
- [ ] Complete a doc upload + check the admin vetting detail shows the clinic location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)