### PR TITLE
feat(coverage): surface MTN Wholesale FWB feasibility in admin checker

### DIFF
--- a/app/admin/coverage/checker/components/MTNWholesaleFeasibilityCard.tsx
+++ b/app/admin/coverage/checker/components/MTNWholesaleFeasibilityCard.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  PiBroadcastBold,
+  PiCheckCircleBold,
+  PiSpinnerBold,
+  PiWarningCircleBold,
+  PiXCircleBold,
+} from 'react-icons/pi';
+import { StatusBadge } from '@/components/admin/shared';
+
+interface MTNWholesaleFeasibilityCardProps {
+  lat: number;
+  lng: number;
+  address: string;
+  autoCheck?: boolean;
+}
+
+interface FwbResult {
+  feasible: boolean;
+  region: string | null;
+  capacityMbps: number | null;
+  medium: string | null;
+  nni: string | null;
+  upNode: string | null;
+  reference: string | null;
+}
+
+// The live MTN Wholesale API returns a flat `outputs[]` where each output is a
+// product result (boolean `product_feasible`, `product_medium: "FWA"`, etc.).
+// The older typed shape nests `outputs[].product_results[]` with `'Yes'|'No'`.
+// Parse defensively so either shape works.
+function parseFwb(data: unknown): FwbResult | null {
+  const outputs = Array.isArray((data as { outputs?: unknown[] })?.outputs)
+    ? (data as { outputs: Record<string, unknown>[] }).outputs
+    : [];
+
+  const products: Record<string, unknown>[] = [];
+  for (const output of outputs) {
+    const nested = output?.product_results;
+    if (Array.isArray(nested) && nested.length > 0) {
+      products.push(...(nested as Record<string, unknown>[]));
+    } else {
+      products.push(output);
+    }
+  }
+  if (products.length === 0) return null;
+
+  const fwb =
+    products.find(
+      (p) =>
+        String(p?.product_medium ?? '').toUpperCase() === 'FWA' ||
+        String(p?.product_name ?? '').toLowerCase().includes('fixed wireless')
+    ) ?? products[0];
+
+  const feasibleRaw = fwb?.product_feasible;
+  const feasible =
+    feasibleRaw === true ||
+    ['yes', 'true'].includes(String(feasibleRaw).toLowerCase());
+
+  const capRaw = fwb?.product_capacity;
+  const capacityNum = capRaw === '' || capRaw == null ? NaN : Number(capRaw);
+
+  const str = (v: unknown): string | null => {
+    const s = String(v ?? '').trim();
+    return s && s.toLowerCase() !== 'none' ? s : null;
+  };
+
+  return {
+    feasible,
+    region: str(fwb?.product_region),
+    capacityMbps: Number.isFinite(capacityNum) ? capacityNum : null,
+    medium: str(fwb?.product_medium),
+    nni: str(fwb?.product_nni),
+    upNode: str(fwb?.product_up_node),
+    reference: str(fwb?.id),
+  };
+}
+
+export default function MTNWholesaleFeasibilityCard({
+  lat,
+  lng,
+  address,
+  autoCheck = true,
+}: MTNWholesaleFeasibilityCardProps) {
+  const [result, setResult] = useState<FwbResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const lastAutoCheckKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setResult(null);
+    setError(null);
+  }, [lat, lng]);
+
+  const checkFeasibility = useCallback(async () => {
+    setIsChecking(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/mtn-wholesale/feasibility', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          inputs: [
+            {
+              latitude: String(lat),
+              longitude: String(lng),
+              customer_name: 'Coverage Checker',
+              address,
+            },
+          ],
+          product_names: ['Fixed Wireless Broadband'],
+          requestor: 'coverage@circletel.co.za',
+        }),
+      });
+
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(
+          (body?.message as string) ||
+            (body?.error as string) ||
+            `MTN Wholesale check failed (${response.status})`
+        );
+      }
+
+      const parsed = parseFwb(body);
+      if (!parsed) {
+        throw new Error('MTN Wholesale returned no feasibility result for this location');
+      }
+      setResult(parsed);
+    } catch (err) {
+      setResult(null);
+      setError(err instanceof Error ? err.message : 'MTN Wholesale feasibility check failed');
+    } finally {
+      setIsChecking(false);
+    }
+  }, [address, lat, lng]);
+
+  useEffect(() => {
+    if (!autoCheck) return;
+    const key = `${lat}:${lng}`;
+    if (lastAutoCheckKeyRef.current === key) return;
+    lastAutoCheckKeyRef.current = key;
+    void checkFeasibility();
+  }, [autoCheck, checkFeasibility, lat, lng]);
+
+  const panelClass = result?.feasible
+    ? 'border-emerald-200 bg-emerald-50'
+    : 'border-red-200 bg-red-50';
+  const PanelIcon = result?.feasible ? PiCheckCircleBold : PiXCircleBold;
+  const iconClass = result?.feasible ? 'text-emerald-600' : 'text-red-600';
+
+  return (
+    <section className="bg-white rounded-xl border border-slate-200 p-5 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="rounded-full bg-orange-50 p-2 text-circleTel-orange">
+            <PiBroadcastBold className="h-5 w-5" />
+          </div>
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-base font-semibold text-slate-900">
+                Fixed Wireless Broadband
+              </h2>
+              <StatusBadge status="MTN Wholesale" variant="info" />
+            </div>
+            <p className="mt-1 max-w-2xl text-sm text-slate-500">
+              MTN National Wholesale CSP feasibility — the product the LTE / 5G coverage maps don&apos;t cover.
+            </p>
+            <p className="mt-1 text-xs text-slate-400 truncate max-w-2xl">{address}</p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => checkFeasibility()}
+          disabled={isChecking}
+          className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg bg-circleTel-orange px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#C45A30] disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {isChecking ? (
+            <PiSpinnerBold className="h-4 w-4 animate-spin" />
+          ) : (
+            <PiBroadcastBold className="h-4 w-4" />
+          )}
+          {isChecking ? 'Checking…' : 'Re-check Feasibility'}
+        </button>
+      </div>
+
+      {isChecking && !result && (
+        <div className="mt-4 flex items-center gap-2 text-sm text-slate-500">
+          <PiSpinnerBold className="h-4 w-4 animate-spin" />
+          Querying MTN Wholesale feasibility…
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <PiWarningCircleBold className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {result && (
+        <div className={`mt-4 rounded-lg border px-4 py-4 ${panelClass}`}>
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="flex items-start gap-3">
+              <PanelIcon className={`mt-0.5 h-5 w-5 shrink-0 ${iconClass}`} />
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-semibold text-slate-900">
+                    {result.feasible ? 'Feasible at this location' : 'Not feasible at this location'}
+                  </p>
+                  <StatusBadge
+                    status={result.feasible ? 'Feasible' : 'Not feasible'}
+                    variant={result.feasible ? 'success' : 'error'}
+                  />
+                </div>
+                {result.region && (
+                  <p className="mt-2 text-sm text-slate-700">Region: {result.region}</p>
+                )}
+              </div>
+            </div>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-slate-600 sm:grid-cols-4 md:text-right">
+              <div>
+                <dt className="text-slate-400">Capacity</dt>
+                <dd className="font-semibold text-slate-800">
+                  {result.capacityMbps != null ? `${result.capacityMbps} Mbps` : '—'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-slate-400">Medium</dt>
+                <dd className="font-semibold text-slate-800">{result.medium ?? '—'}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-400">NNI</dt>
+                <dd className="font-semibold text-slate-800">{result.nni ?? '—'}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-400">Up Node</dt>
+                <dd className="font-semibold text-slate-800">{result.upNode ?? '—'}</dd>
+              </div>
+            </dl>
+          </div>
+          {result.reference && (
+            <p className="mt-3 text-xs text-slate-400">Feasibility ref: {result.reference}</p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/admin/coverage/checker/components/MTNWholesaleFeasibilityCard.tsx
+++ b/app/admin/coverage/checker/components/MTNWholesaleFeasibilityCard.tsx
@@ -27,57 +27,6 @@ interface FwbResult {
   reference: string | null;
 }
 
-// The live MTN Wholesale API returns a flat `outputs[]` where each output is a
-// product result (boolean `product_feasible`, `product_medium: "FWA"`, etc.).
-// The older typed shape nests `outputs[].product_results[]` with `'Yes'|'No'`.
-// Parse defensively so either shape works.
-function parseFwb(data: unknown): FwbResult | null {
-  const outputs = Array.isArray((data as { outputs?: unknown[] })?.outputs)
-    ? (data as { outputs: Record<string, unknown>[] }).outputs
-    : [];
-
-  const products: Record<string, unknown>[] = [];
-  for (const output of outputs) {
-    const nested = output?.product_results;
-    if (Array.isArray(nested) && nested.length > 0) {
-      products.push(...(nested as Record<string, unknown>[]));
-    } else {
-      products.push(output);
-    }
-  }
-  if (products.length === 0) return null;
-
-  const fwb =
-    products.find(
-      (p) =>
-        String(p?.product_medium ?? '').toUpperCase() === 'FWA' ||
-        String(p?.product_name ?? '').toLowerCase().includes('fixed wireless')
-    ) ?? products[0];
-
-  const feasibleRaw = fwb?.product_feasible;
-  const feasible =
-    feasibleRaw === true ||
-    ['yes', 'true'].includes(String(feasibleRaw).toLowerCase());
-
-  const capRaw = fwb?.product_capacity;
-  const capacityNum = capRaw === '' || capRaw == null ? NaN : Number(capRaw);
-
-  const str = (v: unknown): string | null => {
-    const s = String(v ?? '').trim();
-    return s && s.toLowerCase() !== 'none' ? s : null;
-  };
-
-  return {
-    feasible,
-    region: str(fwb?.product_region),
-    capacityMbps: Number.isFinite(capacityNum) ? capacityNum : null,
-    medium: str(fwb?.product_medium),
-    nni: str(fwb?.product_nni),
-    upNode: str(fwb?.product_up_node),
-    reference: str(fwb?.id),
-  };
-}
-
 export default function MTNWholesaleFeasibilityCard({
   lat,
   lng,
@@ -99,37 +48,20 @@ export default function MTNWholesaleFeasibilityCard({
     setError(null);
 
     try {
-      const response = await fetch('/api/mtn-wholesale/feasibility', {
+      const response = await fetch('/api/coverage/mtn/csp-feasibility', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          inputs: [
-            {
-              latitude: String(lat),
-              longitude: String(lng),
-              customer_name: 'Coverage Checker',
-              address,
-            },
-          ],
-          product_names: ['Fixed Wireless Broadband'],
-          requestor: 'coverage@circletel.co.za',
-        }),
+        body: JSON.stringify({ latitude: lat, longitude: lng, capacityMbps: 100 }),
       });
 
       const body = await response.json().catch(() => ({}));
-      if (!response.ok) {
+      if (!response.ok || !body?.success) {
         throw new Error(
-          (body?.message as string) ||
-            (body?.error as string) ||
-            `MTN Wholesale check failed (${response.status})`
+          (body?.error as string) || `MTN CSP feasibility check failed (${response.status})`
         );
       }
 
-      const parsed = parseFwb(body);
-      if (!parsed) {
-        throw new Error('MTN Wholesale returned no feasibility result for this location');
-      }
-      setResult(parsed);
+      setResult(body.data as FwbResult);
     } catch (err) {
       setResult(null);
       setError(err instanceof Error ? err.message : 'MTN Wholesale feasibility check failed');

--- a/app/admin/coverage/checker/page.tsx
+++ b/app/admin/coverage/checker/page.tsx
@@ -20,6 +20,7 @@ import DFAProductTiers from './components/DFAProductTiers';
 import DFAInstallationEstimate from './components/DFAInstallationEstimate';
 import MTNVerdictCard, { type MTNService } from './components/MTNVerdictCard';
 import MTNProductTiers, { type MTNPackage } from './components/MTNProductTiers';
+import MTNWholesaleFeasibilityCard from './components/MTNWholesaleFeasibilityCard';
 import SkyFibreOrderabilityCard from './components/SkyFibreOrderabilityCard';
 import RecentChecksPanel, { saveRecentCheck } from './components/RecentChecksPanel';
 import {
@@ -722,6 +723,12 @@ export default function CoverageCheckerPage() {
           {provider === 'mtn' && mtnResult && !mtnLoading && (
             <div className="space-y-4">
               <MTNVerdictCard services={mtnResult.services} confidence={mtnResult.confidence} />
+              <MTNWholesaleFeasibilityCard
+                lat={mtnResult.lat}
+                lng={mtnResult.lng}
+                address={mtnResult.address}
+                autoCheck
+              />
               <MTNProductTiers
                 products={mtnResult.packages}
                 fiveGAvailable={mtnResult.services.some((s) => s.type === '5g' && s.available)}

--- a/app/api/coverage/mtn/csp-feasibility/route.ts
+++ b/app/api/coverage/mtn/csp-feasibility/route.ts
@@ -1,0 +1,36 @@
+// MTN CSP (newcsp / mtnsi.mtn.co.za) Fixed Wireless Broadband feasibility.
+// Backs the admin coverage checker's MTN tab FWB card. Authenticates with
+// MTN_CSP_USERNAME/MTN_CSP_PASSWORD (no reCAPTCHA / no MTN_SESSION).
+import { NextRequest, NextResponse } from 'next/server';
+import { mtnCspClient } from '@/lib/coverage/skyfibre/csp-client';
+import { apiLogger } from '@/lib/logging';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const latitude = typeof body.latitude === 'number' ? body.latitude : Number(body.latitude);
+    const longitude = typeof body.longitude === 'number' ? body.longitude : Number(body.longitude);
+    const capacityMbps = body.capacityMbps != null ? Number(body.capacityMbps) : 100;
+
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+      return NextResponse.json(
+        { success: false, error: 'latitude and longitude are required' },
+        { status: 400 }
+      );
+    }
+
+    const data = await mtnCspClient.checkFwbFeasibility({ latitude, longitude, capacityMbps });
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    apiLogger.error('[MTN CSP Feasibility] check failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'MTN CSP feasibility check failed',
+      },
+      { status: 502 }
+    );
+  }
+}

--- a/lib/coverage/skyfibre/csp-client.ts
+++ b/lib/coverage/skyfibre/csp-client.ts
@@ -24,6 +24,40 @@ interface CspSession {
 
 let cachedSession: CspSession | null = null;
 
+/**
+ * Rich Fixed Wireless Broadband feasibility result from the CSP `feasibilityCheck`
+ * method (flat `outputs[0]` shape). Used by the admin coverage checker's MTN tab.
+ */
+export interface CspFwbFeasibility {
+  feasible: boolean;
+  region: string | null;
+  capacityMbps: number | null;
+  medium: string | null;
+  nni: string | null;
+  upNode: string | null;
+  reference: string | null;
+}
+
+function cspString(value: unknown): string | null {
+  const s = String(value ?? '').trim();
+  return s && s.toLowerCase() !== 'none' ? s : null;
+}
+
+export function normalizeFwbFeasibility(raw: unknown): CspFwbFeasibility {
+  const output = firstOutput(raw);
+  const capRaw = output?.product_capacity;
+  const cap = capRaw === '' || capRaw == null ? NaN : Number(capRaw);
+  return {
+    feasible: parseBoolean(output?.product_feasible) === true,
+    region: cspString(output?.product_region),
+    capacityMbps: Number.isFinite(cap) ? cap : null,
+    medium: cspString(output?.product_medium),
+    nni: cspString(output?.product_nni),
+    upNode: cspString(output?.product_up_node),
+    reference: cspString(output?.id),
+  };
+}
+
 export function selectCspFeasibilityMethod(
   capacityMbps: SkyFibreCapacityMbps
 ): CspFeasibilityMethod {
@@ -124,6 +158,40 @@ export class MtnCspClient {
         error: error instanceof Error ? error.message : 'CSP orderability check failed',
       };
     }
+  }
+
+  /**
+   * Rich FWB feasibility via the CSP `feasibilityCheck` method (returns region,
+   * capacity, medium, NNI, up-node, ref). Authenticates with username/password.
+   */
+  async checkFwbFeasibility(params: {
+    latitude: number;
+    longitude: number;
+    capacityMbps?: number;
+  }): Promise<CspFwbFeasibility> {
+    const capacityMbps = params.capacityMbps ?? 100;
+    const session = await this.getSession();
+    const query = new URLSearchParams({
+      method: 'feasibilityCheck',
+      latitude: String(params.latitude),
+      longitude: String(params.longitude),
+      capacity_mbps: String(capacityMbps),
+      product_name: CSP_PRODUCT_NAME,
+    });
+
+    const response = await this.fetchImpl(`${this.baseUrl}/feasibility.cfc?${query.toString()}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json, text/plain, */*',
+        Cookie: session.cookieHeader,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`CSP FWB feasibility failed with status ${response.status}`);
+    }
+
+    return normalizeFwbFeasibility(await response.json());
   }
 
   private async getSession(): Promise<CspSession> {


### PR DESCRIPTION
## Problem

The admin coverage checker's **MTN** tab only queried the MTN **WMS GeoServer** (LTE / 5G / Fixed-LTE coverage tiles). MTN **Fixed Wireless Broadband** feasibility lives in a different MTN system, so a feasible address (e.g. Cnr Andrew Mapheto & Thami Mnyele Dr, Thembisa → `Feasible / GAUTENG_TSH / 100 Mbps / FWA`) showed as **no coverage**, forcing manual portal lookups.

## Backend: MTN CSP / newcsp (mtnsi.mtn.co.za) — verified

FWB feasibility is served by the **MTN National Wholesale CSP** (`mtnsi.mtn.co.za/newcsp_api/.../feasibility.cfc`), which authenticates with **username/password** (no reCAPTCHA, no `MTN_SESSION`). Verified live with the portal session — `feasibilityCheck` returns the exact `FS…/FWA/GAUTENG_TSH/up-node X3443-BN-315` result. (The `asp-feasibility.mtnbusiness.co.za` wholesale API returns the same data but needs a reCAPTCHA-gated SSO session that's dead in prod — see #568 — so the CSP path is both correct and far more robust.)

## Change

- **`csp-client.ts`**: add `checkFwbFeasibility()` (`method=feasibilityCheck`) + `normalizeFwbFeasibility()` returning rich fields (feasible, region, capacity, medium, NNI, up-node, ref). Reuses the existing username/password session login.
- **New route** `app/api/coverage/mtn/csp-feasibility` wrapping it.
- **`MTNWholesaleFeasibilityCard`** (self-contained `autoCheck` card, same pattern as `SkyFibreOrderabilityCard`) repointed to the new route; under `MTNVerdictCard` in the MTN results block.

## Config

Requires `MTN_CSP_USERNAME` / `MTN_CSP_PASSWORD` at **runtime**. **Added to prod Coolify env** (runtime=true) — goes live on the next prod deploy (i.e. when this merges).

## Verification

- ✅ `type-check:memory` — 0 errors in changed files.
- ✅ End-to-end **locally** via the real CSP login: `checkFwbFeasibility(Thembisa,100)` → `{feasible:true, region:GAUTENG_TSH, capacityMbps:100, medium:FWA, nni:TJB1, upNode:X3443-BN-315}`.
- ⏳ Prod render verifies after merge+deploy (env already in place).

## Files
- `lib/coverage/skyfibre/csp-client.ts`
- `app/api/coverage/mtn/csp-feasibility/route.ts` (new)
- `app/admin/coverage/checker/components/MTNWholesaleFeasibilityCard.tsx` (new)
- `app/admin/coverage/checker/page.tsx` (+import/render)

Refs #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)