### PR TITLE
fix(whatsapp): capture all outbound messages in whatsapp_message_log

### DIFF
--- a/app/api/admin/unjani/send-link/route.ts
+++ b/app/api/admin/unjani/send-link/route.ts
@@ -32,10 +32,14 @@ export async function POST(request: NextRequest) {
     sendError = 'Customer has no phone number';
   } else if (channel === 'whatsapp') {
     try {
-      const result = await whatsAppService.sendClinicOnboarding(customer.phone, {
-        clinicName: customer.business_name || 'there',
-        token,
-      });
+      const result = await whatsAppService.sendClinicOnboarding(
+        customer.phone,
+        {
+          clinicName: customer.business_name || 'there',
+          token,
+        },
+        { customerId, createdBy: auth.adminUser.email }
+      );
       sent = result.success;
       if (!result.success) {
         sendError = result.error;

--- a/app/api/admin/unjani/send-mandate-reminder/route.ts
+++ b/app/api/admin/unjani/send-mandate-reminder/route.ts
@@ -51,12 +51,16 @@ export async function POST(request: NextRequest) {
   let sent = false;
   let sendError: string | undefined;
   try {
-    const result = await whatsAppService.sendDebiCheckReminder(customer.phone, {
-      firstName: customer.first_name || 'there',
-      clinicName: customer.business_name || 'your clinic',
-      amount,
-      headerImageUrl,
-    });
+    const result = await whatsAppService.sendDebiCheckReminder(
+      customer.phone,
+      {
+        firstName: customer.first_name || 'there',
+        clinicName: customer.business_name || 'your clinic',
+        amount,
+        headerImageUrl,
+      },
+      { customerId: customer.id, createdBy: auth.adminUser.email }
+    );
     sent = result.success;
     if (!result.success) {
       sendError = result.error;

--- a/app/api/onboarding/submit/route.ts
+++ b/app/api/onboarding/submit/route.ts
@@ -294,11 +294,15 @@ export async function POST(request: NextRequest) {
   // Template circletel_docs_received: account number + "we're vetting your documents".
   try {
     if (cust?.phone && cust.account_number) {
-      const result = await whatsAppService.sendClinicDocsReceived(cust.phone, {
-        firstName: cust.first_name || 'there',
-        clinicName: cust.business_name || 'your clinic',
-        accountNumber: cust.account_number,
-      });
+      const result = await whatsAppService.sendClinicDocsReceived(
+        cust.phone,
+        {
+          firstName: cust.first_name || 'there',
+          clinicName: cust.business_name || 'your clinic',
+          accountNumber: cust.account_number,
+        },
+        { customerId, createdBy: 'onboarding-wizard' }
+      );
       if (!result.success) {
         console.warn('[Onboarding] docs-received WhatsApp failed', result.error);
       }

--- a/lib/billing/whatsapp-paynow-service.ts
+++ b/lib/billing/whatsapp-paynow-service.ts
@@ -223,7 +223,11 @@ export class WhatsAppPayNowService {
             dueDate: formatDateForWhatsApp(invoice.due_date),
             paymentUrl,
           };
-          sendResult = await whatsAppService.sendInvoicePayment(customer.phone, params);
+          sendResult = await whatsAppService.sendInvoicePayment(customer.phone, params, {
+            customerId: customer.id,
+            invoiceId,
+            createdBy,
+          });
           break;
         }
 
@@ -234,7 +238,11 @@ export class WhatsAppPayNowService {
             daysOverdue: String(daysOverdue),
             paymentUrl,
           };
-          sendResult = await whatsAppService.sendPaymentReminder(customer.phone, params);
+          sendResult = await whatsAppService.sendPaymentReminder(customer.phone, params, {
+            customerId: customer.id,
+            invoiceId,
+            createdBy,
+          });
           break;
         }
 
@@ -245,7 +253,11 @@ export class WhatsAppPayNowService {
             amount: formatAmountForWhatsApp(invoice.total_amount),
             paymentUrl,
           };
-          sendResult = await whatsAppService.sendDebitFailed(customer.phone, params);
+          sendResult = await whatsAppService.sendDebitFailed(customer.phone, params, {
+            customerId: customer.id,
+            invoiceId,
+            createdBy,
+          });
           break;
         }
       }
@@ -273,16 +285,8 @@ export class WhatsAppPayNowService {
         })
         .eq('id', invoiceId);
 
-      // Log message
-      await supabase.rpc('log_whatsapp_message', {
-        p_message_id: sendResult.messageId,
-        p_wa_id: sendResult.waId,
-        p_phone: customer.phone,
-        p_template_name: `circletel_${notificationType}`,
-        p_customer_id: customer.id,
-        p_invoice_id: invoiceId,
-        p_created_by: createdBy,
-      });
+      // Message is logged centrally in whatsAppService.sendTemplate() (single
+      // logging point) — customer_id/invoice_id/createdBy passed via logMeta above.
 
       billingLogger.info('WhatsApp PayNow: Sent successfully', {
         invoiceId,

--- a/lib/integrations/whatsapp/types.ts
+++ b/lib/integrations/whatsapp/types.ts
@@ -164,6 +164,17 @@ export type TemplateParams =
 // API REQUEST/RESPONSE TYPES
 // =============================================================================
 
+/**
+ * Optional attribution passed to sendTemplate() so every outbound message can be
+ * recorded in whatsapp_message_log (via the log_whatsapp_message RPC). All fields
+ * optional — a send is always logged even with no attribution.
+ */
+export interface WhatsAppLogMeta {
+  customerId?: string;
+  invoiceId?: string;
+  createdBy?: string;   // e.g. admin email or 'api' / 'system'
+}
+
 export interface SendTemplateRequest {
   messaging_product: 'whatsapp';
   to: string;

--- a/lib/integrations/whatsapp/whatsapp-service.ts
+++ b/lib/integrations/whatsapp/whatsapp-service.ts
@@ -25,6 +25,7 @@ import type {
   ClinicOnboardingParams,
   ClinicDocsReceivedParams,
   DebiCheckReminderParams,
+  WhatsAppLogMeta,
 } from './types';
 
 // =============================================================================
@@ -88,7 +89,8 @@ export class WhatsAppService {
     to: string,
     templateName: CircleTelTemplate,
     components: SendTemplateRequest['template']['components'] = [],
-    languageCode = 'en_ZA' // CircleTel templates are created in English (ZAF) — must match the template's language
+    languageCode = 'en_ZA', // CircleTel templates are created in English (ZAF) — must match the template's language
+    logMeta?: WhatsAppLogMeta
   ): Promise<WhatsAppSendResult> {
     const config = this.getConfig();
 
@@ -145,6 +147,13 @@ export class WhatsAppService {
 
       console.log(`[WhatsApp] Message sent successfully: ${messageId}`);
 
+      // Persist the send to whatsapp_message_log so delivery-status webhooks
+      // have a row to update and admin dashboards reflect it. Best-effort —
+      // a logging failure must never fail the send.
+      if (messageId) {
+        await this.logSend(messageId, waId, formattedPhone, templateName, logMeta);
+      }
+
       return {
         success: true,
         messageId,
@@ -156,6 +165,40 @@ export class WhatsAppService {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to send WhatsApp message',
       };
+    }
+  }
+
+  /**
+   * Best-effort insert of an outbound message into whatsapp_message_log via the
+   * log_whatsapp_message RPC. Never throws — logging is observability, not the
+   * send itself. This is the SINGLE logging point for all template sends.
+   */
+  private async logSend(
+    messageId: string,
+    waId: string | undefined,
+    phone: string,
+    templateName: CircleTelTemplate,
+    logMeta?: WhatsAppLogMeta
+  ): Promise<void> {
+    try {
+      const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+      if (!url || !key) return;
+      const { createClient } = await import('@supabase/supabase-js');
+      const supabase = createClient(url, key, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      });
+      await supabase.rpc('log_whatsapp_message', {
+        p_message_id: messageId,
+        p_wa_id: waId || phone,
+        p_phone: phone,
+        p_template_name: templateName,
+        p_customer_id: logMeta?.customerId ?? null,
+        p_invoice_id: logMeta?.invoiceId ?? null,
+        p_created_by: logMeta?.createdBy ?? 'api',
+      });
+    } catch (error) {
+      console.error('[WhatsApp] Failed to log message to whatsapp_message_log', error);
     }
   }
 
@@ -174,7 +217,8 @@ export class WhatsAppService {
    */
   async sendInvoicePayment(
     to: string,
-    params: InvoicePaymentParams
+    params: InvoicePaymentParams,
+    logMeta?: WhatsAppLogMeta
   ): Promise<WhatsAppSendResult> {
     const bodyParams: TemplateParameter[] = [
       { type: 'text', text: params.customerName },
@@ -199,7 +243,7 @@ export class WhatsAppService {
       },
     ];
 
-    return this.sendTemplate(to, 'circletel_invoice_payment', components);
+    return this.sendTemplate(to, 'circletel_invoice_payment', components, 'en_ZA', logMeta);
   }
 
   // ===========================================================================
@@ -216,7 +260,8 @@ export class WhatsAppService {
    */
   async sendPaymentReminder(
     to: string,
-    params: PaymentReminderParams
+    params: PaymentReminderParams,
+    logMeta?: WhatsAppLogMeta
   ): Promise<WhatsAppSendResult> {
     const bodyParams: TemplateParameter[] = [
       { type: 'text', text: params.invoiceNumber },
@@ -237,7 +282,7 @@ export class WhatsAppService {
       },
     ];
 
-    return this.sendTemplate(to, 'circletel_payment_reminder', components);
+    return this.sendTemplate(to, 'circletel_payment_reminder', components, 'en_ZA', logMeta);
   }
 
   // ===========================================================================
@@ -255,7 +300,8 @@ export class WhatsAppService {
    */
   async sendDebitFailed(
     to: string,
-    params: DebitFailedParams
+    params: DebitFailedParams,
+    logMeta?: WhatsAppLogMeta
   ): Promise<WhatsAppSendResult> {
     const bodyParams: TemplateParameter[] = [
       { type: 'text', text: params.customerName },
@@ -278,7 +324,7 @@ export class WhatsAppService {
       // Second button - Update Payment (static URL in template)
     ];
 
-    return this.sendTemplate(to, 'circletel_debit_failed', components);
+    return this.sendTemplate(to, 'circletel_debit_failed', components, 'en_ZA', logMeta);
   }
 
   // ===========================================================================
@@ -358,7 +404,8 @@ export class WhatsAppService {
    */
   async sendClinicOnboarding(
     to: string,
-    params: ClinicOnboardingParams
+    params: ClinicOnboardingParams,
+    logMeta?: WhatsAppLogMeta
   ): Promise<WhatsAppSendResult> {
     const components: SendTemplateRequest['template']['components'] = [
       {
@@ -374,7 +421,7 @@ export class WhatsAppService {
       },
     ];
 
-    return this.sendTemplate(to, 'circletel_clinic_onboarding', components);
+    return this.sendTemplate(to, 'circletel_clinic_onboarding', components, 'en_ZA', logMeta);
   }
 
   /**
@@ -387,7 +434,8 @@ export class WhatsAppService {
    */
   async sendClinicDocsReceived(
     to: string,
-    params: ClinicDocsReceivedParams
+    params: ClinicDocsReceivedParams,
+    logMeta?: WhatsAppLogMeta
   ): Promise<WhatsAppSendResult> {
     const components: SendTemplateRequest['template']['components'] = [
       {
@@ -400,7 +448,7 @@ export class WhatsAppService {
       },
     ];
 
-    return this.sendTemplate(to, 'circletel_docs_received', components);
+    return this.sendTemplate(to, 'circletel_docs_received', components, 'en_ZA', logMeta);
   }
 
   /**
@@ -416,7 +464,8 @@ export class WhatsAppService {
    */
   async sendDebiCheckReminder(
     to: string,
-    params: DebiCheckReminderParams
+    params: DebiCheckReminderParams,
+    logMeta?: WhatsAppLogMeta
   ): Promise<WhatsAppSendResult> {
     const components: SendTemplateRequest['template']['components'] = [
       {
@@ -433,7 +482,7 @@ export class WhatsAppService {
       },
     ];
 
-    return this.sendTemplate(to, 'circletel_debicheck_reminder', components);
+    return this.sendTemplate(to, 'circletel_debicheck_reminder', components, 'en_ZA', logMeta);
   }
 
   // ===========================================================================


### PR DESCRIPTION
## Problem
`whatsapp_message_log` was effectively unused — **0 rows**. Only the billing Pay Now flow called `log_whatsapp_message`; every other WhatsApp send (clinic onboarding invites, docs-received confirmations, and the new DebiCheck reminders) was **never recorded**. As a result:
- the webhook's `update_whatsapp_message_status` had no row to update → logged "Message not found in log" and dropped delivery/read/failed status;
- admin WhatsApp dashboards (billing → WhatsApp stats/messages) showed nothing.

## Fix
Make `whatsAppService.sendTemplate()` the **single logging point** — every successful send best-effort inserts via `log_whatsapp_message` (never fails the send). An optional `WhatsAppLogMeta {customerId, invoiceId, createdBy}` is threaded through the wrapper methods, and the now-redundant explicit log call in `whatsapp-paynow-service` is removed (prevents double-logging).

### Attribution wired at call sites
| Message | customer_id | created_by |
|---|---|---|
| DebiCheck reminder | ✅ | admin email |
| Clinic onboarding invite | ✅ | admin email |
| Docs received | ✅ | `onboarding-wizard` |
| Billing Pay Now | ✅ (+invoice_id) | caller |

## Verification
Sent a real `circletel_debicheck_reminder` template → confirmed a new `whatsapp_message_log` row with `customer_id=b0dba2c2…` (Barcelona), `status='sent'`, `created_by` set. Type-check clean on all 6 touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)