### PR TITLE
Onboarding pipeline + 2-day vetting SLA + nurse notifications (Phase 1)

### DIFF
--- a/__tests__/lib/dates/business-days.test.ts
+++ b/__tests__/lib/dates/business-days.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Business Days Utility Tests
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { addBusinessDays, isBusinessDay, countBusinessDays, getBusinessDaysUntil } from '@/lib/dates/business-days';
+
+describe('Business Days Utilities', () => {
+  describe('isBusinessDay', () => {
+    it('should identify weekdays as business days', () => {
+      // Monday, 2026-06-08
+      const monday = new Date('2026-06-08');
+      expect(isBusinessDay(monday)).toBe(true);
+
+      // Wednesday, 2026-06-10
+      const wednesday = new Date('2026-06-10');
+      expect(isBusinessDay(wednesday)).toBe(true);
+
+      // Friday, 2026-06-12
+      const friday = new Date('2026-06-12');
+      expect(isBusinessDay(friday)).toBe(true);
+    });
+
+    it('should exclude weekends', () => {
+      // Saturday, 2026-06-13
+      const saturday = new Date('2026-06-13');
+      expect(isBusinessDay(saturday)).toBe(false);
+
+      // Sunday, 2026-06-14
+      const sunday = new Date('2026-06-14');
+      expect(isBusinessDay(sunday)).toBe(false);
+    });
+
+    it('should exclude public holidays', () => {
+      // New Year's Day, 2026-01-01
+      const newYear = new Date('2026-01-01');
+      expect(isBusinessDay(newYear)).toBe(false);
+
+      // Workers' Day, 2026-05-01
+      const workersDay = new Date('2026-05-01');
+      expect(isBusinessDay(workersDay)).toBe(false);
+    });
+
+    it('should reject invalid dates', () => {
+      const invalid = new Date('invalid');
+      expect(isBusinessDay(invalid)).toBe(false);
+    });
+  });
+
+  describe('addBusinessDays', () => {
+    it('should add 2 business days from a Friday', () => {
+      // Friday, 2026-06-12
+      const friday = new Date('2026-06-12');
+      const result = addBusinessDays(friday, 2);
+
+      // Sat/Sun skip, Mon 6/15=1, Tue 6/16=HOLIDAY, Wed 6/17=HOLIDAY, Thu 6/18=2
+      expect(result.toISOString().slice(0, 10)).toBe('2026-06-18');
+    });
+
+    it('should add 1 business day from a Monday', () => {
+      // Monday, 2026-06-08
+      const monday = new Date('2026-06-08');
+      const result = addBusinessDays(monday, 1);
+
+      // Should land on Tuesday 2026-06-09
+      expect(result.toISOString().slice(0, 10)).toBe('2026-06-09');
+    });
+
+    it('should add 3 business days across a weekend', () => {
+      // Thursday, 2026-06-11
+      const thursday = new Date('2026-06-11');
+      const result = addBusinessDays(thursday, 3);
+
+      // From Thu 6/11: Fri 12=1, Sat/Sun skip, Mon 15=2, Tue 16=HOLIDAY, Wed 17=HOLIDAY, Thu 18=3
+      expect(result.toISOString().slice(0, 10)).toBe('2026-06-18');
+    });
+
+    it('should add 0 business days (returns same day)', () => {
+      const monday = new Date('2026-06-08');
+      const result = addBusinessDays(monday, 0);
+
+      expect(result.toISOString().slice(0, 10)).toBe('2026-06-08');
+    });
+
+    it('should reject invalid dates', () => {
+      const invalid = new Date('invalid');
+      expect(addBusinessDays(invalid, 2)).toEqual(invalid);
+    });
+  });
+
+  describe('countBusinessDays', () => {
+    it('should count business days between two dates', () => {
+      // Monday 2026-06-08 to Friday 2026-06-12
+      const start = new Date('2026-06-08');
+      const end = new Date('2026-06-12');
+
+      const count = countBusinessDays(start, end);
+      // Mon, Tue, Wed, Thu, Fri = 5 days (Fri inclusive of start, exclusive of end = 4 days)
+      expect(count).toBe(4);
+    });
+
+    it('should skip weekends in count', () => {
+      // Thursday 2026-06-11 to Friday 2026-06-12 (exclusive end)
+      const start = new Date('2026-06-11');
+      const end = new Date('2026-06-12');
+
+      const count = countBusinessDays(start, end);
+      // Thu 11 = 1 business day (exclusive of end date)
+      expect(count).toBe(1);
+    });
+
+    it('should return 0 for same day', () => {
+      const date = new Date('2026-06-08');
+      const count = countBusinessDays(date, date);
+
+      expect(count).toBe(0);
+    });
+
+    it('should return 0 for invalid dates', () => {
+      const invalid = new Date('invalid');
+      const valid = new Date('2026-06-08');
+
+      expect(countBusinessDays(invalid, valid)).toBe(0);
+      expect(countBusinessDays(valid, invalid)).toBe(0);
+    });
+  });
+
+  describe('getBusinessDaysUntil', () => {
+    it('should calculate business days from now to future date', () => {
+      // Monday 2026-06-08 to Friday 2026-06-12
+      const from = new Date('2026-06-08');
+      const until = new Date('2026-06-12');
+
+      const days = getBusinessDaysUntil(from, until);
+      expect(days).toBe(4);
+    });
+
+    it('should return negative for dates in the past', () => {
+      // Friday 2026-06-12 to Monday 2026-06-08 (backwards)
+      const from = new Date('2026-06-12');
+      const until = new Date('2026-06-08');
+
+      const days = getBusinessDaysUntil(from, until);
+      expect(days).toBeLessThan(0);
+    });
+
+    it('should return 0 for same date', () => {
+      const date = new Date('2026-06-08');
+      const days = getBusinessDaysUntil(date, date);
+
+      expect(days).toBe(0);
+    });
+  });
+});

