### PR TITLE
fix(ci): revert BUILD_CPUS=4 — it slowed builds and timed one out

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -137,9 +137,8 @@ jobs:
         run: NODE_OPTIONS='--max-old-space-size=12288' npm run build -- --turbopack
         env:
           SELF_HOSTED: 'true'
-          # 24GB VPS has headroom for parallel webpack workers — un-throttle from 1 CPU.
-          # Lower this if the build OOMs (watch `free -h` in the build logs).
-          BUILD_CPUS: '4'
+          # BUILD_CPUS unset → cpus:1, matching the proven Turbopack run (10m39s).
+          # cpus:4 measured slower (27-34min, memory thrash) — do not re-add.
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
           NEXT_PUBLIC_APP_URL: https://staging.circletel.co.za

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,9 +144,9 @@ jobs:
         run: NODE_OPTIONS='--max-old-space-size=12288' npm run build
         env:
           SELF_HOSTED: 'true'
-          # 24GB VPS has headroom for parallel webpack workers — un-throttle from 1 CPU.
-          # Lower this if the build OOMs (watch `free -h` in the build logs).
-          BUILD_CPUS: '4'
+          # BUILD_CPUS deliberately UNSET → cpus:1. BUILD_CPUS=4 was measured at 27-34min
+          # (memory thrash; one deploy timed out) vs ~21min at cpus:1. The real speedup is
+          # Turbopack (10m39s), not more cores — do not re-add BUILD_CPUS here.
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
           NEXT_PUBLIC_APP_URL: https://www.circletel.co.za


### PR DESCRIPTION
## What & why

The `BUILD_CPUS=4` change from #534 backfired. Measured on the self-hosted VPS (24 GB, single runner):

| Config | Build time | Outcome |
|---|---|---|
| cpus:1 webpack (baseline) | **~21 min** | reliable |
| `BUILD_CPUS=4` webpack | **27 min** / **34.5 min** | slower; #534's deploy **timed out at 40m and was cancelled** |
| Turbopack, cpus:1 | **10m 39s** | the real speedup |

4 parallel webpack workers against the 12 GB heap thrash GC — builds got *slower*, not faster, and one prod deploy timed out (prod stayed healthy on its prior image; #536 later deployed fine).

## Change
- Remove `BUILD_CPUS: '4'` from `deploy.yml` and `deploy-staging.yml` → back to cpus:1 (~21 min, reliable).
- Staging keeps `--turbopack`, now at cpus:1 — matching the proven 10m39s experiment.
- `next.config.js` env-driven mechanism stays (harmless, defaults to 1).

## Follow-up (the actual speedup)
Validate Turbopack serve-parity on staging (push `main→staging`, now builds Turbopack+cpus:1), then promote `--turbopack` to `deploy.yml` for prod → ~10–11 min prod builds.

Merging triggers a prod deploy that should land in ~21 min (cpus:1 baseline).