### PR TITLE
Edit a clinic's contact (phone/email/nurse) from the onboarding drawer

### DIFF
--- a/app/admin/unjani/onboarding/page.tsx
+++ b/app/admin/unjani/onboarding/page.tsx
@@ -218,6 +218,13 @@ export default function UnjaniOnboardingPipelinePage() {
   const [batchSending, setBatchSending] = useState(false);
   const [drawerClinic, setDrawerClinic] = useState<PipelineClinic | null>(null);
 
+  // Inline edit of the clinic's contact (e.g. a nurse asks for the invite on a different number)
+  const [editingContact, setEditingContact] = useState(false);
+  const [editNurse, setEditNurse] = useState('');
+  const [editPhone, setEditPhone] = useState('');
+  const [editEmail, setEditEmail] = useState('');
+  const [savingContact, setSavingContact] = useState(false);
+
   // "Start onboarding" dialog (Register view → create the clinic in the pipeline)
   const [registerDialog, setRegisterDialog] = useState<RegisterClinic | null>(null);
   const [regNurse, setRegNurse] = useState('');
@@ -439,6 +446,55 @@ export default function UnjaniOnboardingPipelinePage() {
     setRegPhone('');
     setRegEmail('');
     setRegAddress('');
+  };
+
+  const startEditContact = () => {
+    if (!drawerClinic) return;
+    setEditNurse(drawerClinic.nurse_name ?? '');
+    setEditPhone(drawerClinic.phone ?? '');
+    setEditEmail(drawerClinic.email ?? '');
+    setEditingContact(true);
+  };
+
+  const saveContact = async () => {
+    if (!drawerClinic) return;
+    setSavingContact(true);
+    try {
+      const response = await fetch('/api/admin/unjani/update-contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify({
+          customerId: drawerClinic.customer_id,
+          nurseName: editNurse.trim(),
+          phone: editPhone.trim(),
+          email: editEmail.trim(),
+        }),
+      });
+      const result = await response.json();
+      if (response.ok && result.success) {
+        toast.success('Contact details updated');
+        setEditingContact(false);
+        // Reflect the change in the open drawer immediately, then refresh the list
+        setDrawerClinic((c) =>
+          c
+            ? {
+                ...c,
+                nurse_name: editNurse.trim() || null,
+                phone: editPhone.trim() || null,
+                email: editEmail.trim() || null,
+              }
+            : c
+        );
+        await fetchPipeline();
+      } else {
+        toast.error(result.error || 'Failed to update contact');
+      }
+    } catch (error) {
+      console.error('Error updating contact:', error);
+      toast.error('Failed to update contact');
+    } finally {
+      setSavingContact(false);
+    }
   };
 
   const submitRegisterClinic = async () => {
@@ -1319,7 +1375,10 @@ export default function UnjaniOnboardingPipelinePage() {
       <Sheet
         open={!!drawerClinic}
         onOpenChange={(open) => {
-          if (!open) setDrawerClinic(null);
+          if (!open) {
+            setDrawerClinic(null);
+            setEditingContact(false);
+          }
         }}
       >
         <SheetContent side="right" className="w-full sm:max-w-md p-0 flex flex-col gap-0 bg-white">
@@ -1341,27 +1400,91 @@ export default function UnjaniOnboardingPipelinePage() {
               </SheetHeader>
               <div className="flex-1 overflow-y-auto p-6 space-y-6">
                 <div>
-                  <h4 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
-                    Contact
-                  </h4>
-                  {(
-                    [
-                      ['Professional nurse', drawerClinic.nurse_name],
-                      ['Phone', drawerClinic.phone],
-                      ['Email', drawerClinic.email],
-                      ['Province', drawerClinic.province],
-                    ] as const
-                  ).map(([label, value]) => (
-                    <div
-                      key={label}
-                      className="flex justify-between gap-4 py-1.5 border-b border-gray-50 text-sm"
-                    >
-                      <span className="text-gray-500 shrink-0">{label}</span>
-                      <span className="font-medium text-gray-900 text-right break-all">
-                        {value || '—'}
-                      </span>
+                  <div className="flex items-center justify-between mb-2">
+                    <h4 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400">
+                      Contact
+                    </h4>
+                    {!editingContact && (
+                      <button
+                        onClick={startEditContact}
+                        className="text-xs font-semibold text-circleTel-orange-accessible hover:text-circleTel-orange"
+                      >
+                        Edit
+                      </button>
+                    )}
+                  </div>
+                  {editingContact ? (
+                    <div className="space-y-3">
+                      <div>
+                        <label className="block text-xs text-gray-500 mb-1">Professional nurse</label>
+                        <input
+                          type="text"
+                          value={editNurse}
+                          onChange={(e) => setEditNurse(e.target.value)}
+                          className="w-full rounded-md border border-gray-200 py-2 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-circleTel-orange"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-gray-500 mb-1">
+                          Phone <span className="text-red-500">*</span>
+                        </label>
+                        <input
+                          type="tel"
+                          value={editPhone}
+                          onChange={(e) => setEditPhone(e.target.value)}
+                          placeholder="082 123 4567"
+                          className="w-full rounded-md border border-gray-200 py-2 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-circleTel-orange"
+                        />
+                        <p className="text-xs text-gray-400 mt-1">The onboarding invite is sent here.</p>
+                      </div>
+                      <div>
+                        <label className="block text-xs text-gray-500 mb-1">Email</label>
+                        <input
+                          type="email"
+                          value={editEmail}
+                          onChange={(e) => setEditEmail(e.target.value)}
+                          className="w-full rounded-md border border-gray-200 py-2 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-circleTel-orange"
+                        />
+                      </div>
+                      <div className="flex gap-2 pt-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setEditingContact(false)}
+                          disabled={savingContact}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          size="sm"
+                          onClick={saveContact}
+                          disabled={savingContact || editPhone.trim().length < 6}
+                          className="bg-circleTel-orange hover:bg-circleTel-orange-dark text-white"
+                        >
+                          {savingContact ? 'Saving…' : 'Save contact'}
+                        </Button>
+                      </div>
                     </div>
-                  ))}
+                  ) : (
+                    (
+                      [
+                        ['Professional nurse', drawerClinic.nurse_name],
+                        ['Phone', drawerClinic.phone],
+                        ['Email', drawerClinic.email],
+                        ['Province', drawerClinic.province],
+                      ] as const
+                    ).map(([label, value]) => (
+                      <div
+                        key={label}
+                        className="flex justify-between gap-4 py-1.5 border-b border-gray-50 text-sm"
+                      >
+                        <span className="text-gray-500 shrink-0">{label}</span>
+                        <span className="font-medium text-gray-900 text-right break-all">
+                          {value || '—'}
+                        </span>
+                      </div>
+                    ))
+                  )}
                 </div>
                 <div>
                   <h4 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-3">

--- a/app/api/admin/unjani/update-contact/__tests__/route.test.ts
+++ b/app/api/admin/unjani/update-contact/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+import { NextRequest } from 'next/server';
+
+import { POST } from '../route';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { svc } from '@/lib/onboarding/onboarding-service';
+
+jest.mock('@/lib/auth/admin-api-auth', () => ({
+  authenticateAdmin: jest.fn(),
+  requirePermission: jest.fn(),
+}));
+
+jest.mock('@/lib/onboarding/onboarding-service', () => ({
+  svc: jest.fn(),
+}));
+
+jest.mock('@/lib/logging/logger', () => ({
+  apiLogger: {
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+const mockAuthenticateAdmin = authenticateAdmin as jest.MockedFunction<typeof authenticateAdmin>;
+const mockRequirePermission = requirePermission as jest.MockedFunction<typeof requirePermission>;
+const mockSvc = svc as jest.MockedFunction<typeof svc>;
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/admin/unjani/update-contact', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe('POST /api/admin/unjani/update-contact', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticateAdmin.mockResolvedValue({
+      success: true,
+      user: { id: 'user-1', email: 'admin@circletel.co.za' } as any,
+      adminUser: { email: 'admin@circletel.co.za', role: 'admin' } as any,
+    });
+    mockRequirePermission.mockReturnValue(null);
+  });
+
+  it('requires the customer-write permission for contact edits', async () => {
+    await POST(request({ customerId: 'clinic-1', phone: 'not-a-phone' }));
+
+    expect(mockRequirePermission).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'admin@circletel.co.za' }),
+      'customers:write'
+    );
+  });
+
+  it('rejects malformed phone numbers before touching the database', async () => {
+    const response = await POST(request({ customerId: 'clinic-1', phone: 'abcdef' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/valid phone/i);
+    expect(mockSvc).not.toHaveBeenCalled();
+  });
+
+  it('rejects blank email values instead of saving an empty customer email', async () => {
+    const response = await POST(request({ customerId: 'clinic-1', email: '   ' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/email/i);
+    expect(mockSvc).not.toHaveBeenCalled();
+  });
+
+  it('normalizes phone and email before saving valid contact details', async () => {
+    const customerLookup = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: {
+          id: 'clinic-1',
+          business_name: 'Unjani Clinic - Training Demo',
+          account_type: 'business',
+          clinic_details: { province: 'Gauteng' },
+        },
+        error: null,
+      }),
+    };
+    const emailLookup = {
+      select: jest.fn().mockReturnThis(),
+      ilike: jest.fn().mockReturnThis(),
+      neq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    const updateEq = jest.fn().mockResolvedValue({ error: null });
+    const updateTable = {
+      update: jest.fn().mockReturnValue({ eq: updateEq }),
+    };
+
+    mockSvc.mockReturnValue({
+      from: jest
+        .fn()
+        .mockReturnValueOnce(customerLookup)
+        .mockReturnValueOnce(emailLookup)
+        .mockReturnValueOnce(updateTable),
+    } as any);
+
+    const response = await POST(
+      request({
+        customerId: 'clinic-1',
+        nurseName: ' Training Nurse ',
+        phone: '073 728-8016',
+        email: ' JEFFREY.DE.WEE+UNJANI-TRAINING@CIRCLETEL.CO.ZA ',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateTable.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phone: '0737288016',
+        email: 'jeffrey.de.wee+unjani-training@circletel.co.za',
+        clinic_details: expect.objectContaining({ nurse_owner_name: 'Training Nurse' }),
+      })
+    );
+  });
+});

