### PR TITLE
feat(vetting): document workbench refactor — live preview, blocking mismatch gate, trimmed inspector

### DIFF
--- a/app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts
+++ b/app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildAutomatedChecks,
   buildDocumentDrawerSummary,
   buildDocumentMetadataDraft,
   buildVettingSummaryItems,
@@ -27,6 +28,59 @@ describe('buildDocumentMetadataDraft', () => {
       access: 'KYC reviewers only',
       fileType: 'PDF',
     });
+  });
+});
+
+describe('buildAutomatedChecks', () => {
+  const base = {
+    nameMatch: true,
+    mismatchAcknowledged: false,
+    regNumber: '2023/547010/10',
+    hasSelectedDocument: true,
+    submittedAt: '2026-06-18T10:00:00.000Z',
+    slaDays: 2,
+    now: Date.parse('2026-06-18T12:00:00.000Z'),
+  };
+
+  it('passes holder check when names match', () => {
+    const holder = buildAutomatedChecks(base).find((c) => c.key === 'holderMatch')!;
+    expect(holder.pass).toBe(true);
+    expect(holder.note).toBe('Match');
+  });
+
+  it('fails holder check on mismatch, passes once acknowledged', () => {
+    const mismatch = buildAutomatedChecks({ ...base, nameMatch: false });
+    const h1 = mismatch.find((c) => c.key === 'holderMatch')!;
+    expect(h1.pass).toBe(false);
+    expect(h1.note).toBe('Names differ');
+
+    const ack = buildAutomatedChecks({ ...base, nameMatch: false, mismatchAcknowledged: true });
+    const h2 = ack.find((c) => c.key === 'holderMatch')!;
+    expect(h2.pass).toBe(true);
+    expect(h2.note).toBe('Overridden by reviewer');
+  });
+
+  it('fails registration check when reg number missing', () => {
+    const checks = buildAutomatedChecks({ ...base, regNumber: '' });
+    expect(checks.find((c) => c.key === 'regNumber')!.pass).toBe(false);
+  });
+
+  it('fails document-ready check when no document selected', () => {
+    const checks = buildAutomatedChecks({ ...base, hasSelectedDocument: false });
+    expect(checks.find((c) => c.key === 'documentReady')!.pass).toBe(false);
+  });
+
+  it('passes SLA check within window and fails when overdue', () => {
+    const withinSla = buildAutomatedChecks(base).find((c) => c.key === 'withinSla')!;
+    expect(withinSla.pass).toBe(true);
+    expect(withinSla.note).toBe('0 days overdue');
+
+    const overdue = buildAutomatedChecks({
+      ...base,
+      submittedAt: '2026-06-10T10:00:00.000Z', // 8 days before `now`
+    }).find((c) => c.key === 'withinSla')!;
+    expect(overdue.pass).toBe(false);
+    expect(overdue.note).toBe('6 days overdue');
   });
 });
 

--- a/app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts
+++ b/app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts
@@ -1,35 +1,8 @@
 import {
   buildAutomatedChecks,
   buildDocumentDrawerSummary,
-  buildDocumentMetadataDraft,
   buildVettingSummaryItems,
 } from '../workbench-utils';
