### PR TITLE
feat(payment): server-authoritative order ownership + hard initiation owner-gate (Phase 2 security core)

### DIFF
--- a/__tests__/api/orders-create-skyfibre-gate.test.ts
+++ b/__tests__/api/orders-create-skyfibre-gate.test.ts
@@ -10,6 +10,20 @@ import { EmailNotificationService } from '@/lib/notifications/notification-servi
 
 jest.mock('@/lib/supabase/server', () => ({
   createClient: jest.fn(),
+  createClientWithSession: jest.fn(),
+}));
+
+// Phase 2: orders/create now requires a verified session. Resolve the Bearer
+// token path to an authenticated user so the test exercises the SkyFibre gate.
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: () => Promise.resolve({
+        data: { user: { id: 'user-1', email: 'test@example.com', user_metadata: {} } },
+        error: null,
+      }),
+    },
+  }),
 }));
 
 jest.mock('@/lib/coverage/skyfibre/orderability', () => ({
@@ -34,7 +48,7 @@ const mockSendOrderConfirmation = EmailNotificationService.sendOrderConfirmation
 function request(body: Record<string, unknown>) {
   return new Request('http://localhost/api/orders/create', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer test-token' },
     body: JSON.stringify(body),
   }) as NextRequest;
 }
@@ -46,6 +60,12 @@ describe('POST /api/orders/create SkyFibre gate', () => {
     mockExtractSkyFibreCapacity.mockReturnValue(100);
     mockSendOrderConfirmation.mockResolvedValue({ success: true } as any);
 
+    // Phase 2: orders/create looks up the owning customer first.
+    const customerQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: { id: 'cust-1' }, error: null }),
+    };
     const duplicateQuery = {
       select: jest.fn().mockReturnThis(),
       eq: jest.fn().mockReturnThis(),
@@ -82,6 +102,7 @@ describe('POST /api/orders/create SkyFibre gate', () => {
     mockCreateClient.mockResolvedValue({
       from: jest
         .fn()
+        .mockReturnValueOnce(customerQuery)
         .mockReturnValueOnce(duplicateQuery)
         .mockReturnValueOnce(orderNumberQuery)
         .mockReturnValueOnce(insertQuery),

--- a/app/api/orders/create/route.ts
+++ b/app/api/orders/create/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, createClientWithSession } from '@/lib/supabase/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import { EmailNotificationService } from '@/lib/notifications/notification-service';
 import type { ConsumerOrder } from '@/lib/types/customer-journey';
 import { apiLogger } from '@/lib/logging';
@@ -58,6 +59,92 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = await createClient();
+
+    // SECURITY (Phase 2): an order must belong to an authenticated user. Resolve
+    // the user from a verified session — Authorization header first, then cookies
+    // (see auth-patterns.md) — and NEVER from the request body. The owner stamped
+    // on the order below is what the payment-initiation owner-gate enforces.
+    let user = null;
+    let authError = null;
+    const authHeader = request.headers.get('authorization');
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.split(' ')[1];
+      const tokenClient = createSupabaseClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      );
+      const { data, error } = await tokenClient.auth.getUser(token);
+      user = data?.user ?? null;
+      authError = error;
+    } else {
+      try {
+        const sessionClient = await createClientWithSession();
+        const { data, error } = await sessionClient.auth.getUser();
+        user = data?.user ?? null;
+        authError = error;
+      } catch (e) {
+        apiLogger.warn('[orders/create] Cookie auth failed', { error: e });
+      }
+    }
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { success: false, error: 'Please sign in to place your order' },
+        { status: 401 }
+      );
+    }
+
+    // Resolve the owning customer record. It normally exists (created at signup or
+    // by /api/customers/ensure); if it is somehow missing, create it here via the
+    // same ensure-path so every order is linked to a customer. customer_id is
+    // server-derived from the verified session — never taken from the request body.
+    let customerId: string | null = null;
+    const { data: existingCustomer } = await supabase
+      .from('customers')
+      .select('id')
+      .eq('auth_user_id', user.id)
+      .single();
+
+    if (existingCustomer) {
+      customerId = existingCustomer.id;
+    } else {
+      const accountNumber = `CT-${Date.now().toString().slice(-8)}`;
+      const { data: createdCustomer, error: createCustomerError } = await supabase
+        .from('customers')
+        .insert({
+          auth_user_id: user.id,
+          email: user.email,
+          first_name: user.user_metadata?.first_name || 'Customer',
+          last_name: user.user_metadata?.last_name || '',
+          phone: user.user_metadata?.phone || user.phone || '',
+          account_number: accountNumber,
+          account_status: 'active',
+          account_type: 'personal',
+        })
+        .select('id')
+        .single();
+
+      if (createCustomerError) {
+        // Concurrent ensure calls can race the insert (unique auth_user_id).
+        if (createCustomerError.code === '23505') {
+          const { data: racedCustomer } = await supabase
+            .from('customers')
+            .select('id')
+            .eq('auth_user_id', user.id)
+            .single();
+          customerId = racedCustomer?.id ?? null;
+        } else {
+          apiLogger.error('[orders/create] Failed to ensure customer', { error: createCustomerError.message });
+          return NextResponse.json(
+            { success: false, error: 'Could not link your account. Please try again.' },
+            { status: 500 }
+          );
+        }
+      } else {
+        customerId = createdCustomer?.id ?? null;
+      }
+    }
+
     let skyFibreOrderability: SkyFibreOrderabilityResult | null = null;
 
     if (isSkyFibrePackage(body)) {
@@ -177,6 +264,10 @@ export async function POST(request: NextRequest) {
       .insert({
         order_number: orderNumber,
         payment_reference: paymentReference,
+
+        // Ownership — server-derived from the verified session, never the body.
+        auth_user_id: user.id,
+        customer_id: customerId,
 
         // Customer details
         first_name: body.first_name,

--- a/app/api/payment/netcash/initiate/route.ts
+++ b/app/api/payment/netcash/initiate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, createClientWithSession } from '@/lib/supabase/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import { getPaymentProvider } from '@/lib/payments/payment-provider-factory';
 import { buildOrderDescription } from '@/lib/payments/description-builder';
 import { logPaymentConsents, extractIpAddress, extractUserAgent } from '@/lib/payments/consent-logger';
@@ -39,6 +40,40 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // SECURITY (Phase 2): payment initiation requires an authenticated session.
+    // Resolve the user from the Authorization header first, then cookies — never
+    // from the request body (same pattern as orders/create). Orders are no longer
+    // guest-created, so the absence of a session is a hard failure.
+    let user = null;
+    let authError = null;
+    const authHeader = request.headers.get('authorization');
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.split(' ')[1];
+      const tokenClient = createSupabaseClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      );
+      const { data, error } = await tokenClient.auth.getUser(token);
+      user = data?.user ?? null;
+      authError = error;
+    } else {
+      try {
+        const sessionClient = await createClientWithSession();
+        const { data, error } = await sessionClient.auth.getUser();
+        user = data?.user ?? null;
+        authError = error;
+      } catch (e) {
+        paymentLogger.warn('[Payment Initiate] Cookie auth failed', { error: e instanceof Error ? e.message : String(e) });
+      }
+    }
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { success: false, error: 'Please sign in to continue payment' },
+        { status: 401 }
+      );
+    }
+
     // Verify order exists and get full order details
     const { data: order, error: orderError } = await supabase
       .from('consumer_orders')
