### PR TITLE
feat(coverage): SkyFibre CSP orderability gate

### DIFF
--- a/__tests__/api/orders-create-skyfibre-gate.test.ts
+++ b/__tests__/api/orders-create-skyfibre-gate.test.ts
@@ -1,0 +1,140 @@
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/orders/create/route';
+import { createClient } from '@/lib/supabase/server';
+import {
+  checkSkyFibreOrderability,
+  extractSkyFibreCapacity,
+  isSkyFibrePackage,
+} from '@/lib/coverage/skyfibre/orderability';
+import { EmailNotificationService } from '@/lib/notifications/notification-service';
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+jest.mock('@/lib/coverage/skyfibre/orderability', () => ({
+  checkSkyFibreOrderability: jest.fn(),
+  extractSkyFibreCapacity: jest.fn(() => 100),
+  isSkyFibrePackage: jest.fn(() => true),
+  redactSkyFibreOrderability: (value: unknown) => value,
+}));
+
+jest.mock('@/lib/notifications/notification-service', () => ({
+  EmailNotificationService: {
+    sendOrderConfirmation: jest.fn(),
+  },
+}));
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+const mockCheckSkyFibreOrderability = checkSkyFibreOrderability as jest.MockedFunction<typeof checkSkyFibreOrderability>;
+const mockExtractSkyFibreCapacity = extractSkyFibreCapacity as jest.MockedFunction<typeof extractSkyFibreCapacity>;
+const mockIsSkyFibrePackage = isSkyFibrePackage as jest.MockedFunction<typeof isSkyFibrePackage>;
+const mockSendOrderConfirmation = EmailNotificationService.sendOrderConfirmation as jest.MockedFunction<typeof EmailNotificationService.sendOrderConfirmation>;
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/orders/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe('POST /api/orders/create SkyFibre gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsSkyFibrePackage.mockReturnValue(true);
+    mockExtractSkyFibreCapacity.mockReturnValue(100);
+    mockSendOrderConfirmation.mockResolvedValue({ success: true } as any);
+
+    const duplicateQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      in: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue({ data: [], error: null }),
+    };
+    const orderNumberQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    const insertQuery = {
+      insert: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: {
+              id: 'order-1',
+              order_number: 'ORD-20260616-0001',
+              payment_reference: 'PAY-ORD-20260616-0001',
+              first_name: 'Test',
+              last_name: 'Customer',
+              email: 'test@example.com',
+              status: 'pending',
+              package_name: 'SkyFibre Home Max',
+              package_price: 999,
+              created_at: '2026-06-16T10:00:00.000Z',
+            },
+            error: null,
+          }),
+        }),
+      }),
+    };
+
+    mockCreateClient.mockResolvedValue({
+      from: jest
+        .fn()
+        .mockReturnValueOnce(duplicateQuery)
+        .mockReturnValueOnce(orderNumberQuery)
+        .mockReturnValueOnce(insertQuery),
+    } as any);
+  });
+
+  it('blocks SkyFibre orders when combined orderability is not orderable', async () => {
+    mockCheckSkyFibreOrderability.mockResolvedValue({
+      decision: 'covered_not_orderable',
+      segment: 'residential',
+      capacityMbps: 100,
+      tcsCoverage: {
+        covered: true,
+        confidence: 'high',
+        nearestBnOnline: true,
+        nearestBnActiveRnCount: 10,
+        reason: 'BN active with RN evidence.',
+      },
+      cspOrderability: {
+        provider: 'mtn-csp',
+        productName: 'Fixed Wireless Broadband',
+        method: 'feasibilityOld',
+        capacityMbps: 100,
+        orderable: false,
+        status: 'not_orderable',
+        checkedAt: '2026-06-16T10:00:00.000Z',
+      },
+    });
+
+    const response = await POST(
+      request({
+        first_name: 'Test',
+        last_name: 'Customer',
+        email: 'test@example.com',
+        phone: '0821234567',
+        installation_address: '1 Test Street, Sandton',
+        coordinates: { lat: -26.1, lng: 28.0 },
+        installation_location_type: 'freestanding_home',
+        package_name: 'SkyFibre Home Max',
+        package_speed: '100/25 Mbps',
+        package_price: 999,
+        coverage_lead_id: 'lead-1',
+      })
+    );
+    const body = await response.json();
+
+    expect(mockIsSkyFibrePackage).toHaveBeenCalledWith(expect.objectContaining({ package_name: 'SkyFibre Home Max' }));
+    expect(response.status).toBe(409);
+    expect(body.error).toMatch(/not orderable/i);
+    expect(mockCheckSkyFibreOrderability).toHaveBeenCalledWith(
+      expect.objectContaining({ leadId: 'lead-1', capacityMbps: 100, segment: 'residential' }),
+      expect.objectContaining({ supabase: expect.any(Object) })
+    );
+    expect(mockSendOrderConfirmation).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/skyfibre-orderability-route.test.ts
+++ b/__tests__/api/skyfibre-orderability-route.test.ts
@@ -1,0 +1,96 @@
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/coverage/skyfibre/orderability/route';
+import { createClient } from '@/lib/supabase/server';
+import { checkSkyFibreOrderability } from '@/lib/coverage/skyfibre/orderability';
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+jest.mock('@/lib/coverage/skyfibre/orderability', () => ({
+  checkSkyFibreOrderability: jest.fn(),
+  isValidSkyFibreCapacity: (value: unknown) => value === 50 || value === 100 || value === 200,
+  redactSkyFibreOrderability: (value: unknown) => value,
+}));
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+const mockCheckSkyFibreOrderability = checkSkyFibreOrderability as jest.MockedFunction<typeof checkSkyFibreOrderability>;
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/coverage/skyfibre/orderability', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe('POST /api/coverage/skyfibre/orderability', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateClient.mockResolvedValue({
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { coverage_results: [] },
+          error: null,
+        }),
+        update: jest.fn().mockReturnValue({
+          eq: jest.fn().mockResolvedValue({ error: null }),
+        }),
+      }),
+    } as any);
+  });
+
+  it('rejects unsupported SkyFibre capacities', async () => {
+    const response = await POST(request({ leadId: 'lead-1', capacityMbps: 150 }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/capacity/i);
+    expect(mockCheckSkyFibreOrderability).not.toHaveBeenCalled();
+  });
+
+  it('requires either a leadId or coordinates', async () => {
+    const response = await POST(request({ capacityMbps: 100 }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/leadId or coordinates/i);
+  });
+
+  it('returns and persists a redacted orderability result for lead checks', async () => {
+    mockCheckSkyFibreOrderability.mockResolvedValue({
+      decision: 'orderable',
+      segment: 'business',
+      capacityMbps: 100,
+      tcsCoverage: {
+        covered: true,
+        confidence: 'high',
+        nearestBnOnline: true,
+        nearestBnActiveRnCount: 12,
+        reason: 'BN active with RN evidence.',
+      },
+      cspOrderability: {
+        provider: 'mtn-csp',
+        productName: 'Fixed Wireless Broadband',
+        method: 'feasibilityOld',
+        capacityMbps: 100,
+        orderable: true,
+        status: 'orderable',
+        checkedAt: '2026-06-16T10:00:00.000Z',
+      },
+    });
+
+    const response = await POST(request({ leadId: 'lead-1', capacityMbps: 100, segment: 'business' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.decision).toBe('orderable');
+    expect(mockCheckSkyFibreOrderability).toHaveBeenCalledWith(
+      expect.objectContaining({ leadId: 'lead-1', capacityMbps: 100, segment: 'business' }),
+      expect.objectContaining({ supabase: expect.any(Object) })
+    );
+  });
+});

--- a/__tests__/lib/skyfibre/admin-ui.test.ts
+++ b/__tests__/lib/skyfibre/admin-ui.test.ts
@@ -1,0 +1,45 @@
+import {
+  buildAdminSkyFibreOrderabilityRequest,
+  getAdminSkyFibreCapacity,
+  getSkyFibreDecisionLabel,
+  isAdminSkyFibrePackage,
+} from '@/lib/coverage/skyfibre/admin-ui';
+
+describe('SkyFibre admin UI helpers', () => {
+  it('builds the admin orderability request for business Tarana/SkyFibre checks', () => {
+    expect(
+      buildAdminSkyFibreOrderabilityRequest({
+        leadId: 'lead-123',
+        lat: -26.1076,
+        lng: 28.0567,
+        capacityMbps: 100,
+      })
+    ).toEqual({
+      leadId: 'lead-123',
+      latitude: -26.1076,
+      longitude: 28.0567,
+      capacityMbps: 100,
+      segment: 'business',
+    });
+  });
+
+  it('uses reader-facing labels for final decisions', () => {
+    expect(getSkyFibreDecisionLabel('orderable')).toBe('Orderable');
+    expect(getSkyFibreDecisionLabel('covered_not_orderable')).toBe('Covered, not orderable');
+    expect(getSkyFibreDecisionLabel('manual_review')).toBe('Manual review');
+    expect(getSkyFibreDecisionLabel('not_covered')).toBe('Not covered');
+  });
+
+  it('identifies selected SkyFibre and Tarana packages for sales feasibility', () => {
+    expect(isAdminSkyFibrePackage({ name: 'SkyFibre Business 100' })).toBe(true);
+    expect(isAdminSkyFibrePackage({ serviceType: 'Tarana FWB' })).toBe(true);
+    expect(isAdminSkyFibrePackage({ serviceType: 'BizFibreConnect' })).toBe(false);
+    expect(isAdminSkyFibrePackage({ serviceType: 'wireless', productCategory: 'connectivity' })).toBe(false);
+  });
+
+  it('extracts supported SkyFibre capacities for admin checks', () => {
+    expect(getAdminSkyFibreCapacity(50)).toBe(50);
+    expect(getAdminSkyFibreCapacity('SkyFibre 200 Mbps')).toBe(200);
+    expect(getAdminSkyFibreCapacity('500 Mbps')).toBeNull();
+  });
+});

--- a/__tests__/lib/skyfibre/base-station-service.test.ts
+++ b/__tests__/lib/skyfibre/base-station-service.test.ts
@@ -1,0 +1,60 @@
+import { createClient } from '@/lib/supabase/server';
+import { checkBaseStationProximity } from '@/lib/coverage/mtn/base-station-service';
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+
+describe('checkBaseStationProximity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hydrates missing RPC device_status before deciding whether a BN is online', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: [
+        {
+          id: '5b21d2e2-6861-4ef0-b426-4027875a4cf2',
+          serial_number: 'BN-LEHLABILE',
+          hostname: 'BN-LEHLABILE',
+          site_name: 'Lehlabile Secondary School',
+          active_connections: 0,
+          market: 'GAUTENG_TSH',
+          lat: -25.7088,
+          lng: 28.3912,
+          distance_km: 0.61,
+        },
+      ],
+      error: null,
+    });
+
+    const inFilter = jest.fn().mockResolvedValue({
+      data: [
+        {
+          serial_number: 'BN-LEHLABILE',
+          device_status: 1,
+          active_connections: 0,
+        },
+      ],
+      error: null,
+    });
+    const select = jest.fn().mockReturnValue({ in: inFilter });
+    const from = jest.fn().mockReturnValue({ select });
+
+    mockCreateClient.mockResolvedValue({ rpc, from } as any);
+
+    const result = await checkBaseStationProximity({
+      lat: -25.7134413,
+      lng: 28.3962027,
+    });
+
+    expect(from).toHaveBeenCalledWith('tarana_base_stations');
+    expect(result.nearestStation?.siteName).toBe('Lehlabile Secondary School');
+    expect(result.nearestStation?.deviceStatus).toBe(1);
+    expect(result.hasCoverage).toBe(true);
+    expect(result.confidence).toBe('low');
+    expect(result.installationNote).toContain('no active customer connections');
+  });
+});

