### PR TITLE
feat(suppliers): HTTP cron for supplier sync (Vercel cron, not Inngest)

### DIFF
--- a/app/api/cron/supplier-sync/route.ts
+++ b/app/api/cron/supplier-sync/route.ts
@@ -1,0 +1,78 @@
+/**
+ * Supplier Product Sync (scheduled, HTTP cron)
+ *
+ * Vercel cron job that syncs distributor catalogues (Scoop, MiRO, Nology,
+ * Rectron) into the supplier_products table via the registry-based
+ * orchestrator. Unlike competitor-scrape, this does the work directly rather
+ * than queueing Inngest — Inngest cron/event execution is not active in this
+ * deployment, so the previous Inngest-cron trigger never fired.
+ *
+ * Schedule: Daily at 2 AM SAST (midnight UTC) — see vercel.json crons.
+ *
+ * Optional query param `?supplier=RECTRON` (comma-separated) restricts the run
+ * to specific supplier codes; omitted = all active suppliers.
+ */
+
+import { NextResponse } from 'next/server';
+import { syncAllSuppliers } from '@/lib/suppliers/sync-orchestrator';
+import { cronLogger } from '@/lib/logging';
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+export async function GET(request: Request) {
+  // Verify the request is from the scheduler
+  const authHeader = request.headers.get('authorization');
+  if (CRON_SECRET && authHeader !== `Bearer ${CRON_SECRET}`) {
+    cronLogger.error('[CronSupplierSync] Unauthorized request');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const supplier = searchParams.get('supplier') || undefined;
+
+  cronLogger.info(
+    `[CronSupplierSync] Starting supplier sync${supplier ? ` (${supplier})` : ' (all active)'}...`
+  );
+
+  try {
+    const result = await syncAllSuppliers({
+      triggered_by: 'scheduled',
+      suppliers: supplier,
+    });
+
+    cronLogger.info('[CronSupplierSync] Complete', {
+      suppliers_synced: result.suppliers_synced,
+      suppliers_failed: result.suppliers_failed,
+      products_found: result.totals.products_found,
+      products_created: result.totals.products_created,
+      products_updated: result.totals.products_updated,
+    });
+
+    return NextResponse.json({
+      success: result.success,
+      suppliers_synced: result.suppliers_synced,
+      suppliers_failed: result.suppliers_failed,
+      suppliers_skipped: result.suppliers_skipped,
+      totals: result.totals,
+      suppliers: result.suppliers.map((o) => ({
+        code: o.supplier_code,
+        success: o.success,
+        error: o.error,
+        skipped: o.skipped,
+        products_found: o.result?.stats.products_found,
+        products_created: o.result?.stats.products_created,
+        products_updated: o.result?.stats.products_updated,
+      })),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    cronLogger.error('[CronSupplierSync] Error', { error: message });
+    return NextResponse.json(
+      { error: 'Failed to sync suppliers', details: message },
+      { status: 500 }
+    );
+  }
+}
+
+export const runtime = 'nodejs';
+export const maxDuration = 300; // suppliers download + parse + upsert thousands of rows

--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,10 @@
       "maxDuration": 300,
       "memory": 1024
     },
+    "app/api/cron/supplier-sync/route.ts": {
+      "maxDuration": 300,
+      "memory": 1024
+    },
     "app/api/admin/competitor-analysis/scrape/route.ts": {
       "maxDuration": 300,
       "memory": 1024
@@ -145,6 +149,10 @@
   "crons": [
     {
       "path": "/api/cron/generate-invoices",
+      "schedule": "0 0 * * *"
+    },
+    {
+      "path": "/api/cron/supplier-sync",
       "schedule": "0 0 * * *"
     },
     {


### PR DESCRIPTION
## Problem

The daily supplier-sync was implemented as an **Inngest cron** (`{ cron: '0 0 * * *' }`). Investigation shows **Inngest cron/event execution isn't active in this deployment**:
- `supplier_sync_logs` has **zero `triggered_by: scheduled` runs ever** — every sync in history was a manual script run.
- A manually-fired `supplier/sync.requested` event was accepted by Inngest but **produced no function run** (no log row in 2 min).
- `deploy.yml` has no Inngest sync step; there's no evidence the app is registered/synced with Inngest Cloud.

Meanwhile the app's ~21 **working** recurring jobs all run as `vercel.json` Vercel-cron entries hitting `/api/cron/*` routes (e.g. `payment-reconciliation` at `0 7 * * *`). Supplier sync was never on that mechanism — so **Rectron (and all suppliers) never auto-synced**.

## Fix

Put supplier sync on the same proven mechanism as the other crons:

- **New `app/api/cron/supplier-sync/route.ts`** — `CRON_SECRET`-protected `GET` that calls the registry-based `syncAllSuppliers()` **directly** (not via the dormant Inngest), mirroring the existing cron-route convention (`cronLogger`, `runtime='nodejs'`, `maxDuration=300`). Optional `?supplier=RECTRON` to scope a run.
- **`vercel.json`** — adds the function config (`maxDuration: 300, memory: 1024`, matching `zoho-sync`/`competitor-scrape`) and a daily cron entry `{ "/api/cron/supplier-sync", "0 0 * * *" }` (2 AM SAST).

`syncAllSuppliers()` already syncs Scoop/MiRO/Nology/**Rectron** (filtered by `is_active`) and writes `supplier_sync_logs`.

## Verification

- `vercel.json` valid JSON; both new entries present.
- Type-check: no errors in the new route.
- Pre-push hook: build-config ✅, scoped type-check ✅.

## Notes

- The Inngest `supplier-sync` cron/functions from PR #575 are left in place (harmless; can be removed later if Inngest stays unused). This PR makes the schedule actually fire.
- After deploy, the first run fires at the next 2 AM SAST. To populate immediately, the route can be hit once with the `CRON_SECRET` bearer (or `?supplier=RECTRON`).
- Does not touch the cron history gap for other Inngest-only features (e.g. competitor-scrape also queues Inngest) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)