### PR TITLE
fix(ci): use prune -a in deploy disk-cleanup (recurring disk-full failures)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -70,8 +70,11 @@ jobs:
           echo "Available: ${AVAIL_MB}MB"
           if [ "$AVAIL_MB" -lt 8000 ]; then
             echo "Low disk — running cleanup..."
-            docker image prune -f
-            docker builder prune -f
+            # -a reclaims ALL unused images + the full build cache (not just dangling);
+            # running containers are unaffected. The -f-only form reclaimed almost nothing
+            # and a staging build failed the 4GB disk guard (2026-06-10).
+            docker image prune -a -f
+            docker builder prune -a -f
             npm cache clean --force 2>/dev/null || true
             journalctl --vacuum-size=100M 2>/dev/null || true
             rm -rf /tmp/buildx-cache /tmp/com.google.Chrome.scoped_dir.* 2>/dev/null || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,8 +77,11 @@ jobs:
           echo "Available: ${AVAIL_MB}MB"
           if [ "$AVAIL_MB" -lt 8000 ]; then
             echo "Low disk — running cleanup..."
-            docker image prune -f
-            docker builder prune -f
+            # -a reclaims ALL unused images + the full build cache (not just dangling);
+            # running containers are unaffected. The -f-only form reclaimed almost nothing
+            # and a staging build failed the 4GB disk guard (2026-06-10).
+            docker image prune -a -f
+            docker builder prune -a -f
             npm cache clean --force 2>/dev/null || true
             journalctl --vacuum-size=100M 2>/dev/null || true
             rm -rf /tmp/buildx-cache /tmp/com.google.Chrome.scoped_dir.* 2>/dev/null || true


### PR DESCRIPTION
## Why
The low-disk cleanup in both deploy workflows used `docker image prune -f` / `docker builder prune -f` — these only remove **dangling** images/cache and reclaimed ~0–361 MB in practice. On 2026-06-10 the VPS hit 97% and a staging build **failed the 4 GB disk guard** before building.

## Change
Switch both `Check disk space and cleanup` steps to `docker image prune -a -f` + `docker builder prune -a -f` (all unused images + full build cache). Running containers (prod/staging/CMS/Coolify) are unaffected — verified manually today, which reclaimed ~4.7 GB (3.6 → 9.3 GB free).

Docs/CI-config only. Triggers a prod deploy on merge (now a fast ~10–11 min Turbopack build).