### PR TITLE
feat(suppliers): sync MiRO pricing from live feed

### DIFF
--- a/__tests__/lib/suppliers/miro-parser.test.ts
+++ b/__tests__/lib/suppliers/miro-parser.test.ts
@@ -1,0 +1,83 @@
+import ExcelJS from 'exceljs'
+import {
+  parseMiRoCsvContent,
+  parseMiRoXlsxBuffer,
+} from '@/lib/suppliers/miro/miro-parser'
+
+describe('MiRO CSV parser', () => {
+  it('parses MiRO pricing CSV rows with quoted prices and product links', () => {
+    const csv = [
+      'Item Code,Item Description,Retail Price,Your Price,Item Link',
+      'RB5009UG,"MikroTik RB5009 router","R3,999.00","R2,750.50",https://miro.co.za/router',
+      'RAP2260,"Reyee WiFi 6 Access Point",R1,499.00,R987.65,https://miro.co.za/ap',
+    ].join('\n')
+
+    const result = parseMiRoCsvContent(csv, 'miro-live.csv')
+
+    expect(result.success).toBe(true)
+    expect(result.products_found).toBe(2)
+    expect(result.products_parsed).toBe(2)
+    expect(result.products).toEqual([
+      {
+        sku: 'RB5009UG',
+        name: 'MikroTik RB5009 router',
+        description: 'MikroTik RB5009 router',
+        manufacturer: 'MiRO',
+        cost_price: 2750.5,
+        retail_price: 3999,
+        source_image_url: '',
+        product_url: 'https://miro.co.za/router',
+        stock_cpt: 0,
+        stock_jhb: 0,
+        stock_dbn: 0,
+        stock_total: 0,
+        category: 'MiRO',
+      },
+      {
+        sku: 'RAP2260',
+        name: 'Reyee WiFi 6 Access Point',
+        description: 'Reyee WiFi 6 Access Point',
+        manufacturer: 'MiRO',
+        cost_price: 987.65,
+        retail_price: 1499,
+        source_image_url: '',
+        product_url: 'https://miro.co.za/ap',
+        stock_cpt: 0,
+        stock_jhb: 0,
+        stock_dbn: 0,
+        stock_total: 0,
+        category: 'MiRO',
+      },
+    ])
+  })
+
+  it('parses MiRO pricing XLSX content from a live feed buffer', async () => {
+    const workbook = new ExcelJS.Workbook()
+    const sheet = workbook.addWorksheet('MikroTik')
+    sheet.addRow(['Price list generated on 16-06-2026'])
+    sheet.addRow(['MiRO Client Code: TEST'])
+    sheet.addRow([])
+    sheet.addRow(['Item Code', 'Item Description', 'Retail Price', 'Your Price', 'Item Link'])
+    sheet.addRow([
+      'RB5009UG',
+      'MikroTik RB5009 router',
+      'R3,999.00',
+      'R2,750.50',
+      'https://miro.co.za/router',
+    ])
+
+    const buffer = await workbook.xlsx.writeBuffer()
+    const result = await parseMiRoXlsxBuffer(buffer, 'miro-live.xlsx')
+
+    expect(result.success).toBe(true)
+    expect(result.products_found).toBe(1)
+    expect(result.products_parsed).toBe(1)
+    expect(result.products[0]).toMatchObject({
+      sku: 'RB5009UG',
+      manufacturer: 'MikroTik',
+      cost_price: 2750.5,
+      retail_price: 3999,
+      product_url: 'https://miro.co.za/router',
+    })
+  })
+})

