### PR TITLE
feat(coverage): MTN LTE/5G coverage check in admin checker

### DIFF
--- a/app/admin/coverage/checker/components/AddressInput.tsx
+++ b/app/admin/coverage/checker/components/AddressInput.tsx
@@ -8,11 +8,12 @@ import { PiMapPinBold, PiCrosshairBold, PiWifiHighBold } from 'react-icons/pi';
 interface AddressInputProps {
   onCheck: (lat: number, lng: number, address: string) => void;
   isLoading: boolean;
+  subtitle?: string;
 }
 
 const GPS_REGEX = /^(-?\d{1,3}\.?\d*)\s*,\s*(-?\d{1,3}\.?\d*)$/;
 
-export default function AddressInput({ onCheck, isLoading }: AddressInputProps) {
+export default function AddressInput({ onCheck, isLoading, subtitle }: AddressInputProps) {
   const [mode, setMode] = useState<'address' | 'gps'>('address');
   const [addressText, setAddressText] = useState('');
   const [gpsText, setGpsText] = useState('');
@@ -103,7 +104,7 @@ export default function AddressInput({ onCheck, isLoading }: AddressInputProps) 
         </div>
         <div>
           <h2 className="text-sm font-semibold text-slate-900">Enter Location</h2>
-          <p className="text-xs text-slate-500">Check Tarana FWB coverage availability</p>
+          <p className="text-xs text-slate-500">{subtitle ?? 'Check Tarana FWB coverage availability'}</p>
         </div>
       </div>
 

--- a/app/admin/coverage/checker/components/CoverageMap.tsx
+++ b/app/admin/coverage/checker/components/CoverageMap.tsx
@@ -13,8 +13,10 @@ interface CoverageMapProps {
   bnLng?: number | null;
   bnSiteName?: string;
   // DFA mode
-  mode?: 'tarana' | 'dfa';
+  mode?: 'tarana' | 'dfa' | 'mtn';
   dfaCoverageType?: 'connected' | 'near-net' | 'none';
+  // MTN mode
+  mtnAvailable?: boolean;
 }
 
 export default function CoverageMap({
@@ -22,6 +24,7 @@ export default function CoverageMap({
   bnLat, bnLng, bnSiteName,
   mode = 'tarana',
   dfaCoverageType,
+  mtnAvailable,
 }: CoverageMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<google.maps.Map | null>(null);
@@ -130,8 +133,28 @@ export default function CoverageMap({
       targetMarker.addListener('click', () => dfaInfo.open(map, targetMarker));
     }
 
+    // MTN mode — signal-area indicator around target (no base-station data from WMS)
+    if (mode === 'mtn') {
+      const mtnColor = mtnAvailable ? '#10B981' : '#EF4444';
+      new google.maps.Circle({
+        map,
+        center: { lat: targetLat, lng: targetLng },
+        radius: 600,
+        fillColor: mtnColor,
+        fillOpacity: 0.12,
+        strokeColor: mtnColor,
+        strokeWeight: 2,
+        strokeOpacity: 0.6,
+      });
+
+      const mtnInfo = new google.maps.InfoWindow({
+        content: `<div style="font-size:12px;font-weight:600;padding:2px 4px">📱 MTN ${mtnAvailable ? 'coverage area' : 'no coverage'}</div>`,
+      });
+      targetMarker.addListener('click', () => mtnInfo.open(map, targetMarker));
+    }
+
     map.fitBounds(bounds, 80);
-  }, [targetLat, targetLng, bnLat, bnLng, targetAddress, bnSiteName, mode, dfaCoverageType]);
+  }, [targetLat, targetLng, bnLat, bnLng, targetAddress, bnSiteName, mode, dfaCoverageType, mtnAvailable]);
 
   return (
     <SectionCard title="Coverage Map" icon={PiMapPinBold}>
@@ -147,6 +170,11 @@ export default function CoverageMap({
               dfaCoverageType === 'connected' ? 'bg-emerald-500' : 'bg-amber-500'
             }`} />
             DFA {dfaCoverageType === 'connected' ? 'Connected' : 'Near-Net'} Zone
+          </span>
+        ) : mode === 'mtn' ? (
+          <span className="flex items-center gap-1.5">
+            <span className={`w-3 h-3 rounded-full inline-block ${mtnAvailable ? 'bg-emerald-500' : 'bg-red-500'}`} />
+            MTN {mtnAvailable ? 'Coverage Area' : 'No Coverage'}
           </span>
         ) : (
           <>

--- a/app/admin/coverage/checker/components/MTNProductTiers.tsx
+++ b/app/admin/coverage/checker/components/MTNProductTiers.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { SectionCard } from '@/components/admin/shared';
+import { PiCheckCircleBold, PiPackageBold, PiInfoBold } from 'react-icons/pi';
+
+export interface MTNPackage {
+  id: string;
+  name: string;
+  download_speed: number;
+  upload_speed: number;
+  price: number;
+  description?: string;
+}
+
+interface MTNProductTiersProps {
+  products: MTNPackage[];
+  fiveGAvailable: boolean;
+}
+
+function formatPrice(price: number): string {
+  return `R${price.toLocaleString('en-ZA', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}/mo`;
+}
+
+function formatSpeed(dl: number, ul: number): string {
+  return dl > 0 ? `${dl}/${ul} Mbps` : 'Best Effort';
+}
+
+// Best value = highest download-per-rand among speed-rated tiers.
+function pickRecommended(products: MTNPackage[]): MTNPackage | null {
+  const rated = products.filter((p) => p.download_speed > 0 && p.price > 0);
+  if (rated.length === 0) return null;
+  return rated.reduce((best, p) =>
+    p.download_speed / p.price > best.download_speed / best.price ? p : best
+  );
+}
+
+export default function MTNProductTiers({ products, fiveGAvailable }: MTNProductTiersProps) {
+  const recommended = pickRecommended(products);
+  const showTiers = fiveGAvailable && products.length > 0;
+
+  return (
+    <SectionCard title="Recommended Packages" icon={PiPackageBold}>
+      {showTiers ? (
+        <div className="grid gap-3 grid-cols-2 lg:grid-cols-3">
+          {products.map((product) => {
+            const isRecommended = recommended?.id === product.id;
+            return (
+              <div
+                key={product.id}
+                className={`relative rounded-lg border-2 p-3 transition-all ${
+                  isRecommended ? 'border-yellow-500 bg-yellow-50 shadow-sm' : 'border-slate-200 bg-white'
+                }`}
+              >
+                {isRecommended && (
+                  <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 text-xs bg-yellow-500 text-white px-2 py-0.5 rounded-full font-semibold whitespace-nowrap">
+                    Best Value
+                  </span>
+                )}
+                <p className="text-xs font-semibold text-slate-500 mb-0.5">
+                  {formatSpeed(product.download_speed, product.upload_speed)}
+                </p>
+                <p className="text-sm font-bold text-slate-900 leading-tight">{product.name}</p>
+                <p className="text-sm font-semibold text-slate-700 mt-1">{formatPrice(product.price)}</p>
+                <p className="text-xs text-slate-400 mt-1.5 flex items-center gap-1">
+                  <PiCheckCircleBold className="text-emerald-500" />
+                  5G · Consumer
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-lg bg-slate-50 border border-slate-200 p-4 text-sm text-slate-500 flex items-center gap-2">
+          <PiInfoBold className="text-slate-400 shrink-0" />
+          {fiveGAvailable
+            ? 'No active 5G packages in the catalogue yet.'
+            : '5G is not available at this location — no 5G packages to recommend.'}
+        </div>
+      )}
+
+      {/* Honest catalogue note: LTE/Fixed-LTE have no active products today */}
+      <p className="text-xs text-slate-400 mt-3 flex items-center gap-1.5">
+        <PiInfoBold className="text-slate-300" />
+        LTE and Fixed-LTE packages are not yet in the catalogue — only 5G is available to sell today.
+      </p>
+    </SectionCard>
+  );
+}

--- a/app/admin/coverage/checker/components/MTNVerdictCard.tsx
+++ b/app/admin/coverage/checker/components/MTNVerdictCard.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { StatusBadge } from '@/components/admin/shared';
+import { PiCheckCircleBold, PiXBold, PiDeviceMobileBold, PiBroadcastBold, PiHouseLineBold } from 'react-icons/pi';
+
+export interface MTNService {
+  type: string;
+  available: boolean;
+  signal: 'excellent' | 'good' | 'fair' | 'poor' | 'none';
+  source?: 'business' | 'consumer';
+  estimatedSpeed?: { download: number; upload: number; unit: 'Mbps' | 'Gbps' };
+}
+
+interface MTNVerdictCardProps {
+  services: MTNService[];
+  confidence?: 'high' | 'medium' | 'low';
+}
+
+// Technologies shown, in display order
+const TECHS: { type: string; label: string; icon: typeof PiBroadcastBold }[] = [
+  { type: '5g', label: '5G', icon: PiBroadcastBold },
+  { type: 'lte', label: 'LTE (Mobile)', icon: PiDeviceMobileBold },
+  { type: 'fixed_lte', label: 'Fixed LTE', icon: PiHouseLineBold },
+];
+
+const SIGNAL_RANK: Record<MTNService['signal'], number> = {
+  excellent: 4, good: 3, fair: 2, poor: 1, none: 0,
+};
+
+const SIGNAL_LABEL: Record<MTNService['signal'], string> = {
+  excellent: 'Excellent', good: 'Good', fair: 'Marginal', poor: 'Weak', none: 'No Coverage',
+};
+
+const SIGNAL_VARIANT: Record<MTNService['signal'], 'success' | 'warning' | 'error' | 'neutral'> = {
+  excellent: 'success', good: 'success', fair: 'warning', poor: 'error', none: 'neutral',
+};
+
+// The same technology can be reported by both business and consumer sources —
+// pick the best (available first, then strongest signal).
+function bestForType(services: MTNService[], type: string): MTNService | null {
+  const matches = services.filter((s) => s.type === type);
+  if (matches.length === 0) return null;
+  return matches.reduce<MTNService | null>((best, s) => {
+    if (!best) return s;
+    if (s.available !== best.available) return s.available ? s : best;
+    return SIGNAL_RANK[s.signal] > SIGNAL_RANK[best.signal] ? s : best;
+  }, null);
+}
+
+export default function MTNVerdictCard({ services, confidence }: MTNVerdictCardProps) {
+  const rows = TECHS.map((tech) => ({ ...tech, service: bestForType(services, tech.type) }));
+  const anyAvailable = rows.some((r) => r.service?.available);
+
+  const cfg = anyAvailable
+    ? { icon: PiCheckCircleBold, color: 'text-emerald-500', bgClass: 'bg-emerald-50 border-emerald-400', badge: 'success' as const, label: 'MTN Coverage Available' }
+    : { icon: PiXBold, color: 'text-red-500', bgClass: 'bg-red-50 border-red-400', badge: 'error' as const, label: 'No MTN LTE / 5G Coverage' };
+  const HeaderIcon = cfg.icon;
+
+  return (
+    <div className={`rounded-xl border-l-4 ${cfg.bgClass} p-5`}>
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <HeaderIcon className={`h-8 w-8 ${cfg.color}`} />
+          <div>
+            <p className="text-xs font-semibold tracking-wider uppercase text-slate-500 mb-1">
+              MTN LTE / 5G Status
+            </p>
+            <StatusBadge variant={cfg.badge} status={cfg.label} />
+          </div>
+        </div>
+        {confidence && (
+          <p className="text-sm text-slate-500 text-right">
+            Model confidence:{' '}
+            <span className="font-semibold text-slate-700">
+              {confidence.charAt(0).toUpperCase() + confidence.slice(1)}
+            </span>
+          </p>
+        )}
+      </div>
+
+      {/* Per-technology breakdown */}
+      <div className="mt-4 space-y-2">
+        {rows.map(({ type, label, icon: Icon, service }) => {
+          const signal = service?.signal ?? 'none';
+          const speed = service?.available ? service.estimatedSpeed : undefined;
+          return (
+            <div key={type} className="flex items-center justify-between gap-3 bg-white/70 rounded-lg px-3 py-2.5">
+              <div className="flex items-center gap-2.5">
+                <Icon className="h-5 w-5 text-slate-400 shrink-0" />
+                <span className="text-sm font-medium text-slate-700">{label}</span>
+              </div>
+              <div className="flex items-center gap-3">
+                {speed && (
+                  <span className="text-xs text-slate-500">
+                    ~{speed.download}{speed.unit} ↓ / {speed.upload}{speed.unit} ↑
+                  </span>
+                )}
+                <StatusBadge variant={SIGNAL_VARIANT[signal]} status={SIGNAL_LABEL[signal]} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="text-xs text-slate-400 mt-3">
+        Estimated speeds are signal-based projections from MTN coverage maps, not guaranteed throughput.
+      </p>
+    </div>
+  );
+}

--- a/app/admin/coverage/checker/components/ProviderSelector.tsx
+++ b/app/admin/coverage/checker/components/ProviderSelector.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { PiRadioBold, PiBroadcastBold } from 'react-icons/pi';
+import { PiRadioBold, PiBroadcastBold, PiDeviceMobileBold } from 'react-icons/pi';
 
-type ProviderType = 'tarana' | 'dfa';
+type ProviderType = 'tarana' | 'dfa' | 'mtn';
 
 interface ProviderSelectorProps {
   provider: ProviderType;
@@ -35,6 +35,18 @@ export default function ProviderSelector({ provider, onChange }: ProviderSelecto
       >
         <PiBroadcastBold className="h-4 w-4" />
         DFA Fibre
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange('mtn')}
+        className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+          provider === 'mtn'
+            ? 'bg-yellow-500 text-white shadow-sm'
+            : 'text-slate-600 hover:text-slate-800 hover:bg-slate-50'
+        }`}
+      >
+        <PiDeviceMobileBold className="h-4 w-4" />
+        MTN LTE/5G
       </button>
     </div>
   );

--- a/app/admin/coverage/checker/page.tsx
+++ b/app/admin/coverage/checker/page.tsx
@@ -17,6 +17,7 @@ import ProviderSelector from './components/ProviderSelector';
 import DFAVerdictCard from './components/DFAVerdictCard';
 import DFAProductTiers from './components/DFAProductTiers';
 import DFAInstallationEstimate from './components/DFAInstallationEstimate';
+import MTNVerdictCard, { type MTNService } from './components/MTNVerdictCard';
 import RecentChecksPanel, { saveRecentCheck } from './components/RecentChecksPanel';
 import {
   PiRulerBold, PiLightningBold, PiGaugeBold, PiCheckCircleBold,
@@ -33,7 +34,7 @@ const TABS = [
 ] as const;
 
 type TabId = typeof TABS[number]['id'];
-type ProviderType = 'tarana' | 'dfa';
+type ProviderType = 'tarana' | 'dfa' | 'mtn';
 
 const QUALITY_LABEL: Record<string, string> = {
   excellent: 'Excellent', good: 'Good', fair: 'Marginal', poor: 'Weak', none: 'None',
@@ -73,6 +74,13 @@ interface DFAResult {
   address: string;
 }
 
+interface MTNResult {
+  services: MTNService[];
+  available: boolean;
+  confidence?: 'high' | 'medium' | 'low';
+  address: string;
+}
+
 export default function CoverageCheckerPage() {
   const [provider, setProvider] = useState<ProviderType>('tarana');
   // Tarana state
@@ -83,6 +91,10 @@ export default function CoverageCheckerPage() {
   const [dfaResult, setDfaResult] = useState<DFAResult | null>(null);
   const [dfaLoading, setDfaLoading] = useState(false);
   const [dfaError, setDfaError] = useState<string | null>(null);
+  // MTN LTE/5G state
+  const [mtnResult, setMtnResult] = useState<MTNResult | null>(null);
+  const [mtnLoading, setMtnLoading] = useState(false);
+  const [mtnError, setMtnError] = useState<string | null>(null);
   // Shared
   const [activeTab, setActiveTab] = useState<TabId>('check');
   const statsRef = useRef<HTMLDivElement>(null);
@@ -98,6 +110,7 @@ export default function CoverageCheckerPage() {
     setError(null);
     setResult(null);
     setDfaResult(null);
+    setMtnResult(null);
     setActiveTab('check');
 
     try {
@@ -154,6 +167,7 @@ export default function CoverageCheckerPage() {
     setDfaError(null);
     setDfaResult(null);
     setResult(null);
+    setMtnResult(null);
     setActiveTab('check');
 
     try {
@@ -174,17 +188,53 @@ export default function CoverageCheckerPage() {
     }
   }, []);
 
+  // ── MTN LTE/5G check ──
+  const handleMtnCheck = useCallback(async (lat: number, lng: number, address: string) => {
+    setMtnLoading(true);
+    setMtnError(null);
+    setMtnResult(null);
+    setResult(null);
+    setDfaResult(null);
+    setActiveTab('check');
+
+    try {
+      const res = await fetch('/api/coverage/mtn/check', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          coordinates: { lat, lng },
+          serviceTypes: ['5g', 'lte', 'fixed_lte'],
+          includeSignalStrength: true,
+        }),
+      });
+
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'MTN coverage check failed');
+
+      setMtnResult({
+        services: Array.isArray(data.data?.services) ? data.data.services : [],
+        available: Boolean(data.data?.available),
+        confidence: data.data?.confidence,
+        address,
+      });
+    } catch (err) {
+      setMtnError(err instanceof Error ? err.message : 'MTN coverage check failed');
+    } finally {
+      setMtnLoading(false);
+    }
+  }, []);
+
   // Scroll stats row into view after result loads
   useEffect(() => {
-    if ((result || dfaResult) && statsRef.current) {
+    if ((result || dfaResult || mtnResult) && statsRef.current) {
       statsRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
-  }, [result, dfaResult]);
+  }, [result, dfaResult, mtnResult]);
 
   const prediction = result?.prediction ?? null;
-  const loading = provider === 'tarana' ? isLoading : dfaLoading;
-  const currentError = provider === 'tarana' ? error : dfaError;
-  const hasResult = provider === 'tarana' ? result !== null : dfaResult !== null;
+  const loading = provider === 'tarana' ? isLoading : provider === 'dfa' ? dfaLoading : mtnLoading;
+  const currentError = provider === 'tarana' ? error : provider === 'dfa' ? dfaError : mtnError;
+  const hasResult = provider === 'tarana' ? result !== null : provider === 'dfa' ? dfaResult !== null : mtnResult !== null;
 
   function getMcsLevel(rssi: number): number {
     if (rssi >= -65)   return 16;
@@ -238,10 +288,16 @@ export default function CoverageCheckerPage() {
                       variant={dfaResult.coverageType === 'connected' ? 'success' : dfaResult.coverageType === 'near-net' ? 'warning' : 'error'}
                     />
                   )}
+                  {mtnResult && (
+                    <StatusBadge
+                      status={mtnResult.available ? 'Coverage Available' : 'No Coverage'}
+                      variant={mtnResult.available ? 'success' : 'error'}
+                    />
+                  )}
                 </div>
-                {(result?.address || dfaResult?.address) && (
+                {(result?.address || dfaResult?.address || mtnResult?.address) && (
                   <p className="text-sm text-slate-500 mt-0.5 truncate max-w-md">
-                    {result?.address || dfaResult?.address}
+                    {result?.address || dfaResult?.address || mtnResult?.address}
                   </p>
                 )}
               </div>
@@ -306,12 +362,12 @@ export default function CoverageCheckerPage() {
         <TabPanel id="check" activeTab={activeTab} className="space-y-5">
 
           {/* Provider Selector */}
-          <ProviderSelector provider={provider} onChange={(p) => { setProvider(p); setResult(null); setDfaResult(null); setError(null); setDfaError(null); }} />
+          <ProviderSelector provider={provider} onChange={(p) => { setProvider(p); setResult(null); setDfaResult(null); setMtnResult(null); setError(null); setDfaError(null); setMtnError(null); }} />
 
           {/* Address input */}
           {mapsLoaded ? (
             <AddressInput
-              onCheck={provider === 'tarana' ? handleCheck : handleDFACheck}
+              onCheck={provider === 'tarana' ? handleCheck : provider === 'dfa' ? handleDFACheck : handleMtnCheck}
               isLoading={loading}
             />
           ) : (
@@ -326,12 +382,18 @@ export default function CoverageCheckerPage() {
             <div className="bg-white rounded-xl border border-slate-200 p-8 text-center">
               <div className="w-8 h-8 border-[3px] border-orange-400 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
               <p className="text-sm font-medium text-slate-700">
-                {provider === 'tarana' ? 'Checking coverage…' : 'Checking DFA fibre coverage…'}
+                {provider === 'tarana'
+                  ? 'Checking coverage…'
+                  : provider === 'dfa'
+                    ? 'Checking DFA fibre coverage…'
+                    : 'Checking MTN LTE / 5G coverage…'}
               </p>
               <p className="text-xs text-slate-400 mt-1">
                 {provider === 'tarana'
                   ? 'Running terrain analysis and link budget calculation'
-                  : 'Querying DFA ArcGIS connected and near-net buildings'}
+                  : provider === 'dfa'
+                    ? 'Querying DFA ArcGIS connected and near-net buildings'
+                    : 'Querying MTN coverage maps (business + consumer)'}
               </p>
             </div>
           )}
@@ -385,13 +447,22 @@ export default function CoverageCheckerPage() {
             </div>
           )}
 
+          {/* ── MTN LTE/5G Results ── */}
+          {provider === 'mtn' && mtnResult && !mtnLoading && (
+            <div className="space-y-4">
+              <MTNVerdictCard services={mtnResult.services} confidence={mtnResult.confidence} />
+            </div>
+          )}
+
           {/* Empty state */}
           {!hasResult && !loading && !currentError && (
             <div className="bg-white rounded-xl border border-dashed border-slate-300 p-12 text-center">
               <p className="text-sm text-slate-400">
                 {provider === 'tarana'
                   ? 'Enter an address above to check Tarana FWB coverage'
-                  : 'Enter an address above to check DFA fibre coverage'}
+                  : provider === 'dfa'
+                    ? 'Enter an address above to check DFA fibre coverage'
+                    : 'Enter an address above to check MTN LTE / 5G coverage'}
               </p>
             </div>
           )}

--- a/app/admin/coverage/checker/page.tsx
+++ b/app/admin/coverage/checker/page.tsx
@@ -18,10 +18,11 @@ import DFAVerdictCard from './components/DFAVerdictCard';
 import DFAProductTiers from './components/DFAProductTiers';
 import DFAInstallationEstimate from './components/DFAInstallationEstimate';
 import MTNVerdictCard, { type MTNService } from './components/MTNVerdictCard';
+import MTNProductTiers, { type MTNPackage } from './components/MTNProductTiers';
 import RecentChecksPanel, { saveRecentCheck } from './components/RecentChecksPanel';
 import {
   PiRulerBold, PiLightningBold, PiGaugeBold, PiCheckCircleBold,
-  PiArrowLeftBold,
+  PiArrowLeftBold, PiBroadcastBold,
 } from 'react-icons/pi';
 import Link from 'next/link';
 
@@ -78,7 +79,26 @@ interface MTNResult {
   services: MTNService[];
   available: boolean;
   confidence?: 'high' | 'medium' | 'low';
+  packages: MTNPackage[];
   address: string;
+  lat: number;
+  lng: number;
+}
+
+const MTN_SIGNAL_RANK: Record<string, number> = {
+  excellent: 4, good: 3, fair: 2, poor: 1, none: 0,
+};
+const MTN_TECH_LABEL: Record<string, string> = {
+  '5g': '5G', lte: 'LTE', fixed_lte: 'Fixed LTE',
+};
+
+// Best available service across the MTN results (for the KPI stat row).
+function bestMtnService(services: MTNService[]): MTNService | null {
+  const avail = services.filter((s) => s.available);
+  if (avail.length === 0) return null;
+  return avail.reduce((best, s) =>
+    (MTN_SIGNAL_RANK[s.signal] ?? 0) > (MTN_SIGNAL_RANK[best.signal] ?? 0) ? s : best
+  );
 }
 
 export default function CoverageCheckerPage() {
@@ -211,11 +231,20 @@ export default function CoverageCheckerPage() {
       const data = await res.json();
       if (!data.success) throw new Error(data.error || 'MTN coverage check failed');
 
+      // Fetch sellable packages in parallel (5G is the only active catalogue today)
+      const packages = await fetch('/api/coverage/mtn/packages')
+        .then((r) => r.json())
+        .then((p) => (p.success && Array.isArray(p.products) ? (p.products as MTNPackage[]) : []))
+        .catch(() => [] as MTNPackage[]);
+
       setMtnResult({
         services: Array.isArray(data.data?.services) ? data.data.services : [],
         available: Boolean(data.data?.available),
         confidence: data.data?.confidence,
+        packages,
         address,
+        lat,
+        lng,
       });
     } catch (err) {
       setMtnError(err instanceof Error ? err.message : 'MTN coverage check failed');
@@ -232,6 +261,12 @@ export default function CoverageCheckerPage() {
   }, [result, dfaResult, mtnResult]);
 
   const prediction = result?.prediction ?? null;
+  const mtnBest = mtnResult ? bestMtnService(mtnResult.services) : null;
+  const mtnTopSpeed = mtnResult
+    ? mtnResult.services
+        .filter((s) => s.available && s.estimatedSpeed)
+        .reduce((max, s) => Math.max(max, s.estimatedSpeed!.download), 0)
+    : 0;
   const loading = provider === 'tarana' ? isLoading : provider === 'dfa' ? dfaLoading : mtnLoading;
   const currentError = provider === 'tarana' ? error : provider === 'dfa' ? dfaError : mtnError;
   const hasResult = provider === 'tarana' ? result !== null : provider === 'dfa' ? dfaResult !== null : mtnResult !== null;
@@ -355,6 +390,48 @@ export default function CoverageCheckerPage() {
         </div>
       )}
 
+      {/* ── Stat Cards (MTN LTE/5G — shown after first result) ── */}
+      {provider === 'mtn' && mtnResult && (
+        <div ref={statsRef} className="bg-white border-b border-slate-100">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              <StatCard
+                icon={<PiBroadcastBold />}
+                label="Best Technology"
+                value={mtnBest ? (MTN_TECH_LABEL[mtnBest.type] ?? mtnBest.type) : 'None'}
+                subtitle={mtnBest ? 'Available at location' : 'No MTN coverage'}
+                iconBgColor="bg-yellow-50"
+                iconColor="text-yellow-500"
+              />
+              <StatCard
+                icon={<PiLightningBold />}
+                label="Best Signal"
+                value={mtnBest ? (QUALITY_LABEL[mtnBest.signal] ?? '—') : 'None'}
+                subtitle={mtnBest ? (MTN_TECH_LABEL[mtnBest.type] ?? mtnBest.type) : '—'}
+                iconBgColor="bg-orange-50"
+                iconColor="text-orange-500"
+              />
+              <StatCard
+                icon={<PiGaugeBold />}
+                label="Top Est. Speed"
+                value={mtnTopSpeed > 0 ? `${mtnTopSpeed} Mbps` : '—'}
+                subtitle="Downlink (est.)"
+                iconBgColor="bg-violet-50"
+                iconColor="text-violet-500"
+              />
+              <StatCard
+                icon={<PiCheckCircleBold />}
+                label="Map Confidence"
+                value={mtnResult.confidence ? mtnResult.confidence.charAt(0).toUpperCase() + mtnResult.confidence.slice(1) : '—'}
+                subtitle="MTN coverage maps"
+                iconBgColor="bg-emerald-50"
+                iconColor="text-emerald-500"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* ── Tab Content ── */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
 
@@ -369,6 +446,13 @@ export default function CoverageCheckerPage() {
             <AddressInput
               onCheck={provider === 'tarana' ? handleCheck : provider === 'dfa' ? handleDFACheck : handleMtnCheck}
               isLoading={loading}
+              subtitle={
+                provider === 'tarana'
+                  ? 'Check Tarana FWB coverage availability'
+                  : provider === 'dfa'
+                    ? 'Check DFA fibre coverage availability'
+                    : 'Check MTN LTE / 5G coverage availability'
+              }
             />
           ) : (
             <div className="bg-white rounded-xl border border-slate-200 p-6 text-sm text-slate-500 flex items-center gap-3">
@@ -451,6 +535,17 @@ export default function CoverageCheckerPage() {
           {provider === 'mtn' && mtnResult && !mtnLoading && (
             <div className="space-y-4">
               <MTNVerdictCard services={mtnResult.services} confidence={mtnResult.confidence} />
+              <MTNProductTiers
+                products={mtnResult.packages}
+                fiveGAvailable={mtnResult.services.some((s) => s.type === '5g' && s.available)}
+              />
+              <CoverageMap
+                targetLat={mtnResult.lat}
+                targetLng={mtnResult.lng}
+                targetAddress={mtnResult.address}
+                mode="mtn"
+                mtnAvailable={mtnResult.available}
+              />
             </div>
           )}
 

--- a/app/api/coverage/mtn/packages/route.ts
+++ b/app/api/coverage/mtn/packages/route.ts
@@ -1,0 +1,37 @@
+// MTN LTE/5G package catalogue — returns active 5G packages for the admin
+// coverage checker's "Recommended packages" section. Only 5G has an active
+// catalogue today (LTE/Fixed-LTE are surfaced as empty states by the UI).
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { apiLogger } from '@/lib/logging';
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from('service_packages')
+      .select('id, name, service_type, speed_down, speed_up, price, description')
+      .eq('service_type', '5G')
+      .eq('active', true)
+      .order('price', { ascending: true });
+
+    if (error) {
+      apiLogger.error('MTN packages query failed', { error: error.message });
+      return NextResponse.json({ success: false, error: 'Failed to load packages' }, { status: 500 });
+    }
+
+    const products = (data || []).map((p) => ({
+      id: p.id,
+      name: p.name,
+      download_speed: p.speed_down ?? 0,
+      upload_speed: p.speed_up ?? 0,
+      price: Number(p.price) || 0,
+      description: p.description ?? undefined,
+    }));
+
+    return NextResponse.json({ success: true, products });
+  } catch (error) {
+    apiLogger.error('MTN packages error', { error: error instanceof Error ? error.message : String(error) });
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## What

Adds an **MTN LTE/5G** provider tab to `/admin/coverage/checker`, alongside the existing Tarana FWB and DFA Fibre tabs, and fixes a pre-existing subtitle bug.

## Why

Sales/admin can now check MTN mobile-broadband coverage (5G, LTE, Fixed LTE) at a location, with sellable 5G packages surfaced inline — no new backend coverage logic required.

## Changes

- **New MTN tab** — reuses the existing `POST /api/coverage/mtn/check` endpoint (MTN dual-source WMS for 5G / LTE / Fixed LTE). New `MTNVerdictCard` renders a per-technology breakdown with signal badges + estimated speeds, deduping the same technology reported by both business and consumer sources.
- **KPI stat cards** — best technology / best signal / top est. speed / map confidence.
- **Coverage Map** — new marker-only `mtn` mode on `CoverageMap` (green/red signal-area circle; MTN WMS has no base-station data, so no link line).
- **Recommended packages** — new `GET /api/coverage/mtn/packages` returns active 5G packages; LTE/Fixed-LTE show an honest "not in catalogue yet" empty state (the DB currently has 0 active LTE/Fixed-LTE products).
- **Subtitle fix** — the "Enter Location" subtitle was hardcoded to "Check Tarana FWB coverage availability" on every tab; it now reflects the active provider.

## Out of scope (deferred)

- **CSP orderability for LTE/5G** — CSP is MTN's Fixed-Wireless-Broadband order-feasibility platform; the `SkyFibreOrderabilityCard` lives on the unmerged `feat/edit-clinic-contact` branch and should land via its own PR. Mobile LTE/5G is generally orderable wherever there's signal (already answered by the coverage check).

## Verification

- `type-check:memory` — clean for all touched files.
- Deployed to staging and browser-verified as `devadmin@circletel.co.za` against **live MTN data**: Sandton returned 5G/LTE/Fixed-LTE available; the 7 CircleConnect 5G packages render with "Best Value" auto-flagged; map + stat cards + subtitle all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)