### PR TITLE
feat(checkout): auth-after-cart UX — land on review, inline just-in-time sign-in (P2-5/6/7)

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import {
@@ -10,7 +10,6 @@ import {
   PiShieldBold,
   PiWifiHighBold,
   PiMapPinBold,
-  PiArrowLeftBold,
 } from 'react-icons/pi';
 import { CheckoutProgressBar } from '@/components/order/CheckoutProgressBar';
 import { useOrderContext } from '@/components/order/context/OrderContext';
@@ -45,9 +44,12 @@ export default function CheckoutPage() {
   const { state: orderState, actions } = useOrderContext();
   const { isAuthenticated, customer, user, signOut, signUp, signIn, signInWithGoogle, loading: authLoading } = useCustomerAuth();
 
-  const [checkoutStep, setCheckoutStep] = useState<CheckoutStep>(
-    isAuthenticated ? 'confirm' : 'account'
-  );
+  // Auth-after-cart: everyone starts on the review/confirm step. A guest reviews
+  // and accepts terms first, then authenticates inline at Place Order. The
+  // 'account' step survives only as the post-sign-out re-auth screen.
+  const [checkoutStep, setCheckoutStep] = useState<CheckoutStep>('confirm');
+  const [showInlineAuth, setShowInlineAuth] = useState(false);
+  const pendingPlaceOrder = useRef(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>('idle');
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
@@ -107,7 +109,7 @@ export default function CheckoutPage() {
     if (typeof window !== 'undefined') {
       sessionStorage.setItem(
         'circletel_checkout_return',
-        JSON.stringify({ serviceAddress, propertyType })
+        JSON.stringify({ serviceAddress, propertyType, pendingPlaceOrder: pendingPlaceOrder.current })
       );
     }
     await signInWithGoogle();
@@ -375,6 +377,17 @@ export default function CheckoutPage() {
 
   const handlePlaceOrder = async () => {
     if (!validateBeforeOrder()) return;
+
+    // Auth-after-cart: a guest reviews the order + accepts terms first, then signs
+    // in inline. Defer placement until a session exists; the auto-resume effect
+    // below finishes the order once isAuthenticated flips true (inline OTP/email).
+    if (!isAuthenticated) {
+      pendingPlaceOrder.current = true;
+      setShowInlineAuth(true);
+      setErrorMessage(undefined);
+      return;
+    }
+
     const email = customer?.email || user?.email || '';
     if (!email) {
       toast.error('No account found. Please sign in again.');
@@ -425,6 +438,19 @@ export default function CheckoutPage() {
       setSubmitStatus('idle');
     }
   };
+
+  // Auto-resume an inline (no-redirect) sign-in: when a guest authenticates via
+  // OTP/email after clicking Place Order, finish the order automatically. Google
+  // OAuth does NOT auto-resume — pendingPlaceOrder.current resets across the page
+  // redirect, so the returning user lands on review with the Pay button ready (§D).
+  useEffect(() => {
+    if (isAuthenticated && pendingPlaceOrder.current) {
+      pendingPlaceOrder.current = false;
+      setShowInlineAuth(false);
+      void handlePlaceOrder();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated]);
 
   const fullName = customer
     ? `${customer.first_name ?? ''} ${customer.last_name ?? ''}`.trim()
@@ -525,14 +551,16 @@ export default function CheckoutPage() {
               />
 
               <div className="bg-white rounded-3xl border border-gray-100 shadow-sm p-7 sm:p-8">
-                <OrderingAsCard
-                  fullName={fullName || 'You'}
-                  email={customer?.email || user?.email || ''}
-                  onSignOut={handleSignOut}
-                />
+                {isAuthenticated && (
+                  <OrderingAsCard
+                    fullName={fullName || 'You'}
+                    email={customer?.email || user?.email || ''}
+                    onSignOut={handleSignOut}
+                  />
+                )}
 
                 {/* Collect missing profile details (Google OAuth users) */}
-                {(!customer?.first_name || !customer?.phone) && (
+                {isAuthenticated && (!customer?.first_name || !customer?.phone) && (
                   <div className="mt-5 space-y-3">
                     <p className="text-sm font-bold text-circleTel-navy">Your details</p>
                     {!customer?.first_name && (
@@ -623,34 +651,44 @@ export default function CheckoutPage() {
                   </div>
                 )}
 
-                {placeOrderBlocked && (
-                  <p className="mt-5 text-xs text-amber-600 text-center font-medium">
-                    Please complete your profile details above before placing your order.
-                  </p>
+                {showInlineAuth && !isAuthenticated ? (
+                  /* Auth-after-cart: reveal sign-in inline once the guest commits */
+                  <div className="mt-6 border-t border-gray-100 pt-6">
+                    <p className="text-sm font-bold text-circleTel-navy mb-1">Sign in to place your order</p>
+                    <p className="text-xs text-gray-500 mb-4">
+                      Your selection is saved — sign in or create an account to finish.
+                    </p>
+                    <AccountSection
+                      isSubmitting={isSubmitting}
+                      onGoogleSignIn={handleGoogleSignIn}
+                      onSignIn={handleSignIn}
+                      onSignUp={handleSignUp}
+                      onPhoneSignupComplete={handlePhoneSignupComplete}
+                      onPhoneSignupError={(msg) => setErrorMessage(msg)}
+                    />
+                  </div>
+                ) : (
+                  <>
+                    {placeOrderBlocked && (
+                      <p className="mt-5 text-xs text-amber-600 text-center font-medium">
+                        Please complete your profile details above before placing your order.
+                      </p>
+                    )}
+
+                    <button
+                      type="button"
+                      onClick={handlePlaceOrder}
+                      disabled={isSubmitting || placeOrderBlocked}
+                      className="mt-4 w-full bg-gradient-to-r from-circleTel-orange to-orange-600 hover:from-orange-600 hover:to-orange-700 disabled:opacity-60 text-white font-bold rounded-xl px-4 py-4 text-base shadow-lg transition-all flex items-center justify-center gap-2"
+                    >
+                      <PiLockSimpleBold className="w-5 h-5" />
+                      {submitLabel}
+                    </button>
+                    <p className="text-center text-xs text-gray-400 mt-3">
+                      R{monthlyPrice}/month billed after activation · No lock-in
+                    </p>
+                  </>
                 )}
-
-                <button
-                  type="button"
-                  onClick={handlePlaceOrder}
-                  disabled={isSubmitting || placeOrderBlocked}
-                  className="mt-4 w-full bg-gradient-to-r from-circleTel-orange to-orange-600 hover:from-orange-600 hover:to-orange-700 disabled:opacity-60 text-white font-bold rounded-xl px-4 py-4 text-base shadow-lg transition-all flex items-center justify-center gap-2"
-                >
-                  <PiLockSimpleBold className="w-5 h-5" />
-                  {submitLabel}
-                </button>
-                <p className="text-center text-xs text-gray-400 mt-3">
-                  R{monthlyPrice}/month billed after activation · No lock-in
-                </p>
-
-                {/* Back link */}
-                <button
-                  type="button"
-                  onClick={() => setCheckoutStep('account')}
-                  className="mt-4 w-full flex items-center justify-center gap-1.5 text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                >
-                  <PiArrowLeftBold className="w-3 h-3" />
-                  Back to sign in
-                </button>
               </div>
 
               {/* Mobile payment detail card */}
@@ -714,8 +752,8 @@ export default function CheckoutPage() {
         </div>
       </div>
 
-      {/* Floating mobile CTA bar */}
-      {pkg && checkoutStep === 'confirm' && (
+      {/* Floating mobile CTA bar — hidden while inline auth is showing */}
+      {pkg && checkoutStep === 'confirm' && !showInlineAuth && (
         <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-white border-t-2 border-circleTel-orange shadow-2xl px-4 py-3 z-40">
           <div className="flex items-center gap-4 max-w-lg mx-auto">
             <div className="flex-1 min-w-0">

--- a/components/order/CheckoutProgressBar.tsx
+++ b/components/order/CheckoutProgressBar.tsx
@@ -12,10 +12,13 @@ interface CheckoutProgressBarProps {
   variant?: 'default' | 'hero';
 }
 
+// Labels reflect the auth-after-cart journey: review the order, then pay (auth
+// folds into the Pay step via inline just-in-time sign-in). Stage `id`s are
+// unchanged for backwards compatibility with stepNumberToStage() and callers.
 const STEPS: { id: CheckoutStage; label: string }[] = [
   { id: 'packages', label: 'Choose Plan' },
-  { id: 'account', label: 'Sign In' },
-  { id: 'checkout', label: 'Confirm & Pay' },
+  { id: 'account', label: 'Review' },
+  { id: 'checkout', label: 'Pay' },
 ];
 
 // Map old numeric step to new stage names for backwards compatibility

--- a/docs/superpowers/plans/2026-06-27-order-journey-redesign-phased.md
+++ b/docs/superpowers/plans/2026-06-27-order-journey-redesign-phased.md
@@ -89,16 +89,18 @@ interface OrderState {
 
 **Success criteria:** entering a fibre-uncovered address surfaces at least one alternative service tab with selectable packages; `% no-coverage sessions → package` rises from ~0.
 
-## Phase 2 — Move auth after the cart (gap #2)
+## Phase 2 — Move auth after the cart (gap #2) ✅ (security core merged #582; UX follow-up PR #584)
 
 **Goal:** stop gating commitment behind sign-in.
 
-- [ ] Extract auth out of the monolithic `/order/checkout` into a step **after** review.
-- [ ] Lead with **OTP** (already live as secondary); keep email/pw + Google as options.
-- [ ] Ensure order state (selected package + enhancements) persists through the auth redirect/round-trip.
-- [ ] RBAC/session: confirm an authed session attaches to the in-progress order, not a fresh one.
+- [x] Reveal auth **after** review — done via **inline just-in-time sign-in** at Place Order (PR #584). A separate `/order/auth` *route* was deliberately deferred to Phase 3 (route-splitting, spec §E); the auth-after-review intent is met inline.
+- [x] Lead with **OTP** (already live as secondary); keep email/pw + Google as options — reused `AccountSection` (OTP-first) inline.
+- [x] Ensure order state persists through the auth redirect/round-trip — OAuth round-trip persists address/property-type + `pendingPlaceOrder` in `sessionStorage`; order draft already survives via root `OrderContextProvider` + localStorage.
+- [x] RBAC/session: an authed session attaches to the in-progress order — **security core (#582)**: `orders/create` requires a verified session and stamps `auth_user_id` + `customer_id`; `initiate` enforces the owner-gate (401/403).
 
-**Success criteria:** a guest can build a full cart before any auth prompt; auth-step drop-off measurable and lower.
+**Success criteria:** a guest can review a full cart before any auth prompt ✅; auth-step drop-off measurable and lower — to confirm via staging/analytics once #584 ships.
+
+> **Outstanding:** #584 awaits **staging visual verification** before merge to `main` (verify up to the inline-auth reveal only; do NOT place orders on staging — shared prod Supabase).
 
 ## Phase 3 — Split checkout into single-purpose pages (gap #3)
 


### PR DESCRIPTION
## What

Phase 2 **UX reorder** (gap #2): move auth *after* the cart. Stacked on #582 (security core) — this PR is the conversion-path UI only, **no API/payment changes**.

Everyone now lands on the **review/confirm** step. A guest reviews the package + accepts terms, then authenticates **inline only at Place Order** (OTP-first). Previously a guest was gated behind a full sign-in step before they could even see the review.

## Changes (`app/order/checkout/page.tsx`, `components/order/CheckoutProgressBar.tsx`)

- **Land on review (P2-5):** `checkoutStep` initialises to `'confirm'` always (was auth-gated). The `'account'` step survives as the **post-sign-out re-auth screen**, so nothing is dead code.
- **Inline just-in-time auth (P2-5):** `handlePlaceOrder` defers for a guest — sets a `pendingPlaceOrder` ref + reveals `AccountSection` inline instead of submitting. An auto-resume effect finishes the order once `isAuthenticated` flips true (inline OTP/email path).
- **OAuth round-trip (P2-6):** `pendingPlaceOrder` is persisted in `sessionStorage` alongside the restored address/property-type. Google OAuth deliberately does **NOT** auto-fire payment on return — the ref resets across the redirect, so the returning user lands on review with **Pay ready (one click)**.
- `OrderingAsCard` + profile-collection gated behind `isAuthenticated`.
- Mobile CTA bar hidden while inline auth is showing.
- **Progress bar (P2-7):** relabelled **"Choose Plan › Review › Pay"** (stage `id`s unchanged for `stepNumberToStage()` compatibility).

## Verification

- ✅ `tsc` clean for both changed files (pre-push scoped type-check passed).
- ⏳ **Staging visual verification outstanding** — this is the gate before merging to `main`. Safe to verify *up to the inline-auth reveal* (load `/order/checkout` as a guest → review renders, OrderingAsCard hidden → click Place Order → inline `AccountSection` appears). **Do not complete a sign-in or place an order on staging** (staging shares the prod Supabase — real rows).

## Sequencing

Base is `feat/phase2-auth-after-cart` (#582). Retarget to `main` once #582 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)