--- a/__tests__/lib/skyfibre/csp-client.test.ts
+++ b/__tests__/lib/skyfibre/csp-client.test.ts
@@ -1,0 +1,74 @@
+import {
+  normalizeCspFeasibilityResponse,
+  selectCspFeasibilityMethod,
+} from '@/lib/coverage/skyfibre/csp-client';
+
+describe('MTN CSP orderability client helpers', () => {
+  it('uses the legacy feasibility endpoint for 50Mbps and 100Mbps', () => {
+    expect(selectCspFeasibilityMethod(50)).toBe('feasibilityOld');
+    expect(selectCspFeasibilityMethod(100)).toBe('feasibilityOld');
+  });
+
+  it('uses the current feasibility endpoint for 200Mbps', () => {
+    expect(selectCspFeasibilityMethod(200)).toBe('feasibilityCheck');
+  });
+
+  it('normalizes old CSP Tarana responses', () => {
+    const result = normalizeCspFeasibilityResponse(
+      {
+        outputs: [
+          {
+            FWA: {
+              Tarana_Feasible: true,
+              Tarana_zone: 3,
+            },
+          },
+        ],
+      },
+      100
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        provider: 'mtn-csp',
+        method: 'feasibilityOld',
+        capacityMbps: 100,
+        orderable: true,
+        status: 'orderable',
+        taranaFeasible: true,
+        taranaZone: 3,
+      })
+    );
+  });
+
+  it('normalizes new CSP product feasibility responses', () => {
+    const result = normalizeCspFeasibilityResponse(
+      {
+        outputs: [
+          {
+            product_feasible: false,
+          },
+        ],
+      },
+      200
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        provider: 'mtn-csp',
+        method: 'feasibilityCheck',
+        capacityMbps: 200,
+        orderable: false,
+        status: 'not_orderable',
+      })
+    );
+  });
+
+  it('marks malformed CSP responses as unknown without leaking raw data', () => {
+    const result = normalizeCspFeasibilityResponse({ outputs: [] }, 50);
+
+    expect(result.orderable).toBeNull();
+    expect(result.status).toBe('unknown');
+    expect(result).not.toHaveProperty('raw');
+  });
+});

--- a/__tests__/lib/skyfibre/orderability.test.ts
+++ b/__tests__/lib/skyfibre/orderability.test.ts
@@ -1,0 +1,196 @@
+import {
+  buildSkyFibreDecision,
+  buildTcsCoverageFromProximity,
+  checkSkyFibreOrderability,
+  isSkyFibrePackage,
+} from '@/lib/coverage/skyfibre/orderability';
+import { checkBaseStationProximity } from '@/lib/coverage/mtn/base-station-service';
+import type { BaseStationProximityResult } from '@/lib/coverage/types';
+
+jest.mock('@/lib/coverage/mtn/base-station-service', () => ({
+  checkBaseStationProximity: jest.fn(),
+}));
+
+const mockCheckBaseStationProximity = checkBaseStationProximity as jest.MockedFunction<typeof checkBaseStationProximity>;
+
+const baseProximity: BaseStationProximityResult = {
+  hasCoverage: true,
+  confidence: 'high',
+  requiresElevatedInstall: false,
+  installationNote: null,
+  nearestStation: {
+    siteName: 'Sandton BN',
+    hostname: 'BN-001',
+    distanceKm: 1.4,
+    activeConnections: 12,
+    market: 'Gauteng',
+    deviceStatus: 1,
+  },
+  allNearbyStations: [],
+  metadata: {
+    checkedAt: '2026-06-16T10:00:00.000Z',
+    coordinatesUsed: { lat: -26.1, lng: 28.0 },
+    stationsChecked: 1,
+  },
+};
+
+describe('SkyFibre orderability decisions', () => {
+  it('allows ordering when TCS confidence is acceptable and CSP is orderable', () => {
+    const decision = buildSkyFibreDecision({
+      segment: 'business',
+      capacityMbps: 100,
+      tcsCoverage: buildTcsCoverageFromProximity(baseProximity),
+      cspOrderability: {
+        provider: 'mtn-csp',
+        productName: 'Fixed Wireless Broadband',
+        method: 'feasibilityOld',
+        capacityMbps: 100,
+        orderable: true,
+        status: 'orderable',
+        taranaZone: 2,
+        checkedAt: '2026-06-16T10:00:00.000Z',
+      },
+    });
+
+    expect(decision.decision).toBe('orderable');
+  });
+
+  it('blocks ordering when TCS is covered but CSP is not orderable', () => {
+    const decision = buildSkyFibreDecision({
+      segment: 'residential',
+      capacityMbps: 50,
+      tcsCoverage: buildTcsCoverageFromProximity(baseProximity),
+      cspOrderability: {
+        provider: 'mtn-csp',
+        productName: 'Fixed Wireless Broadband',
+        method: 'feasibilityOld',
+        capacityMbps: 50,
+        orderable: false,
+        status: 'not_orderable',
+        checkedAt: '2026-06-16T10:00:00.000Z',
+      },
+    });
+
+    expect(decision.decision).toBe('covered_not_orderable');
+  });
+
+  it('allows CSP-orderable addresses even when active BNs have no RN evidence', () => {
+    const tcsCoverage = buildTcsCoverageFromProximity({
+      ...baseProximity,
+      confidence: 'high',
+      nearestStation: {
+        ...baseProximity.nearestStation!,
+        activeConnections: 0,
+      },
+    });
+
+    const decision = buildSkyFibreDecision({
+      segment: 'business',
+      capacityMbps: 200,
+      tcsCoverage,
+      cspOrderability: {
+        provider: 'mtn-csp',
+        productName: 'Fixed Wireless Broadband',
+        method: 'feasibilityCheck',
+        capacityMbps: 200,
+        orderable: true,
+        status: 'orderable',
+        checkedAt: '2026-06-16T10:00:00.000Z',
+      },
+    });
+
+    expect(tcsCoverage.confidence).toBe('medium');
+    expect(tcsCoverage.nearestBnActiveRnCount).toBe(0);
+    expect(decision.decision).toBe('orderable');
+  });
+
+  it('returns not covered when the nearest BN is offline', () => {
+    const tcsCoverage = buildTcsCoverageFromProximity({
+      ...baseProximity,
+      hasCoverage: false,
+      confidence: 'none',
+      nearestStation: {
+        ...baseProximity.nearestStation!,
+        deviceStatus: 0,
+      },
+    });
+
+    const decision = buildSkyFibreDecision({
+      segment: 'residential',
+      capacityMbps: 100,
+      tcsCoverage,
+    });
+
+    expect(decision.decision).toBe('not_covered');
+  });
+
+  it('does not call CSP when TCS has no active coverage', async () => {
+    mockCheckBaseStationProximity.mockResolvedValue({
+      ...baseProximity,
+      hasCoverage: false,
+      confidence: 'none',
+      nearestStation: null,
+    });
+    const cspClient = { checkOrderability: jest.fn() };
+
+    const result = await checkSkyFibreOrderability(
+      {
+        latitude: -26.1,
+        longitude: 28.0,
+        capacityMbps: 100,
+        segment: 'residential',
+      },
+      { cspClient: cspClient as any }
+    );
+
+    expect(result.decision).toBe('not_covered');
+    expect(cspClient.checkOrderability).not.toHaveBeenCalled();
+  });
+
+  it('still calls CSP when an online BN has no RN evidence', async () => {
+    mockCheckBaseStationProximity.mockResolvedValue({
+      ...baseProximity,
+      confidence: 'low',
+      nearestStation: {
+        ...baseProximity.nearestStation!,
+        activeConnections: 0,
+        deviceStatus: 1,
+      },
+    });
+    const cspClient = {
+      checkOrderability: jest.fn().mockResolvedValue({
+        provider: 'mtn-csp',
+        productName: 'Fixed Wireless Broadband',
+        method: 'feasibilityOld',
+        capacityMbps: 50,
+        orderable: true,
+        status: 'orderable',
+        checkedAt: '2026-06-16T10:00:00.000Z',
+      }),
+    };
+
+    const result = await checkSkyFibreOrderability(
+      {
+        latitude: -25.7134413,
+        longitude: 28.3962027,
+        capacityMbps: 50,
+        segment: 'business',
+      },
+      { cspClient: cspClient as any }
+    );
+
+    expect(cspClient.checkOrderability).toHaveBeenCalledWith({
+      latitude: -25.7134413,
+      longitude: 28.3962027,
+      capacityMbps: 50,
+    });
+    expect(result.cspOrderability?.status).toBe('orderable');
+    expect(result.decision).toBe('orderable');
+  });
+
+  it('detects only explicit SkyFibre or Tarana packages for the order gate', () => {
+    expect(isSkyFibrePackage({ package_name: 'SkyFibre Business 100' })).toBe(true);
+    expect(isSkyFibrePackage({ service_type: 'Tarana FWB' })).toBe(true);
+    expect(isSkyFibrePackage({ service_type: 'wireless', product_category: 'connectivity' })).toBe(false);
+  });
+});

--- a/app/admin/coverage/checker/components/CoverageVerdictCard.tsx
+++ b/app/admin/coverage/checker/components/CoverageVerdictCard.tsx
@@ -17,11 +17,11 @@ const QUALITY_CONFIG: Record<SignalQuality, {
   bgClass: string;
   borderClass: string;
 }> = {
-  excellent: { label: 'Excellent Coverage', verdict: 'COVERED', variant: 'success', bars: 5, bgClass: 'bg-emerald-50', borderClass: 'border-emerald-400' },
-  good:      { label: 'Good Coverage',      verdict: 'COVERED', variant: 'success', bars: 4, bgClass: 'bg-emerald-50', borderClass: 'border-emerald-400' },
-  fair:      { label: 'Marginal Coverage',  verdict: 'MARGINAL', variant: 'warning', bars: 3, bgClass: 'bg-amber-50', borderClass: 'border-amber-400' },
-  poor:      { label: 'Weak Coverage',      verdict: 'MARGINAL', variant: 'warning', bars: 2, bgClass: 'bg-orange-50', borderClass: 'border-orange-400' },
-  none:      { label: 'No Coverage',        verdict: 'NOT COVERED', variant: 'error', bars: 0, bgClass: 'bg-red-50', borderClass: 'border-red-400' },
+  excellent: { label: 'Excellent signal estimate', verdict: 'COVERED', variant: 'success', bars: 5, bgClass: 'bg-emerald-50', borderClass: 'border-emerald-400' },
+  good:      { label: 'Good signal estimate',      verdict: 'COVERED', variant: 'success', bars: 4, bgClass: 'bg-emerald-50', borderClass: 'border-emerald-400' },
+  fair:      { label: 'Marginal signal estimate',  verdict: 'MARGINAL', variant: 'warning', bars: 3, bgClass: 'bg-amber-50', borderClass: 'border-amber-400' },
+  poor:      { label: 'Weak signal estimate',      verdict: 'MARGINAL', variant: 'warning', bars: 2, bgClass: 'bg-orange-50', borderClass: 'border-orange-400' },
+  none:      { label: 'No signal estimate',        verdict: 'NOT COVERED', variant: 'error', bars: 0, bgClass: 'bg-red-50', borderClass: 'border-red-400' },
 };
 
 const CONFIDENCE_VARIANT: Record<string, 'success' | 'warning' | 'neutral' | 'info'> = {
@@ -56,11 +56,11 @@ export default function CoverageVerdictCard({ prediction, liveStatus }: Coverage
             <SignalBars filled={0} />
           </div>
           <div>
-            <p className="text-xs font-semibold tracking-wider uppercase text-slate-500 mb-0.5">Coverage Status</p>
-            <StatusBadge variant="error" status="No Coverage" />
+            <p className="text-xs font-semibold tracking-wider uppercase text-slate-500 mb-0.5">RF Signal Estimate</p>
+            <StatusBadge variant="error" status="No Tarana signal" />
           </div>
         </div>
-        <p className="text-sm text-slate-500">No Tarana base stations within 8 km</p>
+        <p className="text-sm text-slate-500">No Tarana base stations within 8 km. Use the final sales decision before quoting.</p>
       </div>
     );
   }