@@ -71,12 +106,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // SECURITY (Phase 2 — closes payment-audit #3): an owned order may only be
+    // paid for by its owner. Reject a verified session that doesn't match the
+    // order's owner. Legacy guest orders (auth_user_id null) skip this check and
+    // remain covered by the payable-state guard above.
+    if (order.auth_user_id && user.id !== order.auth_user_id) {
+      paymentLogger.warn('[Payment Initiate] Owner mismatch', { orderId, userId: user.id });
+      return NextResponse.json(
+        { success: false, error: 'This order belongs to a different account' },
+        { status: 403 }
+      );
+    }
+
     // SECURITY: derive every payment input from the order, not the request body.
     // payment_amount is server-set at order creation; legacy rows (created before
     // the column existed) fall back to the validation-charge constant.
-    // NOTE (Phase 2): once orders carry an owner (auth_user_id), bind this to the
-    // authenticated session and reject mismatches. Today orders are guest/unowned,
-    // so a hard owner-gate would break checkout — see the order-journey plan.
     const amount = Number(order.payment_amount ?? VALIDATION_CHARGE_AMOUNT);
     const customerEmail: string = order.email;
     const customerName: string = `${order.first_name ?? ''} ${order.last_name ?? ''}`.trim();

--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -234,6 +234,16 @@ export default function CheckoutPage() {
     const finalDeliveryAddress =
       isWirelessOrMobile && !sameAsServiceAddress ? deliveryAddress : serviceAddress;
 
+    // Phase 2: attach the authenticated session so the order is created owned
+    // (orders/create stamps auth_user_id + customer_id) and payment initiation can
+    // enforce the owner-gate. The just-in-time auth step guarantees a session here.
+    const supabase = createClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    const authHeaders: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+    };
+
     setSubmitStatus('creating_order');
 
     let confirmedSkyFibreOrderability = skyFibreOrderability;
