### PR TITLE
fix(suppliers): paginate Rectron upsert/deactivate past Supabase 1000-row cap

### DIFF
--- a/lib/suppliers/rectron/rectron-sync.ts
+++ b/lib/suppliers/rectron/rectron-sync.ts
@@ -344,6 +344,44 @@ function findLatestFile(
 /**
  * Upsert products to database
  */
+/**
+ * Fetch ALL supplier_products rows for a supplier, paginating past Supabase's
+ * default 1000-row select cap. A plain `.select()` silently returns at most
+ * 1000 rows; this catalogue exceeds that, which previously caused partial
+ * upserts (missed updates, false "new" inserts) and broken deactivation.
+ */
+async function fetchAllSupplierProducts(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  supplierId: string,
+  columns: string,
+  activeOnly = false
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any[]> {
+  const pageSize = 1000
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const all: any[] = []
+  for (let from = 0; ; from += pageSize) {
+    let q = supabase
+      .from('supplier_products')
+      .select(columns)
+      .eq('supplier_id', supplierId)
+    if (activeOnly) q = q.eq('is_active', true)
+    const { data, error } = await q
+      .order('id', { ascending: true })
+      .range(from, from + pageSize - 1)
+    if (error) {
+      throw new Error(
+        `Failed to fetch existing supplier products: ${error.message}`
+      )
+    }
+    if (!data || data.length === 0) break
+    all.push(...data)
+    if (data.length < pageSize) break
+  }
+  return all
+}
+
 async function upsertProducts(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   supabase: any,
@@ -357,11 +395,12 @@ async function upsertProducts(
     errors: [],
   }
 
-  // Get existing products for comparison
-  const { data: existingProducts } = await supabase
-    .from('supplier_products')
-    .select('id, sku, cost_price, stock_total')
-    .eq('supplier_id', supplierId)
+  // Get ALL existing products for comparison (paginated past the 1000-row cap).
+  const existingProducts = await fetchAllSupplierProducts(
+    supabase,
+    supplierId,
+    'id, sku, cost_price, stock_total'
+  )
 
   interface ExistingProduct {
     sku: string
@@ -505,25 +544,50 @@ async function deactivateMissingProducts(
 ): Promise<number> {
   if (activeSKUs.length === 0) return 0
 
-  const { data, error } = await supabase
-    .from('supplier_products')
-    .update({
-      is_active: false,
-      is_discontinued: true,
-      last_synced_at: new Date().toISOString(),
-    })
-    .eq('supplier_id', supplierId)
-    .eq('is_active', true)
-    .not('sku', 'in', activeSKUs)
-    .select('id')
+  const activeSet = new Set(activeSKUs)
 
-  if (error) {
-    console.warn(
-      '[RectronSync] Failed to deactivate missing products:',
-      error
-    )
-    return 0
+  // Fetch ALL currently-active products (paginated) and compute, in JS, the ones
+  // whose SKU is no longer in the file. The previous `.not('sku','in', array)`
+  // filter was malformed (array not serialized to a PostgREST list) and, with
+  // hundreds of SKUs, would also overflow the request URL — so it deactivated
+  // nothing, leaving obsolete products active.
+  const existingActive = await fetchAllSupplierProducts(
+    supabase,
+    supplierId,
+    'id, sku',
+    true
+  )
+  const toDeactivate = existingActive
+    .filter((p: { sku: string }) => !activeSet.has(p.sku))
+    .map((p: { id: string }) => p.id)
+
+  if (toDeactivate.length === 0) return 0
+
+  const now = new Date().toISOString()
+  const batchSize = 500
+  let deactivated = 0
+
+  for (let i = 0; i < toDeactivate.length; i += batchSize) {
+    const batch = toDeactivate.slice(i, i + batchSize)
+    const { data, error } = await supabase
+      .from('supplier_products')
+      .update({
+        is_active: false,
+        is_discontinued: true,
+        last_synced_at: now,
+      })
+      .in('id', batch)
+      .select('id')
+
+    if (error) {
+      console.warn(
+        '[RectronSync] Failed to deactivate missing products batch:',
+        error
+      )
+      continue
+    }
+    deactivated += data?.length || 0
   }
 
-  return data?.length || 0
+  return deactivated
 }


### PR DESCRIPTION
## Problem (found via the first live prod run)

After #581 made the Rectron sync actually run in prod, the catalogue didn't reconcile:
`created 0, updated 401, unchanged 399, deactivated 0` — DB has **2,106** RECTRON products, only **800 touched, 1,306 left stale-active**.

Two pre-existing bugs in `rectron-sync.ts` (never exposed before because the sync never ran in prod):

1. **`upsertProducts` existing-fetch had no pagination** — a plain `.select(...).eq('supplier_id', …)` silently returns at most **1,000** rows (Supabase default). With 2,106 products the sync only "saw" ~1,000 → partial updates, and SKUs beyond the window would be misclassified as new (latent duplicate-key inserts).
2. **`deactivateMissingProducts` used `.not('sku', 'in', activeSKUs)`** with a raw JS array — not serialized to a PostgREST list, and with hundreds of SKUs it overflows the request URL → it matched nothing and **deactivated 0**, leaving obsolete products active.

## Fix

- Add **`fetchAllSupplierProducts()`** that pages through every row via `.range()`.
- `upsertProducts` now builds its existing-product map from the **full** set → correct create/update/unchanged classification, no dup-key risk.
- `deactivateMissingProducts` now fetches all active rows (paginated), computes the obsolete set **in JS** (`sku ∉ file`), and deactivates **by id in batches** — no malformed filter, no URL overflow.

## Verification

- Rectron unit tests: 11/11 still pass (download + parser).
- Type-check: no errors in `rectron-sync.ts`. Pre-push hook ✅.
- **Post-deploy:** re-run `GET /api/cron/supplier-sync?supplier=RECTRON` and confirm full reconciliation — created+updated+unchanged ≈ parsed products, the ~1,306 obsolete rows deactivated, and **0 stale-active** remaining. (Will verify against the DB after deploy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)