--- a/app/api/admin/unjani/update-contact/route.ts
+++ b/app/api/admin/unjani/update-contact/route.ts
@@ -15,11 +15,20 @@ import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth'
 import { svc } from '@/lib/onboarding/onboarding-service';
 import { apiLogger } from '@/lib/logging/logger';
 
+function normalizeSAPhone(phone: string): string | null {
+  const cleaned = phone.trim().replace(/[\s-]/g, '');
+  return /^(0\d{9}|\+27\d{9})$/.test(cleaned) ? cleaned : null;
+}
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
 export async function POST(request: NextRequest) {
   try {
     const auth = await authenticateAdmin(request);
     if (!auth.success) return auth.response;
-    const perm = requirePermission(auth.adminUser, ['customers:write', 'kyc:verify']);
+    const perm = requirePermission(auth.adminUser, 'customers:write');
     if (perm) return perm;
 
     const body = await request.json().catch(() => ({}));
@@ -28,7 +37,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'customerId required' }, { status: 400 });
     }
 
-    const phone = typeof body.phone === 'string' ? body.phone.trim() : undefined;
+    const phone =
+      typeof body.phone === 'string' ? normalizeSAPhone(body.phone) : undefined;
     const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : undefined;
     const nurseName = typeof body.nurseName === 'string' ? body.nurseName.trim() : undefined;
 
