### PR TITLE
style(emails): standardize logo URLs to canonical www asset

### DIFF
--- a/app/api/admin/support/send-email/route.ts
+++ b/app/api/admin/support/send-email/route.ts
@@ -183,8 +183,9 @@ export async function POST(request: NextRequest) {
 
   } catch (error: unknown) {
     apiLogger.error('[Support Email] Error', { error });
+    const message = error instanceof Error ? error.message : 'Internal server error';
     return NextResponse.json(
-      { error: error.message || 'Internal server error' },
+      { error: message },
       { status: 500 }
     );
   }
@@ -243,7 +244,7 @@ function wrapInEmailTemplate(content: string): string {
 </head>
 <body style="font-family: Arial, Helvetica, sans-serif; line-height: 1.6; color: #1F2937; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9fafb;">
   <div style="background-color: #F5831F; padding: 15px 20px; border-radius: 8px 8px 0 0;">
-    <img src="https://circletel.co.za/images/circletel-logo-white.png" alt="CircleTel" style="height: 40px; width: auto;" />
+    <img src="https://www.circletel.co.za/images/circletel-logo-white.png" alt="CircleTel" style="height: 40px; width: auto;" />
   </div>
   
   <div style="background-color: #ffffff; padding: 30px; border: 1px solid #E6E9EF; border-top: none;">

--- a/emails/contract-ready.tsx
+++ b/emails/contract-ready.tsx
@@ -55,9 +55,9 @@ export default function ContractReadyEmail(props: Partial<ContractReadyEmailProp
           {/* Logo */}
           <Section style={header}>
             <Img
-              src="https://circletel.co.za/logo.png"
-              width="150"
-              height="50"
+              src="https://www.circletel.co.za/images/circletel-enclosed-logo.png"
+              width="140"
+              height="140"
               alt="CircleTel"
               style={logo}
             />

--- a/emails/kyc-completed.tsx
+++ b/emails/kyc-completed.tsx
@@ -46,9 +46,9 @@ export default function KYCCompletedEmail({
           {/* Logo */}
           <Section style={header}>
             <Img
-              src="https://circletel.co.za/logo.png"
-              width="150"
-              height="50"
+              src="https://www.circletel.co.za/images/circletel-enclosed-logo.png"
+              width="140"
+              height="140"
               alt="CircleTel"
               style={logo}
             />

--- a/emails/service-activated.tsx
+++ b/emails/service-activated.tsx
@@ -58,9 +58,9 @@ export default function ServiceActivatedEmail(props: Partial<ServiceActivatedEma
           {/* Logo */}
           <Section style={header}>
             <Img
-              src="https://circletel.co.za/logo.png"
-              width="150"
-              height="50"
+              src="https://www.circletel.co.za/images/circletel-logo-white.png"
+              width="140"
+              height="140"
               alt="CircleTel"
               style={logo}
             />
@@ -292,7 +292,7 @@ const header = {
 
 const logo = {
   margin: '0 auto',
-  filter: 'brightness(0) invert(1)', // Make logo white
+  // Uses the white logo asset directly (no filter needed) on the orange header
 };
 
 const celebrationSection = {


### PR DESCRIPTION
## What
Three React-Email templates pointed at **`https://circletel.co.za/logo.png`** — a stale, non-existent path (the real logo assets live under `/images/…`), so those emails rendered a **broken header logo**. This standardizes them on the same canonical asset the shared `emails/slices/CircleTelHeader.tsx` already uses.

| Template | Fix |
|---|---|
| `contract-ready.tsx` (white header) | → `…/images/circletel-enclosed-logo.png`, dims `150×50` → square `140×140` |
| `kyc-completed.tsx` (white header) | same |
| `service-activated.tsx` (orange-gradient header) | → `…/images/circletel-logo-white.png`, removed the `brightness(0) invert(1)` filter (asset is already white) |
| `support/send-email` route | normalized apex `circletel.co.za` → `www` for the white logo |

## Bonus
The pre-push hook surfaced a **pre-existing type error** at `support/send-email/route.ts:187` (`error.message` on `unknown`) — fixed with an `instanceof Error` guard rather than bypassing the hook.

## Notes
- Both target assets exist in `public/images/` (verified).
- Out of scope but noted: `app/faq/page.tsx` has a JSON-LD `logo` pointing at `www.circletel.co.za/logo.png` (also a non-existent root path) — that's SEO structured data, not email; left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)