### PR TITLE
fix(billing): payment reconciliation silently wrote to non-existent columns

### DIFF
--- a/__tests__/api/cron/payment-reconciliation-payloads.test.ts
+++ b/__tests__/api/cron/payment-reconciliation-payloads.test.ts
@@ -1,0 +1,92 @@
+import {
+  buildPaidInvoiceUpdate,
+  buildUnpaidInvoiceUpdate,
+  buildPaymentTxnRow,
+} from '@/app/api/cron/payment-reconciliation/route';
+
+// Real columns (from information_schema, profile agyjovdugmtopasyvlng).
+const REAL_INVOICE_COLS = new Set(['status', 'amount_paid', 'paid_at', 'updated_at', 'notes']);
+const REAL_PT_COLS = new Set([
+  'id', 'transaction_id', 'customer_invoice_id', 'invoice_id', 'order_id', 'customer_id',
+  'customer_email', 'customer_name', 'amount', 'currency', 'status', 'payment_method',
+  'provider', 'provider_reference', 'provider_response', 'reference', 'reconciliation_source',
+  'reconciliation_queue_id', 'error_code', 'error_message', 'failure_reason', 'initiated_at',
+  'completed_at', 'created_at', 'updated_at', 'created_by', 'expires_at', 'metadata', 'payment_method_details',
+]);
+
+// The phantom columns the old code wrote to — Postgres rejected every write,
+// and the error was never checked, so reconciliation silently persisted nothing.
+const FORBIDDEN = [
+  'payment_reference', 'payment_type', 'netcash_reference', 'netcash_response',
+  'processed_at', 'transaction_date', 'failed_at',
+];
+
+describe('customer_invoices update payloads', () => {
+  it('paid update uses only real columns and sets status=paid', () => {
+    const p = buildPaidInvoiceUpdate(276, '2026-06-26T08:00:00+02:00');
+    for (const k of Object.keys(p)) expect(REAL_INVOICE_COLS.has(k)).toBe(true);
+    expect(p.status).toBe('paid');
+    expect(p.amount_paid).toBe(276);
+    expect(p.paid_at).toBe('2026-06-26T08:00:00+02:00');
+  });
+
+  it('unpaid update uses only real columns and records the reason', () => {
+    const p = buildUnpaidInvoiceUpdate('Insufficient funds', '2', '2026-06-26T00:00:00Z');
+    for (const k of Object.keys(p)) expect(REAL_INVOICE_COLS.has(k)).toBe(true);
+    expect(p.status).toBe('overdue');
+    expect(p.notes).toContain('Insufficient funds');
+    expect(p.notes).toContain('Code: 2');
+  });
+
+  it('neither update reintroduces the phantom columns', () => {
+    const merged = { ...buildPaidInvoiceUpdate(1, 'x'), ...buildUnpaidInvoiceUpdate('r', 'c', 'x') };
+    for (const bad of FORBIDDEN) expect(Object.keys(merged)).not.toContain(bad);
+  });
+});
+
+describe('payment_transactions row payloads', () => {
+  it('completed invoice txn uses only real columns and links the invoice', () => {
+    const row = buildPaymentTxnRow({
+      invoiceId: 'inv-1', amount: 276, reference: 'INV-2026-00014',
+      nowISO: '2026-06-26T08:00:00Z', outcome: 'completed', response: { transactionCode: 'TDD' },
+    });
+    for (const k of Object.keys(row)) expect(REAL_PT_COLS.has(k)).toBe(true);
+    expect(row.status).toBe('completed');
+    expect(row.customer_invoice_id).toBe('inv-1');
+    expect(row.order_id).toBeUndefined();
+    expect(row.payment_method).toBe('debit_order');
+    expect(row.provider).toBe('netcash');
+    expect(row.provider_reference).toBe('INV-2026-00014');
+    expect(row.completed_at).toBe('2026-06-26T08:00:00Z');
+  });
+
+  it('failed invoice txn uses only real columns and records the unpaid reason', () => {
+    const row = buildPaymentTxnRow({
+      invoiceId: 'inv-1', amount: 276, reference: 'INV-2026-00014',
+      nowISO: 'x', outcome: 'failed', unpaidCode: '2', unpaidReason: 'Insufficient funds',
+    });
+    for (const k of Object.keys(row)) expect(REAL_PT_COLS.has(k)).toBe(true);
+    expect(row.status).toBe('failed');
+    expect(row.failure_reason).toContain('Insufficient funds');
+    expect(row.error_code).toBe('2');
+    expect(row.completed_at).toBeUndefined();
+  });
+
+  it('order txn links order_id (not customer_invoice_id)', () => {
+    const row = buildPaymentTxnRow({
+      orderId: 'ord-1', amount: 899, reference: 'PAY-ORD-9841', nowISO: 'x', outcome: 'completed',
+    });
+    for (const k of Object.keys(row)) expect(REAL_PT_COLS.has(k)).toBe(true);
+    expect(row.order_id).toBe('ord-1');
+    expect(row.customer_invoice_id).toBeUndefined();
+  });
+
+  it('never emits the phantom columns that silently failed before', () => {
+    const rows = [
+      buildPaymentTxnRow({ invoiceId: 'i', amount: 1, reference: 'r', nowISO: 'x', outcome: 'completed' }),
+      buildPaymentTxnRow({ invoiceId: 'i', amount: 1, reference: 'r', nowISO: 'x', outcome: 'failed' }),
+      buildPaymentTxnRow({ orderId: 'o', amount: 1, reference: 'r', nowISO: 'x', outcome: 'completed' }),
+    ];
+    for (const row of rows) for (const bad of FORBIDDEN) expect(Object.keys(row)).not.toContain(bad);
+  });
+});

