### PR TITLE
fix(suppliers): Rectron sync parses from in-memory buffer (no disk)

### DIFF
--- a/lib/suppliers/rectron/__tests__/rectron-downloader.test.ts
+++ b/lib/suppliers/rectron/__tests__/rectron-downloader.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'os'
 import {
   resolveLatestRectronFile,
   downloadRectronPricelist,
+  downloadRectronBuffer,
   RECTRON_CDN_BASE,
 } from '../rectron-downloader'
 
@@ -129,5 +130,28 @@ describe('rectron-downloader', () => {
       return { ok: true, status: 200, text: async () => FIXTURE_HTML } as any
     }) as any
     await expect(downloadRectronPricelist({ watchDir: dir })).rejects.toThrow(/magic bytes/)
+  })
+
+  it('downloadRectronBuffer returns the validated bytes in memory (no disk)', async () => {
+    global.fetch = mockFetchRouting() as any
+    const { filename, buffer } = await downloadRectronBuffer()
+    expect(filename).toBe(FILENAME)
+    expect(buffer.length).toBe(ZIP_BYTES.length)
+    expect(Array.from(buffer.subarray(0, 4))).toEqual([0x50, 0x4b, 0x03, 0x04])
+  })
+
+  it('downloadRectronBuffer propagates validation failures (bad magic)', async () => {
+    global.fetch = jest.fn(async (input: any) => {
+      const url = String(input)
+      if (url.startsWith(RECTRON_CDN_BASE)) {
+        const notZip = Buffer.concat([Buffer.from('<html>nope</html>'), Buffer.alloc(11_000)])
+        return {
+          ok: true, status: 200,
+          arrayBuffer: async () => notZip.buffer.slice(notZip.byteOffset, notZip.byteOffset + notZip.byteLength),
+        } as any
+      }
+      return { ok: true, status: 200, text: async () => FIXTURE_HTML } as any
+    }) as any
+    await expect(downloadRectronBuffer()).rejects.toThrow(/magic bytes/)
   })
 })

--- a/lib/suppliers/rectron/__tests__/rectron-parser.test.ts
+++ b/lib/suppliers/rectron/__tests__/rectron-parser.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from '@jest/globals'
+import ExcelJS from 'exceljs'
+import { parseRectronBuffer } from '../rectron-parser'
+
+/**
+ * Build an in-memory .xlsx matching the real Rectron layout:
+ *   rows 1-4 filler, row 5 headers, row 6+ data.
+ * Columns: PRODUCT_LINE | CLASS | SUB_CLASS | ITEM | PRICE | DESCRIPTION | WARRANTY | FilterHelper
+ */
+async function buildRectronWorkbookBuffer(): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook()
+  const ws = wb.addWorksheet('RECTRON_PRICE_LIST')
+
+  ws.getRow(1).values = ['Rectron Price List']
+  ws.getRow(5).values = [
+    'PRODUCT LINE', 'CLASS', 'SUB CLASS', 'ITEM', 'PRICE (R)', 'DESCRIPTION', 'WARRANTY', 'FilterHelper',
+  ]
+  // A real product row
+  ws.getRow(6).values = ['AMD', 'CPU', 'AMD Ryzen', 'ABC-123', 1500, 'AMD Ryzen 5 5600', 12, 1]
+  // A category-header row (same plain text across the first columns) — must be skipped
+  ws.getRow(7).values = ['COMPONENTS', 'COMPONENTS', 'COMPONENTS', 'COMPONENTS', null, null, null, null]
+  // A second product row
+  ws.getRow(8).values = ['Seagate', 'Hard Drives', 'Seagate HDD', 'ST2000', 899.5, '2TB HDD', 24, 1]
+
+  const arr = await wb.xlsx.writeBuffer()
+  return Buffer.from(arr as ArrayBuffer)
+}
+
+describe('parseRectronBuffer', () => {
+  it('parses products from an in-memory xlsx buffer (no disk)', async () => {
+    const buffer = await buildRectronWorkbookBuffer()
+
+    const result = await parseRectronBuffer(buffer, 'RECTRON_PRICE_LIST_test.xlsm')
+
+    expect(result.success).toBe(true)
+    expect(result.file_name).toBe('RECTRON_PRICE_LIST_test.xlsm')
+    expect(result.products_parsed).toBe(2)
+
+    const skus = result.products.map((p) => p.sku).sort()
+    expect(skus).toEqual(['ABC-123', 'ST2000'])
+
+    const amd = result.products.find((p) => p.sku === 'ABC-123')!
+    expect(amd.cost_price).toBe(1500)
+    expect(amd.manufacturer).toBe('AMD')
+    expect(amd.warranty_months).toBe(12)
+  })
+
+  it('returns success:false when the expected sheet is missing', async () => {
+    const wb = new ExcelJS.Workbook()
+    wb.addWorksheet('SOME_OTHER_SHEET')
+    const buffer = Buffer.from((await wb.xlsx.writeBuffer()) as ArrayBuffer)
+
+    const result = await parseRectronBuffer(buffer, 'wrong.xlsm')
+    expect(result.success).toBe(false)
+    expect(result.errors.join(' ')).toMatch(/RECTRON_PRICE_LIST.*not found/i)
+  })
+})

