### PR TITLE
fix(packages): remove "Customize Your Package" add-on upsell

### DIFF
--- a/app/packages/[leadId]/page.tsx
+++ b/app/packages/[leadId]/page.tsx
@@ -15,7 +15,6 @@ import { cn } from '@/lib/utils';
 import { useOrderContext } from '@/components/order/context/OrderContext';
 import { useCustomerAuth } from '@/components/providers/CustomerAuthProvider';
 import type { PackageDetails, SelectedAddon } from '@/lib/order/types';
-import { AddonsSelection } from '@/components/order/AddonsSelection';
 import { NoCoverageOptions } from '@/components/coverage/NoCoverageOptions';
 import { LicensedWirelessLeadCapture } from '@/components/coverage/LicensedWirelessLeadCapture';
 import {
@@ -92,7 +91,7 @@ function PackagesContent() {
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [hasLicensedWireless, setHasLicensedWireless] = useState(false);
   const [requiresQuote, setRequiresQuote] = useState(false);
-  const [selectedAddons, setSelectedAddons] = useState<SelectedAddon[]>([]);
+  const [selectedAddons] = useState<SelectedAddon[]>([]);
 
   // Phase 3: Pagination state - show 8 packages initially
   const [showAllPackages, setShowAllPackages] = useState(false);
@@ -783,13 +782,6 @@ function PackagesContent() {
                     }}
                     recommended={filteredPackages.indexOf(selectedPackage) === 0}
                     onOrderClick={handleContinue}
-                  />
-
-                  {/* Add-ons Selection */}
-                  <AddonsSelection
-                    productCategory={selectedPackage.product_category}
-                    selectedAddons={selectedAddons}
-                    onAddonsChange={setSelectedAddons}
                   />
                 </div>
               )}


### PR DESCRIPTION
## What
Removes the **Customize Your Package** add-on upsell (Static IP Address, Extended Support Hours) from the package-selection sidebar on `/packages/[leadId]`.

## Why
Product decision to drop the add-on cross-sell from the package picker (requested with annotated screenshot).

## Changes
- Remove `<AddonsSelection>` render block from the recommended/sticky sidebar
- Remove the now-unused `AddonsSelection` import
- Drop `setSelectedAddons` from the `useState` destructure (only the upsell called it); `selectedAddons` stays as an empty array so the price calc, order payload, and mobile footer cleanly resolve to **zero add-ons**

Blast radius kept minimal — the `AddonsSelection` component itself is untouched and the order flow works with no add-ons.

## Verification
- `tsc --noEmit` clean on the touched file
- Pre-push gate (build-config + scoped type-check) ✅
- Deployed to **staging** ✅ — run 28302465781 (`build-and-deploy: success`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)