### PR TITLE
fix(admin): correct FK embed hints in onboarding-pipeline query (500)

### DIFF
--- a/app/api/admin/b2b/onboarding-pipeline/route.ts
+++ b/app/api/admin/b2b/onboarding-pipeline/route.ts
@@ -109,7 +109,7 @@ export async function GET(request: NextRequest) {
         business_name,
         onboarding_status,
         clinic_details,
-        onboarding_submissions!onboarding_submissions_customer (
+        onboarding_submissions!onboarding_submissions_customer_id_fkey (
           id,
           status,
           document_vetting_status,
@@ -117,7 +117,7 @@ export async function GET(request: NextRequest) {
           vetting_due_date,
           service_order_issued_at
         ),
-        customer_payment_methods!customer_payment_methods_customer_id (
+        customer_payment_methods!customer_payment_methods_customer_id_fkey (
           id,
           mandate_status,
           method_type


### PR DESCRIPTION
## Bug

`GET /api/admin/b2b/onboarding-pipeline` returned **500** (`{"success":false,"error":"Failed to fetch clinic list"}`), breaking the new **/admin/unjani/onboarding** dashboard immediately on load.

## Root cause

The Supabase query embedded related tables with **non-existent FK hint names**:

| Used (wrong) | Actual FK constraint |
|---|---|
| `onboarding_submissions!onboarding_submissions_customer` | `onboarding_submissions_customer_id_fkey` |
| `customer_payment_methods!customer_payment_methods_customer_id` | `customer_payment_methods_customer_id_fkey` |

PostgREST raised `PGRST200` — *"Could not find a relationship between 'customers' and 'onboarding_submissions' in the schema cache"* — which hit the route's `clinicsError` branch → 500.

## Fix

Use the real constraint names (`…_customer_id_fkey`). One-file change; grep confirmed no other route used the bad pattern.

## Verification
- ✅ Reproduced the exact PostgREST query with the service role → `PGRST200` before, **returns clinic rows after** (e.g. Unjani Clinic – Delmas, CT-2026-00033).
- ✅ Confirmed actual FK names via `information_schema` (`onboarding_submissions_customer_id_fkey`, `customer_payment_methods_customer_id_fkey`).
- ✅ Pre-push type-check — no errors in the changed file.

Found while browser-verifying the sidebar link from PR #544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)