### PR TITLE
fix(admin): vetting page crash — Radix Select.Item empty value

### DIFF
--- a/app/admin/b2b/vetting/page.tsx
+++ b/app/admin/b2b/vetting/page.tsx
@@ -80,14 +80,14 @@ export default function B2BVettingQueuePage() {
   const router = useRouter();
   const [submissions, setSubmissions] = useState<Submission[]>([]);
   const [loading, setLoading] = useState(true);
-  const [segment, setSegment] = useState<string>('');
+  const [segment, setSegment] = useState<string>('all');
 
   useEffect(() => {
     async function fetchSubmissions() {
       setLoading(true);
       try {
         const url = new URL('/api/admin/b2b/vetting', window.location.origin);
-        if (segment) {
+        if (segment && segment !== 'all') {
           url.searchParams.set('segment', segment);
         }
 
@@ -136,7 +136,7 @@ export default function B2BVettingQueuePage() {
                   <SelectValue placeholder="All segments" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">All segments</SelectItem>
+                  <SelectItem value="all">All segments</SelectItem>
                   <SelectItem value="unjani">Unjani</SelectItem>
                   <SelectItem value="smb">SMB</SelectItem>
                   <SelectItem value="edu">Education</SelectItem>


### PR DESCRIPTION
## Bug

`/admin/b2b/vetting` crashed on load (white screen) with:
> A `<Select.Item />` must have a value prop that is not an empty string.

## Cause

The **Segment** filter rendered `<SelectItem value="">All segments</SelectItem>`. Radix Select forbids empty-string item values (empty string is reserved for clearing the selection / showing the placeholder).

## Fix

Use an `'all'` sentinel — default state `'all'`, item `value="all"`, and treat `'all'` as no-filter when building the query string. Filtering behaviour is unchanged.

## Verification
- ✅ Pre-push type-check — no errors in the changed file.
- Will browser-verify on staging (page renders, segment filter works).

## Related (not in this PR)
Same `<SelectItem value="">` pattern also exists in `app/admin/partners/page.tsx` (All Status / All Tiers) and `app/admin/network/mikrotik/page.tsx` (All Provinces) — same latent crash, left out to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)