--- a/lib/inngest/functions/supplier-sync.ts
+++ b/lib/inngest/functions/supplier-sync.ts
@@ -72,12 +72,14 @@ export const supplierSyncFunction = inngest.createFunction(
       const supabase = await createClient()
 
       if (supplierCode === 'ALL') {
-        // Get all active HTML-scrape suppliers
+        // Get all active suppliers handled by this Inngest function.
+        // MiRO/Nology moved from HTML scraping to price-list files/feeds,
+        // so scheduled syncs must include xlsx/csv feed types too.
         const { data: suppliers } = await supabase
           .from('suppliers')
           .select('code')
           .eq('is_active', true)
-          .in('feed_type', ['html', 'xml'])
+          .in('feed_type', ['html', 'xml', 'xlsx', 'csv'])
 
         return (suppliers || []).map((s) => s.code)
       }

--- a/lib/suppliers/miro/miro-parser.ts
+++ b/lib/suppliers/miro/miro-parser.ts
@@ -38,8 +38,6 @@ export async function parseMiRoFile(
   filePath: string
 ): Promise<MiRoParseResult> {
   const startTime = Date.now()
-  const errors: string[] = []
-  const allProducts: ParsedMiRoProduct[] = []
 
   const fileName = filePath.split('/').pop() || 'unknown'
 
@@ -47,53 +45,7 @@ export async function parseMiRoFile(
     const wb = new ExcelJS.Workbook()
     await wb.xlsx.readFile(filePath)
 
-    console.log(
-      `[MiRoParser] Parsing ${fileName}: ${wb.worksheets.length} sheets`
-    )
-
-    let productsFound = 0
-    let rowsSkipped = 0
-    let sheetsProcessed = 0
-
-    for (const ws of wb.worksheets) {
-      const name = ws.name.trim()
-
-      if (SKIP_SHEETS.has(name)) continue
-
-      sheetsProcessed++
-
-      try {
-        const sheetProducts = parseSheet(ws, name)
-        allProducts.push(...sheetProducts)
-        productsFound += ws.rowCount - DATA_START_ROW + 1
-
-        if (sheetProducts.length > 0) {
-          console.log(
-            `[MiRoParser] ${name}: ${sheetProducts.length} products`
-          )
-        }
-      } catch (err) {
-        const msg = `Sheet "${name}": ${err instanceof Error ? err.message : 'Unknown error'}`
-        errors.push(msg)
-      }
-    }
-
-    // Count rows we skipped (empty rows)
-    rowsSkipped = productsFound - allProducts.length
-
-    const durationMs = Date.now() - startTime
-
-    return {
-      success: true,
-      file_name: fileName,
-      sheets_processed: sheetsProcessed,
-      products_found: productsFound,
-      products_parsed: allProducts.length,
-      rows_skipped: Math.max(0, rowsSkipped),
-      products: allProducts,
-      errors,
-      duration_ms: durationMs,
-    }
+    return parseWorkbook(wb, fileName, startTime)
   } catch (error) {
     const durationMs = Date.now() - startTime
     const errorMsg =
@@ -110,6 +62,102 @@ export async function parseMiRoFile(
       products: [],
       errors: [errorMsg],
       duration_ms: durationMs,
+    }
+  }
+}
+
+export async function parseMiRoXlsxBuffer(
+  buffer: ExcelJS.Buffer,
+  fileName = 'miro-pricing.xlsx'
+): Promise<MiRoParseResult> {
+  const startTime = Date.now()
+
+  try {
+    const wb = new ExcelJS.Workbook()
+    await wb.xlsx.load(buffer)
+    return parseWorkbook(wb, fileName, startTime)
+  } catch (error) {
+    const durationMs = Date.now() - startTime
+    const errorMsg =
+      error instanceof Error ? error.message : 'Unknown error'
+    console.error(`[MiRoParser] Failed: ${errorMsg}`)
+
+    return {
+      success: false,
+      file_name: fileName,
+      sheets_processed: 0,
+      products_found: 0,
+      products_parsed: 0,
+      rows_skipped: 0,
+      products: [],
+      errors: [errorMsg],
+      duration_ms: durationMs,
+    }
+  }
+}
+
+export function parseMiRoCsvContent(
+  csvContent: string,
+  fileName = 'miro-pricing.csv'
+): MiRoParseResult {
+  const startTime = Date.now()
+  const errors: string[] = []
+
+  try {
+    const lines = csvContent
+      .replace(/^\uFEFF/, '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+
+    if (lines.length < 2) {
+      throw new Error('CSV does not contain product rows')
+    }
+
+    const headers = parseCsvLine(lines[0]).map(normalizeHeader)
+    const products: ParsedMiRoProduct[] = []
+    let rowsSkipped = 0
+
+    for (let i = 1; i < lines.length; i++) {
+      try {
+        const row = parseCsvLine(lines[i])
+        const product = parseCsvProduct(headers, row)
+
+        if (product) {
+          products.push(product)
+        } else {
+          rowsSkipped++
+        }
+      } catch (error) {
+        rowsSkipped++
+        errors.push(
+          `Row ${i + 1}: ${error instanceof Error ? error.message : 'Unknown error'}`
+        )
+      }
+    }
+
+    return {
+      success: true,
+      file_name: fileName,
+      sheets_processed: 1,
+      products_found: lines.length - 1,
+      products_parsed: products.length,
+      rows_skipped: rowsSkipped,
+      products,
+      errors,
+      duration_ms: Date.now() - startTime,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      file_name: fileName,
+      sheets_processed: 0,
+      products_found: 0,
+      products_parsed: 0,
+      rows_skipped: 0,
+      products: [],
+      errors: [error instanceof Error ? error.message : 'Unknown error'],
+      duration_ms: Date.now() - startTime,
     }
   }
 }
@@ -169,6 +217,172 @@ function parseSheet(
   }
 
   return products
+}
+
+function parseWorkbook(
+  wb: ExcelJS.Workbook,
+  fileName: string,
+  startTime: number
+): MiRoParseResult {
+  const errors: string[] = []
+  const allProducts: ParsedMiRoProduct[] = []
+
+  console.log(
+    `[MiRoParser] Parsing ${fileName}: ${wb.worksheets.length} sheets`
+  )
+
+  let productsFound = 0
+  let sheetsProcessed = 0
+
+  for (const ws of wb.worksheets) {
+    const name = ws.name.trim()
+
+    if (SKIP_SHEETS.has(name)) continue
+
+    sheetsProcessed++
+
+    try {
+      const sheetProducts = parseSheet(ws, name)
+      allProducts.push(...sheetProducts)
+      productsFound += ws.rowCount - DATA_START_ROW + 1
+
+      if (sheetProducts.length > 0) {
+        console.log(
+          `[MiRoParser] ${name}: ${sheetProducts.length} products`
+        )
+      }
+    } catch (err) {
+      const msg = `Sheet "${name}": ${err instanceof Error ? err.message : 'Unknown error'}`
+      errors.push(msg)
+    }
+  }
+
+  const rowsSkipped = productsFound - allProducts.length
+
+  return {
+    success: true,
+    file_name: fileName,
+    sheets_processed: sheetsProcessed,
+    products_found: productsFound,
+    products_parsed: allProducts.length,
+    rows_skipped: Math.max(0, rowsSkipped),
+    products: allProducts,
+    errors,
+    duration_ms: Date.now() - startTime,
+  }
+}
+
+function parseCsvProduct(
+  headers: string[],
+  row: string[]
+): ParsedMiRoProduct | null {
+  const repairedRow = repairMiRoCsvRow(headers, row)
+
+  const get = (...names: string[]): string | null => {
+    for (const name of names) {
+      const index = headers.indexOf(name)
+      if (index >= 0) {
+        const value = repairedRow[index]?.trim()
+        if (value) return value
+      }
+    }
+    return null
+  }
+
+  const sku = get('item_code', 'sku', 'code', 'product_code')
+  const description = get('item_description', 'description', 'name')
+  const retailPrice = parsePrice(get('retail_price', 'rrp', 'list_price'))
+  const costPrice = parsePrice(get('your_price', 'dealer_price', 'cost_price'))
+  const itemLink = get('item_link', 'product_url', 'url', 'link')
+
+  if (!sku || sku.length < 2) return null
+  if (costPrice === null && retailPrice === null) return null
+
+  return {
+    sku: sku.trim(),
+    name: description || sku.trim(),
+    description: description || null,
+    manufacturer: 'MiRO',
+    cost_price: costPrice || 0,
+    retail_price: retailPrice || 0,
+    source_image_url: '',
+    product_url: itemLink || '',
+    stock_cpt: 0,
+    stock_jhb: 0,
+    stock_dbn: 0,
+    stock_total: 0,
+    category: 'MiRO',
+  }
+}
+
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i]
+    const next = line[i + 1]
+
+    if (char === '"' && inQuotes && next === '"') {
+      current += '"'
+      i++
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = !inQuotes
+      continue
+    }
+
+    if (char === ',' && !inQuotes) {
+      cells.push(current.trim())
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  cells.push(current.trim())
+  return cells
+}
+
+function repairMiRoCsvRow(headers: string[], row: string[]): string[] {
+  if (row.length <= headers.length) return row
+
+  const skuIndex = headers.indexOf('item_code')
+  const descriptionIndex = headers.indexOf('item_description')
+  const retailIndex = headers.indexOf('retail_price')
+  const costIndex = headers.indexOf('your_price')
+  const linkIndex = headers.indexOf('item_link')
+
+  if (
+    headers.length === 5 &&
+    skuIndex === 0 &&
+    descriptionIndex === 1 &&
+    retailIndex === 2 &&
+    costIndex === 3 &&
+    linkIndex === 4
+  ) {
+    return [
+      row[0] || '',
+      row[1] || '',
+      row.slice(2, -2).join(','),
+      row[row.length - 2] || '',
+      row[row.length - 1] || '',
+    ]
+  }
+
+  return row.slice(0, headers.length)
+}
+
+function normalizeHeader(header: string): string {
+  return header
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
 }
 
 // =====================================================