--- a/lib/suppliers/rectron/rectron-downloader.ts
+++ b/lib/suppliers/rectron/rectron-downloader.ts
@@ -4,7 +4,10 @@
  * The RectronZone download page is public (no login) and lists the current
  * datestamped price-list filename. The file itself is served publicly by the
  * storefront7 CDN. This module resolves the current filename from the page and
- * downloads it into the watch directory for the existing Rectron sync to parse.
+ * downloads the file — either into memory (`downloadRectronBuffer`, used by the
+ * automated sync so it works in serverless/containerized runtimes with no
+ * writable disk) or onto disk (`downloadRectronPricelist`, for the manual
+ * file-drop workflow on a persistent host).
  *
  * No authentication or credentials are required.
  */
@@ -57,23 +60,10 @@ export async function resolveLatestRectronFile(
 }
 
 /**
- * Ensure the latest Rectron price-list file is present in `watchDir`.
- * Skips the download if a file of that name already exists.
+ * Fetch the file from the CDN and validate it (zip magic bytes + size floor).
+ * Returns the validated bytes in memory.
  */
-export async function downloadRectronPricelist(config: {
-  watchDir: string
-  pageUrl?: string
-  cdnBase?: string
-}): Promise<RectronDownloadResult> {
-  const { filename, url } = await resolveLatestRectronFile(config)
-
-  mkdirSync(config.watchDir, { recursive: true })
-  const filePath = join(config.watchDir, filename)
-
-  if (existsSync(filePath)) {
-    return { filePath, filename, downloaded: false }
-  }
-
+async function fetchValidatedBuffer(url: string, filename: string): Promise<Buffer> {
   const res = await fetch(url)
   if (!res.ok) {
     throw new Error(`Rectron CDN returned HTTP ${res.status} for ${filename}`)
@@ -91,6 +81,41 @@ export async function downloadRectronPricelist(config: {
       `Downloaded Rectron file is not a valid xlsx/zip (bad magic bytes)`
     )
   }
+  return buf
+}
+
+/**
+ * Resolve the latest price-list and download it into memory (no disk).
+ * Preferred path for the automated sync — works in any runtime.
+ */
+export async function downloadRectronBuffer(
+  config: { pageUrl?: string; cdnBase?: string } = {}
+): Promise<{ filename: string; buffer: Buffer }> {
+  const { filename, url } = await resolveLatestRectronFile(config)
+  const buffer = await fetchValidatedBuffer(url, filename)
+  return { filename, buffer }
+}
+
+/**
+ * Ensure the latest Rectron price-list file is present in `watchDir`.
+ * Skips the download if a file of that name already exists. For the manual
+ * file-drop workflow on a host with persistent, writable storage.
+ */
+export async function downloadRectronPricelist(config: {
+  watchDir: string
+  pageUrl?: string
+  cdnBase?: string
+}): Promise<RectronDownloadResult> {
+  const { filename, url } = await resolveLatestRectronFile(config)
+
+  mkdirSync(config.watchDir, { recursive: true })
+  const filePath = join(config.watchDir, filename)
+
+  if (existsSync(filePath)) {
+    return { filePath, filename, downloaded: false }
+  }
+
+  const buf = await fetchValidatedBuffer(url, filename)
 
   // Write to a temp file then atomically rename, so the parser never sees a partial file.
   const tmpPath = `${filePath}.tmp`

--- a/lib/suppliers/rectron/rectron-parser.ts
+++ b/lib/suppliers/rectron/rectron-parser.ts
@@ -57,19 +57,37 @@ const MIN_SKU_LENGTH = 3
 // =====================================================
 
 /**
- * Parse a Rectron .xlsm price list file
+ * Parse a Rectron .xlsm price list from a file path (manual file-drop workflow).
  */
 export async function parseRectronFile(filePath: string): Promise<RectronParseResult> {
-  const startTime = Date.now()
-  const errors: string[] = []
-  const products: ParsedRectronProduct[] = []
-  let rowsSkipped = 0
-
   const fileName = filePath.split('/').pop() || 'unknown'
+  return parseLoaded(fileName, (wb) => wb.xlsx.readFile(filePath))
+}
+
+/**
+ * Parse a Rectron .xlsm price list from an in-memory buffer.
+ * Used by the automated sync, which downloads the file into memory and never
+ * writes it to disk — so it works in serverless/containerized runtimes.
+ */
+export async function parseRectronBuffer(
+  buffer: Buffer,
+  fileName = 'unknown'
+): Promise<RectronParseResult> {
+  return parseLoaded(fileName, (wb) => wb.xlsx.load(buffer))
+}
+
+/**
+ * Shared parse driver: load the workbook via `load`, then extract products.
+ */
+async function parseLoaded(
+  fileName: string,
+  load: (wb: ExcelJS.Workbook) => Promise<unknown>
+): Promise<RectronParseResult> {
+  const startTime = Date.now()
 
   try {
     const wb = new ExcelJS.Workbook()
-    await wb.xlsx.readFile(filePath)
+    await load(wb)
 
     const ws = wb.getWorksheet(SHEET_NAME)
     if (!ws) {
@@ -79,6 +97,10 @@ export async function parseRectronFile(filePath: string): Promise<RectronParseRe
     console.log(
       `[RectronParser] Parsing ${fileName}: ${ws.rowCount} rows, ${ws.columnCount} cols`
     )
+
+    const errors: string[] = []
+    const products: ParsedRectronProduct[] = []
+    let rowsSkipped = 0
 
     for (let r = DATA_START_ROW; r <= ws.rowCount; r++) {
       const row = readRow(ws, r)

--- a/lib/suppliers/rectron/rectron-sync.ts
+++ b/lib/suppliers/rectron/rectron-sync.ts
@@ -14,8 +14,8 @@
 import { readdirSync, statSync } from 'fs'
 import { join, basename } from 'path'
 import { createClient } from '@/lib/supabase/server'
-import { parseRectronFile } from './rectron-parser'
-import { downloadRectronPricelist } from './rectron-downloader'
+import { parseRectronFile, parseRectronBuffer } from './rectron-parser'
+import { downloadRectronBuffer } from './rectron-downloader'
 import type { RectronSyncConfig, ParsedRectronProduct } from './rectron-types'
 import type {
   SyncResult,
@@ -63,21 +63,24 @@ export async function syncRectronProducts(options: {
   const watchDir = config.watch_dir || DEFAULT_WATCH_DIR
   const filePattern = config.file_pattern || DEFAULT_FILE_PATTERN
 
-  // Resolve the file to parse:
-  // 1. explicit override, else 2. auto-download latest, else 3. latest local file.
+  // Resolve the catalogue source:
+  // 1. explicit file override, else 2. auto-download into memory (no disk —
+  //    works in serverless/containers), else 3. latest local file.
+  let downloadBuffer: Buffer | null = null
   let filePath: string | undefined | null = options.file_path
+  let sourceName = ''
   let downloadWarning: string | null = null
 
   if (!filePath && (options.download ?? true)) {
     try {
-      const dl = await downloadRectronPricelist({
-        watchDir,
+      const dl = await downloadRectronBuffer({
         pageUrl: config.download_page_url,
         cdnBase: config.cdn_base_url,
       })
-      filePath = dl.filePath
+      downloadBuffer = dl.buffer
+      sourceName = dl.filename
       console.log(
-        `[RectronSync] Auto-download: ${dl.filename} (downloaded=${dl.downloaded})`
+        `[RectronSync] Auto-download: ${dl.filename} (${dl.buffer.length} bytes, in-memory)`
       )
     } catch (error) {
       downloadWarning = `Auto-download failed, using latest local file: ${
@@ -87,17 +90,16 @@ export async function syncRectronProducts(options: {
     }
   }
 
-  if (!filePath) {
-    filePath = findLatestFile(watchDir, filePattern)
+  if (!downloadBuffer) {
+    filePath = filePath || findLatestFile(watchDir, filePattern)
+    if (!filePath) {
+      throw new Error(
+        `No files matching "${filePattern}" found in ${watchDir}`
+      )
+    }
+    sourceName = basename(filePath)
+    console.log(`[RectronSync] Using file: ${filePath}`)
   }
-
-  if (!filePath) {
-    throw new Error(
-      `No files matching "${filePattern}" found in ${watchDir}`
-    )
-  }
-
-  console.log(`[RectronSync] Using file: ${filePath}`)
 
   // Create sync log entry
   const { data: syncLog, error: logError } = await supabase
@@ -122,9 +124,11 @@ export async function syncRectronProducts(options: {
     .eq('id', supplier.id)
 
   try {
-    // Parse the xlsm file
+    // Parse the xlsm — from the in-memory download when available, else from disk.
     console.log('[RectronSync] Parsing xlsm file...')
-    const parseResult = await parseRectronFile(filePath)
+    const parseResult = downloadBuffer
+      ? await parseRectronBuffer(downloadBuffer, sourceName)
+      : await parseRectronFile(filePath!)
 
     if (!parseResult.success) {
       throw new Error(
@@ -154,7 +158,7 @@ export async function syncRectronProducts(options: {
           completed_at: new Date().toISOString(),
           error_details: {
             dry_run: true,
-            file: basename(filePath),
+            file: sourceName,
             products_parsed: parseResult.products_parsed,
             download_warning: downloadWarning || undefined,
           },


### PR DESCRIPTION
## Problem

The automated Rectron sync (PR #575 + #580) failed in production:

```
RECTRON: No files matching "RECTRON_PRICE_LIST_*.xlsm" found in /home/circletel/products/pricelist
```

The downloader wrote to a hardcoded **`/home/circletel/products/pricelist`** path — a VPS dev-box path that doesn't exist / isn't writable inside the **deployed container**. The `mkdirSync`/write failed immediately (the run aborted in ~1.2s, far too fast for a real download), the error was caught, the local-file fallback found nothing, and the sync reported "No files matching." It only passed earlier because Task 4's live verification ran on the VPS (persistent disk), not in the deployed runtime.

## Fix — parse from memory, no filesystem dependency

- **`rectron-downloader.ts`**: extract `fetchValidatedBuffer()` (zip magic + size floor); add **`downloadRectronBuffer()`** which returns the validated bytes in memory. `downloadRectronPricelist()` (disk, for the manual file-drop workflow) kept, now sharing the same fetch/validate helper.
- **`rectron-parser.ts`**: refactor into a shared `parseLoaded()` driver; add **`parseRectronBuffer(buffer, fileName)`** that loads via `workbook.xlsx.load(buffer)`. `parseRectronFile()` unchanged in behaviour.
- **`rectron-sync.ts`**: automated path now `downloadRectronBuffer()` → `parseRectronBuffer()` (no disk). Falls back to the local-file path only for an explicit `file_path` or when download is disabled. Dry-run log uses the resolved source name.

Works in any runtime (container, serverless, VPS) — no writable disk required.

## Verification

- **11/11 unit tests** in the rectron module:
  - downloader: filename resolve, no-match throw, disk download+validate, idempotent skip, CDN-404, undersized, bad-magic, **`downloadRectronBuffer` returns validated bytes**, buffer validation failure.
  - parser: **parses a real in-memory xlsx buffer** (built with ExcelJS) → 2 products with correct SKU/price/manufacturer/warranty; missing-sheet → `success:false`.
- Type-check: no errors in the changed files. Pre-push hook: build-config ✅, scoped type-check ✅.

## After merge

Deploy, then the daily Vercel cron (`/api/cron/supplier-sync`, `0 0 * * *` from #580) will populate `supplier_products`. To populate immediately, hit `GET /api/cron/supplier-sync?supplier=RECTRON` with the `CRON_SECRET` bearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)