### PR TITLE
Phase 2: Service Order PDF record (back-to-back Unjani MSA)

### DIFF
--- a/__tests__/lib/contracts/service-order-pdf.test.ts
+++ b/__tests__/lib/contracts/service-order-pdf.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for Service Order PDF Generator
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { generateServiceOrderPdf, generateServiceOrderBlob, generateServiceOrderBuffer } from '@/lib/contracts/service-order-pdf';
+
+describe('Service Order PDF Generator', () => {
+  const mockInput = {
+    accountNumber: 'CT-2026-00020',
+    clinicName: 'Unjani Clinic Delmas',
+    clinicAddress: '123 Main Street, Delmas',
+    clinicProvince: 'Gauteng',
+    clinicEmail: 'delmas@unjani.org',
+    clinicPhone: '082 111 2222',
+    monthlyFeeExclVat: 450,
+    vatPercentage: 15,
+    billingDay: '15' as const,
+    activationDate: '2026-06-15T00:00:00Z',
+    submittedAt: '2026-06-10T12:00:00Z',
+  };
+
+  it('should generate a PDF document', () => {
+    const pdf = generateServiceOrderPdf(mockInput);
+
+    // Check that we get a jsPDF instance with expected methods
+    expect(pdf).toBeDefined();
+    expect(typeof pdf.output).toBe('function');
+    expect(typeof pdf.getNumberOfPages).toBe('function');
+
+    // Should be at least 2 pages (header + terms + acceptance)
+    const pageCount = pdf.getNumberOfPages();
+    expect(pageCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should generate a valid PDF blob', () => {
+    const blob = generateServiceOrderBlob(mockInput);
+
+    expect(blob).toBeDefined();
+    expect(blob instanceof Blob).toBe(true);
+    expect(blob.type).toBe('application/pdf');
+    expect(blob.size).toBeGreaterThan(0);
+  });
+
+  it('should generate a valid PDF buffer', () => {
+    const buffer = generateServiceOrderBuffer(mockInput);
+
+    expect(buffer).toBeDefined();
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(buffer.length).toBeGreaterThan(0);
+    // PDF files start with %PDF
+    expect(buffer.toString('utf8', 0, 4)).toBe('%PDF');
+  });
+
+  it('should include clinic details in the PDF', async () => {
+    const blob = generateServiceOrderBlob(mockInput);
+    const arrayBuffer = await blob.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const text = buffer.toString('utf8');
+
+    // Check for key clinic identifiers in the PDF
+    expect(text).toContain('Unjani Clinic Delmas');
+    expect(text).toContain('CT-2026-00020');
+    expect(text).toContain('Gauteng');
+  });
+
+  it('should include pricing information', async () => {
+    const blob = generateServiceOrderBlob(mockInput);
+    const arrayBuffer = await blob.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const text = buffer.toString('utf8');
+
+    // Check for pricing markers (amount may be encoded)
+    expect(text).toContain('450'); // R450 monthly fee
+    expect(text).toContain('15'); // 15% VAT
+  });
+
+  it('should handle different billing days', () => {
+    const billingDays: Array<'1' | '15' | '20' | '25'> = ['1', '15', '20', '25'];
+
+    billingDays.forEach((billingDay) => {
+      const input = { ...mockInput, billingDay };
+      const pdf = generateServiceOrderPdf(input);
+
+      expect(pdf).toBeDefined();
+      expect(pdf.getNumberOfPages()).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('should generate consistent PDF across multiple calls', () => {
+    const blob1 = generateServiceOrderBlob(mockInput);
+    const blob2 = generateServiceOrderBlob(mockInput);
+
+    // Both should be PDFs with same structure
+    expect(blob1.type).toBe('application/pdf');
+    expect(blob2.type).toBe('application/pdf');
+    // Size may vary slightly due to timestamps, but should be similar
+    expect(Math.abs(blob1.size - blob2.size)).toBeLessThan(500);
+  });
+
+  it('should handle clinic names with special characters', () => {
+    const input = {
+      ...mockInput,
+      clinicName: "Unjani Clinic O'Brien & Partners",
+    };
+
+    const pdf = generateServiceOrderPdf(input);
+    expect(pdf.getNumberOfPages()).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should handle long addresses', () => {
+    const input = {
+      ...mockInput,
+      clinicAddress: '123 Very Long Street Name That Goes On For A While, Building 456, Floor 7, Delmas, Gauteng, 2110, South Africa',
+    };
+
+    const pdf = generateServiceOrderPdf(input);
+    expect(pdf.getNumberOfPages()).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should produce a PDF starting with %PDF magic number', () => {
+    const buffer = generateServiceOrderBuffer(mockInput);
+
+    // PDF files must start with %PDF version indicator
+    expect(buffer.toString('ascii', 0, 4)).toBe('%PDF');
+  });
+
+  it('should include Service Order number in output', async () => {
+    const blob = generateServiceOrderBlob(mockInput);
+    const arrayBuffer = await blob.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const text = buffer.toString('utf8');
+
+    // Service Order number should be present
+    expect(text).toContain('SO-CT-2026-00020');
+  });
+});

--- a/app/admin/unjani/onboarding/page.tsx
+++ b/app/admin/unjani/onboarding/page.tsx
@@ -38,6 +38,7 @@ interface PipelineClinic {
   mandate_status: string | null;
   vetting_due_date: string | null;
   submitted_at: string | null;
+  service_order_issued_at: string | null;
   sla: {
     dueDate: string | null;
     overdue: boolean;
@@ -108,6 +109,7 @@ export default function UnjanionboardingPipelinePage() {
   const router = useRouter();
   const [data, setData] = useState<PipelineResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [issuingServiceOrder, setIssuingServiceOrder] = useState<string | null>(null);
 
   useEffect(() => {
     async function fetchPipeline() {
@@ -134,6 +136,40 @@ export default function UnjanionboardingPipelinePage() {
 
     fetchPipeline();
   }, []);
+
+  const handleIssueServiceOrder = async (customerId: string) => {
+    setIssuingServiceOrder(customerId);
+    try {
+      const response = await fetch('/api/admin/b2b/issue-service-order', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+        },
+        body: JSON.stringify({ customerId }),
+      });
+
+      if (response.ok) {
+        // Refresh the pipeline data
+        const pipelineResponse = await fetch('/api/admin/b2b/onboarding-pipeline', {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+          },
+        });
+        const result: PipelineResponse = await pipelineResponse.json();
+        setData(result);
+      } else {
+        const error = await response.json();
+        console.error('Failed to issue service order:', error);
+        alert(`Error: ${error.message || 'Failed to issue service order'}`);
+      }
+    } catch (error) {
+      console.error('Error issuing service order:', error);
+      alert('Error issuing service order');
+    } finally {
+      setIssuingServiceOrder(null);
+    }
+  };
 
   if (loading) {
     return (
@@ -252,6 +288,7 @@ export default function UnjanionboardingPipelinePage() {
                     <TableHead>Province</TableHead>
                     <TableHead>Stage</TableHead>
                     <TableHead>SLA</TableHead>
+                    <TableHead>Service Order</TableHead>
                     <TableHead className="text-right">Action</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -281,6 +318,29 @@ export default function UnjanionboardingPipelinePage() {
                             <span className="text-gray-600">{formatSLADisplay(clinic)}</span>
                           )}
                         </div>
+                      </TableCell>
+                      <TableCell>
+                        {clinic.service_order_issued_at ? (
+                          <div className="text-sm">
+                            <span className="text-green-600 font-medium">Issued</span>
+                            <div className="text-xs text-gray-500">
+                              {new Date(clinic.service_order_issued_at).toLocaleDateString('en-ZA')}
+                            </div>
+                          </div>
+                        ) : (
+                          clinic.stage === 'billing_ready' || clinic.stage === 'docs_approved' || clinic.stage === 'mandate_active' ? (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleIssueServiceOrder(clinic.customer_id)}
+                              disabled={issuingServiceOrder === clinic.customer_id}
+                            >
+                              {issuingServiceOrder === clinic.customer_id ? 'Issuing...' : 'Issue'}
+                            </Button>
+                          ) : (
+                            <span className="text-xs text-gray-400">Pending</span>
+                          )
+                        )}
                       </TableCell>
                       <TableCell className="text-right">
                         {clinic.submission_id ? (

--- a/app/api/admin/b2b/issue-service-order/route.ts
+++ b/app/api/admin/b2b/issue-service-order/route.ts
@@ -1,0 +1,229 @@
+/**
+ * Issue Service Order PDF API
+ *
+ * POST /api/admin/b2b/issue-service-order
+ *
+ * Admin-only endpoint to generate and issue a Service Order PDF to a clinic.
+ * Generates PDF, uploads to kyc-documents bucket, sends email copy to clinic.
+ *
+ * Request body:
+ * {
+ *   customerId: string (UUID)
+ * }
+ *
+ * Response:
+ * {
+ *   success: boolean,
+ *   pdfPath: string,
+ *   emailed: boolean,
+ *   message: string
+ * }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { uploadFile } from '@/lib/storage/supabase-upload';
+import { generateServiceOrderBlob } from '@/lib/contracts/service-order-pdf';
+import { apiLogger } from '@/lib/logging/logger';
+import { Resend } from 'resend';
+
+interface RequestBody {
+  customerId: string;
+}
+
+interface ServiceOrderResponse {
+  success: boolean;
+  pdfPath?: string;
+  emailed?: boolean;
+  message: string;
+  error?: string;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse<ServiceOrderResponse>> {
+  try {
+    // === Admin Auth ===
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response as NextResponse<ServiceOrderResponse>;
+
+    const perm = requirePermission(authResult.adminUser, ['customers:write', 'kyc:verify']);
+    if (perm) return perm as NextResponse<ServiceOrderResponse>;
+
+    const supabase = await createServerClient();
+    const { customerId } = (await request.json()) as RequestBody;
+
+    if (!customerId) {
+      return NextResponse.json<ServiceOrderResponse>(
+        { success: false, message: 'customerId is required' },
+        { status: 400 }
+      );
+    }
+
+    // === Load Customer ===
+    const { data: customer, error: customerError } = await supabase
+      .from('customers')
+      .select('id, account_number, business_name, email, phone, clinic_details, onboarding_status')
+      .eq('id', customerId)
+      .single();
+
+    if (customerError || !customer) {
+      apiLogger.error('[Service Order] Customer not found', { customerId, error: customerError });
+      return NextResponse.json<ServiceOrderResponse>(
+        { success: false, message: 'Customer not found' },
+        { status: 404 }
+      );
+    }
+
+    // === Load Latest Onboarding Submission ===
+    const { data: submission, error: submissionError } = await supabase
+      .from('onboarding_submissions')
+      .select('id, submission_data, submitted_at')
+      .eq('customer_id', customerId)
+      .order('submitted_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (submissionError || !submission) {
+      apiLogger.error('[Service Order] No onboarding submission found', { customerId, error: submissionError });
+      return NextResponse.json<ServiceOrderResponse>(
+        { success: false, message: 'No onboarding submission found for this customer' },
+        { status: 404 }
+      );
+    }
+
+    // === Load Customer Service (for monthly price) ===
+    const { data: service, error: serviceError } = await supabase
+      .from('customer_services')
+      .select('monthly_price, activation_date')
+      .eq('customer_id', customerId)
+      .order('activation_date', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (serviceError || !service) {
+      apiLogger.error('[Service Order] No customer service found', { customerId, error: serviceError });
+      return NextResponse.json<ServiceOrderResponse>(
+        { success: false, message: 'No active service found for this customer' },
+        { status: 404 }
+      );
+    }
+
+    // === Extract Data from Submission ===
+    const submissionData = submission.submission_data as any;
+    const step5 = submissionData?.step5 || {};
+    const billingDay = step5.paymentDate || '1';
+    const clinicDetails = customer.clinic_details as any || {};
+
+    // === Generate Service Order PDF ===
+    const pdfBlob = generateServiceOrderBlob({
+      accountNumber: customer.account_number,
+      clinicName: customer.business_name,
+      clinicAddress: clinicDetails.site_address || 'Not provided',
+      clinicProvince: clinicDetails.province || 'Not provided',
+      clinicEmail: customer.email,
+      clinicPhone: customer.phone,
+      monthlyFeeExclVat: service.monthly_price || 450,
+      vatPercentage: 15,
+      billingDay: billingDay as '1' | '15' | '20' | '25',
+      activationDate: service.activation_date || new Date().toISOString(),
+      submittedAt: submission.submitted_at || new Date().toISOString(),
+    });
+
+    // === Upload PDF to Storage ===
+    // Convert Blob to File for uploadFile API
+    const pdfFile = new File(
+      [pdfBlob],
+      `SO-${customer.account_number}-${Date.now()}.pdf`,
+      { type: 'application/pdf' }
+    );
+
+    const uploadResult = await uploadFile(pdfFile, {
+      bucket: 'kyc-documents',
+      folder: `service-orders/${customerId}`,
+      maxSizeBytes: 5 * 1024 * 1024,
+      allowedTypes: ['application/pdf'],
+      supabaseClient: supabase,
+    });
+
+    if (!uploadResult.success || !uploadResult.path) {
+      apiLogger.error('[Service Order] PDF upload failed', { customerId, error: uploadResult.error });
+      return NextResponse.json<ServiceOrderResponse>(
+        { success: false, message: 'Failed to upload PDF' },
+        { status: 500 }
+      );
+    }
+
+    // === Update Onboarding Submission with PDF Path ===
+    const { error: updateError } = await supabase
+      .from('onboarding_submissions')
+      .update({
+        service_order_pdf_path: uploadResult.path,
+        service_order_issued_at: new Date().toISOString(),
+      })
+      .eq('id', submission.id);
+
+    if (updateError) {
+      apiLogger.error('[Service Order] Failed to update submission', { submissionId: submission.id, error: updateError });
+      return NextResponse.json<ServiceOrderResponse>(
+        { success: false, message: 'Failed to update submission record' },
+        { status: 500 }
+      );
+    }
+
+    // === Send Email (best effort, don't fail the request) ===
+    let emailSent = false;
+    try {
+      const resend = new Resend(process.env.RESEND_API_KEY);
+      const { error: emailError } = await resend.emails.send({
+        from: 'billing@notify.circletel.co.za',
+        to: customer.email,
+        subject: `Your CircleTel Service Order (${customer.account_number})`,
+        html: `
+          <h2>Service Order Issued</h2>
+          <p>Dear ${customer.business_name},</p>
+          <p>Your Service Order has been generated and is attached to this email.</p>
+          <div style="background-color: #f5f5f5; padding: 16px; border-radius: 8px; margin: 16px 0;">
+            <p style="margin: 8px 0;"><strong>Service Order Number:</strong> SO-${customer.account_number}</p>
+            <p style="margin: 8px 0;"><strong>Service:</strong> CircleTel ClinicConnect — Managed Connectivity</p>
+            <p style="margin: 8px 0;"><strong>Monthly Fee:</strong> R${(service.monthly_price || 450).toFixed(2)} ex VAT</p>
+            <p style="margin: 8px 0;"><strong>Billing Day:</strong> ${billingDay === '1' ? '1st' : billingDay === '15' ? '15th' : billingDay === '20' ? '20th' : '25th'}</p>
+          </div>
+          <p>This Service Order is back-to-back with the Master Service Agreement between CircleTel and the Unjani Clinic Network.</p>
+          <p>If you have any questions, please contact our support team at support@circletel.co.za.</p>
+          <p>Regards,<br>CircleTel</p>
+        `,
+      });
+
+      if (!emailError) {
+        emailSent = true;
+      } else {
+        apiLogger.warn('[Service Order] Email send failed but request succeeding', { customerId, error: emailError });
+      }
+    } catch (emailException) {
+      apiLogger.warn('[Service Order] Email exception but request succeeding', { customerId, error: emailException });
+    }
+
+    apiLogger.info('[Service Order] Service Order issued successfully', {
+      customerId,
+      accountNumber: customer.account_number,
+      pdfPath: uploadResult.path,
+      emailed: emailSent,
+    });
+
+    return NextResponse.json<ServiceOrderResponse>(
+      {
+        success: true,
+        pdfPath: uploadResult.path,
+        emailed: emailSent,
+        message: `Service Order issued successfully. Email ${emailSent ? 'sent' : 'could not be sent'}.`,
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    apiLogger.error('[Service Order] Unexpected error', { error });
+    return NextResponse.json<ServiceOrderResponse>(
+      { success: false, message: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/b2b/onboarding-pipeline/route.ts
+++ b/app/api/admin/b2b/onboarding-pipeline/route.ts
@@ -23,6 +23,7 @@ interface PipelineClinic {
   mandate_status: string | null;
   vetting_due_date: string | null;
   submitted_at: string | null;
+  service_order_issued_at: string | null;
   sla: {
     dueDate: string | null;
     overdue: boolean;
@@ -113,7 +114,8 @@ export async function GET(request: NextRequest) {
           status,
           document_vetting_status,
           submitted_at,
-          vetting_due_date
+          vetting_due_date,
+          service_order_issued_at
         ),
         customer_payment_methods!customer_payment_methods_customer_id (
           id,
@@ -195,6 +197,7 @@ export async function GET(request: NextRequest) {
         mandate_status: debitOrderPm?.mandate_status || null,
         vetting_due_date: submission?.vetting_due_date || null,
         submitted_at: submission?.submitted_at || null,
+        service_order_issued_at: submission?.service_order_issued_at || null,
         sla: {
           dueDate: submission?.vetting_due_date || null,
           overdue: isOverdue,

--- a/app/onboarding/components/steps/Step5ServiceOrder.tsx
+++ b/app/onboarding/components/steps/Step5ServiceOrder.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
 import { computeProRata } from '@/lib/onboarding/prorata';
+import { SERVICE_ORDER_TERMS, SERVICE_ORDER_TERMS_TITLE, SERVICE_ORDER_MSA_REFERENCE_UI } from '@/lib/onboarding/service-order-terms';
 import { PiCaretDown, PiCaretUp } from 'react-icons/pi';
 
 export interface Step5ServiceOrderProps {
@@ -22,17 +23,6 @@ export interface Step5ServiceOrderProps {
 }
 
 const PAYMENT_DATES = ['1', '15', '20', '25'];
-
-const SERVICE_ORDER_CLAUSES = [
-  '<b>Commencement:</b> The Service Order terms commence on the Effective Date and continue for one calendar month thereafter, automatically renewing for successive one-month periods unless either party terminates with 30 days written notice.',
-  '<b>Payment:</b> The monthly fee is due and payable in advance on the selected payment date. The first invoice is pro-rated from the Effective Date to the end of that calendar month.',
-  '<b>DebiCheck Authorisation:</b> By accepting this Service Order, you authorise CircleTel to collect the monthly fee via DebiCheck debit order on your nominated payment date, in accordance with the DebiCheck rules.',
-  '<b>Service Suspension:</b> If payment is not received by the due date, CircleTel may suspend service access without further notice.',
-  '<b>Intellectual Property:</b> All CircleTel materials, technology, and know-how remain the property of CircleTel and may not be copied or reproduced without consent.',
-  '<b>Limitation of Liability:</b> CircleTel\'s total liability under this Service Order is limited to the fees paid in the three months preceding the claim.',
-  '<b>Termination:</b> Either party may terminate this Service Order with 30 days written notice. Upon termination, all outstanding fees remain due.',
-  '<b>Governing Law:</b> This Service Order is governed by the laws of the Republic of South Africa.',
-];
 
 export function Step5ServiceOrder({
   value,
@@ -160,7 +150,7 @@ export function Step5ServiceOrder({
               onClick={() => setShowDetails(!showDetails)}
               className="flex items-center justify-between w-full font-semibold text-gray-900 hover:text-circleTel-orange"
             >
-              <span>CircleTel Service Order — Terms & Conditions</span>
+              <span>{SERVICE_ORDER_TERMS_TITLE}</span>
               {showDetails ? (
                 <PiCaretUp className="w-5 h-5" />
               ) : (
@@ -170,13 +160,11 @@ export function Step5ServiceOrder({
 
             {showDetails && (
               <div className="mt-4 space-y-3 text-sm text-gray-700">
-                {SERVICE_ORDER_CLAUSES.map((clause, idx) => (
+                {SERVICE_ORDER_TERMS.map((clause, idx) => (
                   <p key={idx} dangerouslySetInnerHTML={{ __html: clause }} />
                 ))}
                 <p className="text-xs text-gray-600 mt-4 pt-4 border-t">
-                  These terms are back-to-back with the Master Service Agreement
-                  between CircleTel and Unjani Clinics NPC (the "MSA"). In the
-                  event of any conflict, the MSA prevails.
+                  {SERVICE_ORDER_MSA_REFERENCE_UI}
                 </p>
               </div>
             )}

--- a/lib/contracts/service-order-pdf.ts
+++ b/lib/contracts/service-order-pdf.ts
@@ -1,0 +1,415 @@
+/**
+ * Service Order PDF Generator
+ *
+ * Generates a professional Service Order PDF record for Unjani clinics.
+ * This is issued back-to-back with the Master Service Agreement (MSA).
+ *
+ * Layout:
+ * - Page 1: Header + SO Number + Clinic Details + Service Summary (pricing)
+ * - Page 2: Service Order Terms + Acceptance declaration + Footer
+ */
+
+import jsPDF from 'jspdf';
+import { circleTelLogoBase64 } from '@/lib/quotes/circletel-logo-base64';
+import { CONTACT } from '@/lib/constants/contact';
+import { SERVICE_ORDER_TERMS, SERVICE_ORDER_MSA_REFERENCE, stripHtmlFromTerms } from '@/lib/onboarding/service-order-terms';
+
+// CircleTel brand colors (RGB tuples)
+const COLORS = {
+  orange: [245, 131, 31] as [number, number, number],
+  darkText: [31, 41, 55] as [number, number, number],
+  secondaryText: [75, 85, 99] as [number, number, number],
+  lightGray: [243, 244, 246] as [number, number, number],
+  mutedText: [107, 114, 128] as [number, number, number],
+  white: [255, 255, 255] as [number, number, number],
+  borderGray: [209, 213, 219] as [number, number, number],
+  headerGray: [55, 65, 81] as [number, number, number],
+};
+
+/**
+ * Format currency for South Africa (ZAR)
+ */
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-ZA', {
+    style: 'currency',
+    currency: 'ZAR',
+    minimumFractionDigits: 2,
+  }).format(amount);
+}
+
+/**
+ * Format date for display (e.g., "21 June 2026")
+ */
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-ZA', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Add CircleTel header to PDF page
+ */
+function addHeader(doc: jsPDF, pageWidth: number): number {
+  // CircleTel Logo (left side)
+  try {
+    doc.addImage(circleTelLogoBase64, 'PNG', 20, 15, 45, 45);
+  } catch {
+    // Fallback to text if image fails
+    doc.setTextColor(...COLORS.orange);
+    doc.setFontSize(28);
+    doc.setFont('helvetica', 'bold');
+    doc.text('circleTEL', 20, 35);
+  }
+
+  // Contact info (right side, right-aligned)
+  doc.setTextColor(...COLORS.secondaryText);
+  doc.setFontSize(10);
+  doc.setFont('helvetica', 'normal');
+
+  const rightX = pageWidth - 20;
+  doc.text('Tel: +27 87 087 6305', rightX, 25, { align: 'right' });
+  doc.text('Email: sales@circletel.co.za', rightX, 32, { align: 'right' });
+  doc.text('Web: www.circletel.co.za', rightX, 39, { align: 'right' });
+
+  // Orange underline below header
+  doc.setDrawColor(...COLORS.orange);
+  doc.setLineWidth(1.5);
+  doc.line(20, 68, pageWidth - 20, 68);
+
+  return 80; // Starting Y position after header
+}
+
+/**
+ * Add three-column footer to PDF page
+ */
+function addFooter(doc: jsPDF, pageWidth: number, pageHeight: number, pageNum: number, totalPages: number): void {
+  const footerY = pageHeight - 32;
+  const colWidth = (pageWidth - 40) / 3;
+  const col1Center = 20 + colWidth / 2;
+  const col2Center = 20 + colWidth + colWidth / 2;
+  const col3Center = 20 + colWidth * 2 + colWidth / 2;
+
+  // Separator line above footer
+  doc.setDrawColor(...COLORS.borderGray);
+  doc.setLineWidth(0.5);
+  doc.line(20, footerY - 8, pageWidth - 20, footerY - 8);
+
+  doc.setFontSize(9);
+
+  // Column 1: Head Office
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(...COLORS.headerGray);
+  doc.text('HEAD OFFICE', col1Center, footerY, { align: 'center' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(...COLORS.mutedText);
+  doc.text('CircleTel (Pty) Ltd', col1Center, footerY + 5, { align: 'center' });
+  doc.text('Registration: 2008/026404/07', col1Center, footerY + 10, { align: 'center' });
+  doc.text('VAT: 4380269318', col1Center, footerY + 15, { align: 'center' });
+
+  // Column 2: Contact
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  doc.setTextColor(...COLORS.headerGray);
+  doc.text('CONTACT', col2Center, footerY, { align: 'center' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(...COLORS.mutedText);
+  doc.text('Tel: +27 87 087 6305', col2Center, footerY + 5, { align: 'center' });
+  doc.text('Email: sales@circletel.co.za', col2Center, footerY + 10, { align: 'center' });
+  doc.text('Web: www.circletel.co.za', col2Center, footerY + 15, { align: 'center' });
+
+  // Column 3: Support
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  doc.setTextColor(...COLORS.headerGray);
+  doc.text('SUPPORT', col3Center, footerY, { align: 'center' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(...COLORS.mutedText);
+  doc.text('24/7 NOC: support@circletel.co.za', col3Center, footerY + 5, { align: 'center' });
+  doc.text('Business Hours: 08:00 - 17:00', col3Center, footerY + 10, { align: 'center' });
+  doc.text('Emergency: +27 87 087 6305', col3Center, footerY + 15, { align: 'center' });
+
+  // Page number
+  doc.setFontSize(9);
+  doc.setTextColor(...COLORS.mutedText);
+  doc.text(`${pageNum}/${totalPages}`, pageWidth / 2, pageHeight - 10, { align: 'center' });
+}
+
+/**
+ * Add section header with underline
+ */
+function addSectionHeader(doc: jsPDF, title: string, x: number, y: number, width: number): number {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(12);
+  doc.setTextColor(...COLORS.headerGray);
+  doc.text(title, x, y);
+
+  // Underline
+  doc.setDrawColor(...COLORS.borderGray);
+  doc.setLineWidth(0.5);
+  doc.line(x, y + 2, x + width, y + 2);
+
+  return y + 10;
+}
+
+export interface ServiceOrderInput {
+  accountNumber: string;
+  clinicName: string;
+  clinicAddress: string;
+  clinicProvince: string;
+  clinicEmail: string;
+  clinicPhone?: string;
+  monthlyFeeExclVat: number;
+  vatPercentage: number; // Usually 15
+  billingDay: '1' | '15' | '20' | '25';
+  activationDate: string; // ISO 8601
+  submittedAt: string; // ISO 8601
+}
+
+/**
+ * Generate Service Order PDF
+ *
+ * Returns a jsPDF document that can be converted to blob/buffer/base64
+ */
+export function generateServiceOrderPdf(input: ServiceOrderInput): jsPDF {
+  const doc = new jsPDF();
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+
+  // Calculate pricing
+  const vatAmount = input.monthlyFeeExclVat * (input.vatPercentage / 100);
+  const monthlyFeeInclVat = input.monthlyFeeExclVat + vatAmount;
+
+  // Service Order number: SO-<account_number>
+  const soNumber = `SO-${input.accountNumber}`;
+
+  const leftCol = 20;
+  const colWidth = pageWidth - 50;
+
+  // =============================================
+  // PAGE 1: Header + Title + Details
+  // =============================================
+  let yPos = addHeader(doc, pageWidth);
+
+  // === Title Section ===
+  doc.setTextColor(...COLORS.darkText);
+  doc.setFontSize(22);
+  doc.setFont('helvetica', 'bold');
+  doc.text('SERVICE ORDER', leftCol, yPos);
+
+  yPos += 12;
+  doc.setFontSize(10);
+
+  // SO Number
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(...COLORS.secondaryText);
+  doc.text('Service Order No:', leftCol, yPos);
+  doc.setTextColor(...COLORS.orange);
+  doc.setFont('helvetica', 'bold');
+  doc.text(soNumber, leftCol + 50, yPos);
+
+  yPos += 6;
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(...COLORS.secondaryText);
+  doc.text('Date:', leftCol, yPos);
+  doc.setTextColor(...COLORS.darkText);
+  doc.setFont('helvetica', 'bold');
+  doc.text(formatDate(new Date().toISOString()), leftCol + 50, yPos);
+
+  yPos += 6;
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(...COLORS.secondaryText);
+  doc.text('Effective Date:', leftCol, yPos);
+  doc.setTextColor(...COLORS.darkText);
+  doc.setFont('helvetica', 'bold');
+  doc.text(formatDate(input.activationDate), leftCol + 50, yPos);
+
+  yPos += 15;
+
+  // === CLINIC DETAILS ===
+  let clinicY = addSectionHeader(doc, 'CLINIC DETAILS', leftCol, yPos, colWidth);
+
+  const clinicFields = [
+    ['Clinic Name:', input.clinicName],
+    ['Account Number:', input.accountNumber],
+    ['Address:', input.clinicAddress],
+    ['Province:', input.clinicProvince],
+    ['Email:', input.clinicEmail],
+    ['Phone:', input.clinicPhone || '-'],
+  ];
+
+  doc.setFontSize(9);
+  clinicFields.forEach(([label, value]) => {
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(...COLORS.secondaryText);
+    doc.text(label, leftCol, clinicY);
+
+    doc.setTextColor(...COLORS.darkText);
+    const valueLines = doc.splitTextToSize(String(value), colWidth - 45);
+    doc.text(valueLines, leftCol + 50, clinicY);
+    clinicY += 6 * Math.max(valueLines.length, 1);
+  });
+
+  yPos = clinicY + 8;
+
+  // === SERVICE SUMMARY ===
+  let serviceY = addSectionHeader(doc, 'SERVICE SUMMARY', leftCol, yPos, colWidth);
+
+  doc.setFontSize(9);
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(...COLORS.secondaryText);
+  doc.text('Service:', leftCol, serviceY);
+  doc.setTextColor(...COLORS.darkText);
+  doc.text('CircleTel ClinicConnect — Managed Connectivity', leftCol + 50, serviceY);
+  serviceY += 8;
+
+  // Billing day
+  doc.setTextColor(...COLORS.secondaryText);
+  doc.text('Billing Day of Month:', leftCol, serviceY);
+  doc.setTextColor(...COLORS.darkText);
+  const billingDayLabel = input.billingDay === '1' ? '1st' : input.billingDay === '15' ? '15th' : input.billingDay === '20' ? '20th' : '25th';
+  doc.text(billingDayLabel, leftCol + 50, serviceY);
+  serviceY += 8;
+
+  // Pricing box (highlighted)
+  serviceY += 4;
+  doc.setFillColor(...COLORS.lightGray);
+  doc.rect(leftCol, serviceY - 5, colWidth, 28, 'F');
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(9);
+  doc.setTextColor(...COLORS.secondaryText);
+  doc.text('Monthly Fee (Excl. VAT):', leftCol + 5, serviceY);
+  doc.setTextColor(...COLORS.darkText);
+  doc.setFont('helvetica', 'bold');
+  doc.text(formatCurrency(input.monthlyFeeExclVat), leftCol + colWidth - 5, serviceY, { align: 'right' });
+
+  serviceY += 6;
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(...COLORS.secondaryText);
+  doc.text(`VAT (${input.vatPercentage}%):`, leftCol + 5, serviceY);
+  doc.setTextColor(...COLORS.darkText);
+  doc.setFont('helvetica', 'bold');
+  doc.text(formatCurrency(vatAmount), leftCol + colWidth - 5, serviceY, { align: 'right' });
+
+  serviceY += 6;
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(10);
+  doc.setTextColor(...COLORS.orange);
+  doc.text('Monthly Fee (Incl. VAT):', leftCol + 5, serviceY);
+  doc.text(formatCurrency(monthlyFeeInclVat), leftCol + colWidth - 5, serviceY, { align: 'right' });
+
+  yPos = serviceY + 12;
+
+  // === MSA REFERENCE ===
+  yPos += 4;
+  doc.setFontSize(9);
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(...COLORS.secondaryText);
+  const msaLines = doc.splitTextToSize(SERVICE_ORDER_MSA_REFERENCE, colWidth);
+  doc.text(msaLines, leftCol, yPos);
+  yPos += 4 * msaLines.length + 4;
+
+  // Check if we need to go to page 2 for terms
+  if (yPos > pageHeight - 80) {
+    doc.addPage();
+    yPos = addHeader(doc, pageWidth);
+  }
+
+  // =============================================
+  // PAGE 2 (or continuation): Terms + Acceptance
+  // =============================================
+  if (doc.getNumberOfPages() === 1) {
+    // Still on page 1, add a page break for terms
+    doc.addPage();
+    yPos = addHeader(doc, pageWidth);
+  }
+
+  // === TERMS AND CONDITIONS ===
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(12);
+  doc.setTextColor(...COLORS.darkText);
+  doc.text('TERMS AND CONDITIONS', leftCol, yPos);
+  yPos += 8;
+
+  // Plain text terms (without HTML tags)
+  const plainTerms = stripHtmlFromTerms(SERVICE_ORDER_TERMS);
+
+  doc.setFontSize(8);
+  doc.setFont('helvetica', 'normal');
+  plainTerms.forEach((term, index) => {
+    // Extract title (before colon)
+    const colonIndex = term.indexOf(':');
+    if (colonIndex > 0) {
+      const title = term.substring(0, colonIndex + 1);
+      const body = term.substring(colonIndex + 1).trim();
+
+      doc.setFont('helvetica', 'bold');
+      doc.setTextColor(...COLORS.darkText);
+      doc.text(`${index + 1}. ${title}`, leftCol, yPos);
+      yPos += 3;
+
+      doc.setFont('helvetica', 'normal');
+      doc.setTextColor(...COLORS.secondaryText);
+      const bodyLines = doc.splitTextToSize(body, colWidth - 10);
+      doc.text(bodyLines, leftCol + 5, yPos);
+      yPos += 2 + (bodyLines.length * 2.5);
+    }
+  });
+
+  yPos += 5;
+
+  // === ACCEPTANCE DECLARATION ===
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(11);
+  doc.setTextColor(...COLORS.darkText);
+  doc.text('ACCEPTANCE', leftCol, yPos);
+  yPos += 8;
+
+  doc.setFontSize(9);
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(...COLORS.secondaryText);
+  const acceptanceLines = doc.splitTextToSize(
+    `This Service Order was accepted electronically by the clinic on ${formatDate(input.submittedAt)} via the CircleTel onboarding portal (click-accept). No manual signature is required.`,
+    colWidth
+  );
+  doc.text(acceptanceLines, leftCol, yPos);
+
+  // Add footers to all pages
+  const totalPages = doc.getNumberOfPages();
+  for (let i = 1; i <= totalPages; i++) {
+    doc.setPage(i);
+    addFooter(doc, pageWidth, pageHeight, i, totalPages);
+  }
+
+  return doc;
+}
+
+/**
+ * Generate PDF as Blob (for uploading to storage)
+ */
+export function generateServiceOrderBlob(input: ServiceOrderInput): Blob {
+  const pdf = generateServiceOrderPdf(input);
+  return pdf.output('blob');
+}
+
+/**
+ * Generate PDF as Buffer (for Node.js server-side usage)
+ */
+export function generateServiceOrderBuffer(input: ServiceOrderInput): Buffer {
+  const pdf = generateServiceOrderPdf(input);
+  const arrayBuffer = pdf.output('arraybuffer');
+  return Buffer.from(arrayBuffer);
+}
+
+/**
+ * Generate PDF as base64 string (for embedding in URLs)
+ */
+export function generateServiceOrderBase64(input: ServiceOrderInput): string {
+  const pdf = generateServiceOrderPdf(input);
+  return pdf.output('datauristring');
+}

--- a/lib/onboarding/service-order-terms.ts
+++ b/lib/onboarding/service-order-terms.ts
@@ -1,0 +1,48 @@
+/**
+ * Service Order Terms - Shared Source of Truth
+ *
+ * Centralized terms used in both Step5ServiceOrder.tsx (UI) and service-order-pdf.ts (PDF generation).
+ * Single source of truth ensures consistency between web and PDF versions.
+ */
+
+export const SERVICE_ORDER_TERMS_TITLE = 'CircleTel Service Order — Terms & Conditions';
+
+export const SERVICE_ORDER_TERMS = [
+  '<b>Commencement:</b> The Service Order terms commence on the Effective Date and continue for one calendar month thereafter, automatically renewing for successive one-month periods unless either party terminates with 30 days written notice.',
+  '<b>Payment:</b> The monthly fee is due and payable in advance on the selected payment date. The first invoice is pro-rated from the Effective Date to the end of that calendar month.',
+  '<b>DebiCheck Authorisation:</b> By accepting this Service Order, you authorise CircleTel to collect the monthly fee via DebiCheck debit order on your nominated payment date, in accordance with the DebiCheck rules.',
+  '<b>Service Suspension:</b> If payment is not received by the due date, CircleTel may suspend service access without further notice.',
+  '<b>Intellectual Property:</b> All CircleTel materials, technology, and know-how remain the property of CircleTel and may not be copied or reproduced without consent.',
+  '<b>Limitation of Liability:</b> CircleTel\'s total liability under this Service Order is limited to the fees paid in the three months preceding the claim.',
+  '<b>Termination:</b> Either party may terminate this Service Order with 30 days written notice. Upon termination, all outstanding fees remain due.',
+  '<b>Governing Law:</b> This Service Order is governed by the laws of the Republic of South Africa.',
+];
+
+/**
+ * Convert HTML-formatted terms to plain text (removes <b> tags)
+ */
+export function stripHtmlFromTerms(terms: string[]): string[] {
+  return terms.map((term) => term.replace(/<\/?b>/g, ''));
+}
+
+/**
+ * Convert HTML-formatted terms to plain text with manual bold markers
+ */
+export function convertTermsToPlainText(terms: string[]): string[] {
+  return terms.map((term) => {
+    // Replace <b>text</b> with **text**
+    return term.replace(/<b>(.*?)<\/b>/g, '**$1**');
+  });
+}
+
+/**
+ * MSA reference text (shown on Service Order PDF)
+ */
+export const SERVICE_ORDER_MSA_REFERENCE =
+  'This Service Order is issued back-to-back with, and incorporates by reference, the Unjani Master Service Agreement between CircleTel and the Unjani Clinic Network.';
+
+/**
+ * MSA reference text (shown in UI)
+ */
+export const SERVICE_ORDER_MSA_REFERENCE_UI =
+  'These terms are back-to-back with the Master Service Agreement between CircleTel and Unjani Clinics NPC (the "MSA"). In the event of any conflict, the MSA prevails.';

--- a/supabase/migrations/20260610120002_service_order.sql
+++ b/supabase/migrations/20260610120002_service_order.sql
@@ -1,0 +1,10 @@
+-- Service Order PDF record tracking
+-- Additive + idempotent. Safe to run multiple times.
+
+-- Add service order tracking columns to onboarding_submissions
+ALTER TABLE onboarding_submissions ADD COLUMN IF NOT EXISTS service_order_pdf_path text;
+ALTER TABLE onboarding_submissions ADD COLUMN IF NOT EXISTS service_order_issued_at timestamptz;
+
+-- Index for efficient lookups
+CREATE INDEX IF NOT EXISTS idx_onboarding_submissions_service_order
+  ON onboarding_submissions(customer_id, service_order_issued_at);


### PR DESCRIPTION
## Summary
Generates the clinic **Service Order** as a PDF record — no separate signature ceremony, because the nurse already accepts it (click-wrap) in wizard **Step 5**.

- `lib/onboarding/service-order-terms.ts` — single source of truth for the terms (used by Step 5 UI + the PDF).
- `lib/contracts/service-order-pdf.ts` — jsPDF Service Order (clinic, SO-<acct>, R450/R67.50/R517.50, payment date, accepted terms, **"incorporates the Unjani Master Service Agreement by reference"**, electronic-acceptance block from `submitted_at`).
- `POST /api/admin/b2b/issue-service-order` — generate → upload to `kyc-documents/service-orders/<id>` → record `service_order_pdf_path`/`issued_at` (migration applied) → email the nurse (best-effort).
- Pipeline dashboard: "Issue Service Order" button + "Issued <date>".
- 11 PDF unit tests pass; type-check clean.

Completes the post-submission ops set (Phase 1 pipeline/SLA/notifications + mandate-poll backstop already shipped).

## Test plan
- [ ] Issue from /admin/unjani/onboarding for a billing-ready clinic → PDF stored + emailed + "Issued" shows
- [ ] Step 5 still renders the same terms (now from shared module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)