@@ -80,7 +80,7 @@ export default function CoverageVerdictCard({ prediction, liveStatus }: Coverage
             <SignalBars filled={cfg.bars} />
           </div>
           <div>
-            <p className="text-xs font-semibold tracking-wider uppercase text-slate-500 mb-1">Coverage Status</p>
+            <p className="text-xs font-semibold tracking-wider uppercase text-slate-500 mb-1">RF Signal Estimate</p>
             <StatusBadge variant={cfg.variant} status={cfg.label} />
           </div>
         </div>

--- a/app/admin/coverage/checker/components/SalesRecommendationCard.tsx
+++ b/app/admin/coverage/checker/components/SalesRecommendationCard.tsx
@@ -2,12 +2,16 @@
 
 import { useState } from 'react';
 import type { CoveragePrediction, LiveNetworkStatus, SignalQuality } from '@/lib/coverage/prediction/types';
+import type { SkyFibreOrderabilityResult } from '@/lib/coverage/skyfibre/types';
 import { SectionCard } from '@/components/admin/shared';
 import { PiSparkleBold, PiCheckCircleBold, PiWarningBold, PiBuildingsBold, PiHouseBold } from 'react-icons/pi';
 
 interface SalesRecommendationCardProps {
   prediction: CoveragePrediction | null;
   liveStatus?: LiveNetworkStatus | null;
+  orderabilityResult?: SkyFibreOrderabilityResult | null;
+  orderabilityChecking?: boolean;
+  orderabilityError?: string | null;
 }
 
 // ── Product catalogue (source of truth: products/connectivity/) ──────────────
@@ -114,10 +118,86 @@ function getRecommendation(
   }
 }
 
