### PR TITLE
docs(spec): mark admin manual document upload as Implemented (PR #563, live)

### DIFF
--- a/docs/superpowers/specs/2026-06-18-admin-manual-document-upload-design.md
+++ b/docs/superpowers/specs/2026-06-18-admin-manual-document-upload-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-18
 **Surfaces:** `/admin/unjani/onboarding` (clinic drawer) and `/admin/b2b/vetting/[submissionId]` (vetting detail)
-**Status:** Approved design — pending implementation plan
+**Status:** Implemented (PR #563, live)
 
 ## Problem
 


### PR DESCRIPTION
One-line status fix — the design spec still read "Approved design — pending implementation plan" but the feature shipped via #563 and is live in production. Docs-only (prod deploy ignores `docs/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)