--- a/lib/suppliers/miro/miro-sync.ts
+++ b/lib/suppliers/miro/miro-sync.ts
@@ -11,8 +11,8 @@
 import { readdirSync, statSync } from 'fs'
 import { join, basename } from 'path'
 import { createClient } from '@/lib/supabase/server'
-import { parseMiRoFile } from './miro-parser'
-import type { MiRoSyncConfig, ParsedMiRoProduct } from './miro-types'
+import { parseMiRoCsvContent, parseMiRoFile, parseMiRoXlsxBuffer } from './miro-parser'
+import type { MiRoParseResult, MiRoSyncConfig, ParsedMiRoProduct } from './miro-types'
 import type {
   SyncResult,
   UpsertResult,
@@ -38,7 +38,7 @@ export async function syncMiRoProducts(options: {
 
   const { data: supplier, error: supplierError } = await supabase
     .from('suppliers')
-    .select('id, metadata')
+    .select('id, feed_url, metadata')
     .eq('code', MIRO_SUPPLIER_CODE)
     .single()
 
@@ -48,20 +48,29 @@ export async function syncMiRoProducts(options: {
     )
   }
 
-  const config = (supplier.metadata || {}) as MiRoSyncConfig
+  const config = (supplier.metadata || {}) as Partial<MiRoSyncConfig> & {
+    pricing_csv_url?: string
+  }
   const watchDir = config.watch_dir || DEFAULT_WATCH_DIR
   const filePattern = config.file_pattern || DEFAULT_FILE_PATTERN
+  const csvUrl =
+    process.env.MIRO_PRICING_CSV_URL ||
+    config.pricing_csv_url ||
+    supplier.feed_url
 
-  const filePath =
-    options.file_path || findLatestFile(watchDir, filePattern)
+  const filePath = csvUrl
+    ? null
+    : options.file_path || findLatestFile(watchDir, filePattern)
 
-  if (!filePath) {
+  if (!csvUrl && !filePath) {
     throw new Error(
       `No files matching "${filePattern}" found in ${watchDir}`
     )
   }
 
-  console.log(`[MiRoSync] Using file: ${filePath}`)
+  console.log(
+    csvUrl ? '[MiRoSync] Using live CSV feed' : `[MiRoSync] Using file: ${filePath}`
+  )
 
   // Create sync log
   const { data: syncLog, error: logError } = await supabase
@@ -79,14 +88,16 @@ export async function syncMiRoProducts(options: {
     throw new Error(`Failed to create sync log: ${logError?.message}`)
   }
 
-  await supabase
-    .from('suppliers')
-    .update({ sync_status: 'syncing', sync_error: null })
-    .eq('id', supplier.id)
+  if (!options.dry_run) {
+    await supabase
+      .from('suppliers')
+      .update({ sync_status: 'syncing', sync_error: null })
+      .eq('id', supplier.id)
+  }
 
   try {
-    console.log('[MiRoSync] Parsing xlsx file...')
-    const parseResult = await parseMiRoFile(filePath)
+    const source = await loadMiRoPricingSource({ csvUrl, filePath })
+    const parseResult = source.parseResult
 
     if (!parseResult.success) {
       throw new Error(
@@ -115,7 +126,7 @@ export async function syncMiRoProducts(options: {
           completed_at: new Date().toISOString(),
           error_details: {
             dry_run: true,
-            file: basename(filePath),
+            source: source.description,
             products_parsed: parseResult.products_parsed,
             sheets: parseResult.sheets_processed,
           },
@@ -258,6 +269,86 @@ export async function syncMiRoProducts(options: {
 // =====================================================
 // Helpers
 // =====================================================
+
+async function loadMiRoPricingSource({
+  csvUrl,
+  filePath,
+}: {
+  csvUrl: string | null
+  filePath: string | null
+}): Promise<{ parseResult: MiRoParseResult; description: string }> {
+  if (csvUrl) {
+    console.log('[MiRoSync] Fetching live MiRO pricing feed...')
+    const feed = await fetchMiRoPricingFeed(csvUrl)
+    const isWorkbook =
+      feed.contentType.includes('spreadsheet') ||
+      feed.contentType.includes('excel') ||
+      isZipBuffer(feed.buffer)
+
+    return {
+      parseResult: isWorkbook
+        ? await parseMiRoXlsxBuffer(feed.buffer, 'miro-live-pricing.xlsx')
+        : parseMiRoCsvContent(feed.buffer.toString('utf8'), 'miro-live-pricing.csv'),
+      description: isWorkbook ? 'live XLSX feed' : 'live CSV feed',
+    }
+  }
+
+  if (!filePath) {
+    throw new Error('No MiRO xlsx file path supplied')
+  }
+
+  console.log('[MiRoSync] Parsing xlsx file...')
+  return {
+    parseResult: await parseMiRoFile(filePath),
+    description: basename(filePath),
+  }
+}
+
+async function fetchMiRoPricingFeed(url: string): Promise<{
+  buffer: Buffer
+  contentType: string
+}> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 120000)
+  const headers: Record<string, string> = {
+    'User-Agent': 'CircleTel-Sync/1.0',
+    Accept: 'text/csv,text/plain,*/*',
+  }
+
+  const username = process.env.MIRO_PRICING_USERNAME
+  const password = process.env.MIRO_PRICING_PASSWORD
+  if (username && password) {
+    headers.Authorization = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers,
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch MiRO CSV: ${response.status} ${response.statusText}`)
+    }
+
+    return {
+      buffer: Buffer.from(await response.arrayBuffer()),
+      contentType: response.headers.get('content-type') || '',
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('MiRO CSV fetch timeout - feed took too long to respond')
+    }
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+function isZipBuffer(buffer: Buffer): boolean {
+  return buffer.length >= 2 && buffer[0] === 0x50 && buffer[1] === 0x4b
+}
 
 function findLatestFile(
   watchDir: string,


### PR DESCRIPTION
## What
Improves the MiRO supplier pricing sync — parses the live MiRO pricing feed (CSV + XLSX), with expanded `miro-parser` coverage and updated `miro-sync` / `supplier-sync` wiring.

## Why
Split out of the mixed local branch `feat/edit-clinic-contact` (now preserved as `feat/skyfibre-csp-and-miro-sync`). This PR is the **MiRO half** — independent of the SkyFibre CSP work, which ships separately.

## Changes
- `lib/suppliers/miro/miro-parser.ts` — live-feed CSV/XLSX parsing
- `lib/suppliers/miro/miro-sync.ts`, `lib/inngest/functions/supplier-sync.ts` — sync wiring
- `__tests__/lib/suppliers/miro-parser.test.ts` — parser tests (2 pass locally)

## Verification
- Cherry-picked cleanly onto `main` (no conflicts).
- `miro-parser` tests pass locally (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)