@@ -273,7 +283,7 @@ export default function CheckoutPage() {
 
     const orderRes = await fetch('/api/orders/create', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders,
       body: JSON.stringify({
         first_name: firstName,
         last_name: lastName,
@@ -314,7 +324,7 @@ export default function CheckoutPage() {
     try {
       paymentRes = await fetch('/api/payment/netcash/initiate', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: authHeaders,
         body: JSON.stringify({
           orderId: order.id,
           amount: 1.00,

--- a/docs/superpowers/plans/2026-06-27-order-journey-redesign-phased.md
+++ b/docs/superpowers/plans/2026-06-27-order-journey-redesign-phased.md
@@ -136,15 +136,17 @@ interface OrderState {
 >   amount is now persisted on the order (`consumer_orders.payment_amount`, server-set at
 >   creation) and the initiate route derives the charge + recipient + reference from the
 >   order, ignoring the request body.
-> - **Unauth initiation (#3)** — ⚠️ PARTIAL. Active protections shipped (payable-state guard:
->   reject paid/cancelled/failed orders; recipient derived server-side). The **hard owner-gate
->   is deferred to Phase 2**, because consumer orders are currently guest/unowned
->   (`auth_user_id`/`customer_id` are null at creation) — a hard gate today would break checkout.
+> - **Unauth initiation (#3)** — ✅ CLOSED (Phase 2 security core, `feat/phase2-auth-after-cart`).
+>   `orders/create` now requires a verified session and stamps `auth_user_id` + `customer_id`
+>   on every order; `initiate` resolves the verified user and rejects an owner mismatch (403) or
+>   a missing session (401). The earlier payable-state guard + server-derived recipient/amount
+>   remain. Legacy guest orders (`auth_user_id` null) skip the 403 and stay covered by the guard.
 > - **Deferred fast-follow:** #4 browser-exposed NetCash keys (needs key rotation, ops action)
 >   and #5 webhook-signature fail-closed.
 
 - [x] **Pre-req (#2):** client-controlled amount — server-authoritative amount shipped (separate security PR).
-- [ ] **Pre-req (#3, Phase 2):** hard owner-gate on initiation, once orders carry an `auth_user_id`.
+- [x] **Pre-req (#3, Phase 2):** hard owner-gate on initiation — orders now carry `auth_user_id`;
+      `initiate` enforces owner match (403) and requires a session (401). ✅ done in the security core.
 - [ ] **Pre-req (fast-follow):** rotate browser-exposed NetCash keys (#4); webhook-signature fail-closed (#5).
 - [ ] Render in-app **debit-order** form (bank details, debit-date choice 26th/1st like Vox).
 - [ ] Render in-app **credit-card** form (debit-date as Vox restricts it).

--- a/docs/superpowers/specs/2026-06-28-phase2-auth-after-cart-design.md
+++ b/docs/superpowers/specs/2026-06-28-phase2-auth-after-cart-design.md
@@ -1,0 +1,154 @@
+# Phase 2 — Auth After the Cart (design)
+
+**Date:** 2026-06-28
+**Author:** Claude Code
+**Status:** Approved design → implementation
+**Roadmap:** `docs/superpowers/plans/2026-06-27-order-journey-redesign-phased.md` (Phase 2, gap #2)
+**Depends on:** PR #579 (server-authoritative payment amount) — merged. This phase closes the
+#3 owner-gate that #579 deliberately deferred.
+
+---
+
+## Goal
+
+Let a guest build and review the full order, then authenticate **just-in-time at "Place Order"**,
+so the order is created **owned** (`auth_user_id` + `customer_id` stamped server-side). Closes the
+deferred payment-audit **#3** (unauthenticated initiation → hard owner-gate).
+
+**Not** a route rebuild — route-splitting into `/order/summary` etc. stays Phase 3.
+
+## Decisions (locked with user)
+
+1. **Account still required**, just deferred to after the cart (not optional guest checkout).
+2. **Just-in-time auth**: one review page; auth (`AccountSection`, OTP-first) reveals inline at
+   "Place Order" and continues straight to payment on success. No new route.
+3. Ownership is **server-authoritative** — derived from the verified session, never the request body.
+4. Phase 2 **flips the #3 owner-gate to hard** in the initiate route (payment code, in-scope).
+
+---
+
+## Current state (verified 2026-06-28)
+
+- `app/order/checkout/page.tsx`: `type CheckoutStep = 'account' | 'confirm'`; initialized
+  `isAuthenticated ? 'confirm' : 'account'` (line ~48). Auth-first: the order summary/`confirm`
+  step is only reachable after `isAuthenticated` flips (auto-advance effect line ~100). OAuth
+  round-trip persists `{serviceAddress, propertyType}` to `sessionStorage['circletel_checkout_return']`
+  (save line ~106, restore line ~117).
+- `app/api/orders/create/route.ts`: inserts `consumer_orders` via **service-role** `createClient()`,
+  sets **neither** `auth_user_id` nor `customer_id` (both columns exist, both nullable).
+- `components/providers/CustomerAuthProvider.tsx`: provides `user` (auth.users; `user.id` =
+  `auth_user_id`) and `customer` (row in `customers`, `customer.id` = `customer_id`, linked by
+  `auth_user_id`). A `customers` row is auto-created on signup or via `/api/customers/ensure`.
+- `app/api/payment/netcash/initiate/route.ts`: after #579, derives amount/recipient/ref from the
+  order; carries a documented **Phase 2 seam** for the owner-gate (soft today).
+- Existing auth-header pattern is already used elsewhere on the checkout page
+  (`Authorization: Bearer <access_token>`, line ~397) — reuse it.
+
+---
+
+## Design
+
+### A. Reorder the checkout (UX) — `app/order/checkout/page.tsx`
+
+- Initialize `checkoutStep` to **`'confirm'` always** (drop the `isAuthenticated ? …` gate). Guest
+  sees review (service address, property type, `OrderSummarySidebar`, terms) immediately.
+- `handlePlaceOrder`:
+  - if `isAuthenticated` → run `placeOrder()` unchanged.
+  - else → reveal `AccountSection` inline (render it within/above the confirm step, OTP tab first),
+    set a `pendingPlaceOrder` ref/flag. On auth success (`isAuthenticated` flips, or the
+    OTP/`onPhoneSignupComplete` callbacks), if `pendingPlaceOrder` → call `placeOrder()` automatically.
+- Keep `AccountSection` (`signUp`/`signIn`/`signInWithGoogle`/`onPhoneSignupComplete`) — only its
+  **placement/trigger** changes, not its internals.
+- `CheckoutProgressBar`: relabel the middle stage so the journey reads **Choose Plan › Review › Pay**
+  (auth folds into Pay). Confirm the exact `STEPS` label change is display-only.
+
+### B. Server-authoritative ownership — `app/api/orders/create/route.ts` (+ `placeOrder` caller)
+
+- `placeOrder` (checkout page) sends `Authorization: Bearer <session.access_token>` on the
+  `/api/orders/create` fetch (token already available via `supabase.auth.getSession()`).
+- `orders/create`: resolve the verified user from **header OR cookies** (`auth-patterns.md`:
+  Bearer → `getUser(token)`, else `createClientWithSession()`), then:
+  - **Require** a valid session for this consumer path → 401 if absent.
+  - Derive `auth_user_id = user.id`. Look up `customer_id` from `customers` where
+    `auth_user_id = user.id` (the row exists post-signup; if somehow missing, call the same
+    ensure-path used by the provider). Stamp **both** on the insert. Ignore any body-supplied ids.
+  - Keep using the service-role client for the actual insert/duplicate-check (RLS-free), but the
+    **identity** comes from the verified session, not the body.
+- ⚠️ **Pre-flight check (planning):** confirm no *live* unauthenticated caller posts to
+  `orders/create`. Known callers: `app/order/checkout` (will send token), dead `PaymentStage`
+  (0 imports), broken `/checkout/payment` `CircleTelPaymentPage`. Admin order creation is a
+  separate route. If a legit unauthenticated path exists, gate by path/flag instead of a blanket 401.
+
+### C. Close #3 — hard owner-gate — `app/api/payment/netcash/initiate/route.ts` (+ caller)
+
+- `placeOrder` sends the same Bearer token on the `/api/payment/netcash/initiate` fetch.
+- `initiate`: resolve verified user (header OR cookies). If `order.auth_user_id` is set and the
+  verified `user.id !== order.auth_user_id` → **403**. If no session at all → **401** (orders are
+  now always owned, so an unauthenticated initiate is invalid).
+- Replace the soft "NOTE (Phase 2)" seam with this enforcement. Amount/recipient derivation from
+  #579 stays exactly as-is.
+
+### D. OAuth round-trip — `app/order/checkout/page.tsx`
+
+- Before `signInWithGoogle()`, in addition to `{serviceAddress, propertyType}`, persist a
+  `pendingPlaceOrder: true` marker in `sessionStorage['circletel_checkout_return']`.
+- On return (existing restore effect, now authenticated): restore fields, clear the marker, and
+  **land on review with the auth step hidden and the Pay button ready** — do **NOT** auto-fire the
+  payment redirect (no surprise charge). One click to pay. OTP/email are inline (no redirect) and
+  continue automatically per §A.
+
+### E. Out of scope
+
+Route-splitting (`/order/summary`, `/order/enhancements`) — Phase 3. Add-ons/upsells — Phase 3.
+KYC/RICA — Phase 4. Payment-method redesign — Phase 5.
+
+---
+
+## Data flow (happy path, guest)
+
+```
+Guest → /order/checkout (starts at 'confirm'/review)
+  → fills address + property type, reviews summary, accepts terms
+  → clicks "Place Order"
+      ├─ authenticated? → placeOrder()
+      └─ not? → inline AccountSection (OTP/email/Google)
+                 → auth success → placeOrder() (auto-resume)
+  placeOrder():
+    → POST /api/orders/create  (Bearer token)
+         → server verifies session, stamps auth_user_id + customer_id, inserts order
+    → POST /api/payment/netcash/initiate  (Bearer token)
+         → server verifies session.user.id === order.auth_user_id (else 403)
+         → derives amount/recipient/ref from order (#579), returns NetCash form
+    → redirect to NetCash
+```
+
+## Error handling
+
+- `orders/create` no session → 401 "Please sign in to place your order" (UI re-opens auth step).
+- `initiate` owner mismatch → 403; no session → 401 (UI surfaces a retry).
+- OAuth malformed saved state → ignored (existing try/catch).
+- `customers` row missing at create → ensure-path; if that fails → 500 with a clear message
+  (do not create an unowned order).
+
+## Testing / verification
+
+- `npm run type-check:memory` clean for changed files.
+- Reading-only DB check (allowed): after a team staging order, confirm the new row has
+  `auth_user_id` + `customer_id` populated (`SELECT … FROM consumer_orders ORDER BY created_at DESC`).
+- Manual: guest reaches review with **no** auth prompt; auth prompt appears only at Place Order;
+  OTP/email resume to payment; Google returns to a ready-to-pay review.
+- `initiate` returns 403 when a different session's token is used against an order
+  (unit/integration-level assertion).
+- No live payment run by me (no real orders on staging).
+
+## Files touched (estimate)
+
+| File | Change |
+|---|---|
+| `app/order/checkout/page.tsx` | reorder steps, inline auth at Place Order, Bearer tokens on both fetches, OAuth resume marker |
+| `app/api/orders/create/route.ts` | verify session (header/cookies), require auth, stamp `auth_user_id` + `customer_id` |
+| `app/api/payment/netcash/initiate/route.ts` | hard owner-gate (verify session vs `order.auth_user_id`) |
+| `components/order/CheckoutProgressBar.tsx` | relabel middle stage (display only) |
+| `docs/superpowers/plans/2026-06-27-order-journey-redesign-phased.md` | mark Phase 2 done, #3 closed |
+
+`AccountSection.tsx` / `PhoneOTPSection.tsx` / `CustomerAuthProvider.tsx`: **unchanged** (reused).


### PR DESCRIPTION
## What & why

Closes **payment-audit finding #3** (unauthenticated payment initiation). Consumer orders were previously created **guest/unowned** (`auth_user_id`/`customer_id` null), which is why #579 could only *defer* the hard owner-gate. This PR makes orders **owned at creation** and enforces the owner at payment initiation.

This is the **security core** of Phase 2. The auth-after-cart UX reorder (land-on-review, inline just-in-time auth, OAuth resume, progress-bar relabel) is a **separate, staging-visually-verified follow-up PR**.

## Changes

- **`app/api/orders/create/route.ts`** — require a verified session (Authorization header → cookie fallback, mirroring `/api/customers/ensure`); **401** if absent. Stamp `auth_user_id` + `customer_id` (looked up, or ensure-created if missing) on the insert. Body-supplied ids are ignored — identity comes only from the verified session.
- **`app/order/checkout/page.tsx`** — `placeOrder` attaches `Authorization: Bearer <access_token>` (from `getSession()`) to **both** the `orders/create` and `netcash/initiate` POSTs.
- **`app/api/payment/netcash/initiate/route.ts`** — resolve the verified user; **401** if no session; **403** if `order.auth_user_id` is set and the session user mismatches. Legacy guest orders (`auth_user_id` null) skip the 403 and remain covered by the existing payable-state guard. Amount/recipient derivation from #579 unchanged.
- **`__tests__/api/orders-create-skyfibre-gate.test.ts`** — updated to run authenticated (the SkyFibre gate now sits behind the auth check).
- **plan doc** — record #3 as closed.

## Why it's safe to ship standalone

Today's checkout is already **auth-first** (`checkoutStep` initialises to `'account'` for guests), so a valid session always exists by the time Place Order fires. No behavioural regression for the live flow; this purely hardens the server.

## Verification

- ✅ Full `type-check:memory` — **0 errors** in all 4 changed files.
- ✅ `orders-create-skyfibre-gate` test passes (updated to authenticate).
- ✅ Pre-push hook: build-config OK, no type errors in pushed files.
- Backward-compatible: legacy `auth_user_id`-null orders skip the 403.

> Note: the chronically-red "Payment Integration Tests" check (failing on main since 2026-06-09 via `payment-processor.test.ts`) is unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)