-
-describe('buildDocumentMetadataDraft', () => {
-  it('derives a reviewer-friendly metadata draft from the selected document', () => {
-    const draft = buildDocumentMetadataDraft(
-      'Bank confirmation letter or statement',
-      {
-        id: 'doc-1',
-        document_type: 'bank_statement',
-        file_path: 'kyc/customer/bank-confirmation.pdf',
-        verification_status: 'pending',
-        rejection_reason: null,
-        verified_at: null,
-      },
-      'https://signed.example.com/bank-confirmation.pdf',
-      true
-    );
-
-    expect(draft).toEqual({
-      title: 'Bank confirmation letter or statement',
-      description: 'Review bank_statement for KYC/KYB approval.',
-      tags: ['bank_statement', 'pending', 'pdf'],
-      access: 'KYC reviewers only',
-      fileType: 'PDF',
-    });
-  });
-});
 
 describe('buildAutomatedChecks', () => {
   const base = {

--- a/app/admin/b2b/vetting/[submissionId]/page.tsx
+++ b/app/admin/b2b/vetting/[submissionId]/page.tsx
@@ -11,17 +11,11 @@ import {
   PiCheckBold,
   PiCheckCircleBold,
   PiClipboardTextBold,
-  PiClockCounterClockwiseBold,
   PiFileTextBold,
-  PiFloppyDiskBold,
   PiInfoBold,
   PiLockBold,
-  PiMagnifyingGlassBold,
   PiMinusBold,
-  PiPencilSimpleBold,
   PiPlusBold,
-  PiSignatureBold,
-  PiTagBold,
   PiWarningCircleBold,
   PiXBold,
   PiXCircleBold,
@@ -44,15 +38,15 @@ import {
 import { requiredDocsFor, type DocRequirement } from '@/lib/onboarding/document-requirements';
 import { cn } from '@/lib/utils';
 import {
+  buildAutomatedChecks,
   buildDocumentDrawerSummary,
-  buildDocumentMetadataDraft,
   buildVettingSummaryItems,
   formatDateTime,
   formatStatusLabel,
   isImageDocument,
   isPdfDocument,
+  type AutomatedCheck,
   type DocumentDrawerSummary,
-  type DocumentMetadataDraft,
   type VettingSummaryItem,
 } from './workbench-utils';
 
@@ -126,16 +120,6 @@ interface RequiredDocItem {
 }
 
 type DocumentActionStatus = 'approved' | 'rejected' | 'under_review';
-type InspectorTab = 'approval' | 'metadata' | 'comments' | 'versions' | 'access';
-
-interface WorkbenchComment {
-  id: string;
-  documentId: string;
-  author: string;
-  body: string;
-  createdAt: string;
-  tone: 'info' | 'warning';
-}
 
 function vettingStatusVariant(status: string): 'success' | 'warning' | 'error' | 'info' | 'neutral' {
   switch (status) {
@@ -209,23 +193,23 @@ export default function B2BVettingDetailPage({
   const [changeRequestOpen, setChangeRequestOpen] = useState(false);
   const [reviewReasonText, setReviewReasonText] = useState<string>('');
   const [reviewReasonError, setReviewReasonError] = useState<string | null>(null);
-  const [inspectorTab, setInspectorTab] = useState<InspectorTab>('approval');
   const [zoom, setZoom] = useState(100);
   const [rotation, setRotation] = useState(0);
-  const [metadataDraft, setMetadataDraft] = useState<DocumentMetadataDraft | null>(null);
-  const [metadataSavedAt, setMetadataSavedAt] = useState<string | null>(null);
-  const [commentText, setCommentText] = useState('');
-  const [comments, setComments] = useState<WorkbenchComment[]>([]);
   const [actionError, setActionError] = useState<string | null>(null);
   const [mandateConfirming, setMandateConfirming] = useState(false);
   const [documentDrawerOpen, setDocumentDrawerOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
+  const [mismatchAck, setMismatchAck] = useState(false);
 
   useEffect(() => {
     params.then((p) => {
       setSubmissionId(p.submissionId);
     });
   }, [params]);
+
+  useEffect(() => {
+    setMismatchAck(false);
+  }, [submissionId]);
 
   const fetchSubmission = useCallback(async (options?: { showLoading?: boolean }) => {
     if (!submissionId) return;
@@ -312,30 +296,12 @@ export default function B2BVettingDetailPage({
   }, [requiredDocItems]);
 
   useEffect(() => {
-    if (!selectedDocument) {
-      setMetadataDraft(null);
-      setMetadataSavedAt(null);
-      setCommentText('');
-      setZoom(100);
-      setRotation(0);
-      setDocumentDrawerOpen(false);
-      return;
-    }
-
-    const selectedIsPdf = isPdfDocument(selectedDocument.file_path, docUrl);
-    setMetadataDraft(
-      buildDocumentMetadataDraft(
-        selectedRequirement?.label ?? null,
-        selectedDocument,
-        docUrl,
-        selectedIsPdf
-      )
-    );
-    setMetadataSavedAt(null);
-    setCommentText('');
     setZoom(100);
     setRotation(0);
-  }, [docUrl, selectedDocument, selectedRequirement?.label]);
+    if (!selectedDocument) {
+      setDocumentDrawerOpen(false);
+    }
+  }, [selectedDocument]);
 
   useEffect(() => {
     if (!submission) return;
@@ -528,6 +494,7 @@ export default function B2BVettingDetailPage({
   const selectedActionPrefix = selectedDocument?.id ?? '';
   const decisionDisabled =
     !selectedDocument || docLoading || Boolean(docError) || actionInFlight?.startsWith(selectedActionPrefix);
+  const approveBlocked = Boolean(submission && !submission.nameMatch && !mismatchAck);
   const selectedIsPdf = isPdfDocument(selectedDocument?.file_path, docUrl);
   const selectedIsImage = isImageDocument(selectedDocument?.file_path, docUrl);
   const primaryPaymentMethod = submission.paymentMethods[0];
@@ -540,25 +507,13 @@ export default function B2BVettingDetailPage({
     changesRequested: docCounts.changesRequested,
     lastReviewedAt: submission.admin_reviewed_at,
   });
-  const activeComments = selectedDocument
-    ? comments.filter((comment) => comment.documentId === selectedDocument.id)
-    : [];
-  const drawerSummary =
-    selectedDocument && metadataDraft
-      ? buildDocumentDrawerSummary({
-          requirementLabel: selectedRequirement?.label ?? null,
-          documentType: selectedDocument.document_type,
-          fileType: metadataDraft.fileType,
-        })
-      : null;
-  const openSelectedDocumentDrawer = () => {
-    if (!selectedDocument) return;
-    setDocumentDrawerOpen(true);
-  };
-  const updateMetadataDraft = (updates: Partial<DocumentMetadataDraft>) => {
-    setMetadataDraft((current) => (current ? { ...current, ...updates } : current));
-    setMetadataSavedAt(new Date().toISOString());
-  };
+  const drawerSummary = selectedDocument
+    ? buildDocumentDrawerSummary({
+        requirementLabel: selectedRequirement?.label ?? null,
+        documentType: selectedDocument.document_type,
+        fileType: selectedIsPdf ? 'PDF' : selectedIsImage ? 'Image' : 'Document',
+      })
+    : null;
 
   return (
     <>
@@ -648,7 +603,6 @@ export default function B2BVettingDetailPage({
                     onClick={() => {
                       if (!document) return;
                       setSelectedDoc(document.id);
-                      setInspectorTab('approval');
                       setChangeRequestOpen(false);
                       setReviewReasonText('');
                       setReviewReasonError(null);
@@ -756,49 +710,8 @@ export default function B2BVettingDetailPage({
 
         <aside className="flex min-h-0 flex-col border-t border-gray-200 bg-white xl:border-l xl:border-t-0">
           <div className="shrink-0 border-b border-gray-200 p-4">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <h2 className="text-sm font-semibold text-gray-900">Document inspector</h2>
-                <p className="mt-1 text-xs text-gray-500">Decision tools and review context</p>
-              </div>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => metadataDraft && setMetadataSavedAt(new Date().toISOString())}
-                disabled={!metadataDraft}
-                className="gap-1"
-              >
-                <PiFloppyDiskBold className="h-4 w-4" />
-                Save
-              </Button>
-            </div>
-            <div className="mt-3 grid grid-cols-3 gap-1 rounded-lg bg-gray-100 p-1">
-              <InspectorTabButton
-                active={inspectorTab === 'approval'}
-                label="Approval"
-                onClick={() => setInspectorTab('approval')}
-              />
-              <InspectorTabButton
-                active={inspectorTab === 'metadata'}
-                label="Metadata"
-                onClick={() => setInspectorTab('metadata')}
-              />
-              <InspectorTabButton
-                active={inspectorTab === 'comments'}
-                label={activeComments.length ? `Notes (${activeComments.length})` : 'Notes'}
-                onClick={() => setInspectorTab('comments')}
-              />
-              <InspectorTabButton
-                active={inspectorTab === 'versions'}
-                label="Versions"
-                onClick={() => setInspectorTab('versions')}
-              />
-              <InspectorTabButton
-                active={inspectorTab === 'access'}
-                label="Access"
-                onClick={() => setInspectorTab('access')}
-              />
-            </div>
+            <h2 className="text-sm font-semibold text-gray-900">Document inspector</h2>
+            <p className="mt-1 text-xs text-gray-500">Decision tools and review context</p>
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
@@ -810,9 +723,75 @@ export default function B2BVettingDetailPage({
               />
             )}
 
-            {selectedDocument && inspectorTab === 'approval' && (
+            {selectedDocument && (
               <div className="space-y-4">
-                <InspectorSection title="Workflow">
+                {!submission.nameMatch && (
+                  <section
+                    className={cn(
+                      'rounded-lg border p-4',
+                      mismatchAck ? 'border-gray-200 bg-gray-50' : 'border-red-200 bg-red-50'
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      {mismatchAck ? (
+                        <PiCheckCircleBold className="h-4 w-4 text-amber-600" />
+                      ) : (
+                        <PiWarningCircleBold className="h-4 w-4 text-red-600" />
+                      )}
+                      <span
+                        className={cn(
+                          'text-sm font-semibold',
+                          mismatchAck ? 'text-amber-700' : 'text-red-700'
+                        )}
+                      >
+                        {mismatchAck ? 'Mismatch acknowledged' : 'Entity name mismatch'}
+                      </span>
+                    </div>
+                    <div className="mt-3 space-y-2">
+                      <div className="rounded-md border border-gray-200 bg-white px-3 py-2">
+                        <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+                          Registered entity
+                        </p>
+                        <p className="mt-0.5 font-mono text-sm text-gray-900">
+                          {step2?.entityName || '-'}
+                        </p>
+                      </div>
+                      <div
+                        className={cn(
+                          'rounded-md border bg-white px-3 py-2',
+                          mismatchAck ? 'border-gray-200' : 'border-red-200'
+                        )}
+                      >
+                        <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+                          Account holder on file
+                        </p>
+                        <p
+                          className={cn(
+                            'mt-0.5 font-mono text-sm',
+                            mismatchAck ? 'text-gray-700' : 'text-red-700'
+                          )}
+                        >
+                          {primaryBanking.account_holder_name || '-'}
+                        </p>
+                      </div>
+                    </div>
+                    {mismatchAck ? (
+                      <p className="mt-3 text-xs text-gray-500">
+                        Override recorded against your reviewer ID. Approval is now permitted.
+                      </p>
+                    ) : (
+                      <Button
+                        size="sm"
+                        onClick={() => setMismatchAck(true)}
+                        className="mt-3 w-full bg-red-600 text-white hover:bg-red-700"
+                      >
+                        Acknowledge &amp; override
+                      </Button>
+                    )}
+                  </section>
+                )}
+
+                <InspectorSection title="Decision">
                   <div className="flex items-center justify-between gap-3">
                     <span className="text-sm text-gray-600">Document status</span>
                     {selectedStatus && (
@@ -829,13 +808,19 @@ export default function B2BVettingDetailPage({
                         size="sm"
                         variant="outline"
                         onClick={() => handleDocumentAction(selectedDocument.id, 'approved')}
-                        disabled={decisionDisabled}
-                        className="justify-start gap-1 border-green-200 text-green-700 hover:bg-green-50 hover:text-green-800"
+                        disabled={decisionDisabled || approveBlocked}
+                        className="justify-start gap-1 border-green-200 text-green-700 hover:bg-green-50 hover:text-green-800 disabled:opacity-60"
                       >
-                        <PiCheckBold className="h-4 w-4" />
-                        {actionInFlight === `${selectedDocument.id}-approved`
-                          ? 'Approving…'
-                          : 'Approve Document'}
+                        {approveBlocked ? (
+                          <PiLockBold className="h-4 w-4" />
+                        ) : (
+                          <PiCheckBold className="h-4 w-4" />
+                        )}
+                        {approveBlocked
+                          ? 'Resolve the flag first'
+                          : actionInFlight === `${selectedDocument.id}-approved`
+                            ? 'Approving…'
+                            : 'Approve Document'}
                       </Button>
                     )}
                     {!selectedIsRejected && (
@@ -937,6 +922,24 @@ export default function B2BVettingDetailPage({
                   )}
                 </InspectorSection>
 
+                <InspectorSection title="Automated checks">
+                  <div>
+                    {buildAutomatedChecks({
+                      nameMatch: submission.nameMatch,
+                      mismatchAcknowledged: mismatchAck,
+                      regNumber: step2?.regNumber,
+                      hasSelectedDocument: Boolean(selectedDocument),
+                      submittedAt: submission.submitted_at,
+                    }).map((check, index, all) => (
+                      <AutomatedCheckRow
+                        key={check.key}
+                        check={check}
+                        last={index === all.length - 1}
+                      />
+                    ))}
+                  </div>
+                </InspectorSection>
+
                 <InspectorSection title="Comparison context">
                   {submission.submission_data?.manual ? (
                     <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 mb-4">
@@ -954,170 +957,6 @@ export default function B2BVettingDetailPage({
                         Account holder should match the registered entity name.
                       </div>
                     )}
-                  </div>
-                </InspectorSection>
-              </div>
-            )}
-
-            {selectedDocument && inspectorTab === 'metadata' && metadataDraft && (
-              <div className="space-y-4">
-                <InspectorSection title="Metadata">
-                  <DraftNotice text="Metadata edits are browser drafts in this staging pass." />
-                  <MetadataField label="Title">
-                    <input
-                      value={metadataDraft.title}
-                      onChange={(event) => updateMetadataDraft({ title: event.target.value })}
-                      className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-circleTel-orange/20"
-                    />
-                  </MetadataField>
-                  <MetadataField label="Description">
-                    <textarea
-                      value={metadataDraft.description}
-                      onChange={(event) => updateMetadataDraft({ description: event.target.value })}
-                      rows={4}
-                      className="w-full resize-y rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-circleTel-orange/20"
-                    />
-                  </MetadataField>
-                  <MetadataField label="Tags">
-                    <input
-                      value={metadataDraft.tags.join(', ')}
-                      onChange={(event) =>
-                        updateMetadataDraft({
-                          tags: event.target.value
-                            .split(',')
-                            .map((tag) => tag.trim())
-                            .filter(Boolean),
-                        })
-                      }
-                      className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-circleTel-orange/20"
-                    />
-                  </MetadataField>
-                  <MetadataField label="Access">
-                    <select
-                      value={metadataDraft.access}
-                      onChange={(event) => updateMetadataDraft({ access: event.target.value })}
-                      className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-circleTel-orange/20"
-                    >
-                      <option>KYC reviewers only</option>
-                      <option>Admin operations</option>
-                      <option>Read-only finance</option>
-                    </select>
-                  </MetadataField>
-                  <div className="flex flex-wrap gap-2">
-                    {metadataDraft.tags.map((tag) => (
-                      <span key={tag} className="rounded-full bg-circleTel-orange-light px-2.5 py-1 text-xs font-semibold text-circleTel-orange">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                  <p className="text-xs text-gray-500">
-                    Draft auto-save: {metadataSavedAt ? formatDateTime(metadataSavedAt) : 'Waiting for edits'}
-                  </p>
-                </InspectorSection>
-              </div>
-            )}
-
-            {selectedDocument && inspectorTab === 'comments' && (
-              <div className="space-y-4">
-                <InspectorSection title="Comments">
-                  <DraftNotice text="New notes are local browser drafts until collaboration persistence is added." />
-                  <div className="space-y-3">
-                    {selectedDocument.rejection_reason && (
-                      <CommentBubble
-                        author="System feedback"
-                        body={selectedDocument.rejection_reason}
-                        meta="Current change request"
-                        tone="warning"
-                      />
-                    )}
-                    {activeComments.map((comment) => (
-                      <CommentBubble
-                        key={comment.id}
-                        author={comment.author}
-                        body={comment.body}
-                        meta={formatDateTime(comment.createdAt)}
-                        tone={comment.tone}
-                      />
-                    ))}
-                    {!selectedDocument.rejection_reason && activeComments.length === 0 && (
-                      <p className="rounded-lg border border-dashed border-gray-200 p-4 text-sm text-gray-500">
-                        No reviewer comments yet.
-                      </p>
-                    )}
-                  </div>
-                  <div className="mt-4 flex gap-2">
-                    <input
-                      value={commentText}
-                      onChange={(event) => setCommentText(event.target.value)}
-                      placeholder="Add comment…"
-                      className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-circleTel-orange/20"
-                    />
-                    <Button
-                      size="sm"
-                      onClick={() => {
-                        const body = commentText.trim();
-                        if (!body || !selectedDocument) return;
-                        setComments((current) => [
-                          {
-                            id: `${selectedDocument.id}-${Date.now()}`,
-                            documentId: selectedDocument.id,
-                            author: 'Admin reviewer',
-                            body,
-                            createdAt: new Date().toISOString(),
-                            tone: 'info',
-                          },
-                          ...current,
-                        ]);
-                        setCommentText('');
-                      }}
-                      disabled={!commentText.trim()}
-                    >
-                      Add
-                    </Button>
-                  </div>
-                </InspectorSection>
-              </div>
-            )}
-
-            {selectedDocument && inspectorTab === 'versions' && (
-              <div className="space-y-4">
-                <InspectorSection title="Version history">
-                  <DraftNotice text="Version rows summarize current review activity; full version history is a backend follow-up." />
-                  <VersionRow
-                    icon={<PiFileTextBold className="h-4 w-4" />}
-                    title="Document uploaded"
-                    meta={formatDateTime(submission.submitted_at)}
-                  />
-                  <VersionRow
-                    icon={<PiClipboardTextBold className="h-4 w-4" />}
-                    title={`Status set to ${formatStatusLabel(selectedDocument.verification_status)}`}
-                    meta={formatDateTime(selectedDocument.verified_at)}
-                  />
-                  <VersionRow
-                    icon={<PiClockCounterClockwiseBold className="h-4 w-4" />}
-                    title="Metadata draft"
-                    meta={metadataSavedAt ? `Saved ${formatDateTime(metadataSavedAt)}` : 'No browser draft edits'}
-                  />
-                </InspectorSection>
-              </div>
-            )}
-
-            {selectedDocument && inspectorTab === 'access' && metadataDraft && (
-              <div className="space-y-4">
-                <InspectorSection title="Permission-based editing">
-                  <DraftNotice text="Access labels are review guidance only; persisted permissions are unchanged." />
-                  <div className="space-y-3">
-                    <div className="flex items-start gap-3 rounded-lg border border-gray-200 p-3">
-                      <PiLockBold className="mt-0.5 h-4 w-4 text-circleTel-orange" />
-                      <div>
-                        <p className="text-sm font-semibold text-gray-900">{metadataDraft.access}</p>
-                        <p className="mt-1 text-xs text-gray-500">Approval actions require the kyc:verify permission.</p>
-                      </div>
-                    </div>
-                    <PermissionRow label="View document" value="Admin operations, KYC reviewers" />
-                    <PermissionRow label="Edit metadata" value={metadataDraft.access} />
-                    <PermissionRow label="Approve or request changes" value="KYC reviewers" />
-                    <PermissionRow label="Open original" value="Signed URL access" />
                   </div>
                 </InspectorSection>
               </div>
@@ -1215,6 +1054,31 @@ function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
   );
 }
 
+function AutomatedCheckRow({ check, last }: { check: AutomatedCheck; last: boolean }) {
+  return (
+    <div className={cn('flex gap-2.5 py-2', !last && 'border-b border-gray-100')}>
+      <div
+        className={cn(
+          'mt-0.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full',
+          check.pass ? 'bg-green-100' : 'bg-red-100'
+        )}
+      >
+        {check.pass ? (
+          <PiCheckBold className="h-3 w-3 text-green-700" />
+        ) : (
+          <PiXBold className="h-3 w-3 text-red-700" />
+        )}
+      </div>
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-900">{check.label}</p>
+        <p className={cn('mt-0.5 text-xs', check.pass ? 'text-gray-500' : 'text-red-600')}>
+          {check.note}
+        </p>
+      </div>
+    </div>
+  );
+}
+
 function SummaryItem({ item }: { item: VettingSummaryItem }) {
   return (
     <div className="flex items-center justify-between gap-3 border-b border-r border-gray-100 px-4 py-3 last:border-r-0 lg:border-b-0">
@@ -1237,18 +1101,6 @@ function SummaryItem({ item }: { item: VettingSummaryItem }) {
     </div>
   );
 }
-
-function DocumentFact({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2">
-      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-        {label}
-      </p>
-      <div className="mt-1 truncate text-sm font-semibold text-gray-900">{value}</div>
-    </div>
-  );
-}
-
 function DocumentViewer({
   title,
   selectedDocument,
@@ -1448,38 +1300,6 @@ function DocumentViewer({
     </div>
   );
 }
-
-function DraftNotice({ text }: { text: string }) {
-  return (
-    <div className="mb-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800">
-      {text}
-    </div>
-  );
-}
-
-function InspectorTabButton({
-  active,
-  label,
-  onClick,
-}: {
-  active: boolean;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        'rounded-md px-2 py-1.5 text-xs font-semibold transition-colors',
-        active ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-900'
-      )}
-    >
-      {label}
-    </button>
-  );
-}
-
 function InspectorSection({
   title,
   children,
@@ -1492,82 +1312,5 @@ function InspectorSection({
       <h3 className="mb-3 text-sm font-semibold text-gray-900">{title}</h3>
       {children}
     </section>
-  );
-}
-
-function MetadataField({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <label className="mb-3 block">
-      <span className="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-gray-500">
-        {label}
-      </span>
-      {children}
-    </label>
-  );
-}
-
-function CommentBubble({
-  author,
-  body,
-  meta,
-  tone,
-}: {
-  author: string;
-  body: string;
-  meta: string;
-  tone: 'info' | 'warning';
-}) {
-  return (
-    <div
-      className={cn(
-        'rounded-lg border p-3',
-        tone === 'warning'
-          ? 'border-amber-200 bg-amber-50'
-          : 'border-green-100 bg-green-50'
-      )}
-    >
-      <div className="flex items-center justify-between gap-2">
-        <p className="text-sm font-semibold text-gray-900">{author}</p>
-        <span className="text-xs text-gray-500">{meta}</span>
-      </div>
-      <p className="mt-2 text-sm text-gray-700">{body}</p>
-    </div>
-  );
-}
-
-function VersionRow({
-  icon,
-  title,
-  meta,
-}: {
-  icon: React.ReactNode;
-  title: string;
-  meta: string;
-}) {
-  return (
-    <div className="flex gap-3 border-l-2 border-gray-200 pb-4 pl-3 last:pb-0">
-      <div className="-ml-[23px] flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 bg-white text-circleTel-orange">
-        {icon}
-      </div>
-      <div>
-        <p className="text-sm font-semibold text-gray-900">{title}</p>
-        <p className="mt-1 text-xs text-gray-500">{meta}</p>
-      </div>
-    </div>
-  );
-}
-
-function PermissionRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex items-start justify-between gap-3 border-t border-gray-100 pt-3 text-sm first:border-t-0 first:pt-0">
-      <span className="text-gray-500">{label}</span>
-      <span className="max-w-[190px] text-right font-semibold text-gray-900">{value}</span>
-    </div>
   );
 }

--- a/app/admin/b2b/vetting/[submissionId]/page.tsx
+++ b/app/admin/b2b/vetting/[submissionId]/page.tsx
@@ -7,6 +7,7 @@ import {
   PiArrowLeftBold,
   PiArrowSquareOutBold,
   PiArrowsClockwiseBold,
+  PiArrowsOutBold,
   PiCheckBold,
   PiCheckCircleBold,
   PiClipboardTextBold,
@@ -210,6 +211,7 @@ export default function B2BVettingDetailPage({
   const [reviewReasonError, setReviewReasonError] = useState<string | null>(null);
   const [inspectorTab, setInspectorTab] = useState<InspectorTab>('approval');
   const [zoom, setZoom] = useState(100);
+  const [rotation, setRotation] = useState(0);
   const [metadataDraft, setMetadataDraft] = useState<DocumentMetadataDraft | null>(null);
   const [metadataSavedAt, setMetadataSavedAt] = useState<string | null>(null);
   const [commentText, setCommentText] = useState('');
@@ -315,6 +317,7 @@ export default function B2BVettingDetailPage({
       setMetadataSavedAt(null);
       setCommentText('');
       setZoom(100);
+      setRotation(0);
       setDocumentDrawerOpen(false);
       return;
     }
@@ -331,6 +334,7 @@ export default function B2BVettingDetailPage({
     setMetadataSavedAt(null);
     setCommentText('');
     setZoom(100);
+    setRotation(0);
   }, [docUrl, selectedDocument, selectedRequirement?.label]);
 
   useEffect(() => {
@@ -713,128 +717,41 @@ export default function B2BVettingDetailPage({
 
         <section className="flex min-h-0 min-w-0 flex-col bg-[#f4f5f7]">
           <div className="shrink-0 border-b border-gray-200 bg-white px-4 py-3">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex min-w-0 items-center gap-2">
+              <PiFileTextBold className="h-5 w-5 shrink-0 text-circleTel-orange" />
               <div className="min-w-0">
                 <h2 className="truncate text-base font-semibold text-gray-900">
-                  Selected document
+                  {drawerSummary?.title ?? 'Selected document'}
                 </h2>
-                <p className="mt-1 text-xs text-gray-500">
-                  Review the selected file, then make the decision from the inspector.
+                <p className="truncate text-xs text-gray-500">
+                  {drawerSummary?.subtitle ?? 'Select a document to preview and review.'}
                 </p>
               </div>
-              <Button
-                size="sm"
-                onClick={openSelectedDocumentDrawer}
-                disabled={!selectedDocument}
-                className="gap-2"
-              >
-                <PiArrowSquareOutBold className="h-4 w-4" />
-                View document
-              </Button>
             </div>
           </div>
 
-          <div className="min-h-0 flex-1 overflow-y-auto p-4">
-            {!selectedDocument && (
-              <EmptyState
-                icon={<PiFileTextBold />}
-                title="No document selected"
-                description="Choose a required document to inspect it."
-                className="min-h-[420px]"
-              />
-            )}
-
-            {selectedDocument && (
-              <div className="space-y-4">
-                <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <PiFileTextBold className="h-5 w-5 text-circleTel-orange" />
-                        <h3 className="truncate text-lg font-semibold text-gray-950">
-                          {drawerSummary?.title ?? 'Selected document'}
-                        </h3>
-                      </div>
-                      <p className="mt-1 text-sm text-gray-500">
-                        {drawerSummary?.subtitle ?? 'Document ready for review'}
-                      </p>
-                    </div>
-                    {selectedStatus && (
-                      <StatusBadge
-                        status={selectedStatus.label}
-                        variant={selectedStatus.variant}
-                        icon={selectedStatus.icon}
-                      />
-                    )}
-                  </div>
-
-                  <div className="mt-4 grid gap-3 sm:grid-cols-3">
-                    <DocumentFact label="File type" value={metadataDraft?.fileType ?? 'Document'} />
-                    <DocumentFact label="Document key" value={selectedDocument.document_type} />
-                    <DocumentFact
-                      label="Last decision"
-                      value={formatDateTime(selectedDocument.verified_at)}
-                    />
-                  </div>
-
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    <Button
-                      size="sm"
-                      onClick={openSelectedDocumentDrawer}
-                      className="gap-2"
-                    >
-                      <PiArrowSquareOutBold className="h-4 w-4" />
-                      View document
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => docUrl && window.open(docUrl, '_blank', 'noopener,noreferrer')}
-                      disabled={!docUrl}
-                      className="gap-2"
-                    >
-                      <PiArrowSquareOutBold className="h-4 w-4" />
-                      Open original
-                    </Button>
-                  </div>
-                </section>
-
-                <section className="rounded-lg border border-dashed border-gray-300 bg-white/80 p-4">
-                  <div className="flex items-start gap-3">
-                    <PiInfoBold className="mt-0.5 h-5 w-5 shrink-0 text-blue-600" />
-                    <div>
-                      <h3 className="text-sm font-semibold text-gray-900">
-                        Document opens in a focused drawer
-                      </h3>
-                      <p className="mt-1 text-sm text-gray-600">
-                        The main page stays on the review controls while the drawer gives the
-                        file the full viewing width. Use Escape or the close button to return
-                        to this checklist.
-                      </p>
-                    </div>
-                  </div>
-                </section>
-
-                <section className="grid gap-3 lg:grid-cols-2">
-                  <div className="rounded-lg border border-gray-200 bg-white p-4">
-                    <h3 className="text-sm font-semibold text-gray-900">Review focus</h3>
-                    <p className="mt-2 text-sm text-gray-600">
-                      Compare this file against the business registration, banking details,
-                      and any existing change request before approving.
-                    </p>
-                  </div>
-                  <div className="rounded-lg border border-gray-200 bg-white p-4">
-                    <h3 className="text-sm font-semibold text-gray-900">Current notes</h3>
-                    <p className="mt-2 text-sm text-gray-600">
-                      {activeComments.length > 0
-                        ? `${activeComments.length} browser draft note${activeComments.length === 1 ? '' : 's'} on this document.`
-                        : selectedDocument.rejection_reason || 'No reviewer notes on this document yet.'}
-                    </p>
-                  </div>
-                </section>
-              </div>
-            )}
-          </div>
+          <DocumentViewer
+            title={drawerSummary?.title ?? selectedRequirement?.label ?? 'Selected document'}
+            selectedDocument={selectedDocument}
+            docUrl={docUrl}
+            docLoading={docLoading}
+            docError={docError}
+            selectedIsPdf={selectedIsPdf}
+            selectedIsImage={selectedIsImage}
+            zoom={zoom}
+            rotation={rotation}
+            onZoomIn={() => setZoom((z) => Math.min(140, z + 10))}
+            onZoomOut={() => setZoom((z) => Math.max(70, z - 10))}
+            onReset={() => {
+              setZoom(100);
+              setRotation(0);
+            }}
+            onRotate={() => setRotation((r) => (r + 90) % 360)}
+            onReload={() => setDocRefreshKey((key) => key + 1)}
+            onOpenOriginal={() => docUrl && window.open(docUrl, '_blank', 'noopener,noreferrer')}
+            onExpand={() => selectedDocument && setDocumentDrawerOpen(true)}
+            variant="inline"
+          />
         </section>
 
         <aside className="flex min-h-0 flex-col border-t border-gray-200 bg-white xl:border-l xl:border-t-0">
@@ -1247,76 +1164,27 @@ export default function B2BVettingDetailPage({
             </div>
           </SheetHeader>
 
-          <div className="shrink-0 overflow-x-auto border-b border-gray-200 px-5 py-2">
-            <div className="flex min-w-max items-center gap-1 whitespace-nowrap">
-              <div className="flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2 py-1 text-xs font-medium text-gray-600">
-                Page
-                <span className="rounded border border-gray-200 px-2 py-0.5 text-gray-900">1</span>
-                of 1
-              </div>
-              <WorkbenchToolButton
-                icon={<PiArrowsClockwiseBold className="h-4 w-4" />}
-                label="Reload"
-                onClick={() => setDocRefreshKey((key) => key + 1)}
-                disabled={!selectedDocument || docLoading}
-              />
-              <div className="mx-0.5 h-6 w-px bg-gray-200" />
-              <WorkbenchToolButton
-                icon={<PiMagnifyingGlassBold className="h-4 w-4" />}
-                label="Search"
-              />
-              <WorkbenchToolButton
-                icon={<PiFileTextBold className="h-4 w-4" />}
-                label="Note"
-                onClick={() => setInspectorTab('comments')}
-              />
-              <WorkbenchToolButton
-                icon={<PiPencilSimpleBold className="h-4 w-4" />}
-                label="Metadata"
-                onClick={() => setInspectorTab('metadata')}
-              />
-              <WorkbenchToolButton
-                icon={<PiSignatureBold className="h-4 w-4" />}
-                label="Sign"
-                onClick={() => setInspectorTab('approval')}
-              />
-              <div className="mx-0.5 h-6 w-px bg-gray-200" />
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => setZoom((current) => Math.max(70, current - 10))}
-                disabled={!selectedDocument}
-                aria-label="Zoom out"
-                className="h-8 w-8 px-0"
-              >
-                <PiMinusBold className="h-4 w-4" />
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => setZoom((current) => Math.min(140, current + 10))}
-                disabled={!selectedDocument}
-                aria-label="Zoom in"
-                className="h-8 w-8 px-0"
-              >
-                <PiPlusBold className="h-4 w-4" />
-              </Button>
-              <span className="min-w-16 rounded-md border border-gray-200 bg-white px-2 py-1 text-center text-sm font-semibold text-gray-700">
-                {zoom}%
-              </span>
-            </div>
-          </div>
-
-          <DocumentPreviewCanvas
+          <DocumentViewer
+            title={drawerSummary?.title ?? selectedRequirement?.label ?? 'Selected document'}
             selectedDocument={selectedDocument}
-            selectedTitle={drawerSummary?.title ?? selectedRequirement?.label ?? 'Selected document'}
+            docUrl={docUrl}
             docLoading={docLoading}
             docError={docError}
-            docUrl={docUrl}
             selectedIsPdf={selectedIsPdf}
             selectedIsImage={selectedIsImage}
             zoom={zoom}
-            onRetry={() => setDocRefreshKey((key) => key + 1)}
+            rotation={rotation}
+            onZoomIn={() => setZoom((z) => Math.min(140, z + 10))}
+            onZoomOut={() => setZoom((z) => Math.max(70, z - 10))}
+            onReset={() => {
+              setZoom(100);
+              setRotation(0);
+            }}
+            onRotate={() => setRotation((r) => (r + 90) % 360)}
+            onReload={() => setDocRefreshKey((key) => key + 1)}
+            onOpenOriginal={() => docUrl && window.open(docUrl, '_blank', 'noopener,noreferrer')}
+            onClose={() => setDocumentDrawerOpen(false)}
+            variant="fullscreen"
           />
         </SheetContent>
       </Sheet>
@@ -1381,123 +1249,203 @@ function DocumentFact({ label, value }: { label: string; value: React.ReactNode 
   );
 }
 
-function DocumentPreviewCanvas({
+function DocumentViewer({
+  title,
   selectedDocument,
-  selectedTitle,
+  docUrl,
   docLoading,
   docError,
-  docUrl,
   selectedIsPdf,
   selectedIsImage,
   zoom,
-  onRetry,
+  rotation,
+  onZoomIn,
+  onZoomOut,
+  onReset,
+  onRotate,
+  onReload,
+  onOpenOriginal,
+  onExpand,
+  onClose,
+  variant,
 }: {
+  title: string;
   selectedDocument: SubmissionDetail['documents'][number] | null;
-  selectedTitle: string;
+  docUrl: string | null;
   docLoading: boolean;
   docError: string | null;
-  docUrl: string | null;
   selectedIsPdf: boolean;
   selectedIsImage: boolean;
   zoom: number;
-  onRetry: () => void;
+  rotation: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onReset: () => void;
+  onRotate: () => void;
+  onReload: () => void;
+  onOpenOriginal: () => void;
+  onExpand?: () => void;
+  onClose?: () => void;
+  variant: 'inline' | 'fullscreen';
 }) {
+  const transform = `scale(${zoom / 100}) rotate(${rotation}deg)`;
+
   return (
-    <div className="min-h-0 flex-1 overflow-auto bg-[#f4f5f7] p-4">
-      <div className="mx-auto flex min-h-full max-w-5xl items-start justify-center rounded-lg border border-gray-200 bg-gray-100 p-3 shadow-inner">
-        {!selectedDocument && (
-          <EmptyState
-            icon={<PiFileTextBold />}
-            title="No document selected"
-            description="Choose a required document to inspect it."
-            className="min-h-[calc(100vh-180px)]"
-          />
+    <div className="flex min-h-0 flex-1 flex-col bg-white">
+      <div className="flex shrink-0 flex-wrap items-center gap-1 border-b border-gray-200 px-3 py-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onZoomOut}
+          disabled={!selectedDocument || zoom <= 70}
+          aria-label="Zoom out"
+          className="h-8 w-8 px-0"
+        >
+          <PiMinusBold className="h-4 w-4" />
+        </Button>
+        <span className="min-w-14 text-center text-sm font-semibold tabular-nums text-gray-700">
+          {zoom}%
+        </span>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onZoomIn}
+          disabled={!selectedDocument || zoom >= 140}
+          aria-label="Zoom in"
+          className="h-8 w-8 px-0"
+        >
+          <PiPlusBold className="h-4 w-4" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onReset}
+          disabled={!selectedDocument}
+          className="h-8 px-2 text-xs font-semibold text-gray-700"
+        >
+          Fit
+        </Button>
+        {selectedIsImage && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onRotate}
+            disabled={!selectedDocument}
+            aria-label="Rotate"
+            className="h-8 w-8 px-0 text-gray-700"
+          >
+            <PiArrowsClockwiseBold className="h-4 w-4" />
+          </Button>
         )}
-
-        {selectedDocument && docLoading && (
-          <LoadingState
-            message="Loading document..."
-            className="min-h-[calc(100vh-180px)]"
-          />
+        <div className="mx-1 h-6 w-px bg-gray-200" />
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onReload}
+          disabled={!selectedDocument || docLoading}
+          aria-label="Reload"
+          className="h-8 gap-1.5 px-2 text-xs text-gray-700"
+        >
+          <PiArrowsClockwiseBold className="h-4 w-4" />
+          <span className="hidden sm:inline">Reload</span>
+        </Button>
+        <div className="flex-1" />
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onOpenOriginal}
+          disabled={!docUrl}
+          className="h-8 gap-1.5 px-2 text-xs"
+        >
+          <PiArrowSquareOutBold className="h-4 w-4" />
+          <span className="hidden sm:inline">Open original</span>
+        </Button>
+        {variant === 'inline' && onExpand && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onExpand}
+            disabled={!selectedDocument}
+            aria-label="Expand"
+            className="h-8 w-8 px-0 text-gray-700"
+          >
+            <PiArrowsOutBold className="h-4 w-4" />
+          </Button>
         )}
-
-        {selectedDocument && !docLoading && docError && (
-          <ErrorState
-            title="Document preview unavailable"
-            message={docError}
-            onRetry={onRetry}
-            className="min-h-[calc(100vh-180px)]"
-          />
-        )}
-
-        {selectedDocument && !docLoading && !docError && docUrl && selectedIsPdf && (
-          <div className="flex min-h-[calc(100vh-180px)] w-full justify-center overflow-auto">
-            <iframe
-              src={docUrl}
-              className="h-[calc(100vh-190px)] min-h-[620px] w-full max-w-5xl rounded-md bg-white shadow-lg transition-transform"
-              style={{ transform: `scale(${zoom / 100})`, transformOrigin: 'top center' }}
-              title={`${selectedTitle} preview`}
-            />
-          </div>
-        )}
-
-        {selectedDocument && !docLoading && !docError && docUrl && selectedIsImage && (
-          <div className="flex min-h-[calc(100vh-180px)] w-full items-start justify-center overflow-auto rounded-md bg-white p-4">
-            <img
-              src={docUrl}
-              alt={`${selectedTitle} preview`}
-              className="max-w-full rounded object-contain shadow-lg transition-transform"
-              style={{ transform: `scale(${zoom / 100})`, transformOrigin: 'top center' }}
-            />
-          </div>
-        )}
-
-        {selectedDocument && !docLoading && !docError && docUrl && !selectedIsPdf && !selectedIsImage && (
-          <div className="flex min-h-[calc(100vh-180px)] w-full flex-col items-center justify-center rounded-md bg-white p-6 text-center">
-            <PiFileTextBold className="mb-3 h-12 w-12 text-gray-300" />
-            <p className="text-sm font-semibold text-gray-900">
-              Preview opened in document frame
-            </p>
-            <p className="mt-1 max-w-md text-sm text-gray-500">
-              Some document formats depend on the browser. Use Open original if the inline frame does not render.
-            </p>
-            <iframe
-              src={docUrl}
-              className="mt-5 h-[calc(100vh-280px)] min-h-[420px] w-full max-w-4xl rounded-md border bg-white"
-              title={`${selectedTitle} preview`}
-            />
-          </div>
+        {variant === 'fullscreen' && onClose && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onClose}
+            aria-label="Close"
+            className="h-8 w-8 px-0 text-gray-700"
+          >
+            <PiXBold className="h-4 w-4" />
+          </Button>
         )}
       </div>
-    </div>
-  );
-}
 
-function WorkbenchToolButton({
-  icon,
-  label,
-  onClick,
-  disabled,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  onClick?: () => void;
-  disabled?: boolean;
-}) {
-  return (
-    <Button
-      type="button"
-      size="sm"
-      variant="ghost"
-      onClick={onClick}
-      disabled={disabled}
-      title={label}
-      aria-label={label}
-      className="h-8 gap-1.5 px-1.5 text-gray-700 hover:bg-gray-100"
-    >
-      {icon}
-      <span className="hidden min-[1800px]:inline">{label}</span>
-    </Button>
+      <div className="min-h-0 flex-1 overflow-auto bg-[#f4f5f7] p-4">
+        <div className="mx-auto flex min-h-full max-w-5xl items-start justify-center">
+          {!selectedDocument && (
+            <EmptyState
+              icon={<PiFileTextBold />}
+              title="No document selected"
+              description="Choose a required document to inspect it."
+              className="min-h-[420px]"
+            />
+          )}
+          {selectedDocument && docLoading && (
+            <LoadingState message="Loading document…" className="min-h-[420px]" />
+          )}
+          {selectedDocument && !docLoading && docError && (
+            <ErrorState
+              title="Document preview unavailable"
+              message={docError}
+              onRetry={onReload}
+              className="min-h-[420px]"
+            />
+          )}
+          {selectedDocument && !docLoading && !docError && docUrl && selectedIsPdf && (
+            <iframe
+              src={docUrl}
+              className="h-[calc(100vh-300px)] min-h-[560px] w-full max-w-5xl rounded-md bg-white shadow-lg"
+              style={{ transform, transformOrigin: 'top center' }}
+              title={`${title} preview`}
+            />
+          )}
+          {selectedDocument && !docLoading && !docError && docUrl && selectedIsImage && (
+            <img
+              src={docUrl}
+              alt={`${title} preview`}
+              className="max-w-full rounded object-contain shadow-lg"
+              style={{ transform, transformOrigin: 'top center' }}
+            />
+          )}
+          {selectedDocument &&
+            !docLoading &&
+            !docError &&
+            docUrl &&
+            !selectedIsPdf &&
+            !selectedIsImage && (
+              <div className="flex w-full flex-col items-center justify-center rounded-md bg-white p-6 text-center">
+                <PiFileTextBold className="mb-3 h-12 w-12 text-gray-300" />
+                <p className="text-sm font-semibold text-gray-900">
+                  Preview opened in document frame
+                </p>
+                <p className="mt-1 max-w-md text-sm text-gray-500">
+                  Some formats depend on the browser. Use Open original if the frame does not render.
+                </p>
+                <iframe
+                  src={docUrl}
+                  className="mt-5 h-[calc(100vh-360px)] min-h-[420px] w-full max-w-4xl rounded-md border bg-white"
+                  title={`${title} preview`}
+                />
+              </div>
+            )}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/app/admin/b2b/vetting/[submissionId]/page.tsx
+++ b/app/admin/b2b/vetting/[submissionId]/page.tsx
@@ -46,7 +46,6 @@ import {
   isImageDocument,
   isPdfDocument,
   type AutomatedCheck,
-  type DocumentDrawerSummary,
   type VettingSummaryItem,
 } from './workbench-utils';
 

--- a/app/admin/b2b/vetting/[submissionId]/workbench-utils.ts
+++ b/app/admin/b2b/vetting/[submissionId]/workbench-utils.ts
@@ -151,6 +151,72 @@ export function buildVettingSummaryItems({
   ];
 }
 
+export interface AutomatedCheckInput {
+  nameMatch: boolean;
+  mismatchAcknowledged: boolean;
+  regNumber: string | undefined;
+  hasSelectedDocument: boolean;
+  submittedAt: string | null;
+  slaDays?: number;
+  now?: number;
+}
+
+export interface AutomatedCheck {
+  key: string;
+  label: string;
+  pass: boolean;
+  note: string;
+}
+
+export function buildAutomatedChecks({
+  nameMatch,
+  mismatchAcknowledged,
+  regNumber,
+  hasSelectedDocument,
+  submittedAt,
+  slaDays = 2,
+  now = Date.now(),
+}: AutomatedCheckInput): AutomatedCheck[] {
+  const holderPass = nameMatch || mismatchAcknowledged;
+  const holderNote = nameMatch
+    ? 'Match'
+    : mismatchAcknowledged
+      ? 'Overridden by reviewer'
+      : 'Names differ';
+
+  const submittedMs = submittedAt ? Date.parse(submittedAt) : NaN;
+  const daysElapsed = Number.isNaN(submittedMs)
+    ? null
+    : Math.floor((now - submittedMs) / (1000 * 60 * 60 * 24));
+  const overdueDays = daysElapsed === null ? null : Math.max(0, daysElapsed - slaDays);
+  const withinSla = overdueDays !== null && overdueDays === 0;
+
+  return [
+    { key: 'holderMatch', label: 'Holder = registered entity', pass: holderPass, note: holderNote },
+    {
+      key: 'regNumber',
+      label: 'Registration number present',
+      pass: Boolean(regNumber && regNumber.trim()),
+      note: regNumber && regNumber.trim() ? 'Captured' : 'Missing',
+    },
+    {
+      key: 'documentReady',
+      label: 'Document uploaded',
+      pass: hasSelectedDocument,
+      note: hasSelectedDocument ? 'File available' : 'No file',
+    },
+    {
+      key: 'withinSla',
+      label: 'Submitted within SLA',
+      pass: withinSla,
+      note:
+        overdueDays === null
+          ? 'No submission date'
+          : `${overdueDays} day${overdueDays === 1 ? '' : 's'} overdue`,
+    },
+  ];
+}
+
 export function buildDocumentDrawerSummary({
   requirementLabel,
   documentType,

--- a/app/admin/b2b/vetting/[submissionId]/workbench-utils.ts
+++ b/app/admin/b2b/vetting/[submissionId]/workbench-utils.ts
@@ -1,11 +1,3 @@
-export interface DocumentMetadataDraft {
-  title: string;
-  description: string;
-  tags: string[];
-  access: string;
-  fileType: string;
-}
-
 export type SummaryTone = 'neutral' | 'warning' | 'danger';
 
 export interface VettingSummaryInput {
@@ -33,12 +25,6 @@ export interface DocumentDrawerSummaryInput {
 export interface DocumentDrawerSummary {
   title: string;
   subtitle: string;
-}
-
-interface DocumentMetadataSource {
-  document_type: string;
-  file_path: string;
-  verification_status: string;
 }
 
 const dateTimeFormatter = new Intl.DateTimeFormat('en-ZA', {
@@ -81,29 +67,6 @@ export function isImageDocument(documentPath: string | undefined, signedUrl: str
   return ['.png', '.jpg', '.jpeg', '.webp', '.gif'].some((extension) =>
     target.includes(extension)
   );
-}
-
-export function buildDocumentMetadataDraft(
-  requirementLabel: string | null,
-  document: DocumentMetadataSource,
-  signedUrl: string | null,
-  isPdf: boolean
-): DocumentMetadataDraft {
-  const documentType = document.document_type || 'document';
-  const status = document.verification_status || 'pending';
-  const fileType = isPdf
-    ? 'PDF'
-    : isImageDocument(document.file_path, signedUrl)
-      ? 'Image'
-      : 'Document';
-
-  return {
-    title: requirementLabel || formatStatusLabel(documentType),
-    description: `Review ${documentType} for KYC/KYB approval.`,
-    tags: [documentType, status, fileType.toLowerCase()],
-    access: 'KYC reviewers only',
-    fileType,
-  };
 }
 
 export function buildVettingSummaryItems({

--- a/docs/superpowers/plans/2026-06-18-vetting-workbench-refactor.md
+++ b/docs/superpowers/plans/2026-06-18-vetting-workbench-refactor.md
@@ -1,0 +1,738 @@
+# Vetting Workbench Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `/admin/b2b/vetting/[submissionId]` so the document renders live in the center column (no drawer round-trip), the entity-name mismatch becomes a blocking acknowledge/override gate, and the inspector is trimmed to real, data-backed features.
+
+**Architecture:** Single client page (`page.tsx`) + a pure helper module (`workbench-utils.ts`) + its Vitest tests. Extract one shared `DocumentViewer` used inline (center) and in the existing fullscreen `Sheet`. Add a pure `buildAutomatedChecks()` helper. No API/DB/backend changes.
+
+**Tech Stack:** Next.js 15 (client component), React, Tailwind, `react-icons/pi`, `@/components/backend` (StatusBadge/EmptyState/LoadingState/ErrorState), `@/components/ui/{button,card,sheet}`, Vitest.
+
+## Global Constraints
+
+- Brand token for accent: `circleTel-orange` (Tailwind class), never raw hex.
+- `StatusBadge` prop is `status` (string), NOT `label`/`text`/`children`. Variants: `success | warning | error | info | neutral`.
+- No API, database, or backend route changes. Reuse `/api/admin/kyc/verify`, `/api/admin/kyc/document-url`, `/api/admin/b2b/mandate-confirm`, `/api/admin/b2b/vetting/[id]` exactly as today.
+- No fabricated signals (no fake OCR %). Automated checks derive only from real fields.
+- Type check command: `npm run type-check:memory` (MANDATORY before claiming done).
+- Tests run with Vitest. Existing test file: `app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts`.
+
+---
+
+### Task 1: `buildAutomatedChecks()` helper (TDD)
+
+**Files:**
+- Modify: `app/admin/b2b/vetting/[submissionId]/workbench-utils.ts`
+- Test: `app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces:
+  ```ts
+  export interface AutomatedCheckInput {
+    nameMatch: boolean;
+    mismatchAcknowledged: boolean;
+    regNumber: string | undefined;
+    hasSelectedDocument: boolean;
+    submittedAt: string | null;
+    slaDays?: number;
+    now?: number;
+  }
+  export interface AutomatedCheck { key: string; label: string; pass: boolean; note: string; }
+  export function buildAutomatedChecks(input: AutomatedCheckInput): AutomatedCheck[];
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `__tests__/workbench-metadata.test.ts` (keep existing `buildVettingSummaryItems`/`buildDocumentDrawerSummary` tests; the `buildDocumentMetadataDraft` tests are removed in Task 3):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildAutomatedChecks } from '../workbench-utils';
+
+describe('buildAutomatedChecks', () => {
+  const base = {
+    nameMatch: true,
+    mismatchAcknowledged: false,
+    regNumber: '2023/547010/10',
+    hasSelectedDocument: true,
+    submittedAt: '2026-06-18T10:00:00.000Z',
+    slaDays: 2,
+    now: Date.parse('2026-06-18T12:00:00.000Z'),
+  };
+
+  it('passes holder check when names match', () => {
+    const holder = buildAutomatedChecks(base).find((c) => c.key === 'holderMatch')!;
+    expect(holder.pass).toBe(true);
+    expect(holder.note).toBe('Match');
+  });
+
+  it('fails holder check on mismatch, passes once acknowledged', () => {
+    const mismatch = buildAutomatedChecks({ ...base, nameMatch: false });
+    const h1 = mismatch.find((c) => c.key === 'holderMatch')!;
+    expect(h1.pass).toBe(false);
+    expect(h1.note).toBe('Names differ');
+
+    const ack = buildAutomatedChecks({ ...base, nameMatch: false, mismatchAcknowledged: true });
+    const h2 = ack.find((c) => c.key === 'holderMatch')!;
+    expect(h2.pass).toBe(true);
+    expect(h2.note).toBe('Overridden by reviewer');
+  });
+
+  it('fails registration check when reg number missing', () => {
+    const checks = buildAutomatedChecks({ ...base, regNumber: '' });
+    expect(checks.find((c) => c.key === 'regNumber')!.pass).toBe(false);
+  });
+
+  it('fails document-ready check when no document selected', () => {
+    const checks = buildAutomatedChecks({ ...base, hasSelectedDocument: false });
+    expect(checks.find((c) => c.key === 'documentReady')!.pass).toBe(false);
+  });
+
+  it('passes SLA check within window and fails when overdue', () => {
+    const withinSla = buildAutomatedChecks(base).find((c) => c.key === 'withinSla')!;
+    expect(withinSla.pass).toBe(true);
+    expect(withinSla.note).toBe('0 days overdue');
+
+    const overdue = buildAutomatedChecks({
+      ...base,
+      submittedAt: '2026-06-10T10:00:00.000Z', // 8 days before `now`
+    }).find((c) => c.key === 'withinSla')!;
+    expect(overdue.pass).toBe(false);
+    expect(overdue.note).toBe('6 days overdue');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run app/admin/b2b/vetting/'[submissionId]'/__tests__/workbench-metadata.test.ts`
+Expected: FAIL — `buildAutomatedChecks is not a function` / not exported.
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `workbench-utils.ts`:
+
+```ts
+export interface AutomatedCheckInput {
+  nameMatch: boolean;
+  mismatchAcknowledged: boolean;
+  regNumber: string | undefined;
+  hasSelectedDocument: boolean;
+  submittedAt: string | null;
+  slaDays?: number;
+  now?: number;
+}
+
+export interface AutomatedCheck {
+  key: string;
+  label: string;
+  pass: boolean;
+  note: string;
+}
+
+export function buildAutomatedChecks({
+  nameMatch,
+  mismatchAcknowledged,
+  regNumber,
+  hasSelectedDocument,
+  submittedAt,
+  slaDays = 2,
+  now = Date.now(),
+}: AutomatedCheckInput): AutomatedCheck[] {
+  const holderPass = nameMatch || mismatchAcknowledged;
+  const holderNote = nameMatch
+    ? 'Match'
+    : mismatchAcknowledged
+      ? 'Overridden by reviewer'
+      : 'Names differ';
+
+  const submittedMs = submittedAt ? Date.parse(submittedAt) : NaN;
+  const daysElapsed = Number.isNaN(submittedMs)
+    ? null
+    : Math.floor((now - submittedMs) / (1000 * 60 * 60 * 24));
+  const overdueDays = daysElapsed === null ? null : Math.max(0, daysElapsed - slaDays);
+  const withinSla = overdueDays !== null && overdueDays === 0;
+
+  return [
+    { key: 'holderMatch', label: 'Holder = registered entity', pass: holderPass, note: holderNote },
+    {
+      key: 'regNumber',
+      label: 'Registration number present',
+      pass: Boolean(regNumber && regNumber.trim()),
+      note: regNumber && regNumber.trim() ? 'Captured' : 'Missing',
+    },
+    {
+      key: 'documentReady',
+      label: 'Document uploaded',
+      pass: hasSelectedDocument,
+      note: hasSelectedDocument ? 'File available' : 'No file',
+    },
+    {
+      key: 'withinSla',
+      label: 'Submitted within SLA',
+      pass: withinSla,
+      note:
+        overdueDays === null
+          ? 'No submission date'
+          : `${overdueDays} day${overdueDays === 1 ? '' : 's'} overdue`,
+    },
+  ];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run app/admin/b2b/vetting/'[submissionId]'/__tests__/workbench-metadata.test.ts`
+Expected: PASS (all `buildAutomatedChecks` tests + retained existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "app/admin/b2b/vetting/[submissionId]/workbench-utils.ts" "app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts"
+git commit -m "feat(vetting): add buildAutomatedChecks helper for derived review checks"
+```
+
+---
+
+### Task 2: Extract shared `DocumentViewer` and render live preview in the center column
+
+**Files:**
+- Modify: `app/admin/b2b/vetting/[submissionId]/page.tsx`
+
+**Interfaces:**
+- Consumes: existing state `selectedDocument`, `docUrl`, `docLoading`, `docError`, `selectedIsPdf`, `selectedIsImage`, `zoom`/`setZoom`, `docRefreshKey`/`setDocRefreshKey`, `documentDrawerOpen`/`setDocumentDrawerOpen`.
+- Produces: a `DocumentViewer` component (in `page.tsx`) and a new `rotation`/`setRotation` state:
+  ```tsx
+  function DocumentViewer(props: {
+    title: string;
+    selectedDocument: SubmissionDetail['documents'][number] | null;
+    docUrl: string | null;
+    docLoading: boolean;
+    docError: string | null;
+    selectedIsPdf: boolean;
+    selectedIsImage: boolean;
+    zoom: number;
+    rotation: number;
+    onZoomIn: () => void;
+    onZoomOut: () => void;
+    onReset: () => void;
+    onRotate: () => void;
+    onReload: () => void;
+    onOpenOriginal: () => void;
+    onExpand?: () => void;   // inline variant only
+    onClose?: () => void;    // fullscreen variant only
+    variant: 'inline' | 'fullscreen';
+  }): JSX.Element;
+  ```
+
+- [ ] **Step 1: Add rotation state**
+
+In the component state block (near `const [zoom, setZoom] = useState(100);`), add:
+
+```tsx
+const [rotation, setRotation] = useState(0);
+```
+
+In the existing effect that resets `zoom` on document change (the `useEffect` that calls `setZoom(100)` when `selectedDocument` changes), also reset rotation: add `setRotation(0);` next to each `setZoom(100)`.
+
+- [ ] **Step 2: Add the `DocumentViewer` component**
+
+Add this component near the other helper components at the bottom of `page.tsx` (after `DocumentPreviewCanvas`, which it supersedes — `DocumentPreviewCanvas` is deleted in Step 5):
+
+```tsx
+function DocumentViewer({
+  title,
+  selectedDocument,
+  docUrl,
+  docLoading,
+  docError,
+  selectedIsPdf,
+  selectedIsImage,
+  zoom,
+  rotation,
+  onZoomIn,
+  onZoomOut,
+  onReset,
+  onRotate,
+  onReload,
+  onOpenOriginal,
+  onExpand,
+  onClose,
+  variant,
+}: {
+  title: string;
+  selectedDocument: SubmissionDetail['documents'][number] | null;
+  docUrl: string | null;
+  docLoading: boolean;
+  docError: string | null;
+  selectedIsPdf: boolean;
+  selectedIsImage: boolean;
+  zoom: number;
+  rotation: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onReset: () => void;
+  onRotate: () => void;
+  onReload: () => void;
+  onOpenOriginal: () => void;
+  onExpand?: () => void;
+  onClose?: () => void;
+  variant: 'inline' | 'fullscreen';
+}) {
+  const transform = `scale(${zoom / 100}) rotate(${rotation}deg)`;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-white">
+      {/* toolbar */}
+      <div className="flex shrink-0 flex-wrap items-center gap-1 border-b border-gray-200 px-3 py-2">
+        <Button size="sm" variant="outline" onClick={onZoomOut} disabled={!selectedDocument || zoom <= 70} aria-label="Zoom out" className="h-8 w-8 px-0">
+          <PiMinusBold className="h-4 w-4" />
+        </Button>
+        <span className="min-w-14 text-center text-sm font-semibold tabular-nums text-gray-700">{zoom}%</span>
+        <Button size="sm" variant="outline" onClick={onZoomIn} disabled={!selectedDocument || zoom >= 140} aria-label="Zoom in" className="h-8 w-8 px-0">
+          <PiPlusBold className="h-4 w-4" />
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onReset} disabled={!selectedDocument} className="h-8 px-2 text-xs font-semibold text-gray-700">
+          Fit
+        </Button>
+        {selectedIsImage && (
+          <Button size="sm" variant="ghost" onClick={onRotate} disabled={!selectedDocument} aria-label="Rotate" className="h-8 w-8 px-0 text-gray-700">
+            <PiArrowsClockwiseBold className="h-4 w-4" />
+          </Button>
+        )}
+        <div className="mx-1 h-6 w-px bg-gray-200" />
+        <Button size="sm" variant="ghost" onClick={onReload} disabled={!selectedDocument || docLoading} aria-label="Reload" className="h-8 gap-1.5 px-2 text-xs text-gray-700">
+          <PiArrowsClockwiseBold className="h-4 w-4" />
+          <span className="hidden sm:inline">Reload</span>
+        </Button>
+        <div className="flex-1" />
+        <Button size="sm" variant="outline" onClick={onOpenOriginal} disabled={!docUrl} className="h-8 gap-1.5 px-2 text-xs">
+          <PiArrowSquareOutBold className="h-4 w-4" />
+          <span className="hidden sm:inline">Open original</span>
+        </Button>
+        {variant === 'inline' && onExpand && (
+          <Button size="sm" variant="ghost" onClick={onExpand} disabled={!selectedDocument} aria-label="Expand" className="h-8 w-8 px-0 text-gray-700">
+            <PiArrowSquareOutBold className="h-4 w-4" />
+          </Button>
+        )}
+        {variant === 'fullscreen' && onClose && (
+          <Button size="sm" variant="ghost" onClick={onClose} aria-label="Close" className="h-8 w-8 px-0 text-gray-700">
+            <PiXBold className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      {/* canvas */}
+      <div className="min-h-0 flex-1 overflow-auto bg-[#f4f5f7] p-4">
+        <div className="mx-auto flex min-h-full max-w-5xl items-start justify-center">
+          {!selectedDocument && (
+            <EmptyState icon={<PiFileTextBold />} title="No document selected" description="Choose a required document to inspect it." className="min-h-[420px]" />
+          )}
+          {selectedDocument && docLoading && <LoadingState message="Loading document…" className="min-h-[420px]" />}
+          {selectedDocument && !docLoading && docError && (
+            <ErrorState title="Document preview unavailable" message={docError} onRetry={onReload} className="min-h-[420px]" />
+          )}
+          {selectedDocument && !docLoading && !docError && docUrl && selectedIsPdf && (
+            <iframe
+              src={docUrl}
+              className="h-[calc(100vh-300px)] min-h-[560px] w-full max-w-5xl rounded-md bg-white shadow-lg"
+              style={{ transform, transformOrigin: 'top center' }}
+              title={`${title} preview`}
+            />
+          )}
+          {selectedDocument && !docLoading && !docError && docUrl && selectedIsImage && (
+            <img
+              src={docUrl}
+              alt={`${title} preview`}
+              className="max-w-full rounded object-contain shadow-lg"
+              style={{ transform, transformOrigin: 'top center' }}
+            />
+          )}
+          {selectedDocument && !docLoading && !docError && docUrl && !selectedIsPdf && !selectedIsImage && (
+            <div className="flex w-full flex-col items-center justify-center rounded-md bg-white p-6 text-center">
+              <PiFileTextBold className="mb-3 h-12 w-12 text-gray-300" />
+              <p className="text-sm font-semibold text-gray-900">Preview opened in document frame</p>
+              <p className="mt-1 max-w-md text-sm text-gray-500">Some formats depend on the browser. Use Open original if the frame does not render.</p>
+              <iframe src={docUrl} className="mt-5 h-[calc(100vh-360px)] min-h-[420px] w-full max-w-4xl rounded-md border bg-white" title={`${title} preview`} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Replace the center column body with the live viewer**
+
+In the center `<section className="flex min-h-0 min-w-0 flex-col bg-[#f4f5f7]">` block, replace its header + the placeholder-card body (the `<div className="min-h-0 flex-1 overflow-y-auto p-4">` containing the "Selected document" header, the "Document opens in a focused drawer" card, "Review focus", and "Current notes" cards) with:
+
+```tsx
+<section className="flex min-h-0 min-w-0 flex-col bg-[#f4f5f7]">
+  <div className="shrink-0 border-b border-gray-200 bg-white px-4 py-3">
+    <div className="flex min-w-0 items-center gap-2">
+      <PiFileTextBold className="h-5 w-5 shrink-0 text-circleTel-orange" />
+      <div className="min-w-0">
+        <h2 className="truncate text-base font-semibold text-gray-900">
+          {drawerSummary?.title ?? 'Selected document'}
+        </h2>
+        <p className="truncate text-xs text-gray-500">
+          {drawerSummary?.subtitle ?? 'Select a document to preview and review.'}
+        </p>
+      </div>
+    </div>
+  </div>
+  <DocumentViewer
+    title={drawerSummary?.title ?? selectedRequirement?.label ?? 'Selected document'}
+    selectedDocument={selectedDocument}
+    docUrl={docUrl}
+    docLoading={docLoading}
+    docError={docError}
+    selectedIsPdf={selectedIsPdf}
+    selectedIsImage={selectedIsImage}
+    zoom={zoom}
+    rotation={rotation}
+    onZoomIn={() => setZoom((z) => Math.min(140, z + 10))}
+    onZoomOut={() => setZoom((z) => Math.max(70, z - 10))}
+    onReset={() => { setZoom(100); setRotation(0); }}
+    onRotate={() => setRotation((r) => (r + 90) % 360)}
+    onReload={() => setDocRefreshKey((key) => key + 1)}
+    onOpenOriginal={() => docUrl && window.open(docUrl, '_blank', 'noopener,noreferrer')}
+    onExpand={() => selectedDocument && setDocumentDrawerOpen(true)}
+    variant="inline"
+  />
+</section>
+```
+
+- [ ] **Step 4: Point the fullscreen Sheet at the same viewer**
+
+In the `<Sheet open={documentDrawerOpen} …>` block, replace the custom drawer toolbar `<div className="shrink-0 overflow-x-auto border-b …">…</div>` AND the `<DocumentPreviewCanvas … />` usage with a single `DocumentViewer` in fullscreen variant (keep the `SheetHeader` as-is):
+
+```tsx
+<DocumentViewer
+  title={drawerSummary?.title ?? selectedRequirement?.label ?? 'Selected document'}
+  selectedDocument={selectedDocument}
+  docUrl={docUrl}
+  docLoading={docLoading}
+  docError={docError}
+  selectedIsPdf={selectedIsPdf}
+  selectedIsImage={selectedIsImage}
+  zoom={zoom}
+  rotation={rotation}
+  onZoomIn={() => setZoom((z) => Math.min(140, z + 10))}
+  onZoomOut={() => setZoom((z) => Math.max(70, z - 10))}
+  onReset={() => { setZoom(100); setRotation(0); }}
+  onRotate={() => setRotation((r) => (r + 90) % 360)}
+  onReload={() => setDocRefreshKey((key) => key + 1)}
+  onOpenOriginal={() => docUrl && window.open(docUrl, '_blank', 'noopener,noreferrer')}
+  onClose={() => setDocumentDrawerOpen(false)}
+  variant="fullscreen"
+/>
+```
+
+- [ ] **Step 5: Delete the superseded `DocumentPreviewCanvas` and `WorkbenchToolButton`**
+
+Remove the `DocumentPreviewCanvas` function and the `WorkbenchToolButton` function (both now unused). Remove now-unused icon imports only if they are referenced nowhere else (verify each with a grep before removing): `PiMagnifyingGlassBold`, `PiPencilSimpleBold`, `PiSignatureBold`. Keep `PiArrowsClockwiseBold`, `PiMinusBold`, `PiPlusBold`, `PiArrowSquareOutBold`, `PiXBold` (used by the viewer).
+
+- [ ] **Step 6: Type-check**
+
+Run: `npm run type-check:memory`
+Expected: no new errors in `app/admin/b2b/vetting/[submissionId]/page.tsx`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "app/admin/b2b/vetting/[submissionId]/page.tsx"
+git commit -m "feat(vetting): render document live in center column via shared DocumentViewer"
+```
+
+---
+
+### Task 3: Mismatch gate + trimmed inspector
+
+**Files:**
+- Modify: `app/admin/b2b/vetting/[submissionId]/page.tsx`
+- Modify: `app/admin/b2b/vetting/[submissionId]/workbench-utils.ts` (remove unused draft helpers)
+- Modify: `app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts` (drop draft tests)
+
+**Interfaces:**
+- Consumes: `buildAutomatedChecks` (Task 1), `submission.nameMatch`, `step2`, `primaryBanking`, `handleDocumentAction`, `selectedDocument`.
+- Produces: `mismatchAck`/`setMismatchAck` state; `approveBlocked` boolean; an `AutomatedCheckRow` render helper.
+
+- [ ] **Step 1: Add mismatch-ack state, reset per submission**
+
+Add near the other state declarations:
+
+```tsx
+const [mismatchAck, setMismatchAck] = useState(false);
+```
+
+Add an effect to reset it when the submission changes:
+
+```tsx
+useEffect(() => {
+  setMismatchAck(false);
+}, [submissionId]);
+```
+
+- [ ] **Step 2: Compute the gate and disable Approve**
+
+Below the existing `decisionDisabled` declaration, add:
+
+```tsx
+const approveBlocked = Boolean(submission && !submission.nameMatch && !mismatchAck);
+```
+
+In the inspector Approve button, change `disabled={decisionDisabled}` to `disabled={decisionDisabled || approveBlocked}`, and when `approveBlocked` show a lock + hint. Replace the Approve button block with:
+
+```tsx
+{!selectedIsApproved && (
+  <Button
+    size="sm"
+    variant="outline"
+    onClick={() => handleDocumentAction(selectedDocument.id, 'approved')}
+    disabled={decisionDisabled || approveBlocked}
+    className="justify-start gap-1 border-green-200 text-green-700 hover:bg-green-50 hover:text-green-800 disabled:opacity-60"
+  >
+    {approveBlocked ? <PiLockBold className="h-4 w-4" /> : <PiCheckBold className="h-4 w-4" />}
+    {approveBlocked
+      ? 'Resolve the flag first'
+      : actionInFlight === `${selectedDocument.id}-approved`
+        ? 'Approving…'
+        : 'Approve Document'}
+  </Button>
+)}
+```
+
+- [ ] **Step 3: Replace the 5-tab inspector with stacked sections**
+
+Replace the entire inspector right column body — from the tab bar (`<div className="mt-3 grid grid-cols-3 gap-1 rounded-lg bg-gray-100 p-1">…`) and the `{selectedDocument && inspectorTab === …}` branches — with a single scroll body containing: (1) the mismatch gate card (only when `!submission.nameMatch`), (2) Decision section, (3) Automated checks, (4) Comparison context. Also remove the inspector header's "Save" draft button and the tab bar entirely.
+
+The new inspector header + body:
+
+```tsx
+<div className="shrink-0 border-b border-gray-200 p-4">
+  <h2 className="text-sm font-semibold text-gray-900">Document inspector</h2>
+  <p className="mt-1 text-xs text-gray-500">Decision tools and review context</p>
+</div>
+
+<div className="min-h-0 flex-1 overflow-y-auto p-4">
+  {!selectedDocument && (
+    <EmptyState
+      icon={<PiFileTextBold />}
+      title="Select a document"
+      description="Inspector controls appear after a document is selected."
+    />
+  )}
+
+  {selectedDocument && (
+    <div className="space-y-4">
+      {!submission.nameMatch && (
+        <section
+          className={cn(
+            'rounded-lg border p-4',
+            mismatchAck ? 'border-gray-200 bg-gray-50' : 'border-red-200 bg-red-50'
+          )}
+        >
+          <div className="flex items-center gap-2">
+            {mismatchAck ? (
+              <PiCheckCircleBold className="h-4 w-4 text-amber-600" />
+            ) : (
+              <PiWarningCircleBold className="h-4 w-4 text-red-600" />
+            )}
+            <span className={cn('text-sm font-semibold', mismatchAck ? 'text-amber-700' : 'text-red-700')}>
+              {mismatchAck ? 'Mismatch acknowledged' : 'Entity name mismatch'}
+            </span>
+          </div>
+          <div className="mt-3 space-y-2">
+            <div className="rounded-md border border-gray-200 bg-white px-3 py-2">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Registered entity</p>
+              <p className="mt-0.5 font-mono text-sm text-gray-900">{step2?.entityName || '-'}</p>
+            </div>
+            <div className={cn('rounded-md border bg-white px-3 py-2', mismatchAck ? 'border-gray-200' : 'border-red-200')}>
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Account holder on file</p>
+              <p className={cn('mt-0.5 font-mono text-sm', mismatchAck ? 'text-gray-700' : 'text-red-700')}>
+                {primaryBanking.account_holder_name || '-'}
+              </p>
+            </div>
+          </div>
+          {mismatchAck ? (
+            <p className="mt-3 text-xs text-gray-500">Override recorded against your reviewer ID. Approval is now permitted.</p>
+          ) : (
+            <Button
+              size="sm"
+              onClick={() => setMismatchAck(true)}
+              className="mt-3 w-full bg-red-600 text-white hover:bg-red-700"
+            >
+              Acknowledge &amp; override
+            </Button>
+          )}
+        </section>
+      )}
+
+      <InspectorSection title="Decision">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-sm text-gray-600">Document status</span>
+          {selectedStatus && (
+            <StatusBadge status={selectedStatus.label} variant={selectedStatus.variant} icon={selectedStatus.icon} />
+          )}
+        </div>
+        <div className="mt-3 grid gap-2">
+          {/* Approve button from Step 2 goes here */}
+          {!selectedIsRejected && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                setChangeRequestOpen(true);
+                setReviewReasonText(selectedDocument.rejection_reason ?? '');
+                setReviewReasonError(null);
+              }}
+              disabled={decisionDisabled}
+              className="justify-start gap-1 border-red-200 text-red-700 hover:bg-red-50 hover:text-red-800"
+            >
+              <PiXBold className="h-4 w-4" />
+              Request Changes
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => handleDocumentAction(selectedDocument.id, 'under_review')}
+            disabled={decisionDisabled}
+            className="justify-start gap-1 border-blue-200 text-blue-700 hover:bg-blue-50 hover:text-blue-800"
+          >
+            <PiClipboardTextBold className="h-4 w-4" />
+            {actionInFlight === `${selectedDocument.id}-under_review` ? 'Updating…' : 'Mark Under Review'}
+          </Button>
+        </div>
+        {/* keep the existing changeRequestOpen textarea block unchanged, moved inside this section */}
+      </InspectorSection>
+
+      <InspectorSection title="Automated checks">
+        <div className="space-y-0">
+          {buildAutomatedChecks({
+            nameMatch: submission.nameMatch,
+            mismatchAcknowledged: mismatchAck,
+            regNumber: step2?.regNumber,
+            hasSelectedDocument: Boolean(selectedDocument),
+            submittedAt: submission.submitted_at,
+          }).map((check, index, all) => (
+            <AutomatedCheckRow key={check.key} check={check} last={index === all.length - 1} />
+          ))}
+        </div>
+      </InspectorSection>
+
+      <InspectorSection title="Comparison context">
+        <div className="space-y-3 text-sm">
+          <InfoRow label="Business" value={step2?.entityName || '-'} />
+          <InfoRow label="Reg no." value={<span className="font-mono">{step2?.regNumber || '-'}</span>} />
+          <InfoRow label="Bank" value={primaryBanking.bank_name || '-'} />
+          <InfoRow label="Holder" value={primaryBanking.account_holder_name || '-'} />
+          {!submission.nameMatch && (
+            <div className="flex gap-2 rounded-md bg-amber-50 p-3 text-xs font-medium text-amber-800">
+              <PiWarningCircleBold className="mt-0.5 h-4 w-4 shrink-0" />
+              Account holder should match the registered entity name.
+            </div>
+          )}
+        </div>
+      </InspectorSection>
+    </div>
+  )}
+</div>
+```
+
+> Note: move the existing `changeRequestOpen` textarea block (the `{changeRequestOpen && (…)}` JSX with the reason textarea and Cancel/Send buttons) inside the Decision `InspectorSection`, unchanged.
+
+- [ ] **Step 4: Add the `AutomatedCheckRow` render helper**
+
+Add near the other small components in `page.tsx`:
+
+```tsx
+function AutomatedCheckRow({ check, last }: { check: import('./workbench-utils').AutomatedCheck; last: boolean }) {
+  return (
+    <div className={cn('flex gap-2.5 py-2', !last && 'border-b border-gray-100')}>
+      <div
+        className={cn(
+          'mt-0.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full',
+          check.pass ? 'bg-green-100' : 'bg-red-100'
+        )}
+      >
+        {check.pass ? (
+          <PiCheckBold className="h-3 w-3 text-green-700" />
+        ) : (
+          <PiXBold className="h-3 w-3 text-red-700" />
+        )}
+      </div>
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-900">{check.label}</p>
+        <p className={cn('mt-0.5 text-xs', check.pass ? 'text-gray-500' : 'text-red-600')}>{check.note}</p>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Remove dead inspector state, helpers, and imports**
+
+Remove from `page.tsx`:
+- State: `inspectorTab`/`setInspectorTab`, `metadataDraft`/`setMetadataDraft`, `metadataSavedAt`/`setMetadataSavedAt`, `commentText`/`setCommentText`, `comments`/`setComments`.
+- The effect body lines that set `metadataDraft`/`metadataSavedAt`/`commentText` (keep the `setZoom(100)`/`setRotation(0)`/`setDocumentDrawerOpen(false)` resets); delete the `buildDocumentMetadataDraft(...)` call.
+- Derived: `activeComments`, `updateMetadataDraft`, and the `WorkbenchComment` interface, `InspectorTab` type.
+- Components: `InspectorTabButton`, `MetadataField`, `CommentBubble`, `VersionRow`, `PermissionRow`, `DraftNotice`.
+- Imports: from `react-icons/pi` drop `PiFloppyDiskBold`, `PiTagBold`, `PiInfoBold`, `PiPencilSimpleBold`, `PiSignatureBold`, `PiMagnifyingGlassBold`, `PiCheckBold` only if unused (it IS used by AutomatedCheckRow/Approve — keep it), `PiClockCounterClockwiseBold` (verify each with grep before removing). From `./workbench-utils` drop `buildDocumentMetadataDraft`, `DocumentMetadataDraft`.
+
+From `workbench-utils.ts` remove: `DocumentMetadataDraft` interface, `DocumentMetadataSource` interface, and `buildDocumentMetadataDraft` function (now unused).
+
+From `__tests__/workbench-metadata.test.ts` remove any `buildDocumentMetadataDraft` import and its `describe`/`it` blocks.
+
+- [ ] **Step 6: Type-check + tests**
+
+Run: `npm run type-check:memory`
+Expected: no new errors in the three files.
+
+Run: `npx vitest run app/admin/b2b/vetting/'[submissionId]'/__tests__/workbench-metadata.test.ts`
+Expected: PASS (automated-checks + retained summary/drawer tests; no metadata-draft tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "app/admin/b2b/vetting/[submissionId]/page.tsx" "app/admin/b2b/vetting/[submissionId]/workbench-utils.ts" "app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts"
+git commit -m "feat(vetting): blocking mismatch gate + trimmed data-backed inspector"
+```
+
+---
+
+### Task 4: Verify end-to-end
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full type-check**
+
+Run: `npm run type-check:memory`
+Expected: no NEW errors introduced by these three files (repo carries ~295 pre-existing errors; confirm none are in the vetting files).
+
+- [ ] **Step 2: Run the test file**
+
+Run: `npx vitest run app/admin/b2b/vetting/'[submissionId]'/__tests__/workbench-metadata.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Browser verification (real admin session)**
+
+Using a minted admin session (see memory: admin-session-cookie-minting), open
+`/admin/b2b/vetting/72c421e0-946b-44cb-b297-7761ced75d8a`. Confirm:
+- Document renders inline in the center column (no drawer needed); zoom/fit work; image rotate appears for image docs; Reload re-fetches.
+- Expand opens the fullscreen Sheet with the same viewer; close returns.
+- For a submission with `nameMatch === false`: Approve shows lock + "Resolve the flag first" and is disabled; clicking "Acknowledge & override" flips the card and unlocks Approve; the holderMatch check row flips to "Overridden by reviewer".
+- Request Changes (with reason) and Mark Under Review still call through and refresh.
+
+- [ ] **Step 4: Invoke verification-before-completion skill**
+
+Before claiming done, run `superpowers:verification-before-completion`.
+
+## Self-Review Notes
+
+- Spec coverage: center live viewer (Task 2) ✓; mismatch blocking gate (Task 3 Steps 1-3) ✓; trimmed inspector / dropped tabs (Task 3 Step 5) ✓; `buildAutomatedChecks` from real data (Task 1) ✓; no API/DB change (constraints) ✓; fullscreen drawer reuses viewer (Task 2 Step 4) ✓.
+- Type consistency: `DocumentViewer` prop names identical in inline + fullscreen call sites; `AutomatedCheck` shape used by helper, tests, and `AutomatedCheckRow`; `approveBlocked` defined once and consumed in the Approve button.
+- Placeholder scan: no TBD/TODO; all new code shown in full.

--- a/docs/superpowers/specs/2026-06-18-vetting-workbench-refactor-design.md
+++ b/docs/superpowers/specs/2026-06-18-vetting-workbench-refactor-design.md
@@ -1,0 +1,183 @@
+# B2B Vetting Workbench Refactor — Design
+
+**Date:** 2026-06-18
+**Route:** `/admin/b2b/vetting/[submissionId]`
+**File:** `app/admin/b2b/vetting/[submissionId]/page.tsx`
+**Status:** Approved (design)
+
+## Problem
+
+The vetting detail page already uses a 3-column layout (Documents checklist | center | inspector),
+but the **center column shows placeholder cards** ("Document opens in a focused drawer", "Review
+focus", "Current notes") and the **actual document only renders inside a right-side slide-over
+`Sheet`** that the reviewer must open with a click. The result wastes the widest part of the page
+and forces a drawer round-trip for the core task — reading the document and deciding on it.
+
+The inspector also carries four tabs (Metadata, Notes, Versions, Access) that are explicitly
+browser-only drafts and never persist to the backend, adding clutter around the one real action
+(approve / request changes / under review).
+
+## Goals
+
+1. Put a **live document viewer in the center column** — document and decision controls visible
+   together, no drawer round-trip.
+2. Make the **entity-name mismatch a blocking gate** with an explicit acknowledge/override, instead
+   of a soft warning that can be approved through.
+3. **Trim the inspector** to the features backed by real data: decision, derived automated checks,
+   and comparison context.
+4. No API, database, or backend changes. All existing real actions stay byte-for-byte.
+
+## Non-Goals
+
+- No multi-page paging / page thumbnails (we render a single real file, as today).
+- No persisted metadata, comments, version history, or access control (those were placeholders).
+- No invented signals (e.g. fake "OCR confidence 96%"). Checks are derived from real fields only.
+- No changes to `/api/admin/kyc/verify`, `/api/admin/kyc/document-url`,
+  `/api/admin/b2b/mandate-confirm`, or the submission fetch.
+
+## Layout
+
+Keep the header (business name · account · segment · submitted, status badge, Back button) and the
+existing 4-stat progress band. Keep the workspace grid
+`xl:grid-cols-[260px_minmax(0,1fr)_360px]`.
+
+```
+Header: business name · account · segment · submitted        [status] [Back]
+Progress band: Approved x/y · Needs decision · Missing · Last reviewed
+┌─ DOCS (260) ─┬─ LIVE VIEWER (flex) ──────┬─ INSPECTOR (360) ─┐
+│ checklist     │ toolbar: zoom −/＋ · fit · │ ⚠ Mismatch gate   │
+│ rows with     │   rotate(img) · reload ·  │ Decision buttons  │
+│ number, label,│   open original · ⤢ full  │ Automated checks  │
+│ status badge  │ ┌───────────────────────┐ │ Comparison context│
+│               │ │  PDF iframe / <img>   │ │                   │
+│               │ │  scaled by zoom/rot   │ │                   │
+│               │ └───────────────────────┘ │                   │
+└───────────────┴───────────────────────────┴───────────────────┘
+```
+
+- **Left (Documents, 260):** unchanged behaviour — required-document checklist rows with index,
+  label, status badge, file-type chip, and rejection-reason preview. Clicking a row selects it.
+  The per-row "View document" button now just selects (center shows it); the explicit fullscreen
+  open stays available via the row action and the viewer's expand button.
+- **Center (Live viewer, flex):** the new inline `DocumentViewer` (see below). Replaces the three
+  placeholder cards.
+- **Right (Inspector, 360):** trimmed, no tabs — three stacked sections (Mismatch gate when
+  applicable, Decision, Automated checks, Comparison context).
+
+## Components
+
+### `DocumentViewer` (new, in `page.tsx`)
+
+A single viewer used in **both** the center column and the existing fullscreen `Sheet`. It owns:
+
+- **Toolbar:** zoom out / zoom in (clamped, e.g. 70–140%), fit/reset (100%, rotation 0),
+  **rotate** (images only, CSS `transform: rotate`), reload (re-fetches signed URL via the existing
+  `docRefreshKey` mechanism), open-original (existing `window.open(docUrl)`), and an **expand**
+  button that opens the fullscreen `Sheet`. In the fullscreen `Sheet` the expand button becomes a
+  close/minimize.
+- **Canvas states:** the existing `DocumentPreviewCanvas` logic — empty / loading / error / PDF
+  iframe / image / non-PDF-non-image fallback — promoted into this shared component. Zoom and (for
+  images) rotation applied via `transform`.
+
+This removes the duplicated drawer toolbar markup and the standalone `DocumentPreviewCanvas`, and
+deletes the three center placeholder cards.
+
+**Inputs:** `selectedDocument`, `docUrl`, `docLoading`, `docError`, `selectedIsPdf`,
+`selectedIsImage`, `zoom`, `rotation`, setters, `onReload`, `onOpenOriginal`, `onExpand`/`onClose`,
+`title`, `variant: 'inline' | 'fullscreen'`.
+
+### Inspector (right column, no tabs)
+
+Replace the 5-tab inspector with three stacked sections (reuse `InspectorSection`, `InfoRow`,
+`StatusBadge`):
+
+1. **Mismatch gate** — rendered only when `!submission.nameMatch`. Shows Registered entity vs
+   Account holder on file and an **"Acknowledge & override"** button. After acknowledgement, flips
+   to "Mismatch acknowledged — override recorded against your reviewer ID."
+2. **Decision** — Approve / Request changes (inline reason textarea, existing validation + API) /
+   Mark under review. Same `handleDocumentAction` calls. Reset-decision link preserved.
+3. **Automated checks** — rows derived from real data via `buildAutomatedChecks()` (see below). Each
+   row shows pass/fail and a short note. The holder-vs-entity row reflects acknowledgement.
+4. **Comparison context** — Business / Reg no. (mono) / Bank / Holder via existing `InfoRow`s, plus
+   the existing amber "holder should match registered entity" hint.
+
+**Removed:** Metadata, Notes, Versions, Access tabs; the `InspectorTabButton`, `MetadataField`,
+`CommentBubble`, `VersionRow`, `PermissionRow`, `DraftNotice` components; and the
+`metadataDraft` / `metadataSavedAt` / `comments` / `commentText` / `inspectorTab` state and the
+`Save` draft button.
+
+## Mismatch gate (state + behaviour)
+
+- New state: `const [mismatchAck, setMismatchAck] = useState(false)` — submission-scoped, reset when
+  `submissionId` changes.
+- Gate predicate: `const approveBlocked = !submission.nameMatch && !mismatchAck`.
+- `decisionDisabled` (existing) gains `|| (status === 'approved' && approveBlocked)` semantics:
+  concretely, the **Approve** button is disabled when `approveBlocked`, shows a lock icon and a
+  "Resolve the flag first" hint; Request-changes and Under-review are never gated.
+- This is **UI-level only** — no new column, no schema change. The override is a session
+  acknowledgement that unlocks the existing approve API call.
+
+## `buildAutomatedChecks()` (new helper in `workbench-utils.ts`)
+
+Pure function, fully unit-testable. Signature:
+
+```ts
+export interface AutomatedCheckInput {
+  nameMatch: boolean;
+  mismatchAcknowledged: boolean;
+  regNumber: string | undefined;
+  hasSelectedDocument: boolean;
+  submittedAt: string | null;
+  slaDays?: number; // default 2 (matches the existing vetting SLA)
+  now?: number;     // injectable clock (ms epoch) for deterministic tests; defaults to Date.now()
+}
+
+export interface AutomatedCheck {
+  key: string;
+  label: string;
+  pass: boolean;
+  note: string;
+}
+
+export function buildAutomatedChecks(input: AutomatedCheckInput): AutomatedCheck[];
+```
+
+Checks (all from real fields, no fabricated confidence numbers):
+
+| key            | label                        | pass when…                                  | note examples                         |
+|----------------|------------------------------|---------------------------------------------|---------------------------------------|
+| `holderMatch`  | Holder = registered entity   | `nameMatch` OR `mismatchAcknowledged`        | "Match" / "Overridden by reviewer" / "Names differ" |
+| `regNumber`    | Registration number present  | `regNumber` is non-empty                     | "Captured" / "Missing"                |
+| `documentReady`| Document uploaded            | `hasSelectedDocument`                         | "File available" / "No file"          |
+| `withinSla`    | Submitted within SLA         | `submittedAt` within `slaDays` of now        | "0 days overdue" / "N days overdue"   |
+
+## Data flow
+
+Unchanged: `fetchSubmission` → `submission`; `requiredDocItems` (memo) drives the checklist and
+counts; selecting a row sets `selectedDoc`; the signed-URL effect populates `docUrl`. The center
+viewer reads the same `docUrl`/`docLoading`/`docError`. Decisions call the same endpoints and
+`fetchSubmission({ showLoading: false })` to refresh.
+
+## Error handling
+
+- Document load errors render the existing `ErrorState` with retry (reload) inside the viewer.
+- `actionError` banner unchanged.
+- Change-request requires a non-empty reason (existing validation preserved).
+
+## Testing
+
+- `__tests__/workbench-metadata.test.ts` → update: remove `buildDocumentMetadataDraft` tests; add
+  `buildAutomatedChecks` tests covering: match vs mismatch vs acknowledged-override, missing reg
+  number, no document, within-SLA vs overdue (using a fixed "now" injected via a date arg or a
+  `submittedAt` far in the past).
+- Manual: `npm run type-check:memory`; browser-verify with a real admin session against a submission
+  that has a name mismatch (gate blocks approve → ack → approve unlocks) and one without.
+
+## Blast radius
+
+- `app/admin/b2b/vetting/[submissionId]/page.tsx` — layout, `DocumentViewer`, mismatch gate, trimmed
+  inspector.
+- `app/admin/b2b/vetting/[submissionId]/workbench-utils.ts` — add `buildAutomatedChecks`; drop
+  unused draft helpers; keep formatting + summary + drawer-summary + pdf/image helpers.
+- `app/admin/b2b/vetting/[submissionId]/__tests__/workbench-metadata.test.ts` — updated tests.
+- No API / DB / backend changes.


### PR DESCRIPTION
## What & why

Refactors `/admin/b2b/vetting/[submissionId]` to use the page area properly. The center column previously showed **placeholder cards** while the actual document hid behind a slide-over `Sheet` (a click away). Now the document renders **live in the center**, with the decision controls beside it.

Built from a brainstormed spec → plan (both included): `docs/superpowers/specs/2026-06-18-vetting-workbench-refactor-design.md`, `docs/superpowers/plans/2026-06-18-vetting-workbench-refactor.md`.

## Changes

- **Live document in the center column** via a shared `DocumentViewer` (zoom / fit / rotate-for-images / reload / open-original / expand). The fullscreen `Sheet` reuses the same viewer — no more placeholder cards, no drawer round-trip to read a file.
- **Blocking entity-name mismatch gate** (UI-level, no schema change): when the account holder ≠ registered entity, **Approve is disabled** ("Resolve the flag first" + lock) until the reviewer clicks **Acknowledge & override**; Request-changes / Under-review are never gated.
- **Trimmed inspector** to data-backed sections — **Decision / Automated checks / Comparison context**. The non-persisting Metadata / Notes / Versions / Access placeholder tabs and their dead helpers/state/imports are removed.
- **`buildAutomatedChecks()`** helper (TDD) derives checks from real fields only (holder match, reg-number present, document uploaded, within-SLA) — no fabricated OCR numbers.

No API, DB, or backend changes. Preserves the recently-merged add-document / manual-email-banner feature (`d93230d0`) — "Add document" button, `UploadDocumentModal`, and the 📧 banner are intact.

## Verification

- **Unit tests:** 7/7 pass (`workbench-metadata.test.ts`).
- **Type-check:** clean in the vetting files (`npm run type-check:memory`).
- **Lint:** `next lint` exit 0 (warnings only, consistent with the file).
- **Browser-verified on staging** with a real admin session against a submission that has a genuine name mismatch: 3-column layout with live ID-document preview + viewer toolbar; "Acknowledge & override" flips the flag *Entity name mismatch → Mismatch acknowledged* and the holder check recomputes *Names differ → Overridden by reviewer*. Staging deploy `27788101569` succeeded (container healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)