### PR TITLE
fix(payment): server-authoritative charge amount + initiation guards

### DIFF
--- a/app/api/orders/create/route.ts
+++ b/app/api/orders/create/route.ts
@@ -10,6 +10,7 @@ import {
   redactSkyFibreOrderability,
 } from '@/lib/coverage/skyfibre/orderability';
 import type { SkyFibreOrderabilityResult, SkyFibreSegment } from '@/lib/coverage/skyfibre/types';
+import { VALIDATION_CHARGE_AMOUNT } from '@/lib/payments/payment-amounts';
 
 // P4: Valid property types (must match ServiceAddressSection.tsx options)
 const VALID_PROPERTY_TYPES = [
@@ -218,6 +219,9 @@ export async function POST(request: NextRequest) {
         payment_method: null,
         payment_status: 'pending',
         total_paid: 0,
+        // Authoritative charge for initiation — server-set, never client-trusted.
+        // Currently the R1.00 validation charge (see payment-amounts.ts).
+        payment_amount: VALIDATION_CHARGE_AMOUNT,
 
         // Status
         status: 'pending',

--- a/app/api/payment/netcash/initiate/route.ts
+++ b/app/api/payment/netcash/initiate/route.ts
@@ -5,6 +5,7 @@ import { buildOrderDescription } from '@/lib/payments/description-builder';
 import { logPaymentConsents, extractIpAddress, extractUserAgent } from '@/lib/payments/consent-logger';
 import type { PaymentConsents } from '@/components/payments/PaymentConsentCheckboxes';
 import { paymentLogger } from '@/lib/logging';
+import { VALIDATION_CHARGE_AMOUNT } from '@/lib/payments/payment-amounts';
 
 interface InitiatePaymentRequest {
   orderId: string;
@@ -24,13 +25,15 @@ export async function POST(request: NextRequest) {
     const supabase = await createClient();
     const body: InitiatePaymentRequest = await request.json();
 
-    // Validate required fields
-    const { orderId, amount, customerEmail, customerName, paymentReference } = body;
-    if (!orderId || !amount || !customerEmail || !customerName || !paymentReference) {
+    // SECURITY: only the orderId is trusted from the client. The amount,
+    // recipient and reference are derived from the order record below — a
+    // client-supplied amount must never determine what gets charged.
+    const { orderId } = body;
+    if (!orderId) {
       return NextResponse.json(
         {
           success: false,
-          error: 'Missing required payment fields'
+          error: 'Missing orderId'
         },
         { status: 400 }
       );
@@ -52,6 +55,32 @@ export async function POST(request: NextRequest) {
         { status: 404 }
       );
     }
+
+    // Guard: only initiate payment for an order that is awaiting one. Blocks
+    // re-charging an already-paid order or charging a cancelled/failed one.
+    if (order.payment_status === 'paid') {
+      return NextResponse.json(
+        { success: false, error: 'Order has already been paid' },
+        { status: 409 }
+      );
+    }
+    if (order.status === 'cancelled' || order.status === 'failed') {
+      return NextResponse.json(
+        { success: false, error: 'Order is no longer active' },
+        { status: 409 }
+      );
+    }
+
+    // SECURITY: derive every payment input from the order, not the request body.
+    // payment_amount is server-set at order creation; legacy rows (created before
+    // the column existed) fall back to the validation-charge constant.
+    // NOTE (Phase 2): once orders carry an owner (auth_user_id), bind this to the
+    // authenticated session and reject mismatches. Today orders are guest/unowned,
+    // so a hard owner-gate would break checkout — see the order-journey plan.
+    const amount = Number(order.payment_amount ?? VALIDATION_CHARGE_AMOUNT);
+    const customerEmail: string = order.email;
+    const customerName: string = `${order.first_name ?? ''} ${order.last_name ?? ''}`.trim();
+    const paymentReference: string = order.payment_reference;
 
     // Get payment provider
     const provider = getPaymentProvider();

--- a/docs/superpowers/plans/2026-06-27-order-journey-redesign-phased.md
+++ b/docs/superpowers/plans/2026-06-27-order-journey-redesign-phased.md
@@ -128,12 +128,24 @@ interface OrderState {
 **Goal:** the one place even the redesign currently leaves open.
 
 > **GATING DEPENDENCY — do NOT ship payment changes before this.**
-> `PAYMENT_JOURNEY_AUDIT_2026-05-11.md` flags real bugs in this exact step:
-> webhook hits the wrong table (payments never confirm), client-controlled amount,
-> no auth on initiation. These security fixes must land FIRST or alongside.
-> They are more urgent than any UX item above and are a separate track.
+> `PAYMENT_JOURNEY_AUDIT_2026-05-11.md` flagged bugs in this exact step. Status after
+> verifying each against live code (2026-06-28):
+> - **Wrong webhook table** — ✅ ALREADY FIXED. `netcash-webhook-processor.ts` uses
+>   `consumer_orders` throughout; the audit's `.from('orders')` claim no longer applies.
+> - **Client-controlled amount (#2)** — ✅ FIXED in the security PR (`payment-amount-server-authoritative`):
+>   amount is now persisted on the order (`consumer_orders.payment_amount`, server-set at
+>   creation) and the initiate route derives the charge + recipient + reference from the
+>   order, ignoring the request body.
+> - **Unauth initiation (#3)** — ⚠️ PARTIAL. Active protections shipped (payable-state guard:
+>   reject paid/cancelled/failed orders; recipient derived server-side). The **hard owner-gate
+>   is deferred to Phase 2**, because consumer orders are currently guest/unowned
+>   (`auth_user_id`/`customer_id` are null at creation) — a hard gate today would break checkout.
+> - **Deferred fast-follow:** #4 browser-exposed NetCash keys (needs key rotation, ops action)
+>   and #5 webhook-signature fail-closed.
 
-- [ ] **Pre-req:** fix payment-security audit items (wrong webhook table, client-controlled amount, unauth initiation).
+- [x] **Pre-req (#2):** client-controlled amount — server-authoritative amount shipped (separate security PR).
+- [ ] **Pre-req (#3, Phase 2):** hard owner-gate on initiation, once orders carry an `auth_user_id`.
+- [ ] **Pre-req (fast-follow):** rotate browser-exposed NetCash keys (#4); webhook-signature fail-closed (#5).
 - [ ] Render in-app **debit-order** form (bank details, debit-date choice 26th/1st like Vox).
 - [ ] Render in-app **credit-card** form (debit-date as Vox restricts it).
 - [ ] Replace/supplement the NetCash redirect with in-app method selection.

--- a/lib/payments/payment-amounts.ts
+++ b/lib/payments/payment-amounts.ts
@@ -1,0 +1,17 @@
+/**
+ * Authoritative, server-side payment amounts (in Rands).
+ *
+ * SECURITY: payment initiation must NEVER trust a client-supplied amount.
+ * The order's `payment_amount` column is the source of truth, stamped at order
+ * creation from the constants here. The initiate route derives the NetCash
+ * charge from the order, not from the request body.
+ *
+ * VALIDATION_CHARGE_AMOUNT — the R1.00 card-validation charge used by the
+ * current consumer order flow. The NetCash webhook treats any payment <= R1.01
+ * as a validation: it stores the payment method for recurring debit and does
+ * NOT activate the order (see lib/payment/netcash-webhook-processor.ts).
+ *
+ * Phase 5 (in-app payment parity) replaces this with the once-off processing
+ * fee — at that point set the order's `payment_amount` to the fee instead.
+ */
+export const VALIDATION_CHARGE_AMOUNT = 1.0;

--- a/supabase/migrations/20260628090000_consumer_orders_add_payment_amount.sql
+++ b/supabase/migrations/20260628090000_consumer_orders_add_payment_amount.sql
@@ -1,0 +1,13 @@
+-- Persist the authoritative charge amount for payment initiation.
+--
+-- Security: /api/payment/netcash/initiate previously trusted a client-supplied
+-- `amount`. It now derives the NetCash charge from this column, which is set
+-- server-side at order creation. Nullable + no default so legacy rows (created
+-- before this column existed) fall back to the validation-charge constant in
+-- the initiate route.
+
+ALTER TABLE consumer_orders
+  ADD COLUMN IF NOT EXISTS payment_amount numeric;
+
+COMMENT ON COLUMN consumer_orders.payment_amount IS
+  'Authoritative charge amount (Rands) for payment initiation. Server-set at order creation; never client-trusted. Currently the R1.00 card-validation charge; becomes the once-off processing fee in Phase 5.';


### PR DESCRIPTION
## Summary

Security hardening of the consumer payment-initiation path. Closes payment-audit item **#2** (client-controlled amount) and the **active portion of #3** (unauthenticated initiation). Scoped deliberately small (security only) ahead of the Phase 5 in-app payment work.

**Audit re-verified against live code (2026-06-28):** the audit's "webhook hits the wrong table" claim is **already fixed** — `lib/payment/netcash-webhook-processor.ts` uses `consumer_orders` throughout. No change needed there.

## #2 — amount is no longer trusted from the client
Previously `/api/payment/netcash/initiate` passed the request-body `amount` straight to NetCash. A caller could set any amount.

- New column `consumer_orders.payment_amount` (nullable numeric), **server-set at order creation**.
- New `lib/payments/payment-amounts.ts` → `VALIDATION_CHARGE_AMOUNT = 1.00` (single source of truth; becomes the Phase-5 processing fee).
- `orders/create` stamps `payment_amount` server-side (ignores the client's `payment_amount`).
- `initiate` derives **amount + recipient email/name + payment reference** from the fetched order, ignoring the request body. Amount is `Number()`-coerced; legacy rows (pre-column) fall back to the constant.

## #3 — initiation hardening (no checkout breakage)
- **Payable-state guard**: reject initiation when the order is already `paid`, or `cancelled`/`failed` → 409. Stops re-charging / abuse against arbitrary orders.
- Recipient derived server-side → no email/name/description spoofing.
- **Hard owner-gate deferred to Phase 2.** Consumer orders are currently guest/unowned (`auth_user_id`/`customer_id` are null at creation and the client sends no token), so a hard ownership gate today would break checkout. Phase 2 (auth-after-cart) attaches an owner; the gate lands there. Seam documented in-code.

## Blast radius
Three callers of `initiate` exist; only `/order/checkout` is live (already charges R1.00 → **unchanged**). `PaymentStage.tsx` has zero imports (dead); `CircleTelPaymentPage.tsx` (`/checkout/payment`) already can't produce a valid `orderId` against the current `orders/create` (already broken). No live path charges full price via this redirect.

## Migration
`supabase/migrations/20260628090000_consumer_orders_add_payment_amount.sql` — additive nullable column, **already applied** to the shared Supabase project.

## Deferred fast-follow (separate track)
- **#4** browser-exposed NetCash keys → needs key rotation (ops action).
- **#5** webhook-signature fail-closed.

## Testing
Type-check clean for all changed files (repo's ~280 pre-existing errors untouched). Live end-to-end payment test not run — placing real orders on staging is disallowed (staging shares prod Supabase). Verification is via code-path tracing + blast-radius analysis + type-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)