### PR TITLE
docs(ci): fix build-config enforcement claims + env-aware pre-push cpus check

### DIFF
--- a/.claude/rules/coding-standards.md
+++ b/.claude/rules/coding-standards.md
@@ -195,7 +195,13 @@ Rollout is **staging-first**: `deploy-staging.yml` uses `--turbopack`; prod (`de
 webpack until a staging container boots healthy and serves routes (Turbopack `standalone`-output
 parity is the one remaining risk to confirm on a real container boot, not just a compile).
 
-**CRITICAL**: These values are enforced by `.github/workflows/pr-checks.yml`. Any PR that lowers heap below 6144MB or raises cpus above 1 will fail the `validate-build-config` check and block the merge.
+**CRITICAL — where these are actually enforced** (two places, not one):
+- `.github/workflows/pr-checks.yml` (`validate-dockerfile` job) checks that `deploy.yml`'s
+  `NODE_OPTIONS` heap is **≥8192MB** and that `next.config.js` has `output: 'standalone'`. It does
+  **not** check cpus.
+- `.githooks/pre-push` checks `vercel.json` heap **≥6144MB** and the `cpus` setting. Since `cpus` is
+  now env-driven (`BUILD_CPUS`, default 1 — only the VPS deploy sets it to 4), the hook treats the
+  env-driven form as Vercel-safe.
 
 **Allowed in NODE_OPTIONS**:
 - `--max-old-space-size=<MB>` - Set heap memory limit

--- a/.claude/rules/pre-push-hook.md
+++ b/.claude/rules/pre-push-hook.md
@@ -13,8 +13,9 @@ Enabled via `core.hooksPath`, auto-applied on `npm install` / `npm ci` by the
 
 ## What it checks (in order)
 
-1. **Build config** — heap ≥6144 in `vercel.json`, `cpus:1` in `next.config.js`.
-   Mirrors the `validate-build-config` job in `.github/workflows/pr-checks.yml`.
+1. **Build config** — heap ≥6144 in `vercel.json`, and the `cpus` setting in `next.config.js`.
+   `cpus` is now env-driven (`BUILD_CPUS`, default 1 — only the VPS deploy sets it to 4), so the
+   hook recognizes that form as Vercel-safe; a bare `cpus: N>1` literal still fails.
    Catches OOM-risk config before it reaches the self-hosted runner.
 2. **Scoped type-check** — runs `npm run type-check:memory` once, blocks **only if a
    `.ts/.tsx` file in this push has an error**. Pushes with no TS changes skip it.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,14 +30,21 @@ else
   echo "✅ vercel.json heap: ${HEAP}MB"
 fi
 
-CPUS=$(grep -E '^\s*cpus:' next.config.js 2>/dev/null | grep -o '[0-9]*')
-if [ -z "$CPUS" ]; then
-  echo "⚠️  WARNING: Could not find cpus setting in next.config.js"
-elif [ "$CPUS" -gt 1 ]; then
-  echo "❌ next.config.js cpus=${CPUS} — must be 1 (Vercel OOM risk with 2+ workers)"
-  FAILED=1
+# cpus may be a literal (cpus: 1) or env-driven (cpus: ...BUILD_CPUS... || 1). The
+# env-driven form defaults to 1 and only the VPS deploy sets BUILD_CPUS, so Vercel/CI
+# still build at cpus:1 — treat it as safe.
+if grep -q 'BUILD_CPUS' next.config.js 2>/dev/null; then
+  echo "✅ next.config.js cpus is env-driven (BUILD_CPUS, defaults to 1 — Vercel-safe)"
 else
-  echo "✅ next.config.js cpus: ${CPUS}"
+  CPUS=$(grep -E '^\s*cpus:' next.config.js 2>/dev/null | grep -o '[0-9]*' | head -1)
+  if [ -z "$CPUS" ]; then
+    echo "⚠️  WARNING: Could not find cpus setting in next.config.js"
+  elif [ "$CPUS" -gt 1 ]; then
+    echo "❌ next.config.js cpus=${CPUS} — must be 1 (Vercel OOM risk with 2+ workers)"
+    FAILED=1
+  else
+    echo "✅ next.config.js cpus: ${CPUS}"
+  fi
 fi
 
 # ----- 2. Scoped type-check ------------------------------------------------

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - '*.md'
       - '.claude/**'
+      - '.githooks/**'
       - 'designs/**'
       - 'memory-os/**'
       - 'agent-os/**'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - '*.md'
       - '.claude/**'
+      - '.githooks/**'
       - 'designs/**'
       - 'memory-os/**'
       - 'agent-os/**'


### PR DESCRIPTION
Quick follow-up cleanups after #534 made `cpus` env-driven (`BUILD_CPUS`).

- **`coding-standards.md`** — corrected a wrong claim. It said pr-checks blocks any PR raising cpus>1; actually `validate-dockerfile` only checks `deploy.yml` heap≥8192 + `output: standalone`. The cpus/6144-heap checks live in `.githooks/pre-push`. Documented the real split.
- **`.githooks/pre-push`** — recognizes the env-driven `cpus` form (greps `BUILD_CPUS`) and prints a ✅ "Vercel-safe" line instead of the confusing "could not find cpus" warning #534 introduced. A bare `cpus: N>1` literal still fails as before. (Self-verified: this push printed the new ✅ line.)
- **`pre-push-hook.md`** — documents the env-driven cpus behavior.

Docs/tooling only — no app code, no build/deploy impact.