### PR TITLE
feat(admin-nav): surface Clinic Onboarding + Document Vetting in sidebar

### DIFF
--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -147,6 +147,8 @@ const navigationSections: NavSection[] = [
         icon: PiBuildingsBold,
         description: 'Business customer journey',
         children: [
+          { name: 'Clinic Onboarding', href: '/admin/unjani/onboarding', icon: PiUserPlusBold },
+          { name: 'Document Vetting', href: '/admin/b2b/vetting', icon: PiUserCheckBold },
           { name: 'All B2B Customers', href: '/admin/b2b-customers', icon: PiBuildingsBold },
           { name: 'Site Details', href: '/admin/b2b-customers/site-details', icon: PiMapPinBold },
           { name: 'Journey Overview', href: '/admin/b2b-customers?view=journey', icon: PiTrendUpBold },


### PR DESCRIPTION
## What

Adds two entries to the admin sidebar under the existing **B2B Customers** group:
- **Clinic Onboarding** → `/admin/unjani/onboarding`
- **Document Vetting** → `/admin/b2b/vetting`

## Why

The clinic onboarding pipeline and the B2B document-vetting queue shipped live in PRs #536/#539/#542 but were never linked in the admin sidebar — they were reachable only by typing the URL directly. Sales admins couldn't discover the onboarding back office from the menu.

## Scope

One-line-each additive change to `components/admin/layout/Sidebar.tsx`. Both target routes verified to exist on `main`; both icons (`PiUserPlusBold`, `PiUserCheckBold`) already imported. No migration, no env change.

## Verification
- ✅ Pre-push build-config check (heap/cpus)
- ✅ Scoped type-check — no type errors in the changed file
- ✅ Both routes confirmed present on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)