-export default function SalesRecommendationCard({ prediction, liveStatus }: SalesRecommendationCardProps) {
+function getGateMessage(
+  orderabilityResult: SkyFibreOrderabilityResult | null | undefined,
+  orderabilityChecking: boolean,
+  orderabilityError: string | null | undefined
+): { title: string; text: string; tone: 'info' | 'warning' | 'error' | 'success' } | null {
+  if (orderabilityChecking) {
+    return {
+      title: 'Confirming SkyFibre orderability',
+      text: 'Waiting for the MTN CSP and TCS gate before recommending a package.',
+      tone: 'info',
+    };
+  }
+
+  if (orderabilityError) {
+    return {
+      title: 'Unable to confirm orderability',
+      text: 'Do not quote SkyFibre yet. Capture the lead and retry the CSP check or escalate for manual review.',
+      tone: 'warning',
+    };
+  }
+
+  if (!orderabilityResult) {
+    return {
+      title: 'Waiting for SkyFibre orderability result',
+      text: 'Do not recommend a package until the combined TCS and MTN CSP check has completed.',
+      tone: 'info',
+    };
+  }
+
+  switch (orderabilityResult.decision) {
+    case 'orderable':
+      return null;
+    case 'covered_not_orderable':
+      return {
+        title: 'Covered by RF model, but MTN CSP will not accept the order',
+        text: 'Do not create a SkyFibre order. Capture the lead for sales follow-up or recommend an alternative service.',
+        tone: 'warning',
+      };
+    case 'manual_review':
+      return {
+        title: 'Manual review required before quoting',
+        text: 'SkyFibre looks promising, but the evidence is not strong enough for a quick sale. Capture the lead and request a site survey or operations review.',
+        tone: 'warning',
+      };
+    case 'not_covered':
+      return {
+        title: 'Not currently covered for SkyFibre',
+        text: 'Do not quote SkyFibre at this address. Recommend another access technology or capture demand for future expansion.',
+        tone: 'error',
+      };
+    case 'error':
+      return {
+        title: 'SkyFibre check returned an error',
+        text: 'Do not quote SkyFibre until the orderability check can be completed.',
+        tone: 'warning',
+      };
+    default:
+      return null;
+  }
+}
+
+const GATE_MESSAGE_CLASS = {
+  info: 'border-blue-200 bg-blue-50 text-blue-800',
+  warning: 'border-amber-200 bg-amber-50 text-amber-800',
+  error: 'border-red-200 bg-red-50 text-red-800',
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+};
+
+export default function SalesRecommendationCard({
+  prediction,
+  liveStatus,
+  orderabilityResult,
+  orderabilityChecking = false,
+  orderabilityError = null,
+}: SalesRecommendationCardProps) {
   const [customerType, setCustomerType] = useState<CustomerType>('smb');
   const { text, tiers, warning } = getRecommendation(prediction, customerType, liveStatus ?? null);
   const noService = !prediction || prediction.signalQuality === 'none';
+  const gateMessage = getGateMessage(orderabilityResult, orderabilityChecking, orderabilityError);
+  const canRecommendPackages = !gateMessage && orderabilityResult?.decision === 'orderable';
 
   return (
     <SectionCard title="Sales Recommendation" icon={PiSparkleBold}>
@@ -150,9 +230,16 @@ export default function SalesRecommendationCard({ prediction, liveStatus }: Sale
         </button>
       </div>
 
-      <p className="text-sm text-slate-700 mb-4">{text}</p>
+      {gateMessage ? (
+        <div className={`mb-4 rounded-lg border px-3 py-3 ${GATE_MESSAGE_CLASS[gateMessage.tone]}`}>
+          <p className="text-sm font-semibold">{gateMessage.title}</p>
+          <p className="mt-1 text-xs">{gateMessage.text}</p>
+        </div>
+      ) : (
+        <p className="text-sm text-slate-700 mb-4">{text}</p>
+      )}
 
-      {!noService && (
+      {!noService && canRecommendPackages && (
         <div className={`grid gap-3 mb-4 ${tiers.length === 2 ? 'grid-cols-2' : 'grid-cols-3'}`}>
           {tiers.map(tier => (
             <div
@@ -189,7 +276,7 @@ export default function SalesRecommendationCard({ prediction, liveStatus }: Sale
         </div>
       )}
 
-      {warning && (
+      {warning && canRecommendPackages && (
         <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
           <PiWarningBold className="text-amber-500 mt-0.5 shrink-0" />
           <p className="text-xs text-amber-800">{warning}</p>

--- a/app/admin/coverage/checker/components/SkyFibreOrderabilityCard.tsx
+++ b/app/admin/coverage/checker/components/SkyFibreOrderabilityCard.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/admin/skyfibre/SkyFibreOrderabilityCard';

--- a/app/admin/coverage/checker/page.tsx
+++ b/app/admin/coverage/checker/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useJsApiLoader } from '@react-google-maps/api';
 import type { CoveragePrediction, LiveNetworkStatus } from '@/lib/coverage/prediction/types';
+import type { SkyFibreOrderabilityResult } from '@/lib/coverage/skyfibre/types';
 import {
   StatCard, StatusBadge, UnderlineTabs, TabPanel,
 } from '@/components/admin/shared';
@@ -19,10 +20,11 @@ import DFAProductTiers from './components/DFAProductTiers';
 import DFAInstallationEstimate from './components/DFAInstallationEstimate';
 import MTNVerdictCard, { type MTNService } from './components/MTNVerdictCard';
 import MTNProductTiers, { type MTNPackage } from './components/MTNProductTiers';
+import SkyFibreOrderabilityCard from './components/SkyFibreOrderabilityCard';
 import RecentChecksPanel, { saveRecentCheck } from './components/RecentChecksPanel';
 import {
   PiRulerBold, PiLightningBold, PiGaugeBold, PiCheckCircleBold,
-  PiArrowLeftBold, PiBroadcastBold,
+  PiArrowLeftBold, PiBroadcastBold, PiClockBold, PiWarningCircleBold, PiXCircleBold,
 } from 'react-icons/pi';
 import Link from 'next/link';
 
@@ -38,7 +40,7 @@ type TabId = typeof TABS[number]['id'];
 type ProviderType = 'tarana' | 'dfa' | 'mtn';
 
 const QUALITY_LABEL: Record<string, string> = {
-  excellent: 'Excellent', good: 'Good', fair: 'Marginal', poor: 'Weak', none: 'None',
+  excellent: 'Excellent signal', good: 'Good signal', fair: 'Marginal signal', poor: 'Weak signal', none: 'No signal',
 };
 
 const QUALITY_VARIANT: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
@@ -101,12 +103,138 @@ function bestMtnService(services: MTNService[]): MTNService | null {
   );
 }
 
+function normalizeName(value: string | null | undefined): string {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function hasBaseStationMismatch(
+  prediction: CoveragePrediction | null,
+  orderability: SkyFibreOrderabilityResult | null
+): boolean {
+  const rfBn = normalizeName(prediction?.nearestBnSiteName);
+  const gateBn = normalizeName(orderability?.tcsCoverage.nearestStation?.siteName);
+  return Boolean(rfBn && gateBn && rfBn !== gateBn);
+}
+
+function getSalesDecisionBanner(params: {
+  orderability: SkyFibreOrderabilityResult | null;
+  checking: boolean;
+  error: string | null;
+  bnMismatch: boolean;
+}) {
+  const { orderability, checking, error, bnMismatch } = params;
+
+  if (checking) {
+    return {
+      title: 'Checking SkyFibre availability',
+      text: 'Running the combined TCS and MTN CSP gate. Wait for this result before advising the customer.',
+      badge: 'Checking',
+      variant: 'info' as const,
+      icon: PiClockBold,
+      className: 'border-blue-200 bg-blue-50 text-blue-900',
+    };
+  }
+
+  if (error) {
+    return {
+      title: 'Unable to confirm SkyFibre availability',
+      text: 'Do not quote SkyFibre yet. Retry the CSP orderability check or capture the lead for manual review.',
+      badge: 'Unable to confirm',
+      variant: 'warning' as const,
+      icon: PiWarningCircleBold,
+      className: 'border-amber-200 bg-amber-50 text-amber-900',
+    };
+  }
+
+  if (!orderability) return null;
+
+  if (bnMismatch) {
+    return {
+      title: 'Manual review required',
+      text: 'The RF model and TCS gate matched different base stations. Capture the lead and ask operations to confirm serviceability before quoting.',
+      badge: 'Manual review',
+      variant: 'warning' as const,
+      icon: PiWarningCircleBold,
+      className: 'border-amber-200 bg-amber-50 text-amber-900',
+    };
+  }
+
+  switch (orderability.decision) {
+    case 'orderable': {
+      const needsInstallReview =
+        orderability.tcsCoverage.nearestBnActiveRnCount === 0 ||
+        orderability.tcsCoverage.confidence === 'low';
+
+      if (needsInstallReview) {
+        return {
+          title: 'CSP orderable - site survey recommended',
+          text: 'MTN CSP accepts this SkyFibre order. TCS has low confidence or no active RN evidence, so confirm install details before committing the installation date.',
+          badge: 'CSP orderable',
+          variant: 'warning' as const,
+          icon: PiWarningCircleBold,
+          className: 'border-amber-200 bg-amber-50 text-amber-900',
+        };
+      }
+
+      return {
+        title: 'Available to sell',
+        text: 'TCS coverage evidence is acceptable and MTN CSP will accept the selected SkyFibre order.',
+        badge: 'Orderable',
+        variant: 'success' as const,
+        icon: PiCheckCircleBold,
+        className: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+      };
+    }
+    case 'covered_not_orderable':
+      return {
+        title: 'Covered, but not orderable',
+        text: 'The RF model is promising, but MTN CSP will not accept an order at this address. Capture the lead for sales follow-up.',
+        badge: 'Do not order',
+        variant: 'warning' as const,
+        icon: PiWarningCircleBold,
+        className: 'border-amber-200 bg-amber-50 text-amber-900',
+      };
+    case 'manual_review':
+      return {
+        title: 'Manual review required',
+        text: 'SkyFibre may be possible, but the coverage evidence is not strong enough for a quick sale. Request site survey or operations review.',
+        badge: 'Manual review',
+        variant: 'warning' as const,
+        icon: PiWarningCircleBold,
+        className: 'border-amber-200 bg-amber-50 text-amber-900',
+      };
+    case 'not_covered':
+      return {
+        title: 'Not currently covered for SkyFibre',
+        text: 'Do not quote SkyFibre at this address. Recommend another access technology or capture demand for future expansion.',
+        badge: 'Not covered',
+        variant: 'error' as const,
+        icon: PiXCircleBold,
+        className: 'border-red-200 bg-red-50 text-red-900',
+      };
+    case 'error':
+      return {
+        title: 'Unable to confirm SkyFibre availability',
+        text: 'The orderability gate returned an error. Do not quote SkyFibre until the check succeeds.',
+        badge: 'Error',
+        variant: 'warning' as const,
+        icon: PiWarningCircleBold,
+        className: 'border-amber-200 bg-amber-50 text-amber-900',
+      };
+    default:
+      return null;
+  }
+}
+
 export default function CoverageCheckerPage() {
   const [provider, setProvider] = useState<ProviderType>('tarana');
   // Tarana state
   const [result, setResult] = useState<CheckResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [skyFibreOrderability, setSkyFibreOrderability] = useState<SkyFibreOrderabilityResult | null>(null);
+  const [skyFibreOrderabilityChecking, setSkyFibreOrderabilityChecking] = useState(false);
+  const [skyFibreOrderabilityError, setSkyFibreOrderabilityError] = useState<string | null>(null);
   // DFA state
   const [dfaResult, setDfaResult] = useState<DFAResult | null>(null);
   const [dfaLoading, setDfaLoading] = useState(false);
@@ -129,6 +257,9 @@ export default function CoverageCheckerPage() {
     setIsLoading(true);
     setError(null);
     setResult(null);
+    setSkyFibreOrderability(null);
+    setSkyFibreOrderabilityChecking(false);
+    setSkyFibreOrderabilityError(null);
     setDfaResult(null);
     setMtnResult(null);
     setActiveTab('check');
@@ -188,6 +319,9 @@ export default function CoverageCheckerPage() {
     setDfaResult(null);
     setResult(null);
     setMtnResult(null);
+    setSkyFibreOrderability(null);
+    setSkyFibreOrderabilityChecking(false);
+    setSkyFibreOrderabilityError(null);
     setActiveTab('check');
 
     try {
@@ -270,6 +404,18 @@ export default function CoverageCheckerPage() {
   const loading = provider === 'tarana' ? isLoading : provider === 'dfa' ? dfaLoading : mtnLoading;
   const currentError = provider === 'tarana' ? error : provider === 'dfa' ? dfaError : mtnError;
   const hasResult = provider === 'tarana' ? result !== null : provider === 'dfa' ? dfaResult !== null : mtnResult !== null;
+  const bnMismatch = provider === 'tarana' && hasBaseStationMismatch(prediction, skyFibreOrderability);
+  const salesDecisionBanner = provider === 'tarana' && result
+    ? getSalesDecisionBanner({
+        orderability: skyFibreOrderability,
+        checking: skyFibreOrderabilityChecking,
+        error: skyFibreOrderabilityError,
+        bnMismatch,
+      })
+    : null;
+  const effectiveSkyFibreOrderability = bnMismatch && skyFibreOrderability
+    ? { ...skyFibreOrderability, decision: 'manual_review' as const }
+    : skyFibreOrderability;
 
   function getMcsLevel(rssi: number): number {
     if (rssi >= -65)   return 16;
@@ -439,7 +585,18 @@ export default function CoverageCheckerPage() {
         <TabPanel id="check" activeTab={activeTab} className="space-y-5">
 
           {/* Provider Selector */}
-          <ProviderSelector provider={provider} onChange={(p) => { setProvider(p); setResult(null); setDfaResult(null); setMtnResult(null); setError(null); setDfaError(null); setMtnError(null); }} />
+          <ProviderSelector provider={provider} onChange={(p) => {
+            setProvider(p);
+            setResult(null);
+            setDfaResult(null);
+            setMtnResult(null);
+            setError(null);
+            setDfaError(null);
+            setMtnError(null);
+            setSkyFibreOrderability(null);
+            setSkyFibreOrderabilityChecking(false);
+            setSkyFibreOrderabilityError(null);
+          }} />
 
           {/* Address input */}
           {mapsLoaded ? (
@@ -492,14 +649,44 @@ export default function CoverageCheckerPage() {
           {/* ── Tarana Results ── */}
           {provider === 'tarana' && result && !isLoading && (
             <div className="space-y-4">
+              {salesDecisionBanner && (
+                <section className={`rounded-xl border p-5 shadow-sm ${salesDecisionBanner.className}`}>
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex items-start gap-3">
+                      <salesDecisionBanner.icon className="mt-0.5 h-6 w-6 shrink-0" />
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide opacity-70">Final Sales Decision</p>
+                        <h2 className="mt-1 text-xl font-bold">{salesDecisionBanner.title}</h2>
+                        <p className="mt-1 text-sm">{salesDecisionBanner.text}</p>
+                      </div>
+                    </div>
+                    <StatusBadge status={salesDecisionBanner.badge} variant={salesDecisionBanner.variant} />
+                  </div>
+                </section>
+              )}
               <CoverageVerdictCard prediction={result.prediction} liveStatus={result.liveStatus} />
+              <SkyFibreOrderabilityCard
+                lat={result.lat}
+                lng={result.lng}
+                address={result.address}
+                autoCheck
+                onCheckingChange={setSkyFibreOrderabilityChecking}
+                onResult={setSkyFibreOrderability}
+                onError={setSkyFibreOrderabilityError}
+              />
               {result.prediction && (
                 <TierEligibilityTable prediction={result.prediction} />
               )}
               {result.liveStatus && (
                 <NetworkStatusCard liveStatus={result.liveStatus} />
               )}
-              <SalesRecommendationCard prediction={result.prediction} liveStatus={result.liveStatus} />
+              <SalesRecommendationCard
+                prediction={result.prediction}
+                liveStatus={result.liveStatus}
+                orderabilityResult={effectiveSkyFibreOrderability}
+                orderabilityChecking={skyFibreOrderabilityChecking}
+                orderabilityError={skyFibreOrderabilityError}
+              />
               <CoverageMap
                 targetLat={result.lat}
                 targetLng={result.lng}

--- a/app/admin/sales/feasibility/components/SingleSiteStepper.tsx
+++ b/app/admin/sales/feasibility/components/SingleSiteStepper.tsx
@@ -12,6 +12,12 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from 'sonner';
 import type { CoverageDetail, DetailedCoverage } from '../page';
+import SkyFibreOrderabilityCard from '@/components/admin/skyfibre/SkyFibreOrderabilityCard';
+import {
+  getAdminSkyFibreCapacity,
+  isAdminSkyFibrePackage,
+} from '@/lib/coverage/skyfibre/admin-ui';
+import type { SkyFibreCapacityMbps } from '@/lib/coverage/skyfibre/types';
 // import { mapDarkStyle } from './MapStyles';  // Dark styles no longer used
 
 // ============================================================================
@@ -52,6 +58,8 @@ interface SelectedPackage {
   installationFee: number;
   technology: string;
   provider: string;
+  serviceType?: string;
+  productCategory?: string;
   itemType: 'primary' | 'secondary' | 'additional';
 }
 
@@ -219,6 +227,18 @@ export function SingleSiteStepper() {
         default: return 0;
       }
     });
+
+  const selectedSkyFibrePackages = formData.selectedPackages
+    .filter((pkg) => isAdminSkyFibrePackage({
+      name: pkg.name,
+      serviceType: pkg.serviceType,
+      productCategory: pkg.productCategory,
+      technology: pkg.technology,
+    }))
+    .map((pkg) => ({
+      ...pkg,
+      capacityMbps: getAdminSkyFibreCapacity(pkg.speed) ?? (100 as SkyFibreCapacityMbps),
+    }));
 
   // Load Google Maps
   const { isLoaded, loadError } = useJsApiLoader({
@@ -518,6 +538,8 @@ export function SingleSiteStepper() {
               installationFee: pkg.installation_fee || 0,
               technology: pkg.service_type || pkg.product_category,
               provider: pkg.provider || 'CircleTel',
+              serviceType: pkg.service_type,
+              productCategory: pkg.product_category,
               itemType,
             },
           ],
@@ -1011,6 +1033,31 @@ export function SingleSiteStepper() {
                     </div>
                   ))}
                 </div>
+
+                {selectedSkyFibrePackages.length > 0 && formData.coordinates && (
+                  <div className="space-y-4">
+                    <div className="bg-white rounded-xl border border-slate-200 p-6 shadow-sm">
+                      <h3 className="text-sm font-black text-slate-900 uppercase tracking-widest flex items-center gap-2">
+                        <PiBroadcastBold className="h-5 w-5 text-circleTel-orange" />
+                        SkyFibre CSP Validation
+                      </h3>
+                      <p className="mt-2 text-sm text-slate-600">
+                        Run CSP orderability for selected Tarana/SkyFibre packages before generating the business quote.
+                      </p>
+                    </div>
+                    {selectedSkyFibrePackages.map((pkg) => (
+                      <SkyFibreOrderabilityCard
+                        key={pkg.id}
+                        leadId={formData.leadId}
+                        lat={formData.coordinates!.lat}
+                        lng={formData.coordinates!.lng}
+                        address={formData.address}
+                        packageName={pkg.name}
+                        initialCapacityMbps={pkg.capacityMbps}
+                      />
+                    ))}
+                  </div>
+                )}
 
                 {/* Totals Card */}
                 <div className="bg-slate-50 rounded-xl border border-slate-200 p-8 shadow-sm">

--- a/app/api/coverage/skyfibre/orderability/route.ts
+++ b/app/api/coverage/skyfibre/orderability/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import {
+  checkSkyFibreOrderability,
+  isValidSkyFibreCapacity,
+  redactSkyFibreOrderability,
+} from '@/lib/coverage/skyfibre/orderability';
+import type {
+  SkyFibreOrderabilityResult,
+  SkyFibreSegment,
+} from '@/lib/coverage/skyfibre/types';
+import { apiLogger } from '@/lib/logging';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = await request.json();
+    const leadId = typeof body.leadId === 'string' ? body.leadId : undefined;
+    const latitude = typeof body.latitude === 'number' ? body.latitude : undefined;
+    const longitude = typeof body.longitude === 'number' ? body.longitude : undefined;
+    const capacityMbps = body.capacityMbps;
+    const segment = normalizeSegment(body.segment);
+
+    if (!isValidSkyFibreCapacity(capacityMbps)) {
+      return NextResponse.json(
+        { success: false, error: 'capacityMbps must be one of 50, 100, or 200' },
+        { status: 400 }
+      );
+    }
+
+    if (!leadId && (latitude === undefined || longitude === undefined)) {
+      return NextResponse.json(
+        { success: false, error: 'Either leadId or coordinates are required' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await createClient();
+    const result = await checkSkyFibreOrderability(
+      {
+        leadId,
+        latitude,
+        longitude,
+        capacityMbps,
+        ...(segment ? { segment } : {}),
+      },
+      { supabase }
+    );
+
+    const redacted = redactSkyFibreOrderability(result);
+
+    if (leadId) {
+      await appendCoverageResult(supabase, leadId, redacted);
+    }
+
+    apiLogger.info('[SkyFibreOrderability] Check complete', {
+      leadId: leadId || null,
+      segment: redacted.segment,
+      capacityMbps: redacted.capacityMbps,
+      decision: redacted.decision,
+      cspStatus: redacted.cspOrderability?.status || null,
+      tcsConfidence: redacted.tcsCoverage.confidence,
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: redacted,
+    });
+  } catch (error) {
+    apiLogger.error('[SkyFibreOrderability] Unexpected error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    const message = error instanceof Error ? error.message : 'SkyFibre orderability check failed';
+    const status = /lead not found/i.test(message) ? 404 : 500;
+
+    return NextResponse.json(
+      { success: false, error: message },
+      { status }
+    );
+  }
+}
+
+async function appendCoverageResult(
+  supabase: any,
+  leadId: string,
+  result: SkyFibreOrderabilityResult
+): Promise<void> {
+  const { data, error } = await supabase
+    .from('coverage_leads')
+    .select('coverage_results')
+    .eq('id', leadId)
+    .single();
+
+  if (error) {
+    apiLogger.error('[SkyFibreOrderability] Failed to load coverage_results', {
+      leadId,
+      error: error.message,
+    });
+    return;
+  }
+
+  const existingResults = Array.isArray(data?.coverage_results)
+    ? data.coverage_results
+    : [];
+
+  const entry = {
+    technology: 'SkyFibre',
+    provider: 'mtn-csp',
+    is_feasible: result.decision === 'orderable',
+    confidence: result.tcsCoverage.confidence,
+    checked_at: new Date().toISOString(),
+    decision: result.decision,
+    segment: result.segment,
+    capacity_mbps: result.capacityMbps,
+    tcs: result.tcsCoverage,
+    csp: result.cspOrderability
+      ? {
+          provider: result.cspOrderability.provider,
+          method: result.cspOrderability.method,
+          status: result.cspOrderability.status,
+          orderable: result.cspOrderability.orderable,
+          taranaZone: result.cspOrderability.taranaZone ?? null,
+          checkedAt: result.cspOrderability.checkedAt,
+        }
+      : null,
+  };
+
+  const { error: updateError } = await supabase
+    .from('coverage_leads')
+    .update({ coverage_results: [...existingResults, entry] })
+    .eq('id', leadId);
+
+  if (updateError) {
+    apiLogger.error('[SkyFibreOrderability] Failed to persist coverage_results', {
+      leadId,
+      error: updateError.message,
+    });
+  }
+}
+
+function normalizeSegment(value: unknown): SkyFibreSegment | undefined {
+  return value === 'business' || value === 'residential' ? value : undefined;
+}

--- a/app/api/orders/create/route.ts
+++ b/app/api/orders/create/route.ts
@@ -3,6 +3,13 @@ import { createClient } from '@/lib/supabase/server';
 import { EmailNotificationService } from '@/lib/notifications/notification-service';
 import type { ConsumerOrder } from '@/lib/types/customer-journey';
 import { apiLogger } from '@/lib/logging';
+import {
+  checkSkyFibreOrderability,
+  extractSkyFibreCapacity,
+  isSkyFibrePackage,
+  redactSkyFibreOrderability,
+} from '@/lib/coverage/skyfibre/orderability';
+import type { SkyFibreOrderabilityResult, SkyFibreSegment } from '@/lib/coverage/skyfibre/types';
 
 // P4: Valid property types (must match ServiceAddressSection.tsx options)
 const VALID_PROPERTY_TYPES = [
@@ -50,6 +57,63 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = await createClient();
+    let skyFibreOrderability: SkyFibreOrderabilityResult | null = null;
+
+    if (isSkyFibrePackage(body)) {
+      const capacityMbps = extractSkyFibreCapacity(body);
+      if (!capacityMbps) {
+        return NextResponse.json(
+          { success: false, error: 'Unable to determine SkyFibre capacity for orderability check' },
+          { status: 400 }
+        );
+      }
+
+      const leadId = typeof body.coverage_lead_id === 'string'
+        ? body.coverage_lead_id
+        : typeof body.leadId === 'string'
+          ? body.leadId
+          : undefined;
+      const coordinates = extractOrderCoordinates(body.coordinates);
+
+      if (!leadId && !coordinates) {
+        return NextResponse.json(
+          { success: false, error: 'SkyFibre orders require a coverage lead or installation coordinates' },
+          { status: 400 }
+        );
+      }
+
+      skyFibreOrderability = redactSkyFibreOrderability(
+        await checkSkyFibreOrderability(
+          {
+            leadId,
+            latitude: coordinates?.lat,
+            longitude: coordinates?.lng,
+            capacityMbps,
+            segment: body.account_type === 'business' ? 'business' : 'residential',
+          },
+          { supabase }
+        )
+      );
+
+      if (skyFibreOrderability.decision !== 'orderable') {
+        apiLogger.info('[orders/create] SkyFibre order blocked by orderability gate', {
+          decision: skyFibreOrderability.decision,
+          capacityMbps,
+          leadId: leadId || null,
+          cspStatus: skyFibreOrderability.cspOrderability?.status || null,
+          tcsConfidence: skyFibreOrderability.tcsCoverage.confidence,
+        });
+
+        return NextResponse.json(
+          {
+            success: false,
+            error: `SkyFibre is not orderable at this address (${skyFibreOrderability.decision})`,
+            orderability: skyFibreOrderability,
+          },
+          { status: 409 }
+        );
+      }
+    }
 
     // Check for existing pending/active orders with same email, address, and package
     // This prevents duplicate orders for the same service at the same address
@@ -174,7 +238,7 @@ export async function POST(request: NextRequest) {
         referral_code: body.referral_code || null,
 
         // Metadata
-        metadata: body.metadata || {},
+        metadata: buildOrderMetadata(body.metadata, body.account_type, skyFibreOrderability),
         internal_notes: null,
       })
       .select()
@@ -230,6 +294,41 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+function extractOrderCoordinates(value: unknown): { lat: number; lng: number } | null {
+  if (!value || typeof value !== 'object') return null;
+  const coords = value as { lat?: unknown; lng?: unknown; coordinates?: unknown; type?: unknown };
+
+  if (typeof coords.lat === 'number' && typeof coords.lng === 'number') {
+    return { lat: coords.lat, lng: coords.lng };
+  }
+
+  if (coords.type === 'Point' && Array.isArray(coords.coordinates)) {
+    const [lng, lat] = coords.coordinates;
+    if (typeof lat === 'number' && typeof lng === 'number') {
+      return { lat, lng };
+    }
+  }
+
+  return null;
+}
+
+function buildOrderMetadata(
+  metadata: unknown,
+  accountType: unknown,
+  skyFibreOrderability: SkyFibreOrderabilityResult | null
+): Record<string, unknown> {
+  const base = metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+    ? metadata as Record<string, unknown>
+    : {};
+  const normalizedAccountType = accountType === 'business' ? 'business' : 'personal';
+
+  return {
+    ...base,
+    account_type: normalizedAccountType as SkyFibreSegment | 'personal',
+    ...(skyFibreOrderability ? { skyfibre_orderability: skyFibreOrderability } : {}),
+  };
 }
 
 // Helper function to generate unique order number

--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -24,6 +24,12 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { createClient } from '@/lib/supabase/client';
+import type { PackageDetails } from '@/lib/order/types';
+import type {
+  SkyFibreCapacityMbps,
+  SkyFibreOrderabilityResult,
+  SkyFibreSegment,
+} from '@/lib/coverage/skyfibre/types';
 
 type CheckoutStep = 'account' | 'confirm';
 type SubmitStatus = 'idle' | 'creating_order' | 'redirecting';
@@ -65,12 +71,18 @@ export default function CheckoutPage() {
   const [propertyTypeError, setPropertyTypeError] = useState<string | undefined>();
   const [sameAsServiceAddress, setSameAsServiceAddress] = useState(true);
   const [deliveryAddress, setDeliveryAddress] = useState('');
+  const [skyFibreOrderability, setSkyFibreOrderability] = useState<SkyFibreOrderabilityResult | null>(null);
 
   const isWirelessOrMobile =
     pkg?.type === 'wireless' || pkg?.type === 'mobile' ||
     (pkg?.service_type || '').toLowerCase().includes('lte') ||
     (pkg?.service_type || '').toLowerCase().includes('5g') ||
     (pkg?.product_category || '').toLowerCase().includes('mobile');
+
+  const isSkyFibreSelected =
+    hasSkyFibreSignal(pkg?.name) ||
+    hasSkyFibreSignal(pkg?.service_type) ||
+    hasSkyFibreSignal(pkg?.product_category);
 
   // Guard: require package + coverage
   // Wait for auth to settle before redirecting — on return from Google OAuth,
@@ -224,6 +236,41 @@ export default function CheckoutPage() {
 
     setSubmitStatus('creating_order');
 
+    let confirmedSkyFibreOrderability = skyFibreOrderability;
+    if (isSkyFibreSelected) {
+      const capacityMbps = getSkyFibreCapacity(pkg);
+      if (!capacityMbps) {
+        setSubmitStatus('idle');
+        throw new Error('Unable to confirm the selected SkyFibre speed. Please choose the package again.');
+      }
+
+      const orderabilityRes = await fetch('/api/coverage/skyfibre/orderability', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          leadId: coverage?.leadId,
+          latitude: serviceCoordinates?.lat,
+          longitude: serviceCoordinates?.lng,
+          capacityMbps,
+          segment: getSkyFibreSegment(coverage?.coverageType),
+        }),
+      });
+
+      const orderabilityBody = await orderabilityRes.json().catch(() => ({}));
+      if (!orderabilityRes.ok || !orderabilityBody?.success) {
+        setSubmitStatus('idle');
+        throw new Error(orderabilityBody?.error || 'Unable to confirm SkyFibre orderability. Please contact support.');
+      }
+
+      confirmedSkyFibreOrderability = orderabilityBody.data as SkyFibreOrderabilityResult;
+      setSkyFibreOrderability(confirmedSkyFibreOrderability);
+
+      if (confirmedSkyFibreOrderability.decision !== 'orderable') {
+        setSubmitStatus('idle');
+        throw new Error(getSkyFibreDecisionMessage(confirmedSkyFibreOrderability));
+      }
+    }
+
     const orderRes = await fetch('/api/orders/create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -236,6 +283,9 @@ export default function CheckoutPage() {
         package_name: pkg.name,
         package_speed: pkg.speed,
         package_price: pkg.monthlyPrice,
+        service_type: pkg.service_type,
+        product_category: pkg.product_category,
+        speed_down: pkg.speed_down,
         installation_fee: pkg.installation_fee ?? 0,
         payment_amount: 1.00,
         is_validation_charge: true,
@@ -244,6 +294,10 @@ export default function CheckoutPage() {
         coordinates: serviceCoordinates,
         installation_location_type: propertyType,
         account_type: coverage?.coverageType === 'business' ? 'business' : 'personal',
+        coverage_lead_id: coverage?.leadId,
+        metadata: confirmedSkyFibreOrderability
+          ? { skyfibre_orderability: confirmedSkyFibreOrderability }
+          : {},
       }),
     });
 
@@ -672,4 +726,39 @@ export default function CheckoutPage() {
       )}
     </div>
   );
+}
+
+function getSkyFibreCapacity(pkg: PackageDetails): SkyFibreCapacityMbps | null {
+  if (pkg.speed_down === 50 || pkg.speed_down === 100 || pkg.speed_down === 200) {
+    return pkg.speed_down;
+  }
+
+  const match = `${pkg.speed || ''} ${pkg.name || ''}`.match(/\b(50|100|200)\b/);
+  if (!match) return null;
+
+  const parsed = Number(match[1]);
+  return parsed === 50 || parsed === 100 || parsed === 200 ? parsed : null;
+}
+
+function getSkyFibreSegment(coverageType: string | undefined): SkyFibreSegment {
+  return coverageType === 'business' ? 'business' : 'residential';
+}
+
+function getSkyFibreDecisionMessage(result: SkyFibreOrderabilityResult): string {
+  switch (result.decision) {
+    case 'covered_not_orderable':
+      return 'SkyFibre coverage looks possible, but MTN CSP is not allowing an order for this address yet. Our sales team will need to review it.';
+    case 'manual_review':
+      return 'SkyFibre needs a manual feasibility review for this address before an order can be placed.';
+    case 'not_covered':
+      return 'SkyFibre is not currently covered at this address.';
+    default:
+      return 'SkyFibre orderability could not be confirmed for this address.';
+  }
+}
+
+function hasSkyFibreSignal(value: unknown): boolean {
+  const normalized = String(value || '').toLowerCase();
+  const compact = normalized.replace(/[^a-z0-9]/g, '');
+  return compact.includes('skyfibre') || normalized.includes('tarana');
 }

--- a/components/admin/skyfibre/SkyFibreOrderabilityCard.tsx
+++ b/components/admin/skyfibre/SkyFibreOrderabilityCard.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  PiCheckCircleBold,
+  PiClockBold,
+  PiRadioBold,
+  PiSpinnerBold,
+  PiWarningCircleBold,
+  PiXCircleBold,
+} from 'react-icons/pi';
+import { StatusBadge } from '@/components/admin/shared';
+import {
+  buildAdminSkyFibreOrderabilityRequest,
+  getSkyFibreDecisionLabel,
+} from '@/lib/coverage/skyfibre/admin-ui';
+import type {
+  SkyFibreCapacityMbps,
+  SkyFibreOrderabilityDecision,
+  SkyFibreOrderabilityResult,
+} from '@/lib/coverage/skyfibre/types';
+
+interface SkyFibreOrderabilityCardProps {
+  lat: number;
+  lng: number;
+  address: string;
+  leadId?: string | null;
+  packageName?: string;
+  initialCapacityMbps?: SkyFibreCapacityMbps;
+  autoCheck?: boolean;
+  onCheckingChange?: (isChecking: boolean) => void;
+  onResult?: (result: SkyFibreOrderabilityResult | null) => void;
+  onError?: (error: string | null) => void;
+}
+
+const CAPACITIES: SkyFibreCapacityMbps[] = [50, 100, 200];
+
+const DECISION_STYLES: Record<SkyFibreOrderabilityDecision, {
+  icon: typeof PiCheckCircleBold;
+  variant: 'success' | 'warning' | 'error' | 'neutral';
+  panelClass: string;
+  iconClass: string;
+}> = {
+  orderable: {
+    icon: PiCheckCircleBold,
+    variant: 'success',
+    panelClass: 'border-emerald-200 bg-emerald-50',
+    iconClass: 'text-emerald-600',
+  },
+  covered_not_orderable: {
+    icon: PiXCircleBold,
+    variant: 'warning',
+    panelClass: 'border-amber-200 bg-amber-50',
+    iconClass: 'text-amber-600',
+  },
+  manual_review: {
+    icon: PiWarningCircleBold,
+    variant: 'warning',
+    panelClass: 'border-amber-200 bg-amber-50',
+    iconClass: 'text-amber-600',
+  },
+  not_covered: {
+    icon: PiXCircleBold,
+    variant: 'error',
+    panelClass: 'border-red-200 bg-red-50',
+    iconClass: 'text-red-600',
+  },
+  error: {
+    icon: PiWarningCircleBold,
+    variant: 'error',
+    panelClass: 'border-red-200 bg-red-50',
+    iconClass: 'text-red-600',
+  },
+};
+
+function getCspStatusVariant(status: string | undefined): 'success' | 'warning' | 'error' | 'neutral' {
+  if (status === 'orderable') return 'success';
+  if (status === 'not_orderable') return 'warning';
+  if (status === 'error') return 'error';
+  return 'neutral';
+}
+
+function getTcsConfidenceVariant(confidence: string): 'success' | 'warning' | 'error' | 'neutral' {
+  if (confidence === 'high') return 'success';
+  if (confidence === 'medium' || confidence === 'low') return 'warning';
+  if (confidence === 'none') return 'error';
+  return 'neutral';
+}
+
+export default function SkyFibreOrderabilityCard({
+  lat,
+  lng,
+  address,
+  leadId,
+  packageName,
+  initialCapacityMbps = 100,
+  autoCheck = false,
+  onCheckingChange,
+  onResult,
+  onError,
+}: SkyFibreOrderabilityCardProps) {
+  const [capacityMbps, setCapacityMbps] = useState<SkyFibreCapacityMbps>(initialCapacityMbps);
+  const [result, setResult] = useState<SkyFibreOrderabilityResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const lastAutoCheckKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setCapacityMbps(initialCapacityMbps);
+    setResult(null);
+    setError(null);
+  }, [initialCapacityMbps, lat, lng, leadId]);
+
+  const checkOrderability = useCallback(async (capacityOverride?: SkyFibreCapacityMbps) => {
+    const selectedCapacity = capacityOverride ?? capacityMbps;
+    setIsChecking(true);
+    setError(null);
+    onCheckingChange?.(true);
+    onError?.(null);
+
+    try {
+      const response = await fetch('/api/coverage/skyfibre/orderability', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(
+          buildAdminSkyFibreOrderabilityRequest({ leadId, lat, lng, capacityMbps: selectedCapacity })
+        ),
+      });
+
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok || !body?.success) {
+        throw new Error(body?.error || 'SkyFibre orderability check failed');
+      }
+
+      const nextResult = body.data as SkyFibreOrderabilityResult;
+      setResult(nextResult);
+      onResult?.(nextResult);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'SkyFibre orderability check failed';
+      setResult(null);
+      setError(message);
+      onResult?.(null);
+      onError?.(message);
+    } finally {
+      setIsChecking(false);
+      onCheckingChange?.(false);
+    }
+  }, [capacityMbps, lat, leadId, lng, onCheckingChange, onError, onResult]);
+
+  useEffect(() => {
+    if (!autoCheck) return;
+
+    const autoCheckKey = `${leadId || 'coords'}:${lat}:${lng}:${initialCapacityMbps}`;
+    if (lastAutoCheckKeyRef.current === autoCheckKey) return;
+
+    lastAutoCheckKeyRef.current = autoCheckKey;
+    void checkOrderability(initialCapacityMbps);
+  }, [autoCheck, checkOrderability, initialCapacityMbps, lat, leadId, lng]);
+
+  const decision = result?.decision;
+  const style = decision ? DECISION_STYLES[decision] : null;
+  const DecisionIcon = style?.icon;
+
+  return (
+    <section className="bg-white rounded-xl border border-slate-200 p-5 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="rounded-full bg-orange-50 p-2 text-circleTel-orange">
+            <PiRadioBold className="h-5 w-5" />
+          </div>
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-base font-semibold text-slate-900">SkyFibre Orderability</h2>
+              <StatusBadge status="MTN CSP" variant="info" />
+            </div>
+            <p className="mt-1 max-w-2xl text-sm text-slate-500">
+              Confirm whether MTN CSP will accept a SkyFibre order at this Tarana location.
+            </p>
+            {packageName && (
+              <p className="mt-2 text-xs font-semibold text-slate-600">{packageName}</p>
+            )}
+            <p className="mt-1 text-xs text-slate-400 truncate max-w-2xl">{address}</p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="inline-flex rounded-lg border border-slate-200 bg-slate-50 p-1">
+            {CAPACITIES.map((capacity) => (
+              <button
+                key={capacity}
+                type="button"
+                onClick={() => setCapacityMbps(capacity)}
+                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                  capacityMbps === capacity
+                    ? 'bg-white text-slate-900 shadow-sm'
+                    : 'text-slate-500 hover:text-slate-800'
+                }`}
+                aria-pressed={capacityMbps === capacity}
+              >
+                {capacity} Mbps
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => checkOrderability()}
+            disabled={isChecking}
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-circleTel-orange px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#C45A30] disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isChecking ? (
+              <PiSpinnerBold className="h-4 w-4 animate-spin" />
+            ) : (
+              <PiClockBold className="h-4 w-4" />
+            )}
+            {isChecking ? 'Checking...' : 'Check CSP Orderability'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {result && style && DecisionIcon && (
+        <div className={`mt-4 rounded-lg border px-4 py-4 ${style.panelClass}`}>
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="flex items-start gap-3">
+              <DecisionIcon className={`mt-0.5 h-5 w-5 shrink-0 ${style.iconClass}`} />
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-semibold text-slate-900">
+                    {getSkyFibreDecisionLabel(result.decision)}
+                  </p>
+                  <StatusBadge
+                    status={`CSP: ${result.cspOrderability?.status ?? 'not checked'}`}
+                    variant={getCspStatusVariant(result.cspOrderability?.status)}
+                  />
+                  <StatusBadge
+                    status={`TCS: ${result.tcsCoverage.confidence} confidence`}
+                    variant={getTcsConfidenceVariant(result.tcsCoverage.confidence)}
+                  />
+                </div>
+                <p className="mt-2 text-sm text-slate-700">{result.tcsCoverage.reason}</p>
+              </div>
+            </div>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-slate-600 sm:grid-cols-4 md:text-right">
+              <div>
+                <dt className="text-slate-400">Speed</dt>
+                <dd className="font-semibold text-slate-800">{result.capacityMbps} Mbps</dd>
+              </div>
+              <div>
+                <dt className="text-slate-400">Method</dt>
+                <dd className="font-semibold text-slate-800">{result.cspOrderability?.method ?? '-'}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-400">RN Evidence</dt>
+                <dd className="font-semibold text-slate-800">{result.tcsCoverage.nearestBnActiveRnCount}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-400">Zone</dt>
+                <dd className="font-semibold text-slate-800">{result.cspOrderability?.taranaZone ?? '-'}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/lib/coverage/mtn/base-station-service.ts
+++ b/lib/coverage/mtn/base-station-service.ts
@@ -108,18 +108,20 @@ export async function checkBaseStationProximity(
       };
     }
 
+    const stationsWithStatus = await hydrateBaseStationStatus(supabase, stations);
+
     // Map database results
-    const nearbyStations: TaranaBaseStation[] = stations.map((s: any) => ({
+    const nearbyStations: TaranaBaseStation[] = stationsWithStatus.map((s: any) => ({
       id: s.id,
       serial_number: s.serial_number,
       hostname: s.hostname,
       site_name: s.site_name,
-      active_connections: s.active_connections,
+      active_connections: Number(s.active_connections ?? 0),
       market: s.market,
       lat: Number(s.lat),
       lng: Number(s.lng),
       distance_km: Number(s.distance_km),
-      device_status: s.device_status ?? 0,
+      device_status: normalizeDeviceStatus(s.device_status),
     }));
 
     // Separate online and offline — only online BNs can serve customers
@@ -205,6 +207,61 @@ export async function checkBaseStationProximity(
     console.error('[BaseStationService] Unexpected error:', error);
     return createFallbackResult(coordinates, 'Unexpected error');
   }
+}
+
+async function hydrateBaseStationStatus(
+  supabase: any,
+  stations: any[]
+): Promise<any[]> {
+  const serials = stations
+    .map((station) => station?.serial_number)
+    .filter((serial): serial is string => typeof serial === 'string' && serial.length > 0);
+
+  if (serials.length === 0) return stations;
+
+  const needsHydration = stations.some(
+    (station) => station?.device_status === undefined || station?.device_status === null
+  );
+
+  if (!needsHydration) return stations;
+
+  const { data, error } = await supabase
+    .from('tarana_base_stations')
+    .select('serial_number, device_status, active_connections')
+    .in('serial_number', serials);
+
+  if (error || !Array.isArray(data)) {
+    if (error) {
+      console.warn('[BaseStationService] Failed to hydrate BN statuses:', error.message);
+    }
+    return stations;
+  }
+
+  const statusBySerial = new Map(
+    data.map((row: any) => [row.serial_number, row])
+  );
+
+  return stations.map((station) => {
+    const statusRow = statusBySerial.get(station.serial_number);
+    if (!statusRow) return station;
+
+    return {
+      ...station,
+      device_status: station.device_status ?? statusRow.device_status,
+      active_connections: station.active_connections ?? statusRow.active_connections,
+    };
+  });
+}
+
+function normalizeDeviceStatus(value: unknown): number {
+  if (value === 1 || value === true) return 1;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === '1' || normalized === 'online' || normalized === 'connected' || normalized === 'active') {
+      return 1;
+    }
+  }
+  return 0;
 }
 
 /**

--- a/lib/coverage/skyfibre/admin-ui.ts
+++ b/lib/coverage/skyfibre/admin-ui.ts
@@ -1,0 +1,79 @@
+import type {
+  SkyFibreCapacityMbps,
+  SkyFibreOrderabilityDecision,
+  SkyFibreSegment,
+} from './types';
+
+export interface AdminSkyFibreOrderabilityRequestInput {
+  leadId?: string | null;
+  lat: number;
+  lng: number;
+  capacityMbps: SkyFibreCapacityMbps;
+}
+
+export interface AdminSkyFibreOrderabilityRequest {
+  leadId?: string;
+  latitude: number;
+  longitude: number;
+  capacityMbps: SkyFibreCapacityMbps;
+  segment: SkyFibreSegment;
+}
+
+export function buildAdminSkyFibreOrderabilityRequest(
+  input: AdminSkyFibreOrderabilityRequestInput
+): AdminSkyFibreOrderabilityRequest {
+  return {
+    ...(input.leadId ? { leadId: input.leadId } : {}),
+    latitude: input.lat,
+    longitude: input.lng,
+    capacityMbps: input.capacityMbps,
+    segment: 'business',
+  };
+}
+
+export function getSkyFibreDecisionLabel(decision: SkyFibreOrderabilityDecision): string {
+  switch (decision) {
+    case 'orderable':
+      return 'Orderable';
+    case 'covered_not_orderable':
+      return 'Covered, not orderable';
+    case 'manual_review':
+      return 'Manual review';
+    case 'not_covered':
+      return 'Not covered';
+    case 'error':
+      return 'Error';
+    default:
+      return 'Unknown';
+  }
+}
+
+export function isAdminSkyFibrePackage(input: {
+  name?: unknown;
+  serviceType?: unknown;
+  productCategory?: unknown;
+  technology?: unknown;
+}): boolean {
+  return (
+    hasSkyFibreSignal(input.name) ||
+    hasSkyFibreSignal(input.serviceType) ||
+    hasSkyFibreSignal(input.productCategory) ||
+    hasSkyFibreSignal(input.technology)
+  );
+}
+
+export function getAdminSkyFibreCapacity(value: unknown): SkyFibreCapacityMbps | null {
+  if (value === 50 || value === 100 || value === 200) return value;
+
+  const match = String(value || '').match(/\b(50|100|200)\b/);
+  if (!match) return null;
+
+  const parsed = Number(match[1]);
+  return parsed === 50 || parsed === 100 || parsed === 200 ? parsed : null;
+}
+
+function hasSkyFibreSignal(value: unknown): boolean {
+  const normalized = String(value || '').toLowerCase();
+  const compact = normalized.replace(/[^a-z0-9]/g, '');
+  return compact.includes('skyfibre') || normalized.includes('tarana');
+}

--- a/lib/coverage/skyfibre/csp-client.ts
+++ b/lib/coverage/skyfibre/csp-client.ts
@@ -1,0 +1,216 @@
+import type {
+  CspFeasibilityMethod,
+  CspOrderabilityResult,
+  SkyFibreCapacityMbps,
+} from './types';
+
+const DEFAULT_CSP_API_BASE = 'https://mtnsi.mtn.co.za/newcsp_api/components';
+const CSP_PRODUCT_NAME = 'Fixed Wireless Broadband';
+const SESSION_TTL_MS = 25 * 60 * 1000;
+
+type FetchLike = typeof fetch;
+
+interface CspClientOptions {
+  baseUrl?: string;
+  username?: string;
+  password?: string;
+  fetchImpl?: FetchLike;
+}
+
+interface CspSession {
+  cookieHeader: string;
+  expiresAt: number;
+}
+
+let cachedSession: CspSession | null = null;
+
+export function selectCspFeasibilityMethod(
+  capacityMbps: SkyFibreCapacityMbps
+): CspFeasibilityMethod {
+  return capacityMbps >= 200 ? 'feasibilityCheck' : 'feasibilityOld';
+}
+
+export function normalizeCspFeasibilityResponse(
+  raw: unknown,
+  capacityMbps: SkyFibreCapacityMbps,
+  responseTimeMs?: number
+): CspOrderabilityResult {
+  const method = selectCspFeasibilityMethod(capacityMbps);
+  const output = firstOutput(raw);
+  let orderable: boolean | null = null;
+  let taranaFeasible: boolean | undefined;
+  let taranaZone: number | null | undefined;
+
+  if (method === 'feasibilityCheck') {
+    orderable = parseBoolean(output?.product_feasible);
+  } else {
+    const fwa = asRecord(output?.FWA);
+    taranaFeasible = parseBoolean(fwa?.Tarana_Feasible) ?? undefined;
+    taranaZone = parseNullableNumber(fwa?.Tarana_zone);
+    orderable = taranaFeasible ?? null;
+  }
+
+  return {
+    provider: 'mtn-csp',
+    productName: CSP_PRODUCT_NAME,
+    method,
+    capacityMbps,
+    orderable,
+    status: orderable === true ? 'orderable' : orderable === false ? 'not_orderable' : 'unknown',
+    ...(taranaFeasible !== undefined ? { taranaFeasible } : {}),
+    ...(taranaZone !== undefined ? { taranaZone } : {}),
+    checkedAt: new Date().toISOString(),
+    ...(responseTimeMs !== undefined ? { responseTimeMs } : {}),
+  };
+}
+
+export class MtnCspClient {
+  private readonly baseUrl: string;
+  private readonly username: string;
+  private readonly password: string;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(options: CspClientOptions = {}) {
+    this.baseUrl = stripTrailingSlash(
+      options.baseUrl || process.env.MTN_CSP_API_BASE || DEFAULT_CSP_API_BASE
+    );
+    this.username = options.username || process.env.MTN_CSP_USERNAME || '';
+    this.password = options.password || process.env.MTN_CSP_PASSWORD || '';
+    this.fetchImpl = options.fetchImpl || fetch;
+  }
+
+  async checkOrderability(params: {
+    latitude: number;
+    longitude: number;
+    capacityMbps: SkyFibreCapacityMbps;
+  }): Promise<CspOrderabilityResult> {
+    const startedAt = Date.now();
+
+    try {
+      const session = await this.getSession();
+      const method = selectCspFeasibilityMethod(params.capacityMbps);
+      const query = new URLSearchParams({
+        method,
+        latitude: String(params.latitude),
+        longitude: String(params.longitude),
+        capacity_mbps: String(params.capacityMbps),
+        product_name: CSP_PRODUCT_NAME,
+      });
+
+      const response = await this.fetchImpl(`${this.baseUrl}/feasibility.cfc?${query.toString()}`, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json, text/plain, */*',
+          Cookie: session.cookieHeader,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`CSP feasibility failed with status ${response.status}`);
+      }
+
+      const raw = await response.json();
+      return normalizeCspFeasibilityResponse(raw, params.capacityMbps, Date.now() - startedAt);
+    } catch (error) {
+      return {
+        provider: 'mtn-csp',
+        productName: CSP_PRODUCT_NAME,
+        method: selectCspFeasibilityMethod(params.capacityMbps),
+        capacityMbps: params.capacityMbps,
+        orderable: null,
+        status: 'error',
+        checkedAt: new Date().toISOString(),
+        responseTimeMs: Date.now() - startedAt,
+        error: error instanceof Error ? error.message : 'CSP orderability check failed',
+      };
+    }
+  }
+
+  private async getSession(): Promise<CspSession> {
+    const now = Date.now();
+    if (cachedSession && cachedSession.expiresAt > now) {
+      return cachedSession;
+    }
+
+    if (!this.username || !this.password) {
+      throw new Error('MTN CSP credentials are not configured');
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl}/login.cfc?method=login`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/plain, */*',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username: this.username,
+        password: this.password,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`CSP login failed with status ${response.status}`);
+    }
+
+    const cookieHeader = extractCookieHeader(response.headers);
+    if (!cookieHeader) {
+      throw new Error('CSP login did not return a session cookie');
+    }
+
+    cachedSession = {
+      cookieHeader,
+      expiresAt: now + SESSION_TTL_MS,
+    };
+
+    return cachedSession;
+  }
+}
+
+export const mtnCspClient = new MtnCspClient();
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function extractCookieHeader(headers: Headers): string {
+  const raw = headers.get('set-cookie');
+  if (!raw) return '';
+
+  return raw
+    .split(/,(?=[^;,]+=)/)
+    .map((cookie) => cookie.split(';')[0]?.trim())
+    .filter(Boolean)
+    .join('; ');
+}
+
+function firstOutput(raw: unknown): Record<string, unknown> | null {
+  const record = asRecord(raw);
+  const outputs = Array.isArray(record?.outputs) ? record.outputs : [];
+  return asRecord(outputs[0]);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function parseNullableNumber(value: unknown): number | null | undefined {
+  if (value === null) return null;
+  if (value === undefined) return undefined;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function parseBoolean(value: unknown): boolean | null {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value === 1 ? true : value === 0 ? false : null;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', 'yes', 'y', '1', 'feasible', 'available'].includes(normalized)) return true;
+    if (['false', 'no', 'n', '0', 'not feasible', 'unavailable'].includes(normalized)) return false;
+  }
+  return null;
+}

--- a/lib/coverage/skyfibre/index.ts
+++ b/lib/coverage/skyfibre/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './csp-client';
+export * from './orderability';

--- a/lib/coverage/skyfibre/orderability.ts
+++ b/lib/coverage/skyfibre/orderability.ts
@@ -1,0 +1,269 @@
+import { checkBaseStationProximity } from '@/lib/coverage/mtn/base-station-service';
+import type {
+  BaseStationCoverageConfidence,
+  BaseStationProximityResult,
+  Coordinates,
+} from '@/lib/coverage/types';
+import { validateCoordinates } from '@/lib/coverage/utils/validation';
+import { mtnCspClient } from './csp-client';
+import type {
+  CspOrderabilityResult,
+  SkyFibreCapacityMbps,
+  SkyFibreOrderabilityInput,
+  SkyFibreOrderabilityResult,
+  SkyFibreSegment,
+  TcsCoverageResult,
+} from './types';
+
+interface LeadRecord {
+  id: string;
+  address?: string | null;
+  customer_type?: string | null;
+  coordinates?: {
+    type?: string;
+    coordinates?: [number, number];
+    lat?: number;
+    lng?: number;
+  } | null;
+  coverage_results?: unknown;
+}
+
+interface SupabaseLike {
+  from: (table: string) => any;
+}
+
+export function buildTcsCoverageFromProximity(
+  proximity: BaseStationProximityResult
+): TcsCoverageResult {
+  const nearest = proximity.nearestStation;
+  const nearestBnOnline = nearest?.deviceStatus === 1;
+  const nearestBnActiveRnCount = nearest?.activeConnections ?? 0;
+  let confidence: BaseStationCoverageConfidence = proximity.confidence;
+  let covered = proximity.hasCoverage && nearestBnOnline && confidence !== 'none';
+  let reason = proximity.installationNote || 'Tarana coverage validated.';
+
+  if (!nearest) {
+    covered = false;
+    confidence = 'none';
+    reason = 'No active Tarana base station could be matched to this location.';
+  } else if (!nearestBnOnline) {
+    covered = false;
+    confidence = 'none';
+    reason = `Nearest base station ${nearest.siteName} is offline.`;
+  } else if (nearestBnActiveRnCount === 0 && confidence !== 'none') {
+    confidence = confidence === 'high' ? 'medium' : confidence;
+    reason = `${nearest.siteName} is active but has no active RN evidence, so coverage needs manual review.`;
+  } else {
+    reason = `${nearest.siteName} is active with ${nearestBnActiveRnCount} active RN connection(s).`;
+  }
+
+  return {
+    covered,
+    confidence,
+    nearestBnOnline,
+    nearestBnActiveRnCount,
+    reason,
+    nearestStation: nearest
+      ? {
+          siteName: nearest.siteName,
+          hostname: nearest.hostname,
+          distanceKm: nearest.distanceKm,
+          deviceStatus: nearest.deviceStatus,
+          activeConnections: nearest.activeConnections,
+        }
+      : null,
+  };
+}
+
+export function buildSkyFibreDecision(params: {
+  segment: SkyFibreSegment;
+  capacityMbps: SkyFibreCapacityMbps;
+  tcsCoverage: TcsCoverageResult;
+  cspOrderability?: CspOrderabilityResult;
+}): SkyFibreOrderabilityResult {
+  const { segment, capacityMbps, tcsCoverage, cspOrderability } = params;
+
+  let decision: SkyFibreOrderabilityResult['decision'];
+
+  if (!tcsCoverage.covered || tcsCoverage.confidence === 'none') {
+    decision = 'not_covered';
+  } else if (cspOrderability?.orderable === true) {
+    decision = 'orderable';
+  } else if (cspOrderability?.orderable === false) {
+    decision = 'covered_not_orderable';
+  } else if (
+    !cspOrderability ||
+    cspOrderability.status === 'unknown' ||
+    cspOrderability.status === 'error' ||
+    tcsCoverage.nearestBnActiveRnCount === 0 ||
+    tcsCoverage.confidence === 'low'
+  ) {
+    decision = 'manual_review';
+  } else {
+    decision = 'manual_review';
+  }
+
+  return {
+    decision,
+    segment,
+    capacityMbps,
+    tcsCoverage,
+    ...(cspOrderability ? { cspOrderability } : {}),
+  };
+}
+
+export async function checkSkyFibreOrderability(
+  input: SkyFibreOrderabilityInput,
+  deps: {
+    supabase?: SupabaseLike;
+    cspClient?: typeof mtnCspClient;
+  } = {}
+): Promise<SkyFibreOrderabilityResult> {
+  const lead = input.leadId && deps.supabase
+    ? await loadLead(deps.supabase, input.leadId)
+    : null;
+
+  const coordinates = getCoordinates(input, lead);
+  const segment = input.segment || segmentFromLead(lead);
+  const coordinateValidation = validateCoordinates(coordinates);
+
+  if (!coordinateValidation.valid) {
+    return buildSkyFibreDecision({
+      segment,
+      capacityMbps: input.capacityMbps,
+      tcsCoverage: {
+        covered: false,
+        confidence: 'none',
+        nearestBnOnline: false,
+        nearestBnActiveRnCount: 0,
+        reason: coordinateValidation.error || 'Invalid coordinates.',
+        nearestStation: null,
+      },
+    });
+  }
+
+  const proximity = await checkBaseStationProximity(coordinates, {
+    limit: 3,
+    includeTerrainPrediction: true,
+  });
+  const tcsCoverage = buildTcsCoverageFromProximity(proximity);
+
+  if (!tcsCoverage.covered || tcsCoverage.confidence === 'none') {
+    return buildSkyFibreDecision({
+      segment,
+      capacityMbps: input.capacityMbps,
+      tcsCoverage,
+    });
+  }
+
+  const cspOrderability = await (deps.cspClient || mtnCspClient).checkOrderability({
+    latitude: coordinates.lat,
+    longitude: coordinates.lng,
+    capacityMbps: input.capacityMbps,
+  });
+
+  return buildSkyFibreDecision({
+    segment,
+    capacityMbps: input.capacityMbps,
+    tcsCoverage,
+    cspOrderability,
+  });
+}
+
+export function isValidSkyFibreCapacity(value: unknown): value is SkyFibreCapacityMbps {
+  return value === 50 || value === 100 || value === 200;
+}
+
+export function isSkyFibrePackage(input: {
+  package_name?: unknown;
+  service_type?: unknown;
+  product_category?: unknown;
+}): boolean {
+  return (
+    hasSkyFibreSignal(input.package_name) ||
+    hasSkyFibreSignal(input.service_type) ||
+    hasSkyFibreSignal(input.product_category)
+  );
+}
+
+export function extractSkyFibreCapacity(input: {
+  capacityMbps?: unknown;
+  package_speed?: unknown;
+  speed_down?: unknown;
+  package_name?: unknown;
+}): SkyFibreCapacityMbps | null {
+  if (isValidSkyFibreCapacity(input.capacityMbps)) return input.capacityMbps;
+  if (isValidSkyFibreCapacity(input.speed_down)) return input.speed_down;
+
+  const text = `${input.package_speed || ''} ${input.package_name || ''}`;
+  const match = text.match(/\b(50|100|200)\b/);
+  if (!match) return null;
+
+  const parsed = Number(match[1]);
+  return isValidSkyFibreCapacity(parsed) ? parsed : null;
+}
+
+export function redactSkyFibreOrderability(
+  result: SkyFibreOrderabilityResult
+): SkyFibreOrderabilityResult {
+  return {
+    ...result,
+    cspOrderability: result.cspOrderability
+      ? {
+          ...result.cspOrderability,
+          error: result.cspOrderability.error ? 'CSP orderability check failed' : undefined,
+        }
+      : undefined,
+  };
+}
+
+async function loadLead(supabase: SupabaseLike, leadId: string): Promise<LeadRecord> {
+  const { data, error } = await supabase
+    .from('coverage_leads')
+    .select('id, address, customer_type, coordinates, coverage_results')
+    .eq('id', leadId)
+    .single();
+
+  if (error || !data) {
+    throw new Error('Coverage lead not found');
+  }
+
+  return data as LeadRecord;
+}
+
+function getCoordinates(input: SkyFibreOrderabilityInput, lead: LeadRecord | null): Coordinates {
+  if (typeof input.latitude === 'number' && typeof input.longitude === 'number') {
+    return { lat: input.latitude, lng: input.longitude };
+  }
+
+  const leadCoordinates = lead?.coordinates;
+  if (leadCoordinates?.type === 'Point' && Array.isArray(leadCoordinates.coordinates)) {
+    return {
+      lat: leadCoordinates.coordinates[1],
+      lng: leadCoordinates.coordinates[0],
+    };
+  }
+
+  if (
+    typeof leadCoordinates?.lat === 'number' &&
+    typeof leadCoordinates?.lng === 'number'
+  ) {
+    return {
+      lat: leadCoordinates.lat,
+      lng: leadCoordinates.lng,
+    };
+  }
+
+  return { lat: Number.NaN, lng: Number.NaN };
+}
+
+function segmentFromLead(lead: LeadRecord | null): SkyFibreSegment {
+  const customerType = lead?.customer_type;
+  return customerType === 'smme' || customerType === 'enterprise' ? 'business' : 'residential';
+}
+
+function hasSkyFibreSignal(value: unknown): boolean {
+  const normalized = String(value || '').toLowerCase();
+  const compact = normalized.replace(/[^a-z0-9]/g, '');
+  return compact.includes('skyfibre') || normalized.includes('tarana');
+}

--- a/lib/coverage/skyfibre/types.ts
+++ b/lib/coverage/skyfibre/types.ts
@@ -1,0 +1,57 @@
+import type { BaseStationCoverageConfidence } from '@/lib/coverage/types';
+
+export type SkyFibreSegment = 'residential' | 'business';
+export type SkyFibreCapacityMbps = 50 | 100 | 200;
+export type CspFeasibilityMethod = 'feasibilityOld' | 'feasibilityCheck';
+export type CspOrderabilityStatus = 'orderable' | 'not_orderable' | 'unknown' | 'error';
+export type SkyFibreOrderabilityDecision =
+  | 'orderable'
+  | 'covered_not_orderable'
+  | 'manual_review'
+  | 'not_covered'
+  | 'error';
+
+export interface CspOrderabilityResult {
+  provider: 'mtn-csp';
+  productName: 'Fixed Wireless Broadband';
+  method: CspFeasibilityMethod;
+  capacityMbps: SkyFibreCapacityMbps;
+  orderable: boolean | null;
+  status: CspOrderabilityStatus;
+  taranaFeasible?: boolean;
+  taranaZone?: number | null;
+  checkedAt: string;
+  responseTimeMs?: number;
+  error?: string;
+}
+
+export interface TcsCoverageResult {
+  covered: boolean;
+  confidence: BaseStationCoverageConfidence;
+  nearestBnOnline: boolean;
+  nearestBnActiveRnCount: number;
+  reason: string;
+  nearestStation?: {
+    siteName: string;
+    hostname: string;
+    distanceKm: number;
+    deviceStatus: number;
+    activeConnections: number;
+  } | null;
+}
+
+export interface SkyFibreOrderabilityResult {
+  decision: SkyFibreOrderabilityDecision;
+  segment: SkyFibreSegment;
+  capacityMbps: SkyFibreCapacityMbps;
+  tcsCoverage: TcsCoverageResult;
+  cspOrderability?: CspOrderabilityResult;
+}
+
+export interface SkyFibreOrderabilityInput {
+  leadId?: string;
+  latitude?: number;
+  longitude?: number;
+  capacityMbps: SkyFibreCapacityMbps;
+  segment?: SkyFibreSegment;
+}


### PR DESCRIPTION
## What
Adds MTN's **CSP order-feasibility gate** for SkyFibre (Fixed Wireless Broadband) to the admin coverage checker and the order-creation flow — confirming a SkyFibre order is actually *orderable*, not merely *covered*.

## Why
Split out of the local-only branch `feat/edit-clinic-contact` (now preserved on origin as `feat/skyfibre-csp-and-miro-sync`). This is the **SkyFibre CSP half**; MiRO pricing-sync ships separately in #560.

## Changes
- `lib/coverage/skyfibre/` — `csp-client.ts` (MTN `newcsp_api`), `orderability.ts` engine, `types.ts`, `admin-ui.ts`
- `SkyFibreOrderabilityCard` + sales-decision banner on the **Tarana** tab — auto-runs the combined TCS + MTN CSP gate. Coexists with the MTN LTE/5G tab from #559.
- New `POST /api/coverage/skyfibre/orderability`
- ⚠️ **Order-flow change:** `app/api/orders/create/route.ts` now **blocks** a SkyFibre order when the combined orderability decision ≠ `orderable`; `app/order/checkout/page.tsx` wires the result
- `base-station-service` hydrates BN `device_status` before the gate

## Conflict resolution
The only conflict was `app/admin/coverage/checker/page.tsx` (also edited by the now-merged MTN tab #559). Resolved as a **union** — both the MTN LTE/5G provider path and the SkyFibre orderability path coexist. MiRO files reverted to `main` so this PR is CSP-only.

## Verification
- `type-check:memory` clean for all CSP/coverage files (incl. the hand-merged page.tsx).
- **21 SkyFibre tests pass** (csp-client, orderability, the orders-create gate, the orderability route, base-station hydration).
- ⏳ Pending: staging deploy + manual verification of the order-blocking gate before merge (payment-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)