### PR TITLE
feat(admin): brand-align dashboard charts on unified backend UI kit

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -455,7 +455,7 @@ export default function AdminDashboard() {
           {/* Revenue Chart */}
           {analyticsData && (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <RevenueTrendChart data={analyticsData.history} />
+              <RevenueTrendChart data={analyticsData.history} className="col-span-4 lg:col-span-2" />
               {/* Quick Actions beside chart on large screens if needed, or below */}
             </div>
           )}
@@ -518,7 +518,7 @@ export default function AdminDashboard() {
           </div>
           {analyticsData && (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <CustomerGrowthChart data={analyticsData.history} />
+              <CustomerGrowthChart data={analyticsData.history} className="col-span-4 lg:col-span-2" />
             </div>
           )}
         </TabsContent>
@@ -529,7 +529,7 @@ export default function AdminDashboard() {
           </div>
           {analyticsData && (
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              <OrderStatusPieChart data={analyticsData.orderStatus} />
+              <OrderStatusPieChart data={analyticsData.orderStatus} className="col-span-4 lg:col-span-1" />
             </div>
           )}
         </TabsContent>

--- a/components/admin/dashboard/charts/CustomerGrowthChart.tsx
+++ b/components/admin/dashboard/charts/CustomerGrowthChart.tsx
@@ -1,5 +1,4 @@
 'use client';
-import {} from 'react-icons/pi';
 
 import {
   BarChart,
@@ -11,51 +10,45 @@ import {
   Legend,
   ResponsiveContainer
 } from 'recharts';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PiUsersBold } from 'react-icons/pi';
+import { SectionCard, EmptyState } from '@/components/backend';
+import { CHART_COLORS, axisProps, gridProps, tooltipStyle } from './chart-theme';
 
-interface CustomerGrowthChartProps {
-  data: any[];
+export interface CustomerGrowthDatum {
+  name: string;
+  customers: number;
+  orders: number;
 }
 
-export function CustomerGrowthChart({ data }: CustomerGrowthChartProps) {
+interface CustomerGrowthChartProps {
+  data: CustomerGrowthDatum[];
+  className?: string;
+}
+
+export function CustomerGrowthChart({ data, className }: CustomerGrowthChartProps) {
   return (
-    <Card className="col-span-4 lg:col-span-2">
-      <CardHeader>
-        <CardTitle>Customer & Order Growth</CardTitle>
-      </CardHeader>
-      <CardContent className="pl-2">
+    <SectionCard title="Customer & Order Growth" className={className}>
+      {data.length === 0 ? (
+        <EmptyState
+          icon={<PiUsersBold />}
+          title="No growth data yet"
+          description="New customers and orders will appear here over time."
+        />
+      ) : (
         <div className="h-[300px] w-full">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#E5E7EB" />
-              <XAxis
-                dataKey="name"
-                stroke="#6B7280"
-                fontSize={12}
-                tickLine={false}
-                axisLine={false}
-              />
-              <YAxis
-                stroke="#6B7280"
-                fontSize={12}
-                tickLine={false}
-                axisLine={false}
-              />
-              <Tooltip
-                cursor={{ fill: '#F3F4F6' }}
-                contentStyle={{
-                  backgroundColor: '#FFFFFF',
-                  border: '1px solid #E5E7EB',
-                  borderRadius: '0.5rem'
-                }}
-              />
+              <CartesianGrid {...gridProps} />
+              <XAxis dataKey="name" {...axisProps} />
+              <YAxis {...axisProps} />
+              <Tooltip cursor={{ fill: '#F3F4F6' }} contentStyle={tooltipStyle} />
               <Legend />
-              <Bar dataKey="customers" name="New Customers" fill="#4F46E5" radius={[4, 4, 0, 0]} />
-              <Bar dataKey="orders" name="New Orders" fill="#10B981" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="customers" name="New Customers" fill={CHART_COLORS.customers} radius={[4, 4, 0, 0]} />
+              <Bar dataKey="orders" name="New Orders" fill={CHART_COLORS.orders} radius={[4, 4, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         </div>
-      </CardContent>
-    </Card>
+      )}
+    </SectionCard>
   );
 }

--- a/components/admin/dashboard/charts/OrderStatusPieChart.tsx
+++ b/components/admin/dashboard/charts/OrderStatusPieChart.tsx
@@ -1,21 +1,32 @@
 'use client';
 
-import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PieChart, Pie, Cell, Label, ResponsiveContainer, Legend, Tooltip } from 'recharts';
+import { PiShoppingCartBold } from 'react-icons/pi';
+import { SectionCard, EmptyState } from '@/components/backend';
+import { STATUS_PALETTE, tooltipStyle } from './chart-theme';
 
-interface OrderStatusPieChartProps {
-  data: any[];
+export interface OrderStatusDatum {
+  name: string;
+  value: number;
 }
 
-const COLORS = ['#10B981', '#F59E0B', '#3B82F6', '#6366F1', '#EF4444', '#9CA3AF'];
+interface OrderStatusPieChartProps {
+  data: OrderStatusDatum[];
+  className?: string;
+}
 
-export function OrderStatusPieChart({ data }: OrderStatusPieChartProps) {
+export function OrderStatusPieChart({ data, className }: OrderStatusPieChartProps) {
+  const total = data.reduce((sum, entry) => sum + (entry.value || 0), 0);
+
   return (
-    <Card className="col-span-4 lg:col-span-1">
-      <CardHeader>
-        <CardTitle>Order Status</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <SectionCard title="Order Status" className={className}>
+      {data.length === 0 ? (
+        <EmptyState
+          icon={<PiShoppingCartBold />}
+          title="No orders yet"
+          description="Order status distribution will appear here once orders come in."
+        />
+      ) : (
         <div className="h-[300px] w-full">
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
@@ -29,15 +40,32 @@ export function OrderStatusPieChart({ data }: OrderStatusPieChartProps) {
                 dataKey="value"
               >
                 {data.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  <Cell key={`cell-${index}`} fill={STATUS_PALETTE[index % STATUS_PALETTE.length]} />
                 ))}
+                <Label
+                  position="center"
+                  content={({ viewBox }) => {
+                    if (!viewBox || !('cx' in viewBox)) return null;
+                    const { cx, cy } = viewBox;
+                    return (
+                      <text x={cx} y={cy} textAnchor="middle" dominantBaseline="middle">
+                        <tspan x={cx} dy="-0.4em" className="fill-gray-900 text-2xl font-bold">
+                          {total.toLocaleString()}
+                        </tspan>
+                        <tspan x={cx} dy="1.6em" className="fill-gray-500 text-xs">
+                          Total Orders
+                        </tspan>
+                      </text>
+                    );
+                  }}
+                />
               </Pie>
-              <Tooltip />
-              <Legend verticalAlign="bottom" height={36}/>
+              <Tooltip contentStyle={tooltipStyle} />
+              <Legend verticalAlign="bottom" height={36} />
             </PieChart>
           </ResponsiveContainer>
         </div>
-      </CardContent>
-    </Card>
+      )}
+    </SectionCard>
   );
 }

--- a/components/admin/dashboard/charts/RevenueTrendChart.tsx
+++ b/components/admin/dashboard/charts/RevenueTrendChart.tsx
@@ -9,56 +9,50 @@ import {
   Tooltip,
   ResponsiveContainer
 } from 'recharts';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PiCurrencyDollarBold } from 'react-icons/pi';
+import { SectionCard, EmptyState } from '@/components/backend';
+import { CHART_COLORS, axisProps, gridProps, tooltipStyle, formatRand, formatRandTick } from './chart-theme';
 
-interface RevenueTrendChartProps {
-  data: any[];
+export interface RevenueTrendDatum {
+  name: string;
+  revenue: number;
 }
 
-export function RevenueTrendChart({ data }: RevenueTrendChartProps) {
+interface RevenueTrendChartProps {
+  data: RevenueTrendDatum[];
+  className?: string;
+}
+
+export function RevenueTrendChart({ data, className }: RevenueTrendChartProps) {
   return (
-    <Card className="col-span-4 lg:col-span-2">
-      <CardHeader>
-        <CardTitle>Revenue Trend (Last 12 Months)</CardTitle>
-      </CardHeader>
-      <CardContent className="pl-2">
+    <SectionCard title="Revenue Trend (Last 12 Months)" className={className}>
+      {data.length === 0 ? (
+        <EmptyState
+          icon={<PiCurrencyDollarBold />}
+          title="No revenue data yet"
+          description="Revenue will appear here once orders and quotes are recorded."
+        />
+      ) : (
         <div className="h-[300px] w-full">
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={data}>
               <defs>
                 <linearGradient id="colorRevenue" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#F5831F" stopOpacity={0.3} />
-                  <stop offset="95%" stopColor="#F5831F" stopOpacity={0} />
+                  <stop offset="5%" stopColor={CHART_COLORS.revenue} stopOpacity={0.3} />
+                  <stop offset="95%" stopColor={CHART_COLORS.revenue} stopOpacity={0} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#E5E7EB" />
-              <XAxis
-                dataKey="name"
-                stroke="#6B7280"
-                fontSize={12}
-                tickLine={false}
-                axisLine={false}
-              />
-              <YAxis
-                stroke="#6B7280"
-                fontSize={12}
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={(value) => `R${value}`}
-              />
+              <CartesianGrid {...gridProps} />
+              <XAxis dataKey="name" {...axisProps} />
+              <YAxis {...axisProps} tickFormatter={formatRandTick} />
               <Tooltip
-                contentStyle={{
-                  backgroundColor: '#FFFFFF',
-                  border: '1px solid #E5E7EB',
-                  borderRadius: '0.5rem',
-                  boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
-                }}
-                formatter={(value: number) => [`R${value.toLocaleString()}`, 'Revenue']}
+                contentStyle={tooltipStyle}
+                formatter={(value: number) => [formatRand(value), 'Revenue']}
               />
               <Area
                 type="monotone"
                 dataKey="revenue"
-                stroke="#F5831F"
+                stroke={CHART_COLORS.revenue}
                 strokeWidth={2}
                 fillOpacity={1}
                 fill="url(#colorRevenue)"
@@ -66,7 +60,7 @@ export function RevenueTrendChart({ data }: RevenueTrendChartProps) {
             </AreaChart>
           </ResponsiveContainer>
         </div>
-      </CardContent>
-    </Card>
+      )}
+    </SectionCard>
   );
 }

--- a/components/admin/dashboard/charts/chart-theme.ts
+++ b/components/admin/dashboard/charts/chart-theme.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared theme for the admin dashboard charts.
+ *
+ * Single source of truth for brand-aligned colours, axis/grid/tooltip styling,
+ * and currency formatters so the Revenue, Customer-growth and Order-status
+ * charts stay visually consistent with the unified backend UI kit.
+ *
+ * Brand hexes mirror tailwind.config.ts `colors.circleTel`
+ * (orange #E87A1E, navy #1B2A4A).
+ */
+
+/** Semantic colours for the two-series bar/area charts. */
+export const CHART_COLORS = {
+  revenue: '#E87A1E', // circleTel-orange — primary accent
+  orders: '#E87A1E', // orange
+  customers: '#1B2A4A', // circleTel-navy
+} as const;
+
+/**
+ * Ordered palette for the order-status donut. Anchored on brand orange/navy
+ * with harmonizing accents; cycled by index. Red is last so it tends to land
+ * on error/failure-type statuses.
+ */
+export const STATUS_PALETTE = [
+  '#E87A1E', // orange
+  '#1B2A4A', // navy
+  '#F59E0B', // amber
+  '#0E7C86', // teal
+  '#64748B', // slate
+  '#EF4444', // red
+] as const;
+
+/** Shared XAxis/YAxis styling. Spread onto <XAxis {...axisProps} />. */
+export const axisProps = {
+  stroke: '#6B7280',
+  fontSize: 12,
+  tickLine: false,
+  axisLine: false,
+} as const;
+
+/** Shared CartesianGrid styling. */
+export const gridProps = {
+  strokeDasharray: '3 3',
+  vertical: false,
+  stroke: '#E5E7EB',
+} as const;
+
+/** Shared Recharts <Tooltip contentStyle={tooltipStyle} />. */
+export const tooltipStyle: React.CSSProperties = {
+  backgroundColor: '#FFFFFF',
+  border: '1px solid #E5E7EB',
+  borderRadius: '0.5rem',
+  boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+};
+
+/** Full Rand value with thousands separators — for tooltips. e.g. R12,345 */
+export function formatRand(value: number): string {
+  return `R${value.toLocaleString()}`;
+}
+
+/** Compact Rand value for axis ticks. e.g. R45k, R1.2m */
+export function formatRandTick(value: number): string {
+  if (Math.abs(value) >= 1_000_000) {
+    return `R${(value / 1_000_000).toFixed(1).replace(/\.0$/, '')}m`;
+  }
+  if (Math.abs(value) >= 1_000) {
+    return `R${(value / 1_000).toFixed(1).replace(/\.0$/, '')}k`;
+  }
+  return `R${value}`;
+}


### PR DESCRIPTION
## What

Migrates the three `/admin/dashboard` charts (revenue area, customer/order bars, order-status donut) off raw shadcn Cards and off-brand colors onto the unified backend UI kit (`components/backend/`) shipped in #543.

## Changes

- **New `chart-theme.ts`** — shared brand palette (orange `#E87A1E`, navy `#1B2A4A`), axis/grid/tooltip props, and Rand formatters. Removes styling that was duplicated across all three charts.
- **Revenue** — brand orange gradient + `Rxxk`-abbreviated Y-axis ticks, `R12,345` tooltip.
- **Customer & Order Growth** — navy + orange bars (was indigo `#4F46E5` / emerald `#10B981`).
- **Order Status** — cohesive brand `STATUS_PALETTE` + **donut center total label**.
- All three wrapped in `SectionCard` (was shadcn `Card`); `col-span` moved to the `className` prop in `page.tsx`.
- Replaced `data: any[]` with typed prop interfaces; added `EmptyState` for the no-data case.

## Verification

- `npm run type-check:memory` — no errors in the 5 touched files (also enforced by the pre-push hook).
- **Browser-verified locally** with live admin data across the Overview / Sales & Marketing / Operations tabs: brand orange revenue area with formatted axis, navy+orange growth bars, and the donut center total ("22 / Total Orders"), all in the unified `SectionCard` chrome.

## Scope / risk

Pure UI restyle of existing charts — no API, data-shape, RBAC, or routing changes. Depends only on `components/backend/` already merged via #543. 5 files, +173/−88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)