### PR TITLE
fix(offers): non-partial unique index on offers.source_uid (upsert arbiter)

### DIFF
--- a/supabase/migrations/20260628120000_fix_offers_source_uid_unique.sql
+++ b/supabase/migrations/20260628120000_fix_offers_source_uid_unique.sql
@@ -1,0 +1,14 @@
+-- supabase/migrations/20260628120000_fix_offers_source_uid_unique.sql
+-- Fix: the Offer Spine migration created a PARTIAL unique index on offers.source_uid
+-- (WHERE source_uid IS NOT NULL). Postgres cannot use a partial index as an
+-- ON CONFLICT arbiter, so publisher.persistOfferDraft (upsert onConflict: 'source_uid')
+-- failed with "no unique or exclusion constraint matching the ON CONFLICT specification".
+--
+-- A plain (non-partial) unique index on a nullable column already permits multiple NULL
+-- source_uid rows (manual, non-source offers) because SQL treats NULLs as distinct, so the
+-- WHERE predicate was redundant. Replace it with a non-partial unique index of the same name.
+
+DROP INDEX IF EXISTS public.offers_source_uid_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS offers_source_uid_key
+  ON public.offers (source_uid);


### PR DESCRIPTION
## What

Corrective migration for the Offer Spine (follow-up to #578).

`offers.source_uid` was given a **partial** unique index (`WHERE source_uid IS NOT NULL`). Postgres cannot use a partial index as an `ON CONFLICT` arbiter, so `publisher.persistOfferDraft` — which upserts with `onConflict: 'source_uid'` — failed at runtime with:

```
there is no unique or exclusion constraint matching the ON CONFLICT specification
```

This migration replaces it with a **non-partial** unique index of the same name. A plain unique index on a nullable column already permits multiple `NULL` `source_uid` rows (manual, non-source offers) because SQL treats NULLs as distinct — so the `WHERE` predicate was redundant as well as broken.

## How it was caught

Post-merge **live verification** of #578: applied the migration to the shared Supabase project, then ran `scripts/offers/verify-publish.ts`. First run failed with the ON CONFLICT error; after this fix it published a real offer (DFA BizFibreConnect 25Mbps — R1899 price / R1287.34 cost / **32% margin** / guardrail `pass`) and a second run reused the same `offerId` (idempotent — 1 offer / 1 component / 1 snapshot, no duplication).

## DB state

The shared project DB has **already been corrected** via this same SQL. This PR brings the migration history in line so any future environment is created correctly.

## Verification

- ✅ Live publish + snapshot write succeeds
- ✅ Idempotent republish (no duplicate rows)
- ✅ Security advisor clean for the 3 offer tables (only the by-design INFO: "RLS enabled, no policy" — Phase 0 is service-role only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)