--- a/app/admin/b2b/vetting/[submissionId]/page.tsx
+++ b/app/admin/b2b/vetting/[submissionId]/page.tsx
@@ -106,6 +106,7 @@ export default function B2BVettingDetailPage({
   const [showRejectReason, setShowRejectReason] = useState<string | null>(null);
   const [rejectReasonText, setRejectReasonText] = useState<string>('');
   const [actionError, setActionError] = useState<string | null>(null);
+  const [mandateConfirming, setMandateConfirming] = useState(false);
 
   // Handle async params
   useEffect(() => {
@@ -223,6 +224,40 @@ export default function B2BVettingDetailPage({
       );
     } finally {
       setActionInFlight(null);
+    }
+  };
+
+  // Handle mandate confirmation
+  const handleConfirmMandate = async () => {
+    if (!submission?.customers?.id) return;
+
+    setMandateConfirming(true);
+    setActionError(null);
+
+    try {
+      const response = await fetch('/api/admin/b2b/mandate-confirm', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+        },
+        body: JSON.stringify({ customerId: submission.customers.id }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || 'Failed to confirm mandate');
+      }
+
+      // Re-fetch submission to show updated mandate_status
+      await fetchSubmission();
+    } catch (error) {
+      console.error('Error confirming mandate:', error);
+      setActionError(
+        error instanceof Error ? error.message : 'Failed to confirm mandate'
+      );
+    } finally {
+      setMandateConfirming(false);
     }
   };
 
@@ -594,7 +629,7 @@ export default function B2BVettingDetailPage({
                         <p className="text-sm text-gray-600">Branch Code</p>
                         <p className="font-mono text-sm">{encrypted.branch_code || '-'}</p>
                       </div>
-                      <div className="pt-2">
+                      <div className="pt-2 flex items-center justify-between">
                         <Badge
                           variant={
                             pm.mandate_status === 'active' ? 'default' : 'secondary'
@@ -602,6 +637,18 @@ export default function B2BVettingDetailPage({
                         >
                           {pm.mandate_status}
                         </Badge>
+                        {pm.mandate_status !== 'active' && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={handleConfirmMandate}
+                            disabled={mandateConfirming}
+                            className="gap-1 text-blue-600 hover:text-blue-700"
+                          >
+                            <PiCheckBold className="w-3 h-3" />
+                            {mandateConfirming ? 'Confirming...' : 'Confirm Active'}
+                          </Button>
+                        )}
                       </div>
                     </div>
                   );

--- a/app/admin/unjani/onboarding/page.tsx
+++ b/app/admin/unjani/onboarding/page.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  PiCheckCircleBold,
+  PiClockBold,
+  PiXCircleBold,
+  PiCaretRightBold,
+  PiWarningBold,
+} from 'react-icons/pi';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface PipelineClinic {
+  account_number: string;
+  customer_id: string;
+  business_name: string;
+  province: string;
+  stage: string;
+  document_vetting_status: string | null;
+  mandate_status: string | null;
+  vetting_due_date: string | null;
+  submitted_at: string | null;
+  sla: {
+    dueDate: string | null;
+    overdue: boolean;
+    businessDaysLeft: number | null;
+  };
+  submission_id: string | null;
+}
+
+interface PipelineResponse {
+  clinics: PipelineClinic[];
+  stageCounts: {
+    invited: number;
+    submitted: number;
+    changes_requested: number;
+    docs_approved: number;
+    mandate_active: number;
+    billing_ready: number;
+    pending: number;
+  };
+  overdueCount: number;
+}
+
+function getStageBadge(stage: string) {
+  const variants: Record<
+    string,
+    { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }
+  > = {
+    invited: { variant: 'secondary', label: 'Invited' },
+    submitted: { variant: 'secondary', label: 'Submitted' },
+    changes_requested: { variant: 'destructive', label: 'Changes Requested' },
+    docs_approved: { variant: 'outline', label: 'Docs Approved' },
+    mandate_active: { variant: 'outline', label: 'Mandate Active' },
+    billing_ready: { variant: 'default', label: 'Billing Ready' },
+    pending: { variant: 'outline', label: 'Pending' },
+  };
+  const config = variants[stage] || { variant: 'outline', label: stage };
+  return <Badge variant={config.variant}>{config.label}</Badge>;
+}
+
+function getStageIcon(stage: string) {
+  switch (stage) {
+    case 'billing_ready':
+      return <PiCheckCircleBold className="w-4 h-4 text-green-600" />;
+    case 'changes_requested':
+      return <PiXCircleBold className="w-4 h-4 text-red-600" />;
+    default:
+      return <PiClockBold className="w-4 h-4 text-amber-600" />;
+  }
+}
+
+function formatSLADisplay(clinic: PipelineClinic): string {
+  if (!clinic.sla.dueDate) {
+    return '-';
+  }
+
+  if (clinic.sla.overdue && clinic.sla.businessDaysLeft !== null) {
+    return `${Math.abs(clinic.sla.businessDaysLeft)} days overdue`;
+  }
+
+  if (clinic.sla.businessDaysLeft !== null) {
+    return `${clinic.sla.businessDaysLeft} days left`;
+  }
+
+  return '-';
+}
+
+export default function UnjanionboardingPipelinePage() {
+  const router = useRouter();
+  const [data, setData] = useState<PipelineResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchPipeline() {
+      setLoading(true);
+      try {
+        const response = await fetch('/api/admin/b2b/onboarding-pipeline', {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch pipeline');
+        }
+
+        const result: PipelineResponse = await response.json();
+        setData(result);
+      } catch (error) {
+        console.error('Error fetching pipeline:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchPipeline();
+  }, []);
+
+  if (loading) {
+    return (
+      <main className="max-w-7xl mx-auto px-4 py-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2">Clinic Onboarding Pipeline</h1>
+          <p className="text-gray-600">Track Unjani clinic onboarding progress</p>
+        </div>
+
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      </main>
+    );
+  }
+
+  if (!data) {
+    return (
+      <main className="max-w-7xl mx-auto px-4 py-8">
+        <div className="text-center py-8 text-gray-500">Failed to load pipeline data</div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">Clinic Onboarding Pipeline</h1>
+        <p className="text-gray-600">Track Unjani clinic onboarding progress and SLAs</p>
+      </div>
+
+      {/* Stage Count Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center">
+              <div className="text-2xl font-bold">{data.stageCounts.invited}</div>
+              <div className="text-xs text-gray-600">Invited</div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center">
+              <div className="text-2xl font-bold">{data.stageCounts.submitted}</div>
+              <div className="text-xs text-gray-600">Submitted</div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center">
+              <div className="text-2xl font-bold text-red-600">
+                {data.stageCounts.changes_requested}
+              </div>
+              <div className="text-xs text-gray-600">Changes Req.</div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center">
+              <div className="text-2xl font-bold">{data.stageCounts.docs_approved}</div>
+              <div className="text-xs text-gray-600">Docs Approved</div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center">
+              <div className="text-2xl font-bold">{data.stageCounts.mandate_active}</div>
+              <div className="text-xs text-gray-600">Mandate Active</div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center">
+              <div className="text-2xl font-bold text-green-600">
+                {data.stageCounts.billing_ready}
+              </div>
+              <div className="text-xs text-gray-600">Ready</div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={data.overdueCount > 0 ? 'border-red-300 bg-red-50' : ''}>
+          <CardContent className="pt-6">
+            <div className="text-center">
+              <div className={`text-2xl font-bold ${data.overdueCount > 0 ? 'text-red-600' : ''}`}>
+                {data.overdueCount}
+              </div>
+              <div className="text-xs text-gray-600">Overdue</div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Pipeline Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Clinics</CardTitle>
+          <CardDescription>{data.clinics.length} total clinics</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.clinics.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">No clinics in pipeline</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Account</TableHead>
+                    <TableHead>Clinic</TableHead>
+                    <TableHead>Province</TableHead>
+                    <TableHead>Stage</TableHead>
+                    <TableHead>SLA</TableHead>
+                    <TableHead className="text-right">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.clinics.map((clinic) => (
+                    <TableRow
+                      key={clinic.customer_id}
+                      className={clinic.sla.overdue ? 'bg-red-50' : 'hover:bg-gray-50'}
+                    >
+                      <TableCell className="font-mono text-sm">{clinic.account_number}</TableCell>
+                      <TableCell className="font-medium">{clinic.business_name}</TableCell>
+                      <TableCell className="text-sm text-gray-600">{clinic.province}</TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          {getStageIcon(clinic.stage)}
+                          {getStageBadge(clinic.stage)}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="text-sm">
+                          {clinic.sla.overdue ? (
+                            <div className="flex items-center gap-1 text-red-600 font-medium">
+                              <PiWarningBold className="w-4 h-4" />
+                              {formatSLADisplay(clinic)}
+                            </div>
+                          ) : (
+                            <span className="text-gray-600">{formatSLADisplay(clinic)}</span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {clinic.submission_id ? (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() =>
+                              router.push(`/admin/b2b/vetting/${clinic.submission_id}`)
+                            }
+                          >
+                            <PiCaretRightBold className="w-4 h-4" />
+                          </Button>
+                        ) : (
+                          <span className="text-xs text-gray-400">No submission</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/api/admin/b2b/mandate-confirm/route.ts
+++ b/app/api/admin/b2b/mandate-confirm/route.ts
@@ -1,0 +1,121 @@
+/**
+ * Mandate Manual Confirmation API
+ *
+ * Manually confirms a debit-order mandate as active when NetCash webhook
+ * is unreliable or delayed. Sets mandate_status='active' + verified flag.
+ *
+ * POST /api/admin/b2b/mandate-confirm
+ * Body: { customerId: string }
+ *
+ * Requires admin auth + kyc:verify permission
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { maybeMarkBillingReady } from '@/lib/onboarding/billing-ready';
+import { apiLogger } from '@/lib/logging/logger';
+
+interface ConfirmMandateRequest {
+  customerId: string;
+}
+
+interface ConfirmMandateResponse {
+  success: boolean;
+  billingReadyMarked?: boolean;
+  error?: string;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse<ConfirmMandateResponse>> {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response as any;
+
+    const perm = requirePermission(authResult.adminUser, ['customers:write', 'kyc:verify']);
+    if (perm) return perm as any;
+
+    const supabase = await createServerClient();
+
+    const body = (await request.json()) as ConfirmMandateRequest;
+    const { customerId } = body;
+
+    if (!customerId) {
+      return NextResponse.json(
+        { success: false, error: 'Customer ID is required' },
+        { status: 400 }
+      );
+    }
+
+    // Find the debit-order payment method for this customer
+    const { data: paymentMethod, error: pmError } = await supabase
+      .from('customer_payment_methods')
+      .select('id, encrypted_details')
+      .eq('customer_id', customerId)
+      .eq('method_type', 'debit_order')
+      .maybeSingle();
+
+    if (pmError) {
+      apiLogger.error('Failed to fetch payment method', { error: pmError });
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch payment method' },
+        { status: 500 }
+      );
+    }
+
+    if (!paymentMethod) {
+      return NextResponse.json(
+        { success: false, error: 'No debit-order payment method found for customer' },
+        { status: 404 }
+      );
+    }
+
+    // Update payment method: set mandate_status='active', mark verified, set is_active=true
+    const updatedDetails = {
+      ...(typeof paymentMethod.encrypted_details === 'object'
+        ? paymentMethod.encrypted_details
+        : {}),
+      verified: true,
+    };
+
+    const { error: updateError } = await supabase
+      .from('customer_payment_methods')
+      .update({
+        mandate_status: 'active',
+        encrypted_details: updatedDetails,
+        is_active: true,
+      })
+      .eq('id', paymentMethod.id);
+
+    if (updateError) {
+      apiLogger.error('Failed to update payment method', { error: updateError });
+      return NextResponse.json(
+        { success: false, error: 'Failed to update payment method' },
+        { status: 500 }
+      );
+    }
+
+    // Try to mark customer billing_ready if all conditions are met
+    const billingReadyMarked = await maybeMarkBillingReady(supabase, customerId);
+
+    // Audit log
+    apiLogger.info('[Admin] Mandate confirmed manually', {
+      customerId,
+      billingReadyMarked,
+      adminId: authResult.adminUser.id,
+    });
+
+    return NextResponse.json({
+      success: true,
+      billingReadyMarked,
+    });
+  } catch (error: unknown) {
+    apiLogger.error('API error', { error });
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/b2b/onboarding-pipeline/route.ts
+++ b/app/api/admin/b2b/onboarding-pipeline/route.ts
@@ -1,0 +1,222 @@
+/**
+ * Clinic Onboarding Pipeline Dashboard API
+ *
+ * Returns per-clinic rows for Unjani clinics (or any customers with active onboarding)
+ * with stage indicators, SLA tracking, and aggregate counts.
+ *
+ * GET /api/admin/b2b/onboarding-pipeline
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { apiLogger } from '@/lib/logging/logger';
+import { differenceInDays } from 'date-fns';
+
+interface PipelineClinic {
+  account_number: string;
+  customer_id: string;
+  business_name: string;
+  province: string;
+  stage: string;
+  document_vetting_status: string | null;
+  mandate_status: string | null;
+  vetting_due_date: string | null;
+  submitted_at: string | null;
+  sla: {
+    dueDate: string | null;
+    overdue: boolean;
+    businessDaysLeft: number | null;
+  };
+  submission_id: string | null;
+}
+
+interface PipelineResponse {
+  clinics: PipelineClinic[];
+  stageCounts: {
+    invited: number;
+    submitted: number;
+    changes_requested: number;
+    docs_approved: number;
+    mandate_active: number;
+    billing_ready: number;
+    pending: number;
+  };
+  overdueCount: number;
+}
+
+/**
+ * Determine the clinic's current stage in the onboarding pipeline
+ */
+function determineStage(
+  onboarding_status: string | null,
+  submission_status: string | null,
+  document_vetting_status: string | null,
+  mandate_status: string | null
+): string {
+  // billing_ready takes precedence
+  if (onboarding_status === 'billing_ready') {
+    return 'billing_ready';
+  }
+
+  // mandate_active (docs approved + mandate active but not billing_ready yet)
+  if (mandate_status === 'active') {
+    return 'mandate_active';
+  }
+
+  // docs_approved (vetting approved but mandate not yet active)
+  if (document_vetting_status === 'approved') {
+    return 'docs_approved';
+  }
+
+  // changes_requested (rejected docs)
+  if (document_vetting_status === 'rejected') {
+    return 'changes_requested';
+  }
+
+  // submitted (docs pending or under review)
+  if (submission_status === 'submitted') {
+    return 'submitted';
+  }
+
+  // invited (in_progress but no submission yet)
+  if (onboarding_status === 'in_progress') {
+    return 'invited';
+  }
+
+  return 'pending';
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response;
+
+    const perm = requirePermission(authResult.adminUser, ['customers:write', 'kyc:verify']);
+    if (perm) return perm;
+
+    const supabase = await createServerClient();
+
+    // Query: Get all Unjani clinics (business_name ilike '%unjani%' OR has onboarding_submission)
+    // with their latest onboarding_submission + payment method info
+    const { data: clinics, error: clinicsError } = await supabase
+      .from('customers')
+      .select(
+        `
+        id,
+        account_number,
+        business_name,
+        onboarding_status,
+        clinic_details,
+        onboarding_submissions!onboarding_submissions_customer (
+          id,
+          status,
+          document_vetting_status,
+          submitted_at,
+          vetting_due_date
+        ),
+        customer_payment_methods!customer_payment_methods_customer_id (
+          id,
+          mandate_status,
+          method_type
+        )
+      `
+      )
+      .or(`business_name.ilike.%unjani%,onboarding_submissions.not.is.null`)
+      .order('created_at', { ascending: false });
+
+    if (clinicsError) {
+      apiLogger.error('Failed to fetch clinic list', { error: clinicsError });
+      return NextResponse.json(
+        { success: false, error: 'Failed to fetch clinic list' },
+        { status: 500 }
+      );
+    }
+
+    const now = new Date();
+    const result: PipelineResponse = {
+      clinics: [],
+      stageCounts: {
+        invited: 0,
+        submitted: 0,
+        changes_requested: 0,
+        docs_approved: 0,
+        mandate_active: 0,
+        billing_ready: 0,
+        pending: 0,
+      },
+      overdueCount: 0,
+    };
+
+    // Transform each clinic row
+    for (const clinic of clinics || []) {
+      // Latest submission (most recent, if any)
+      const submission = Array.isArray(clinic.onboarding_submissions)
+        ? clinic.onboarding_submissions[0]
+        : null;
+
+      // Debit-order payment method (method_type='debit_order')
+      const debitOrderPm = Array.isArray(clinic.customer_payment_methods)
+        ? clinic.customer_payment_methods.find((pm: any) => pm.method_type === 'debit_order')
+        : null;
+
+      const province =
+        clinic.clinic_details && typeof clinic.clinic_details === 'object'
+          ? (clinic.clinic_details as any).province || ''
+          : '';
+
+      const stage = determineStage(
+        clinic.onboarding_status,
+        submission?.status || null,
+        submission?.document_vetting_status || null,
+        debitOrderPm?.mandate_status || null
+      );
+
+      // SLA calculation: vetting_due_date (if submitted) vs now
+      let businessDaysLeft: number | null = null;
+      let isOverdue = false;
+
+      if (submission?.vetting_due_date) {
+        const dueDate = new Date(submission.vetting_due_date);
+        businessDaysLeft = Math.ceil((dueDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+        isOverdue = businessDaysLeft < 0;
+        if (isOverdue) {
+          result.overdueCount++;
+        }
+      }
+
+      const clinic_row: PipelineClinic = {
+        account_number: clinic.account_number,
+        customer_id: clinic.id,
+        business_name: clinic.business_name,
+        province,
+        stage,
+        document_vetting_status: submission?.document_vetting_status || null,
+        mandate_status: debitOrderPm?.mandate_status || null,
+        vetting_due_date: submission?.vetting_due_date || null,
+        submitted_at: submission?.submitted_at || null,
+        sla: {
+          dueDate: submission?.vetting_due_date || null,
+          overdue: isOverdue,
+          businessDaysLeft,
+        },
+        submission_id: submission?.id || null,
+      };
+
+      result.clinics.push(clinic_row);
+
+      // Increment stage count
+      if (stage in result.stageCounts) {
+        result.stageCounts[stage as keyof typeof result.stageCounts]++;
+      }
+    }
+
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    apiLogger.error('API error', { error });
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/kyc/verify/route.ts
+++ b/app/api/admin/kyc/verify/route.ts
@@ -11,6 +11,8 @@ import { EmailNotificationService } from '@/lib/notifications/notification-servi
 import { apiLogger } from '@/lib/logging/logger';
 import { computeVettingStatus, requiredDocsFor } from '@/lib/onboarding/document-requirements';
 import { maybeMarkBillingReady } from '@/lib/onboarding/billing-ready';
+import { WhatsAppService } from '@/lib/integrations/whatsapp/whatsapp-service';
+import { issueToken, buildMagicLinkUrl } from '@/lib/onboarding/onboarding-service';
 
 export async function POST(request: NextRequest) {
   try {
@@ -161,6 +163,114 @@ export async function POST(request: NextRequest) {
 
           // Try to mark customer billing_ready if all conditions are met
           const marked = await maybeMarkBillingReady(supabase, submission.customer_id);
+
+          // Send notifications (best-effort; failures don't break the API response)
+          try {
+            // Fetch customer + clinic details for notification
+            const { data: customer } = await supabase
+              .from('customers')
+              .select('id, first_name, business_name, phone, email, clinic_details')
+              .eq('id', submission.customer_id)
+              .single();
+
+            if (customer) {
+              const firstName = customer.first_name || 'Clinic Owner';
+              const clinicName = customer.business_name || 'Your Clinic';
+              const phone = customer.phone;
+              const email = customer.email;
+
+              const whatsAppService = new WhatsAppService();
+
+              // APPROVAL path: send approval notifications
+              if (vetting === 'approved' && phone) {
+                try {
+                  // Send WhatsApp approval notification (best-effort)
+                  // Note: circletel_docs_approved template submitted to Meta (PENDING approval)
+                  await whatsAppService.sendTemplate(
+                    phone,
+                    'circletel_docs_approved' as any,
+                    [
+                      {
+                        type: 'body',
+                        parameters: [
+                          { type: 'text', text: firstName },
+                          { type: 'text', text: clinicName },
+                        ],
+                      },
+                    ]
+                  );
+                } catch (err) {
+                  apiLogger.error('[KYC B2B] WhatsApp approval send failed', { error: err });
+                }
+
+                // Send email approval notification (best-effort)
+                if (email) {
+                  try {
+                    await EmailNotificationService.sendKycApproval(
+                      email,
+                      firstName,
+                      customer.id
+                    );
+                  } catch (err) {
+                    apiLogger.error('[KYC B2B] Email approval send failed', { error: err });
+                  }
+                }
+              }
+
+              // REJECTION path: send rejection notifications + magic link
+              if (vetting === 'rejected' && phone) {
+                try {
+                  // Issue a fresh token for the clinic to re-upload documents
+                  const token = await issueToken(customer.id, 'whatsapp');
+                  const magicLink = buildMagicLinkUrl(
+                    'https://www.circletel.co.za',
+                    token
+                  );
+
+                  // Send WhatsApp rejection notification with link to fix documents
+                  // Note: circletel_docs_changes template submitted to Meta (PENDING approval)
+                  await whatsAppService.sendTemplate(
+                    phone,
+                    'circletel_docs_changes' as any,
+                    [
+                      {
+                        type: 'body',
+                        parameters: [
+                          { type: 'text', text: firstName },
+                          { type: 'text', text: clinicName },
+                          { type: 'text', text: rejectionReason || 'Documents require review' },
+                        ],
+                      },
+                      {
+                        type: 'button',
+                        sub_type: 'url',
+                        index: 0,
+                        parameters: [{ type: 'text', text: magicLink }],
+                      },
+                    ]
+                  );
+                } catch (err) {
+                  apiLogger.error('[KYC B2B] WhatsApp rejection send failed', { error: err });
+                }
+
+                // Send email rejection notification
+                if (email) {
+                  try {
+                    await EmailNotificationService.sendKycRejection(
+                      email,
+                      firstName,
+                      customer.id,
+                      rejectionReason || 'Documents require review'
+                    );
+                  } catch (err) {
+                    apiLogger.error('[KYC B2B] Email rejection send failed', { error: err });
+                  }
+                }
+              }
+            }
+          } catch (notifyErr) {
+            apiLogger.error('[KYC B2B] Notification error (non-fatal)', { error: notifyErr });
+          }
 
           return NextResponse.json({
             success: true,

--- a/app/api/onboarding/submit/route.ts
+++ b/app/api/onboarding/submit/route.ts
@@ -4,6 +4,7 @@ import { step1Schema, step2Schema, step3Schema, step5Schema } from '@/lib/onboar
 import { requiredDocsFor } from '@/lib/onboarding/document-requirements';
 import { buildEMandateRequest } from '@/lib/onboarding/emandate-request';
 import { NetCashEMandateBatchService } from '@/lib/payments/netcash-emandate-batch-service';
+import { addBusinessDays, now } from '@/lib/dates';
 
 export async function POST(request: NextRequest) {
   const supabase = svc();
@@ -176,11 +177,14 @@ export async function POST(request: NextRequest) {
   }
 
   // 4) Finalize submission
+  const vettingDueDate = addBusinessDays(now(), 2); // 2 business days from now
   const { error: subErr } = await supabase
     .from('onboarding_submissions')
     .update({
       status: 'submitted',
       document_vetting_status: 'documents_pending',
+      submitted_at: new Date().toISOString(),
+      vetting_due_date: vettingDueDate.toISOString(),
       submission_data: {
         step1: s1.data,
         step2: s2.data,

--- a/app/onboarding/components/steps/Step4Documents.tsx
+++ b/app/onboarding/components/steps/Step4Documents.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { requiredDocsFor } from '@/lib/onboarding/document-requirements';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { PiCheckCircle, PiUploadSimple } from 'react-icons/pi';
+import { PiCheckCircle, PiCameraBold } from 'react-icons/pi';
 
 export interface Step4DocumentsProps {
   token: string;
@@ -93,6 +93,10 @@ export function Step4Documents({
           Upload the required documents to verify your company details and
           banking.
         </p>
+        <p className="text-sm text-circleTel-orange-accessible mt-2">
+          📷 On your phone, tap a document below to <strong>take a photo</strong> with your
+          camera — or choose a PDF/image you already have.
+        </p>
       </div>
 
       {error && (
@@ -142,8 +146,8 @@ export function Step4Documents({
                   asChild
                 >
                   <span className="cursor-pointer">
-                    <PiUploadSimple className="w-4 h-4 mr-1" />
-                    {busy === doc.type ? 'Uploading...' : 'Upload'}
+                    <PiCameraBold className="w-4 h-4 mr-1" />
+                    {busy === doc.type ? 'Uploading...' : 'Take photo or upload'}
                   </span>
                 </Button>
               </label>

--- a/lib/dates/business-days.ts
+++ b/lib/dates/business-days.ts
@@ -1,0 +1,134 @@
+/**
+ * Business Day Utilities
+ *
+ * Calculates business days excluding weekends (Sat/Sun) and South African public holidays.
+ * Used for SLA tracking in the onboarding pipeline.
+ *
+ * @module lib/dates/business-days
+ */
+
+import { addDays, isWeekend, parseISO, isValid } from 'date-fns';
+
+/**
+ * South African public holidays (2025-2027) as date strings (YYYY-MM-DD)
+ * Used for business day calculations. Add new holidays as needed.
+ */
+const SA_PUBLIC_HOLIDAYS = [
+  // 2026
+  '2026-01-01', // New Year's Day
+  '2026-03-21', // Human Rights Day
+  '2026-04-10', // Good Friday
+  '2026-04-13', // Family Day
+  '2026-04-27', // Freedom Day
+  '2026-05-01', // Workers' Day
+  '2026-06-16', // Youth Day
+  '2026-06-17', // Public Holiday (Youth Day observed)
+  '2026-08-09', // National Women's Day
+  '2026-09-24', // Heritage Day
+  '2026-12-25', // Christmas Day
+  '2026-12-26', // Day of Goodwill
+];
+
+/**
+ * Parse a date and normalize to YYYY-MM-DD string for holiday matching
+ */
+function dateToString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Check if a date is a South African public holiday
+ */
+export function isPublicHoliday(date: Date): boolean {
+  const dateStr = dateToString(date);
+  return SA_PUBLIC_HOLIDAYS.includes(dateStr);
+}
+
+/**
+ * Check if a date is a business day (not weekend, not public holiday)
+ */
+export function isBusinessDay(date: Date): boolean {
+  if (!isValid(date)) return false;
+  return !isWeekend(date) && !isPublicHoliday(date);
+}
+
+/**
+ * Add N business days to a date
+ *
+ * Skips weekends (Sat/Sun) and South African public holidays.
+ * For SLA tracking: addBusinessDays(submittedAt, 2) = vetting due date.
+ *
+ * @param date - Start date
+ * @param days - Number of business days to add
+ * @returns Date N business days later
+ */
+export function addBusinessDays(date: Date, days: number): Date {
+  if (!isValid(date)) return date;
+
+  let current = new Date(date);
+  let count = 0;
+
+  // Add days until we reach the target count
+  while (count < days) {
+    current = addDays(current, 1);
+    if (isBusinessDay(current)) {
+      count++;
+    }
+  }
+
+  return current;
+}
+
+/**
+ * Calculate business days between two dates (inclusive of start, exclusive of end)
+ */
+export function countBusinessDays(start: Date, end: Date): number {
+  if (!isValid(start) || !isValid(end)) return 0;
+
+  let current = new Date(start);
+  let count = 0;
+
+  while (current < end) {
+    if (isBusinessDay(current)) {
+      count++;
+    }
+    current = addDays(current, 1);
+  }
+
+  return count;
+}
+
+/**
+ * Get business days remaining until a date
+ *
+ * Returns negative if the date is in the past.
+ *
+ * @param fromDate - Reference date
+ * @param untilDate - Target date
+ * @returns Number of business days until untilDate
+ */
+export function getBusinessDaysUntil(fromDate: Date, untilDate: Date): number {
+  if (!isValid(fromDate) || !isValid(untilDate)) return 0;
+
+  let current = new Date(fromDate);
+  let count = 0;
+  const isNegative = fromDate > untilDate;
+
+  // If counting backwards, swap direction
+  if (isNegative) {
+    [fromDate, untilDate] = [untilDate, fromDate];
+    current = new Date(fromDate);
+  }
+
+  while (current < untilDate) {
+    if (isBusinessDay(current)) {
+      count++;
+    }
+    current = addDays(current, 1);
+  }
+
+  return isNegative ? -count : count;
+}

--- a/lib/dates/index.ts
+++ b/lib/dates/index.ts
@@ -651,3 +651,15 @@ export function getAge(date: DateInput): string {
   if (years === 1) return '1 year old';
   return `${years} years old`;
 }
+
+// =============================================================================
+// RE-EXPORT BUSINESS DAY UTILITIES
+// =============================================================================
+
+export {
+  isBusinessDay,
+  addBusinessDays,
+  countBusinessDays,
+  getBusinessDaysUntil,
+  isPublicHoliday,
+} from './business-days';

--- a/lib/inngest/functions/clinic-vetting-sla.ts
+++ b/lib/inngest/functions/clinic-vetting-sla.ts
@@ -1,0 +1,234 @@
+/**
+ * Clinic Vetting SLA Reminder Inngest Function
+ *
+ * Daily cron job that checks for clinics awaiting document vetting with due dates
+ * approaching or past. Sends digest email to sales admin with overdue clinics.
+ *
+ * Trigger: Daily at 09:00 SAST (configured in vercel.json, when activated)
+ * Retries: 2
+ * Concurrency: 1 (digest only)
+ *
+ * IMPORTANT: This function must be wired in Coolify's cron settings.
+ * vercel.json cron definitions are inactive (Coolify uses its own cron system).
+ */
+
+import { inngest } from '../client';
+import { createClient } from '@/lib/supabase/server';
+import { apiLogger } from '@/lib/logging/logger';
+import { differenceInDays } from 'date-fns';
+import { Resend } from 'resend';
+
+interface OverdueClinic {
+  account_number: string;
+  business_name: string;
+  province: string;
+  vetting_due_date: string;
+  daysOverdue: number;
+  customerEmail?: string;
+}
+
+// =============================================================================
+// INNGEST FUNCTION
+// =============================================================================
+
+export const clinicVettingSlaFunction = inngest.createFunction(
+  {
+    id: 'clinic-vetting-sla',
+    name: 'Clinic Vetting SLA Reminder',
+    retries: 2,
+    concurrency: { limit: 1 }, // Digest only; no parallelization needed
+  },
+  { cron: 'TZ=Africa/Johannesburg 0 9 * * *' }, // Daily at 09:00 SAST
+  async ({ step }) => {
+    const supabase = await createClient();
+    const now = new Date();
+    const reminderDeadline = new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000); // 1 day from now
+
+    apiLogger.info('[SLA Cron] Running clinic vetting SLA reminder');
+
+    try {
+      // Fetch clinics awaiting vetting with due dates approaching or overdue
+      const { data: submissions, error: submissionsError } = await supabase
+        .from('onboarding_submissions')
+        .select(
+          `
+          id,
+          customer_id,
+          vetting_due_date,
+          document_vetting_status,
+          customers:customer_id (
+            id,
+            account_number,
+            business_name,
+            email,
+            phone,
+            clinic_details
+          )
+        `
+        )
+        .eq('status', 'submitted')
+        .in('document_vetting_status', ['documents_pending', 'under_review'])
+        .not('vetting_due_date', 'is', null)
+        .lte('vetting_due_date', reminderDeadline.toISOString());
+
+      if (submissionsError) {
+        apiLogger.error('[SLA Cron] Failed to fetch submissions', { error: submissionsError });
+        return {
+          success: false,
+          error: 'Failed to fetch submissions',
+        };
+      }
+
+      const overdue: OverdueClinic[] = [];
+      const soonDue: OverdueClinic[] = [];
+
+      // Categorize clinics
+      for (const submission of submissions || []) {
+        const customer = Array.isArray(submission.customers)
+          ? submission.customers[0]
+          : submission.customers;
+
+        if (!customer) continue;
+
+        const dueDate = new Date(submission.vetting_due_date);
+        const daysLeft = differenceInDays(dueDate, now);
+
+        const clinic: OverdueClinic = {
+          account_number: customer.account_number,
+          business_name: customer.business_name,
+          province:
+            customer.clinic_details && typeof customer.clinic_details === 'object'
+              ? (customer.clinic_details as any).province || ''
+              : '',
+          vetting_due_date: submission.vetting_due_date,
+          daysOverdue: daysLeft < 0 ? Math.abs(daysLeft) : 0,
+          customerEmail: customer.email,
+        };
+
+        if (daysLeft < 0) {
+          overdue.push(clinic);
+        } else if (daysLeft <= 1) {
+          soonDue.push(clinic);
+        }
+      }
+
+      const totalDue = overdue.length + soonDue.length;
+
+      if (totalDue === 0) {
+        apiLogger.info('[SLA Cron] No clinics with SLA concerns');
+        return {
+          success: true,
+          totalDue: 0,
+          overdueCount: 0,
+          soonDueCount: 0,
+        };
+      }
+
+      // Step: Send digest email to sales admin
+      const emailSent = await step.run('send-sla-digest-email', async () => {
+        const salesAdminEmail = process.env.CLINIC_VETTING_EMAIL || 'sales@circletel.co.za';
+        const resend = new Resend(process.env.RESEND_API_KEY);
+
+        // Build HTML content for the digest
+        const overdueHtml =
+          overdue.length > 0
+            ? `
+          <h3 style="color: #d00;">Overdue (${overdue.length})</h3>
+          <table style="border-collapse: collapse; width: 100%; margin-bottom: 20px; font-size: 13px;">
+            <thead>
+              <tr style="background-color: #fee; border-bottom: 1px solid #ddd;">
+                <th style="text-align: left; padding: 8px 4px;">Account</th>
+                <th style="text-align: left; padding: 8px 4px;">Clinic</th>
+                <th style="text-align: left; padding: 8px 4px;">Days Overdue</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${overdue.map(c => `
+                <tr style="border-bottom: 1px solid #eee;">
+                  <td style="padding: 6px 4px; font-family: monospace;">${c.account_number}</td>
+                  <td style="padding: 6px 4px;">${c.business_name}</td>
+                  <td style="padding: 6px 4px; font-weight: bold; color: #d00;">${c.daysOverdue}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        `
+            : '';
+
+        const soonDueHtml =
+          soonDue.length > 0
+            ? `
+          <h3 style="color: #f80;">Due Soon (${soonDue.length})</h3>
+          <table style="border-collapse: collapse; width: 100%; font-size: 13px;">
+            <thead>
+              <tr style="background-color: #ffe; border-bottom: 1px solid #ddd;">
+                <th style="text-align: left; padding: 8px 4px;">Account</th>
+                <th style="text-align: left; padding: 8px 4px;">Clinic</th>
+                <th style="text-align: left; padding: 8px 4px;">Due Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${soonDue.map(c => `
+                <tr style="border-bottom: 1px solid #eee;">
+                  <td style="padding: 6px 4px; font-family: monospace;">${c.account_number}</td>
+                  <td style="padding: 6px 4px;">${c.business_name}</td>
+                  <td style="padding: 6px 4px;">${new Date(c.vetting_due_date).toLocaleDateString()}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        `
+            : '';
+
+        const htmlContent = `
+          <h2 style="color: #333; margin-top: 0;">Clinic Vetting SLA Alert</h2>
+          <p style="font-size: 14px; color: #666;">Total clinics awaiting vetting: <strong>${totalDue}</strong></p>
+
+          ${overdueHtml}
+          ${soonDueHtml}
+
+          <p style="margin-top: 20px; padding-top: 20px; border-top: 1px solid #ddd; color: #999; font-size: 12px;">
+            <a href="https://www.circletel.co.za/admin/unjani/onboarding" style="color: #0066cc;">View Onboarding Pipeline</a>
+          </p>
+        `;
+
+        try {
+          const result = await resend.emails.send({
+            from: 'billing@notify.circletel.co.za',
+            to: salesAdminEmail,
+            subject: `⏰ Clinic Vetting SLA Alert: ${overdue.length} overdue, ${soonDue.length} due soon`,
+            html: htmlContent,
+          });
+
+          return { success: !result.error, error: result.error?.message };
+        } catch (err) {
+          return {
+            success: false,
+            error: err instanceof Error ? err.message : 'Failed to send email',
+          };
+        }
+      });
+
+      apiLogger.info('[SLA Cron] Digest sent', {
+        totalDue,
+        overdueCount: overdue.length,
+        soonDueCount: soonDue.length,
+        emailSent: emailSent.success,
+      });
+
+      return {
+        success: true,
+        totalDue,
+        overdueCount: overdue.length,
+        soonDueCount: soonDue.length,
+        emailSent: emailSent.success,
+      };
+    } catch (error) {
+      apiLogger.error('[SLA Cron] Unexpected error', { error });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unexpected error',
+      };
+    }
+  }
+);

--- a/lib/inngest/index.ts
+++ b/lib/inngest/index.ts
@@ -140,6 +140,10 @@ export {
   b2bSiteActivationInvoice,
 } from './functions/b2b-site-activation-invoice';
 
+export {
+  clinicVettingSlaFunction,
+} from './functions/clinic-vetting-sla';
+
 // Collect all functions for the serve handler
 import {
   competitorScrapeFunction,
@@ -273,6 +277,10 @@ import {
   b2bSiteActivationInvoice,
 } from './functions/b2b-site-activation-invoice';
 
+import {
+  clinicVettingSlaFunction,
+} from './functions/clinic-vetting-sla';
+
 export const functions = [
   // Competitor analysis
   competitorScrapeFunction,
@@ -354,4 +362,7 @@ export const functions = [
   zohoDeskTokenRefreshFailedFunction,
   // B2B site activation pro-rata invoice
   b2bSiteActivationInvoice,
+  // Clinic vetting SLA reminder (daily at 09:00 SAST)
+  // NOTE: This cron must be wired in Coolify; vercel.json crons are inactive
+  clinicVettingSlaFunction,
 ];

--- a/supabase/migrations/20260610120000_onboarding_pipeline.sql
+++ b/supabase/migrations/20260610120000_onboarding_pipeline.sql
@@ -1,0 +1,9 @@
+-- Onboarding Pipeline: Add vetting SLA tracking
+-- Additive + idempotent. Safe to run multiple times.
+
+ALTER TABLE onboarding_submissions
+ADD COLUMN IF NOT EXISTS vetting_due_date timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_submissions_vetting_due_date
+ON onboarding_submissions(vetting_due_date)
+WHERE status = 'submitted' AND document_vetting_status IN ('documents_pending', 'under_review');

--- a/supabase/migrations/20260610120001_kyc_documents_allow_onboarding_reference.sql
+++ b/supabase/migrations/20260610120001_kyc_documents_allow_onboarding_reference.sql
@@ -1,0 +1,10 @@
+-- Allow kyc_documents to reference either a consumer_order, business_quote, or onboarding_submission
+-- Idempotent: checks and drops existing constraint before re-creating.
+
+ALTER TABLE kyc_documents DROP CONSTRAINT IF EXISTS kyc_order_reference_check;
+ALTER TABLE kyc_documents ADD CONSTRAINT kyc_order_reference_check CHECK (
+  (consumer_order_id IS NOT NULL AND business_quote_id IS NULL)
+  OR (consumer_order_id IS NULL AND business_quote_id IS NOT NULL)
+  OR (consumer_order_id IS NULL AND business_quote_id IS NULL
+      AND (customer_id IS NOT NULL OR onboarding_submission_id IS NOT NULL))
+);


### PR DESCRIPTION
## Summary
Operationalises the post-submission onboarding steps for the sales administrator (builds on the shipped wizard/vetting).

- **Pipeline dashboard** `/admin/unjani/onboarding` + API — per-clinic stage (invited→submitted→vetting→docs-approved→mandate→billing-ready) with stage counts.
- **2-business-day vetting SLA** — `lib/dates/business-days.ts`, `onboarding_submissions.vetting_due_date` (migration applied), daily Inngest reminder digest to the sales admin (must be wired in Coolify cron).
- **Nurse notifications** on the vetting decision — WhatsApp (`circletel_docs_approved`/`circletel_docs_changes`, PENDING Meta approval) + email; rejection includes a fresh magic link.
- **Manual "Confirm mandate active"** admin action — mitigates the unreliable NetCash postback; flips to billing-ready.
- Tracks the `kyc_documents` onboarding-reference constraint migration (already live on prod).
- Bundles the Step-4 "Take photo or upload" copy.

Phase 2 (Service Order via Zoho Sign) is a follow-up.

## Test plan
- [ ] /admin/unjani/onboarding renders pipeline + SLA counts
- [ ] Approve docs → nurse WhatsApp/email; reject → changes message + link
- [ ] Confirm-mandate → billing-ready
- [ ] business-days unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)