--- a/app/api/cron/payment-reconciliation/route.ts
+++ b/app/api/cron/payment-reconciliation/route.ts
@@ -221,6 +221,72 @@ async function runReconciliation(customDate?: Date): Promise<ReconciliationResul
   return result;
 }
 
+// ============================================================================
+// Pure payload builders (schema-correct; unit-tested in
+// __tests__/api/cron/payment-reconciliation-payloads.test.ts).
+//
+// These exist because the previous writers targeted columns that DO NOT EXIST
+// (customer_invoices.payment_reference/payment_method; payment_transactions
+// .payment_type/netcash_reference/netcash_response/processed_at/transaction_date
+// /failed_at). Postgres rejected every write, but the calls never checked the
+// returned error — so reconciliation reported success while persisting nothing.
+// Keeping the row shapes as pure functions lets a test lock the column contract.
+// ============================================================================
+
+/** customer_invoices update for a successful collection. */
+export function buildPaidInvoiceUpdate(amount: number, nowISO: string) {
+  return { status: 'paid', amount_paid: amount, paid_at: nowISO, updated_at: nowISO };
+}
+
+/** customer_invoices update for a failed/unpaid collection. */
+export function buildUnpaidInvoiceUpdate(reason: string | undefined, code: string | undefined, nowISO: string) {
+  return {
+    status: 'overdue',
+    notes: `Debit order failed: ${reason || 'Unknown reason'} (Code: ${code || 'N/A'})`,
+    updated_at: nowISO,
+  };
+}
+
+interface TxnInput {
+  invoiceId?: string;
+  orderId?: string;
+  amount: number;
+  reference: string;        // NetCash account reference (= invoice/order number)
+  nowISO: string;
+  outcome: 'completed' | 'failed';
+  unpaidCode?: string;
+  unpaidReason?: string;
+  response?: unknown;       // raw statement result, stored as provider_response (jsonb)
+}
+
+/** payment_transactions row for a reconciled debit (completed or failed). */
+export function buildPaymentTxnRow(input: TxnInput): Record<string, unknown> {
+  const subject = input.invoiceId ? `INV-${input.invoiceId}` : input.orderId;
+  const prefix = input.outcome === 'failed' ? 'NETCASH-FAILED-' : 'NETCASH-RECONCILE-';
+  const row: Record<string, unknown> = {
+    transaction_id: `${prefix}${subject}-${Date.now()}`,
+    amount: input.amount,
+    currency: 'ZAR',
+    status: input.outcome,
+    payment_method: 'debit_order',
+    provider: 'netcash',
+    provider_reference: input.reference,
+    reference: input.reference,
+    reconciliation_source: 'netcash_statement',
+  };
+  if (input.invoiceId) row.customer_invoice_id = input.invoiceId;
+  if (input.orderId) row.order_id = input.orderId;
+  if (input.outcome === 'completed') {
+    row.completed_at = input.nowISO;
+    if (input.response !== undefined) row.provider_response = input.response;
+  } else {
+    row.failure_reason = `${input.unpaidReason || 'Unknown'} (Code: ${input.unpaidCode || 'N/A'})`;
+    row.error_code = input.unpaidCode ?? null;
+    row.error_message = input.unpaidReason ?? null;
+  }
+  return row;
+}
+
 async function updateInvoiceAsPaid(
   supabase: Awaited<ReturnType<typeof createClient>>,
   invoiceId: string,
@@ -228,17 +294,11 @@ async function updateInvoiceAsPaid(
 ) {
   const now = new Date().toISOString();
 
-  await supabase
+  const { error: updateError } = await supabase
     .from('customer_invoices')
-    .update({
-      status: 'paid',
-      amount_paid: debitResult.amount,
-      paid_at: now,
-      payment_method: 'debit_order',
-      payment_reference: debitResult.accountReference,
-      updated_at: now,
-    })
+    .update(buildPaidInvoiceUpdate(debitResult.amount, now))
     .eq('id', invoiceId);
+  if (updateError) throw new Error(`customer_invoices paid update failed: ${updateError.message}`);
 
   // Idempotency check: don't insert duplicate payment transaction if one already exists
   const { data: existingPaid } = await supabase
@@ -254,20 +314,17 @@ async function updateInvoiceAsPaid(
   }
 
   // Create payment transaction record linked to the invoice for Zoho Books sync
-  await supabase
+  const { error: insertError } = await supabase
     .from('payment_transactions')
-    .insert({
-      transaction_id: `NETCASH-RECONCILE-INV-${invoiceId}-${Date.now()}`,
-      customer_invoice_id: invoiceId,
+    .insert(buildPaymentTxnRow({
+      invoiceId,
       amount: debitResult.amount,
-      currency: 'ZAR',
-      payment_type: 'debit_order',
-      status: 'completed',
-      netcash_reference: debitResult.accountReference,
-      netcash_response: debitResult,
-      processed_at: now,
-      transaction_date: now,
-    });
+      reference: debitResult.accountReference,
+      nowISO: now,
+      outcome: 'completed',
+      response: debitResult,
+    }));
+  if (insertError) throw new Error(`payment_transactions insert failed: ${insertError.message}`);
 }
 
 async function updateOrderAsPaid(
@@ -277,7 +334,7 @@ async function updateOrderAsPaid(
 ) {
   const now = new Date().toISOString();
 
-  await supabase
+  const { error: updateError } = await supabase
     .from('consumer_orders')
     .update({
       payment_status: 'paid',
@@ -285,22 +342,28 @@ async function updateOrderAsPaid(
       updated_at: now,
     })
     .eq('id', orderId);
+  if (updateError) throw new Error(`consumer_orders paid update failed: ${updateError.message}`);
 
-  // Create payment transaction record
-  await supabase
+  // Idempotency check: don't insert duplicate payment transaction if one already exists
+  const { data: existingPaid } = await supabase
     .from('payment_transactions')
-    .insert({
-      transaction_id: `NETCASH-RECONCILE-${orderId}-${Date.now()}`,
-      order_id: orderId,
+    .select('id')
+    .eq('order_id', orderId)
+    .eq('status', 'completed')
+    .limit(1);
+  if (existingPaid && existingPaid.length > 0) return;
+
+  const { error: insertError } = await supabase
+    .from('payment_transactions')
+    .insert(buildPaymentTxnRow({
+      orderId,
       amount: debitResult.amount,
-      currency: 'ZAR',
-      payment_type: 'debit_order',
-      status: 'completed',
-      netcash_reference: debitResult.accountReference,
-      netcash_response: debitResult,
-      processed_at: now,
-      transaction_date: now,
-    });
+      reference: debitResult.accountReference,
+      nowISO: now,
+      outcome: 'completed',
+      response: debitResult,
+    }));
+  if (insertError) throw new Error(`payment_transactions insert failed: ${insertError.message}`);
 }
 
 async function markInvoiceUnpaid(
@@ -310,14 +373,11 @@ async function markInvoiceUnpaid(
 ) {
   const now = new Date().toISOString();
 
-  await supabase
+  const { error: updateError } = await supabase
     .from('customer_invoices')
-    .update({
-      status: 'overdue',
-      notes: `Debit order failed: ${debitResult.unpaidReason || 'Unknown reason'} (Code: ${debitResult.unpaidCode || 'N/A'})`,
-      updated_at: now,
-    })
+    .update(buildUnpaidInvoiceUpdate(debitResult.unpaidReason, debitResult.unpaidCode, now))
     .eq('id', invoiceId);
+  if (updateError) throw new Error(`customer_invoices unpaid update failed: ${updateError.message}`);
 
   // Idempotency check: don't insert duplicate payment transaction if one already exists
   const { data: existingFailed } = await supabase
@@ -333,50 +393,48 @@ async function markInvoiceUnpaid(
   }
 
   // Create failed payment transaction record linked to the invoice
-  await supabase
+  const { error: insertError } = await supabase
     .from('payment_transactions')
-    .insert({
-      transaction_id: `NETCASH-FAILED-INV-${invoiceId}-${Date.now()}`,
-      customer_invoice_id: invoiceId,
+    .insert(buildPaymentTxnRow({
+      invoiceId,
       amount: debitResult.amount,
-      currency: 'ZAR',
-      payment_type: 'debit_order',
-      status: 'failed',
-      failure_reason: `${debitResult.unpaidReason || 'Unknown'} (Code: ${debitResult.unpaidCode || 'N/A'})`,
-      netcash_reference: debitResult.accountReference,
-      failed_at: now,
-      transaction_date: now,
-    });
+      reference: debitResult.accountReference,
+      nowISO: now,
+      outcome: 'failed',
+      unpaidCode: debitResult.unpaidCode,
+      unpaidReason: debitResult.unpaidReason,
+    }));
+  if (insertError) throw new Error(`payment_transactions failed-insert failed: ${insertError.message}`);
 }
 
 async function markOrderUnpaid(
   supabase: Awaited<ReturnType<typeof createClient>>,
   orderId: string,
-  debitResult: { unpaidCode?: string; unpaidReason?: string; amount: number; transactionCode: string }
+  debitResult: { unpaidCode?: string; unpaidReason?: string; amount: number; transactionCode: string; accountReference: string }
 ) {
   const now = new Date().toISOString();
 
-  await supabase
+  const { error: updateError } = await supabase
     .from('consumer_orders')
     .update({
       payment_status: 'failed',
       updated_at: now,
     })
     .eq('id', orderId);
+  if (updateError) throw new Error(`consumer_orders unpaid update failed: ${updateError.message}`);
 
   // Create failed payment transaction record
-  await supabase
+  const { error: insertError } = await supabase
     .from('payment_transactions')
-    .insert({
-      transaction_id: `NETCASH-FAILED-${orderId}-${Date.now()}`,
-      order_id: orderId,
+    .insert(buildPaymentTxnRow({
+      orderId,
       amount: debitResult.amount,
-      currency: 'ZAR',
-      payment_type: 'debit_order',
-      status: 'failed',
-      failure_reason: `${debitResult.unpaidReason || 'Unknown'} (Code: ${debitResult.unpaidCode || 'N/A'})`,
-      failed_at: now,
-      transaction_date: now,
-    });
+      reference: debitResult.accountReference,
+      nowISO: now,
+      outcome: 'failed',
+      unpaidCode: debitResult.unpaidCode,
+      unpaidReason: debitResult.unpaidReason,
+    }));
+  if (insertError) throw new Error(`payment_transactions failed-insert failed: ${insertError.message}`);
 }
 


### PR DESCRIPTION
## Problem

The daily `payment-reconciliation` cron **fires on schedule** (43 runs logged, `vercel_cron`) but has been **reconciling nothing**. Every write targeted columns that don't exist in the schema, and the code **never checked the Supabase `.error`** — so it reported `successful` while persisting zero changes.

Result: clinic debit collections stayed `sent`/unpaid in Supabase even after NetCash confirmed the money. Verified on **INV-2026-00014 (Heidelberg)** + **INV-2026-00015 (Barcelona)** — collected via TDD on 26 Jun (statement + balance +R552), yet both invoices remained `sent` until posted manually.

### Phantom columns (rejected by Postgres, error swallowed)
| Table | Wrong | Real |
|---|---|---|
| `customer_invoices` | `payment_reference`, `payment_method` | _(removed)_ |
| `payment_transactions` | `payment_type`, `netcash_reference`, `netcash_response`, `processed_at`, `transaction_date`, `failed_at` | `payment_method`, `provider`, `provider_reference`, `provider_response`, `completed_at`, `error_code`, `error_message`, `failure_reason` |

## Fix
- **Schema-correct pure builders** (`buildPaidInvoiceUpdate`, `buildUnpaidInvoiceUpdate`, `buildPaymentTxnRow`) so the column contract is testable and a regression can't silently return.
- **Check `.error` on every write and throw** — failures now surface in the cron result (`records_failed`/`partial`) instead of false success.
- Order-path idempotency guard (parity with the invoice path).
- **7 unit tests** asserting payloads use only real columns and never re-emit the phantom ones.

## Verification
- `npx jest __tests__/api/cron/payment-reconciliation-payloads.test.ts` → 7/7 pass
- `tsc --noEmit` → no errors in changed files
- The two 26-Jun collections were already posted manually with the corrected schema (verified `paid` + linked `payment_transactions`, `zoho_sync_status=pending`). This fix makes the **daily cron do it automatically** going forward — Cosmo (29 Jun), Kayamandi + Fleurhof (01 Jul) will then reconcile themselves.

## Follow-up (not in this PR)
The 07:00 SAST run shows `partial`/`failed:1` — the previous-day statement may not be fully published that early. Consider shifting/retrying so the statement is matchable (the evening manual run matched cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)