### PR TITLE
feat(coverage): no-coverage mobile cross-sell (Phase 1)

### DIFF
--- a/app/(marketing)/check-coverage/CheckCoverageContent.tsx
+++ b/app/(marketing)/check-coverage/CheckCoverageContent.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-icons/pi';
 import { toast } from 'sonner';
 import { AddressAutocomplete } from '@/components/coverage/AddressAutocomplete';
-import { NoCoverageLeadCapture } from '@/components/coverage/NoCoverageLeadCapture';
+import { NoCoverageOptions } from '@/components/coverage/NoCoverageOptions';
 import { getWhatsAppLink, CONTACT } from '@/lib/constants/contact';
 import Link from 'next/link';
 
@@ -109,7 +109,7 @@ export function CheckCoverageContent() {
           </p>
 
           {noCoverage ? (
-            <NoCoverageLeadCapture
+            <NoCoverageOptions
               address={location?.address ?? ''}
               latitude={location?.latitude}
               longitude={location?.longitude}

--- a/app/packages/[leadId]/page.tsx
+++ b/app/packages/[leadId]/page.tsx
@@ -16,7 +16,7 @@ import { useOrderContext } from '@/components/order/context/OrderContext';
 import { useCustomerAuth } from '@/components/providers/CustomerAuthProvider';
 import type { PackageDetails, SelectedAddon } from '@/lib/order/types';
 import { AddonsSelection } from '@/components/order/AddonsSelection';
-import { NoCoverageLeadCapture } from '@/components/coverage/NoCoverageLeadCapture';
+import { NoCoverageOptions } from '@/components/coverage/NoCoverageOptions';
 import { LicensedWirelessLeadCapture } from '@/components/coverage/LicensedWirelessLeadCapture';
 import {
   Tooltip,
@@ -549,9 +549,9 @@ function PackagesContent() {
             />
           </div>
         ) : packages.length === 0 ? (
-          /* No Coverage - Show Lead Capture */
+          /* No Coverage - Show mobile cross-sell + lead capture */
           <div className="max-w-4xl mx-auto">
-            <NoCoverageLeadCapture
+            <NoCoverageOptions
               address={address}
               latitude={coordinates?.lat}
               longitude={coordinates?.lng}

--- a/components/coverage/NoCoverageLeadCapture.tsx
+++ b/components/coverage/NoCoverageLeadCapture.tsx
@@ -7,7 +7,7 @@ import { PiBellBold, PiCheckCircleBold, PiMapPinBold, PiSpinnerBold, PiWarningCi
  * Captures contact info for future expansion opportunities
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -22,14 +22,29 @@ interface NoCoverageLeadCaptureProps {
   address: string;
   latitude?: number;
   longitude?: number;
+  /** Pre-selects the "Interested in" service (e.g. '5g', 'lte') when the visitor picks a cross-sell option. */
+  defaultServiceType?: string;
+  /** Human label for a chosen cross-sell package; folded into the lead notes on submit. */
+  selectedPackageLabel?: string;
+  /** Optional header overrides — used by the cross-sell context where "No Coverage" wording is wrong. */
+  title?: string;
+  description?: string;
 }
 
-export function NoCoverageLeadCapture({ address, latitude, longitude }: NoCoverageLeadCaptureProps) {
+export function NoCoverageLeadCapture({
+  address,
+  latitude,
+  longitude,
+  defaultServiceType,
+  selectedPackageLabel,
+  title,
+  description,
+}: NoCoverageLeadCaptureProps) {
   const [formData, setFormData] = useState({
     full_name: '',
     email: '',
     phone: '',
-    service_type: 'any',
+    service_type: defaultServiceType ?? 'any',
     expected_usage: 'moderate',
     budget_range: '500_1000',
     urgency: 'medium',
@@ -39,6 +54,18 @@ export function NoCoverageLeadCapture({ address, latitude, longitude }: NoCovera
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
+
+  // Sync the selected service when a cross-sell option is picked after mount,
+  // without disturbing fields the visitor may have already typed.
+  useEffect(() => {
+    if (defaultServiceType) {
+      setFormData((prev) =>
+        prev.service_type === defaultServiceType
+          ? prev
+          : { ...prev, service_type: defaultServiceType }
+      );
+    }
+  }, [defaultServiceType]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,12 +78,21 @@ export function NoCoverageLeadCapture({ address, latitude, longitude }: NoCovera
 
     setIsSubmitting(true);
 
+    // Fold a chosen cross-sell package into the notes so sales sees the intent.
+    const mergedNotes = [
+      selectedPackageLabel ? `Interested in: ${selectedPackageLabel}` : null,
+      formData.notes.trim() || null,
+    ]
+      .filter(Boolean)
+      .join('\n');
+
     try {
       const response = await fetch('/api/leads/no-coverage', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           ...formData,
+          notes: mergedNotes,
           address,
           latitude,
           longitude,
@@ -123,11 +159,16 @@ export function NoCoverageLeadCapture({ address, latitude, longitude }: NoCovera
           </div>
         </div>
         <CardTitle className="text-2xl text-gray-900">
-          No Coverage Available Yet
+          {title ?? 'No Coverage Available Yet'}
         </CardTitle>
         <CardDescription className="text-base text-gray-600 max-w-xl mx-auto">
-          We don't currently offer service at <span className="font-semibold">{address}</span>, but we're expanding!
-          Leave your details and we'll notify you when coverage becomes available.
+          {description ?? (
+            <>
+              We don&apos;t currently offer service at{' '}
+              <span className="font-semibold">{address}</span>, but we&apos;re expanding! Leave
+              your details and we&apos;ll notify you when coverage becomes available.
+            </>
+          )}
         </CardDescription>
       </CardHeader>
 
@@ -139,6 +180,15 @@ export function NoCoverageLeadCapture({ address, latitude, longitude }: NoCovera
             Get priority access when we launch in your area.
           </AlertDescription>
         </Alert>
+
+        {selectedPackageLabel && (
+          <Alert className="mb-6 border-circleTel-orange/30 bg-orange-50/50">
+            <PiCheckCircleBold className="h-5 w-5 text-circleTel-orange" />
+            <AlertDescription className="text-gray-800">
+              Registering interest in: <span className="font-semibold">{selectedPackageLabel}</span>
+            </AlertDescription>
+          </Alert>
+        )}
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* Contact Information */}

--- a/components/coverage/NoCoverageOptions.tsx
+++ b/components/coverage/NoCoverageOptions.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+/**
+ * No Coverage Options (Phase 1 — no-coverage cross-sell)
+ *
+ * Shown when SkyFibre/primary coverage is NOT available at an address.
+ * Instead of dropping the visitor straight into a lead-capture dead-end, this
+ * runs a live MTN mobile check (5G / LTE / Fixed-LTE) and surfaces any available
+ * mobile internet options. The existing NoCoverageLeadCapture form is always
+ * rendered below as the capture mechanism + graceful fallback — if the MTN check
+ * finds nothing (or fails), the visitor sees exactly the previous experience.
+ *
+ * Scope note: there is no Satellite/Wireless provider API wired into this flow,
+ * so only MTN mobile services are offered here. Only 5G has buyable products
+ * today; LTE/Fixed-LTE surface as a "register interest" option.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  PiSpinnerBold,
+  PiCheckCircleBold,
+  PiLightningBold,
+  PiArrowRightBold,
+} from 'react-icons/pi';
+import { NoCoverageLeadCapture } from './NoCoverageLeadCapture';
+
+interface NoCoverageOptionsProps {
+  address: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+interface MtnService {
+  type: string;
+  available: boolean;
+  signal?: string;
+  estimatedSpeed?: { download: number; upload: number; unit: string };
+}
+
+interface CrossSellPackage {
+  id: string;
+  name: string;
+  download_speed: number;
+  upload_speed: number;
+  price: number; // ex-VAT, per service_packages convention
+  description?: string;
+}
+
+const VAT_RATE = 0.15;
+const inclVAT = (exVat: number): number => Math.round(exVat * (1 + VAT_RATE));
+
+function serviceLabel(type: string): string {
+  switch (type) {
+    case '5g':
+      return '5G';
+    case 'lte':
+      return 'LTE';
+    case 'fixed_lte':
+      return 'Fixed LTE';
+    default:
+      return type.toUpperCase();
+  }
+}
+
+export function NoCoverageOptions({ address, latitude, longitude }: NoCoverageOptionsProps) {
+  const [loading, setLoading] = useState(true);
+  const [services, setServices] = useState<MtnService[]>([]);
+  const [products, setProducts] = useState<CrossSellPackage[]>([]);
+  const [selectedService, setSelectedService] = useState<string | undefined>(undefined);
+  const [selectedPackageLabel, setSelectedPackageLabel] = useState<string | undefined>(undefined);
+  const formRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkMobile() {
+      // No coordinates → can't run a mobile check; fall straight to the lead form.
+      if (latitude === undefined || longitude === undefined) {
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const [checkRes, pkgRes] = await Promise.all([
+          fetch('/api/coverage/mtn/check', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              coordinates: { lat: latitude, lng: longitude },
+              serviceTypes: ['5g', 'lte', 'fixed_lte'],
+              includeSignalStrength: true,
+            }),
+          }),
+          fetch('/api/coverage/mtn/packages'),
+        ]);
+
+        const checkData = await checkRes.json();
+        const pkgData = await pkgRes.json();
+        if (cancelled) return;
+
+        const found: MtnService[] = Array.isArray(checkData?.data?.services)
+          ? checkData.data.services.filter((s: MtnService) => s?.available)
+          : [];
+        setServices(found);
+        setProducts(Array.isArray(pkgData?.products) ? pkgData.products : []);
+      } catch (err) {
+        // Graceful: any failure leaves the lead form as the experience (no regression).
+        console.error('[NoCoverageOptions] MTN mobile check failed:', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    checkMobile();
+    return () => {
+      cancelled = true;
+    };
+  }, [latitude, longitude]);
+
+  const fiveGAvailable = services.some((s) => s.type === '5g' && s.available);
+  const showFiveG = fiveGAvailable && products.length > 0;
+  const otherMobile = services.filter(
+    (s) => (s.type === 'lte' || s.type === 'fixed_lte') && s.available
+  );
+  const showOther = !showFiveG && otherMobile.length > 0;
+  const hasOffer = showFiveG || showOther;
+
+  function selectPackage(pkg: CrossSellPackage) {
+    setSelectedService('5g');
+    setSelectedPackageLabel(
+      `${pkg.name} (${pkg.download_speed}/${pkg.upload_speed} Mbps) — R${inclVAT(pkg.price)}/mo incl VAT`
+    );
+    formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function selectService(type: string) {
+    setSelectedService(type);
+    setSelectedPackageLabel(`${serviceLabel(type)} mobile internet`);
+    formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  return (
+    <div className="space-y-6">
+      {loading && (
+        <div className="bg-white rounded-2xl border border-gray-100 p-8 text-center shadow-sm">
+          <PiSpinnerBold className="h-8 w-8 text-circleTel-orange animate-spin mx-auto mb-3" />
+          <p className="text-gray-600 text-sm">
+            Checking for mobile internet options at your address…
+          </p>
+        </div>
+      )}
+
+      {!loading && hasOffer && (
+        <div className="bg-white rounded-2xl border border-emerald-200 shadow-sm overflow-hidden text-left">
+          <div className="bg-gradient-to-r from-emerald-500 to-emerald-600 px-6 py-4">
+            <div className="flex items-center gap-2 text-white">
+              <PiCheckCircleBold className="h-5 w-5 shrink-0" />
+              <p className="font-bold text-lg">Good news — mobile internet is available here</p>
+            </div>
+            <p className="text-white/85 text-sm mt-0.5">
+              SkyFibre isn&apos;t at this address yet, but MTN mobile data reaches it.
+            </p>
+          </div>
+
+          <div className="p-6 space-y-5">
+            {showFiveG && (
+              <div>
+                <p className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-1.5">
+                  <PiLightningBold className="text-circleTel-orange" /> 5G packages you can order
+                </p>
+                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                  {products.map((pkg) => (
+                    <button
+                      key={pkg.id}
+                      type="button"
+                      onClick={() => selectPackage(pkg)}
+                      className="text-left rounded-xl border-2 border-gray-200 hover:border-circleTel-orange p-4 transition-colors group"
+                    >
+                      <p className="text-xs font-semibold text-gray-400">
+                        {pkg.download_speed > 0
+                          ? `${pkg.download_speed}/${pkg.upload_speed} Mbps`
+                          : 'Best effort'}
+                      </p>
+                      <p className="text-sm font-bold text-gray-900 leading-tight mt-0.5">
+                        {pkg.name}
+                      </p>
+                      <p className="text-lg font-extrabold text-circleTel-orange mt-1">
+                        R{inclVAT(pkg.price)}
+                        <span className="text-xs font-medium text-gray-400">/mo</span>
+                      </p>
+                      <span className="text-xs font-semibold text-circleTel-orange mt-2 inline-flex items-center gap-1 group-hover:gap-2 transition-all">
+                        Register interest <PiArrowRightBold />
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <p className="text-xs text-gray-400 mt-2">
+                  Prices incl. VAT. A consultant confirms availability before activation.
+                </p>
+              </div>
+            )}
+
+            {showOther && (
+              <div className="rounded-xl border border-gray-200 p-4 flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-sm font-bold text-gray-900">
+                    {otherMobile.map((s) => serviceLabel(s.type)).join(' / ')} coverage available
+                  </p>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    Register your interest and we&apos;ll match you to a mobile plan.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => selectService(otherMobile[0].type)}
+                  className="shrink-0 bg-circleTel-orange hover:bg-orange-600 text-white text-sm font-semibold px-4 py-2.5 rounded-lg transition-colors"
+                >
+                  Register
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Lead capture — always present as the capture mechanism + graceful fallback */}
+      <div ref={formRef}>
+        <NoCoverageLeadCapture
+          address={address}
+          latitude={latitude}
+          longitude={longitude}
+          defaultServiceType={selectedService}
+          selectedPackageLabel={selectedPackageLabel}
+          title={hasOffer ? 'Register your interest' : undefined}
+          description={
+            hasOffer
+              ? `Leave your details and a CircleTel consultant will set up ${
+                  selectedPackageLabel ? 'your selected plan' : 'mobile internet'
+                } at ${address}.`
+              : undefined
+          }
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Turns the fibre **no-coverage dead-end into a conversion moment**. When `/packages/[leadId]` (or `/check-coverage`) resolves to **zero SkyFibre packages**, we now check MTN mobile coverage and surface available alternatives before the lead-capture form, instead of dropping straight to a generic "no coverage" form.

This is **Phase 1** of the order-journey redesign roadmap (`docs/superpowers/plans/2026-06-27-order-journey-redesign-phased.md`) — the highest-ROI, lowest-risk gap.

## How

New orchestrator `components/coverage/NoCoverageOptions.tsx`:
- On mount (when coords exist) calls the existing **public** MTN APIs in parallel: `POST /api/coverage/mtn/check` + `GET /api/coverage/mtn/packages`.
- **5G branch** — if 5G is available *and* has buyable products → renders selectable tier buttons (incl-VAT prices).
- **LTE / Fixed-LTE branch** — if only mobile-LTE reaches the address → renders a "register your interest" card.
- **Fallback** — no coords / no MTN offer / API error → graceful fall-through to the existing lead-capture form (try/catch/finally, no infinite spinner).

`NoCoverageLeadCapture.tsx` extended **backward-compatibly** (all new props optional): `defaultServiceType`, `selectedPackageLabel`, `title`, `description`. Selecting a 5G tier / LTE register pre-fills `service_type`, scrolls to the form, shows a confirmation alert, and tags the lead's notes with the chosen plan. Existing callers are unaffected.

Wired into both entry points: `app/packages/[leadId]/page.tsx` and `app/(marketing)/check-coverage/CheckCoverageContent.tsx`.

## Scope

4 files, +308/-11. No DB schema changes — `service_type` + `notes` already supported by `/api/leads/no-coverage`.

## Verification

- ✅ **Verified live on staging** at an uncovered address (Loxton St, Kenhardt) → LTE register branch renders: green "mobile internet is available here" banner, LTE card, contextual form title/description, Register click pre-fills LTE + scrolls + shows confirmation alert. Console clean.
- ✅ Pre-push scoped type-check passed on all changed `.tsx` files.
- ⚠️ The **5G-tier button branch** is logically complete but was not visually exercised on staging (5G-product addresses also have SkyFibre and route to the normal packages page).

## Follow-up (out of scope)

Layout/UI polish of this page is tracked separately (redundant stacked callouts, no hero band, heavy form). See memory note `no-coverage-page-ui-backlog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)