@@ -38,9 +48,21 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-    if (phone !== undefined && phone.length < 6) {
+    if (typeof body.phone === 'string' && phone === null) {
       return NextResponse.json(
         { success: false, error: 'Please enter a valid phone number' },
+        { status: 400 }
+      );
+    }
+    if (typeof body.email === 'string' && email.length === 0) {
+      return NextResponse.json(
+        { success: false, error: 'Email cannot be blank' },
+        { status: 400 }
+      );
+    }
+    if (email !== undefined && !isValidEmail(email)) {
+      return NextResponse.json(
+        { success: false, error: 'Please enter a valid email address' },
         { status: 400 }
       );
     }

--- a/app/api/admin/unjani/update-contact/route.ts
+++ b/app/api/admin/unjani/update-contact/route.ts
@@ -1,0 +1,111 @@
+/**
+ * Update-contact API — lets an admin change a clinic's contact details
+ * (phone / email / nurse) before or during onboarding, e.g. a nurse asks for
+ * the invite to go to a different number.
+ *
+ * POST /api/admin/unjani/update-contact
+ * Body: { customerId: string; phone?: string; email?: string; nurseName?: string }
+ *
+ * At least one of phone/email/nurseName must be provided. The phone is what the
+ * send-link / send-invite flow uses, so changing it here re-targets the invite.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { svc } from '@/lib/onboarding/onboarding-service';
+import { apiLogger } from '@/lib/logging/logger';
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticateAdmin(request);
+    if (!auth.success) return auth.response;
+    const perm = requirePermission(auth.adminUser, ['customers:write', 'kyc:verify']);
+    if (perm) return perm;
+
+    const body = await request.json().catch(() => ({}));
+    const customerId: string = body.customerId;
+    if (!customerId) {
+      return NextResponse.json({ success: false, error: 'customerId required' }, { status: 400 });
+    }
+
+    const phone = typeof body.phone === 'string' ? body.phone.trim() : undefined;
+    const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : undefined;
+    const nurseName = typeof body.nurseName === 'string' ? body.nurseName.trim() : undefined;
+
+    if (phone === undefined && email === undefined && nurseName === undefined) {
+      return NextResponse.json(
+        { success: false, error: 'Provide at least one of phone, email or nurseName' },
+        { status: 400 }
+      );
+    }
+    if (phone !== undefined && phone.length < 6) {
+      return NextResponse.json(
+        { success: false, error: 'Please enter a valid phone number' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = svc();
+
+    const { data: customer, error: findErr } = await supabase
+      .from('customers')
+      .select('id, business_name, clinic_details, account_type')
+      .eq('id', customerId)
+      .single();
+    if (findErr || !customer) {
+      return NextResponse.json({ success: false, error: 'Clinic not found' }, { status: 404 });
+    }
+
+    // Guard: the phone-uniqueness index only applies to personal accounts; clinics
+    // are business accounts so they can share/change numbers freely. Still block an
+    // email collision with another customer for cleanliness.
+    if (email !== undefined && email) {
+      const { data: emailTaken } = await supabase
+        .from('customers')
+        .select('id')
+        .ilike('email', email)
+        .neq('id', customerId)
+        .maybeSingle();
+      if (emailTaken) {
+        return NextResponse.json(
+          { success: false, error: `Email ${email} is already used by another customer.` },
+          { status: 409 }
+        );
+      }
+    }
+
+    const update: Record<string, unknown> = {};
+    if (phone !== undefined) update.phone = phone;
+    if (email !== undefined) update.email = email;
+    if (nurseName !== undefined) {
+      const details =
+        customer.clinic_details && typeof customer.clinic_details === 'object'
+          ? (customer.clinic_details as Record<string, unknown>)
+          : {};
+      update.clinic_details = { ...details, nurse_owner_name: nurseName || null };
+    }
+
+    const { error: updErr } = await supabase
+      .from('customers')
+      .update(update)
+      .eq('id', customerId);
+    if (updErr) {
+      apiLogger.error('[Update contact] update failed', { customerId, error: updErr.message });
+      return NextResponse.json({ success: false, error: updErr.message }, { status: 500 });
+    }
+
+    apiLogger.info('[Update contact] Clinic contact updated', {
+      customerId,
+      changed: Object.keys(update),
+      updatedBy: auth.adminUser.email,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    apiLogger.error('[Update contact] API error', { error });
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
A nurse (e.g. Cosmo City) asked for the onboarding invite to go to a different number, and admins had no way to change it. This adds inline editing of a clinic's contact details from the onboarding dashboard's clinic detail drawer.

## Changes
- **New `POST /api/admin/unjani/update-contact`**: admin-auth gated; updates `customers.phone`/`email` + `clinic_details.nurse_owner_name`. Email-collision guard against other customers. (Phone uniqueness only applies to personal accounts; clinics are business accounts, so they change numbers freely.)
- **Drawer Contact section**: gains an "Edit" affordance → inline edit of nurse name, **phone** (the number the invite is sent to), and email, with Save/Cancel. The drawer reflects the change immediately, then refreshes the pipeline.

Since `send-link`/`send-invite` read `customers.phone`, changing it here re-targets the invite.

## Verification
- Type-check clean on both files (scoped)
- Verified end-to-end on dev: opened the training clinic drawer, changed the phone, confirmed it persisted to the DB, then restored it

## Note
Branched directly from `main` (not via `staging`) because `staging` had diverged with concurrent product-workspace work — avoided force-pushing it. Feature is small and dev-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)