### PR TITLE
Add admin-assisted B2B onboarding intake

### DIFF
--- a/app/admin/b2b/manual-intake/page.tsx
+++ b/app/admin/b2b/manual-intake/page.tsx
@@ -1,0 +1,545 @@
+'use client';
+
+import Link from 'next/link';
+import { FormEvent, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  PiArrowRightBold,
+  PiBankBold,
+  PiBuildingsBold,
+  PiCheckCircleBold,
+  PiClipboardTextBold,
+  PiFileTextBold,
+  PiFloppyDiskBold,
+} from 'react-icons/pi';
+import { PageHeader, SectionCard, StatusBadge } from '@/components/backend';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+
+type BillingDay = '1' | '15' | '20' | '25';
+
+interface FormState {
+  customerId: string;
+  segment: string;
+  businessName: string;
+  entityType: string;
+  registrationNumber: string;
+  vatRegistered: boolean;
+  vatNumber: string;
+  registeredAddress: string;
+  contactName: string;
+  email: string;
+  phone: string;
+  clinicName: string;
+  province: string;
+  siteAddress: string;
+  packageName: string;
+  serviceType: string;
+  monthlyPrice: string;
+  activationDate: string;
+  billingDay: BillingDay;
+  includeDebitOrder: boolean;
+  accountHolderName: string;
+  bankName: string;
+  accountType: string;
+  accountNumber: string;
+  branchCode: string;
+}
+
+interface IntakeResult {
+  customerId: string;
+  accountNumber: string | null;
+  submissionId: string;
+  createdCustomer: boolean;
+  createdSubmission: boolean;
+  serviceId?: string;
+  paymentMethodId?: string;
+}
+
+const initialState: FormState = {
+  customerId: '',
+  segment: 'unjani',
+  businessName: '',
+  entityType: 'Private Company',
+  registrationNumber: '',
+  vatRegistered: false,
+  vatNumber: '',
+  registeredAddress: '',
+  contactName: '',
+  email: '',
+  phone: '',
+  clinicName: '',
+  province: '',
+  siteAddress: '',
+  packageName: 'CircleTel ClinicConnect',
+  serviceType: 'managed_connectivity',
+  monthlyPrice: '450',
+  activationDate: '',
+  billingDay: '25',
+  includeDebitOrder: true,
+  accountHolderName: '',
+  bankName: '',
+  accountType: 'Cheque',
+  accountNumber: '',
+  branchCode: '',
+};
+
+function trimOrUndefined(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function Field({
+  id,
+  label,
+  children,
+}: {
+  id: string;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id} className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+        {label}
+      </Label>
+      {children}
+    </div>
+  );
+}
+
+export default function ManualB2BIntakePage() {
+  const [form, setForm] = useState<FormState>(initialState);
+  const [saving, setSaving] = useState(false);
+  const [result, setResult] = useState<IntakeResult | null>(null);
+
+  const serviceMonthlyPrice = useMemo(() => {
+    const parsed = Number(form.monthlyPrice);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }, [form.monthlyPrice]);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((current) => ({ ...current, [key]: value }));
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    setResult(null);
+
+    const payload = {
+      customerId: trimOrUndefined(form.customerId),
+      segment: form.segment,
+      business: {
+        businessName: form.businessName.trim(),
+        entityType: form.entityType,
+        registrationNumber: form.registrationNumber.trim(),
+        vatRegistered: form.vatRegistered,
+        vatNumber: form.vatRegistered ? trimOrUndefined(form.vatNumber) : undefined,
+        registeredAddress: form.registeredAddress.trim(),
+      },
+      contact: {
+        contactName: form.contactName.trim(),
+        email: form.email.trim(),
+        phone: form.phone.trim(),
+      },
+      site: {
+        clinicName: trimOrUndefined(form.clinicName),
+        province: trimOrUndefined(form.province),
+        siteAddress: trimOrUndefined(form.siteAddress),
+      },
+      service: {
+        packageName: form.packageName.trim(),
+        serviceType: form.serviceType.trim(),
+        monthlyPrice: serviceMonthlyPrice || 450,
+        activationDate: trimOrUndefined(form.activationDate),
+        billingDay: form.billingDay,
+      },
+      debitOrder: form.includeDebitOrder
+        ? {
+            accountHolderName: form.accountHolderName.trim(),
+            bankName: form.bankName.trim(),
+            accountType: form.accountType,
+            accountNumber: form.accountNumber.trim(),
+            branchCode: form.branchCode.trim(),
+          }
+        : undefined,
+    };
+
+    try {
+      const response = await fetch('/api/admin/b2b/manual-intake', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('admin_token') || ''}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Manual intake failed');
+      }
+      setResult(data.intake);
+      toast.success(
+        data.intake.createdCustomer
+          ? `Business customer created: ${data.intake.accountNumber || data.intake.customerId}`
+          : 'Business customer updated'
+      );
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Manual intake failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 py-8">
+      <PageHeader
+        title="Manual B2B Intake"
+        subtitle="Admin-assisted capture for emailed onboarding packs"
+        actions={
+          <>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/admin/unjani/onboarding">
+                <PiBuildingsBold className="mr-2 h-4 w-4" />
+                Pipeline
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/admin/b2b/vetting">
+                <PiFileTextBold className="mr-2 h-4 w-4" />
+                Vetting
+              </Link>
+            </Button>
+          </>
+        }
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <SectionCard title="Customer Record" icon={PiClipboardTextBold}>
+            <div className="grid gap-4 md:grid-cols-2">
+              <Field id="customerId" label="Existing customer ID">
+                <Input
+                  id="customerId"
+                  value={form.customerId}
+                  onChange={(event) => update('customerId', event.target.value)}
+                  placeholder="Leave blank for a new customer"
+                />
+              </Field>
+              <Field id="segment" label="Segment">
+                <Select value={form.segment} onValueChange={(value) => update('segment', value)}>
+                  <SelectTrigger id="segment">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="unjani">Unjani</SelectItem>
+                    <SelectItem value="smb">SMB</SelectItem>
+                    <SelectItem value="edu">Education</SelectItem>
+                    <SelectItem value="enterprise">Enterprise</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field id="businessName" label="Registered business name">
+                <Input
+                  id="businessName"
+                  value={form.businessName}
+                  onChange={(event) => update('businessName', event.target.value)}
+                  required
+                />
+              </Field>
+              <Field id="entityType" label="Entity type">
+                <Select value={form.entityType} onValueChange={(value) => update('entityType', value)}>
+                  <SelectTrigger id="entityType">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Private Company">Private Company</SelectItem>
+                    <SelectItem value="Sole Proprietor">Sole Proprietor</SelectItem>
+                    <SelectItem value="Non-Profit Company">Non-Profit Company</SelectItem>
+                    <SelectItem value="Partnership">Partnership</SelectItem>
+                    <SelectItem value="Trust">Trust</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field id="registrationNumber" label="Registration or owner ID">
+                <Input
+                  id="registrationNumber"
+                  value={form.registrationNumber}
+                  onChange={(event) => update('registrationNumber', event.target.value)}
+                  required
+                />
+              </Field>
+              <Field id="vatNumber" label="VAT number">
+                <div className="flex gap-3">
+                  <div className="flex h-10 items-center gap-2 rounded-md border border-gray-200 px-3">
+                    <Checkbox
+                      id="vatRegistered"
+                      checked={form.vatRegistered}
+                      onCheckedChange={(checked) => update('vatRegistered', checked === true)}
+                    />
+                    <Label htmlFor="vatRegistered" className="text-sm text-gray-700">
+                      VAT
+                    </Label>
+                  </div>
+                  <Input
+                    id="vatNumber"
+                    value={form.vatNumber}
+                    onChange={(event) => update('vatNumber', event.target.value)}
+                    disabled={!form.vatRegistered}
+                  />
+                </div>
+              </Field>
+              <Field id="registeredAddress" label="Registered address">
+                <Textarea
+                  id="registeredAddress"
+                  value={form.registeredAddress}
+                  onChange={(event) => update('registeredAddress', event.target.value)}
+                  required
+                  className="min-h-24 md:col-span-2"
+                />
+              </Field>
+            </div>
+          </SectionCard>
+
+          <SectionCard title="Contact And Site" icon={PiBuildingsBold}>
+            <div className="grid gap-4 md:grid-cols-2">
+              <Field id="contactName" label="Authorized contact">
+                <Input
+                  id="contactName"
+                  value={form.contactName}
+                  onChange={(event) => update('contactName', event.target.value)}
+                  required
+                />
+              </Field>
+              <Field id="email" label="Email">
+                <Input
+                  id="email"
+                  type="email"
+                  value={form.email}
+                  onChange={(event) => update('email', event.target.value)}
+                  required
+                />
+              </Field>
+              <Field id="phone" label="Phone">
+                <Input
+                  id="phone"
+                  value={form.phone}
+                  onChange={(event) => update('phone', event.target.value)}
+                  required
+                />
+              </Field>
+              <Field id="clinicName" label="Trading or clinic name">
+                <Input
+                  id="clinicName"
+                  value={form.clinicName}
+                  onChange={(event) => update('clinicName', event.target.value)}
+                />
+              </Field>
+              <Field id="province" label="Province">
+                <Input
+                  id="province"
+                  value={form.province}
+                  onChange={(event) => update('province', event.target.value)}
+                />
+              </Field>
+              <Field id="siteAddress" label="Service address">
+                <Input
+                  id="siteAddress"
+                  value={form.siteAddress}
+                  onChange={(event) => update('siteAddress', event.target.value)}
+                />
+              </Field>
+            </div>
+          </SectionCard>
+
+          <SectionCard title="Billable Service" icon={PiCheckCircleBold}>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <Field id="packageName" label="Package">
+                <Input
+                  id="packageName"
+                  value={form.packageName}
+                  onChange={(event) => update('packageName', event.target.value)}
+                  required
+                />
+              </Field>
+              <Field id="serviceType" label="Service type">
+                <Input
+                  id="serviceType"
+                  value={form.serviceType}
+                  onChange={(event) => update('serviceType', event.target.value)}
+                  required
+                />
+              </Field>
+              <Field id="monthlyPrice" label="Monthly ex VAT">
+                <Input
+                  id="monthlyPrice"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={form.monthlyPrice}
+                  onChange={(event) => update('monthlyPrice', event.target.value)}
+                  required
+                />
+              </Field>
+              <Field id="billingDay" label="Billing day">
+                <Select
+                  value={form.billingDay}
+                  onValueChange={(value) => update('billingDay', value as BillingDay)}
+                >
+                  <SelectTrigger id="billingDay">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="1">1st</SelectItem>
+                    <SelectItem value="15">15th</SelectItem>
+                    <SelectItem value="20">20th</SelectItem>
+                    <SelectItem value="25">25th</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field id="activationDate" label="Activation date">
+                <Input
+                  id="activationDate"
+                  type="date"
+                  value={form.activationDate}
+                  onChange={(event) => update('activationDate', event.target.value)}
+                />
+              </Field>
+            </div>
+          </SectionCard>
+
+          <SectionCard
+            title="Debit Order"
+            icon={PiBankBold}
+            action={
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="includeDebitOrder"
+                  checked={form.includeDebitOrder}
+                  onCheckedChange={(checked) => update('includeDebitOrder', checked === true)}
+                />
+                <Label htmlFor="includeDebitOrder" className="text-sm text-gray-700">
+                  Capture
+                </Label>
+              </div>
+            }
+          >
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              <Field id="accountHolderName" label="Account holder">
+                <Input
+                  id="accountHolderName"
+                  value={form.accountHolderName}
+                  onChange={(event) => update('accountHolderName', event.target.value)}
+                  required={form.includeDebitOrder}
+                  disabled={!form.includeDebitOrder}
+                />
+              </Field>
+              <Field id="bankName" label="Bank">
+                <Input
+                  id="bankName"
+                  value={form.bankName}
+                  onChange={(event) => update('bankName', event.target.value)}
+                  required={form.includeDebitOrder}
+                  disabled={!form.includeDebitOrder}
+                />
+              </Field>
+              <Field id="accountType" label="Account type">
+                <Select
+                  value={form.accountType}
+                  onValueChange={(value) => update('accountType', value)}
+                  disabled={!form.includeDebitOrder}
+                >
+                  <SelectTrigger id="accountType">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Cheque">Cheque</SelectItem>
+                    <SelectItem value="Savings">Savings</SelectItem>
+                    <SelectItem value="Transmission">Transmission</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field id="accountNumber" label="Account number">
+                <Input
+                  id="accountNumber"
+                  value={form.accountNumber}
+                  onChange={(event) => update('accountNumber', event.target.value)}
+                  required={form.includeDebitOrder}
+                  disabled={!form.includeDebitOrder}
+                />
+              </Field>
+              <Field id="branchCode" label="Branch code">
+                <Input
+                  id="branchCode"
+                  value={form.branchCode}
+                  onChange={(event) => update('branchCode', event.target.value)}
+                  required={form.includeDebitOrder}
+                  disabled={!form.includeDebitOrder}
+                />
+              </Field>
+            </div>
+          </SectionCard>
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={saving}>
+              <PiFloppyDiskBold className="mr-2 h-4 w-4" />
+              {saving ? 'Saving...' : 'Save Intake'}
+            </Button>
+          </div>
+        </form>
+
+        <aside className="space-y-4">
+          <SectionCard title="Capture Status" icon={PiClipboardTextBold} compact>
+            <div className="space-y-4">
+              <StatusBadge
+                status={result ? (result.createdCustomer ? 'New customer' : 'Updated customer') : 'Not saved'}
+                variant={result ? 'success' : 'neutral'}
+              />
+              {result ? (
+                <div className="space-y-3 text-sm">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                      Account
+                    </p>
+                    <p className="font-medium text-gray-900">{result.accountNumber || result.customerId}</p>
+                  </div>
+                  <div className="grid gap-2">
+                    <Button asChild variant="outline" size="sm" className="justify-between">
+                      <Link href={`/admin/customers/${result.customerId}`}>
+                        Customer Record
+                        <PiArrowRightBold className="h-4 w-4" />
+                      </Link>
+                    </Button>
+                    <Button asChild variant="outline" size="sm" className="justify-between">
+                      <Link href={`/admin/b2b/vetting/${result.submissionId}`}>
+                        Vetting Workbench
+                        <PiArrowRightBold className="h-4 w-4" />
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="grid gap-2">
+                  <StatusBadge status="Customer pending" variant="neutral" />
+                  <StatusBadge status="Submission pending" variant="neutral" />
+                  <StatusBadge status="Service order pending" variant="warning" />
+                </div>
+              )}
+            </div>
+          </SectionCard>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/unjani/onboarding/page.tsx
+++ b/app/admin/unjani/onboarding/page.tsx
@@ -73,6 +73,7 @@ interface PipelineClinic {
   vetting_due_date: string | null;
   submitted_at: string | null;
   service_order_issued_at: string | null;
+  service_order_status: 'not_issued' | 'pending_signoff' | 'accepted';
   sla: {
     dueDate: string | null;
     overdue: boolean;
@@ -92,6 +93,7 @@ interface PipelineResponse {
     submitted: number;
     changes_requested: number;
     docs_approved: number;
+    service_order_pending: number;
     billing_ready: number;
     pending: number;
   };
@@ -116,6 +118,7 @@ const STAGES: StageMeta[] = [
   { id: 'submitted', label: 'Docs submitted', pillBg: '#FDF2E9', pillFg: '#D76026', color: '#E87A1E', action: 'Vet documents' },
   { id: 'changes_requested', label: 'Changes requested', pillBg: '#FCF6E5', pillFg: '#CA8A04', color: '#CA8A04', action: 'Review changes' },
   { id: 'docs_approved', label: 'Docs approved', pillBg: '#EBF1FE', pillFg: '#2563EB', color: '#5B8DEF', action: 'Issue service order' },
+  { id: 'service_order_pending', label: 'SO signoff', pillBg: '#F5F3FF', pillFg: '#6D28D9', color: '#7C3AED', action: 'Resend service order' },
   { id: 'billing_ready', label: 'Ready to install', pillBg: '#16A34A', pillFg: '#FFFFFF', color: '#16A34A', action: 'Issue service order' },
 ];
 
@@ -760,6 +763,7 @@ export default function UnjaniOnboardingPipelinePage() {
         }
         break;
       case 'docs_approved':
+      case 'service_order_pending':
       case 'billing_ready':
         issueServiceOrder(clinic);
         break;
@@ -1137,7 +1141,7 @@ export default function UnjaniOnboardingPipelinePage() {
                             {meta.label}
                           </span>
                           <div className="flex gap-0.5 mt-1.5">
-                            {STAGES.slice(0, 5).map((_, i) => (
+                            {STAGES.map((_, i) => (
                               <span
                                 key={i}
                                 className={cn(
@@ -1182,7 +1186,18 @@ export default function UnjaniOnboardingPipelinePage() {
                         <TableCell>
                           {issued ? (
                             <div className="text-sm">
-                              <span className="text-green-600 font-medium">Issued</span>
+                              <span
+                                className={cn(
+                                  'font-medium',
+                                  clinic.service_order_status === 'accepted'
+                                    ? 'text-green-600'
+                                    : 'text-purple-700'
+                                )}
+                              >
+                                {clinic.service_order_status === 'accepted'
+                                  ? 'Accepted'
+                                  : 'Awaiting signoff'}
+                              </span>
                               <div className="text-xs text-gray-400">
                                 {new Date(
                                   clinic.service_order_issued_at!
@@ -1816,7 +1831,7 @@ export default function UnjaniOnboardingPipelinePage() {
               </div>
               <div className="border-t border-gray-100 p-4 flex flex-col gap-2">
                 {drawerClinic.email &&
-                  !['docs_approved', 'billing_ready'].includes(drawerClinic.stage) && (
+                  !['docs_approved', 'service_order_pending', 'billing_ready'].includes(drawerClinic.stage) && (
                     <Button
                       variant="outline"
                       className="w-full"

--- a/app/api/admin/b2b/__tests__/onboarding-pipeline.test.ts
+++ b/app/api/admin/b2b/__tests__/onboarding-pipeline.test.ts
@@ -17,6 +17,17 @@ describe('determineStage', () => {
       expect(stage).toBe('docs_approved');
     });
 
+    it('should return service_order_pending when docs are approved and the service order is awaiting signoff', () => {
+      const stage = determineStage(
+        'in_progress',
+        'submitted',
+        'approved',
+        'pending',
+        'pending_signoff'
+      );
+      expect(stage).toBe('service_order_pending');
+    });
+
     it('should NOT return mandate_active for any input (stage is retired)', () => {
       // Verify that no combination of inputs returns 'mandate_active'
       const inputs = [

--- a/app/api/admin/b2b/__tests__/upload-document.test.ts
+++ b/app/api/admin/b2b/__tests__/upload-document.test.ts
@@ -1,0 +1,169 @@
+import { NextRequest } from 'next/server';
+
+import { POST } from '../upload-document/route';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { svc } from '@/lib/onboarding/onboarding-service';
+import { uploadFile } from '@/lib/storage/supabase-upload';
+
+jest.mock('@/lib/auth/admin-api-auth', () => ({
+  authenticateAdmin: jest.fn(),
+  requirePermission: jest.fn(),
+}));
+
+jest.mock('@/lib/onboarding/onboarding-service', () => ({
+  svc: jest.fn(),
+}));
+
+jest.mock('@/lib/storage/supabase-upload', () => ({
+  uploadFile: jest.fn(),
+}));
+
+jest.mock('@/lib/logging/logger', () => ({
+  apiLogger: {
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+const mockAuthenticateAdmin = authenticateAdmin as jest.MockedFunction<typeof authenticateAdmin>;
+const mockRequirePermission = requirePermission as jest.MockedFunction<typeof requirePermission>;
+const mockSvc = svc as jest.MockedFunction<typeof svc>;
+const mockUploadFile = uploadFile as jest.MockedFunction<typeof uploadFile>;
+
+function formRequest(form: FormData) {
+  return new Request('http://localhost/api/admin/b2b/upload-document', {
+    method: 'POST',
+    body: form,
+  }) as NextRequest;
+}
+
+function createSupabaseMock() {
+  const operations: Array<{ table: string; action: string; payload?: unknown }> = [];
+
+  const from = jest.fn((table: string) => {
+    let action = 'select';
+    let payload: unknown;
+
+    const builder: any = {
+      select: jest.fn(() => builder),
+      eq: jest.fn(() => builder),
+      order: jest.fn(() => builder),
+      limit: jest.fn(() => builder),
+      neq: jest.fn(() => Promise.resolve({ error: null })),
+      insert: jest.fn((nextPayload) => {
+        action = 'insert';
+        payload = nextPayload;
+        operations.push({ table, action, payload });
+        return builder;
+      }),
+      update: jest.fn((nextPayload) => {
+        action = 'update';
+        payload = nextPayload;
+        operations.push({ table, action, payload });
+        return builder;
+      }),
+      maybeSingle: jest.fn(() => Promise.resolve({ data: null, error: null })),
+      single: jest.fn(() => {
+        if (table === 'customers' && action === 'select') {
+          return Promise.resolve({
+            data: {
+              business_name: 'Future Business Client',
+              email: 'ops@example.co.za',
+              phone: '0821234567',
+              onboarding_status: 'pending',
+            },
+            error: null,
+          });
+        }
+        if (table === 'onboarding_submissions') {
+          return Promise.resolve({ data: { id: 'submission-1' }, error: null });
+        }
+        if (table === 'kyc_documents') {
+          return Promise.resolve({ data: { id: 'document-1' }, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      }),
+    };
+    return builder;
+  });
+
+  return { supabase: { from } as any, operations };
+}
+
+describe('POST /api/admin/b2b/upload-document', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticateAdmin.mockResolvedValue({
+      success: true,
+      user: { id: 'user-1', email: 'admin@circletel.co.za' } as any,
+      adminUser: {
+        id: 'admin-1',
+        email: 'admin@circletel.co.za',
+        role: 'admin',
+      } as any,
+    });
+    mockRequirePermission.mockReturnValue(null);
+    mockUploadFile.mockResolvedValue({
+      success: true,
+      path: 'onboarding/customer-1/company_registration/doc.pdf',
+      url: 'signed-url',
+    } as any);
+  });
+
+  it('stores email provenance and selected segment on admin-uploaded documents', async () => {
+    const { supabase, operations } = createSupabaseMock();
+    mockSvc.mockReturnValue(supabase);
+
+    const form = new FormData();
+    form.append('customerId', 'customer-1');
+    form.append('documentType', 'company_registration');
+    form.append('segment', 'enterprise');
+    form.append('emailFrom', 'client@example.co.za');
+    form.append('emailSubject', 'Onboarding documents');
+    form.append('emailReceivedAt', '2026-06-30T09:00');
+    form.append(
+      'file',
+      new File(['test'], 'doc.pdf', { type: 'application/pdf' })
+    );
+
+    const response = await POST(formRequest(form));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+
+    const shellInsert = operations.find(
+      (op) => op.table === 'onboarding_submissions' && op.action === 'insert'
+    );
+    expect(shellInsert?.payload).toEqual(
+      expect.objectContaining({
+        segment: 'enterprise',
+        submission_data: expect.objectContaining({
+          source: 'admin_email',
+          email_provenance: {
+            from: 'client@example.co.za',
+            subject: 'Onboarding documents',
+            received_at: '2026-06-30T09:00',
+          },
+        }),
+      })
+    );
+
+    const documentInsert = operations.find(
+      (op) => op.table === 'kyc_documents' && op.action === 'insert'
+    );
+    expect(documentInsert?.payload).toEqual(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          source: 'admin_email',
+          segment: 'enterprise',
+          email_provenance: {
+            from: 'client@example.co.za',
+            subject: 'Onboarding documents',
+            received_at: '2026-06-30T09:00',
+          },
+        }),
+      })
+    );
+  });
+});

--- a/app/api/admin/b2b/issue-service-order/route.ts
+++ b/app/api/admin/b2b/issue-service-order/route.ts
@@ -1,33 +1,15 @@
 /**
- * Issue Service Order PDF API
- *
  * POST /api/admin/b2b/issue-service-order
  *
- * Admin-only endpoint to generate and issue a Service Order PDF to a clinic.
- * Generates PDF, uploads to kyc-documents bucket, sends email copy to clinic.
- *
- * Request body:
- * {
- *   customerId: string (UUID)
- * }
- *
- * Response:
- * {
- *   success: boolean,
- *   pdfPath: string,
- *   emailed: boolean,
- *   message: string
- * }
+ * Generates a Service Order PDF, stores it against the onboarding submission,
+ * emails the PDF to the customer, and includes a customer-owned signoff link.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import crypto from 'crypto';
 import { createClient as createServerClient } from '@/lib/supabase/server';
 import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
-import { uploadFile } from '@/lib/storage/supabase-upload';
-import { generateServiceOrderBlob } from '@/lib/contracts/service-order-pdf';
+import { issueServiceOrderForCustomer } from '@/lib/onboarding/service-order-issuer';
 import { apiLogger } from '@/lib/logging/logger';
-import { Resend } from 'resend';
 
 interface RequestBody {
   customerId: string;
@@ -37,22 +19,28 @@ interface ServiceOrderResponse {
   success: boolean;
   pdfPath?: string;
   emailed?: boolean;
+  signoffUrl?: string;
   message: string;
   error?: string;
 }
 
+function baseUrlFromRequest(request: NextRequest): string {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    request.headers.get('origin') ||
+    new URL(request.url).origin
+  );
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse<ServiceOrderResponse>> {
   try {
-    // === Admin Auth ===
     const authResult = await authenticateAdmin(request);
     if (!authResult.success) return authResult.response as NextResponse<ServiceOrderResponse>;
 
     const perm = requirePermission(authResult.adminUser, ['customers:write', 'kyc:verify']);
     if (perm) return perm as NextResponse<ServiceOrderResponse>;
 
-    const supabase = await createServerClient();
     const { customerId } = (await request.json()) as RequestBody;
-
     if (!customerId) {
       return NextResponse.json<ServiceOrderResponse>(
         { success: false, message: 'customerId is required' },
@@ -60,216 +48,40 @@ export async function POST(request: NextRequest): Promise<NextResponse<ServiceOr
       );
     }
 
-    // === Load Customer ===
-    const { data: customer, error: customerError } = await supabase
-      .from('customers')
-      .select('id, account_number, business_name, email, phone, clinic_details, onboarding_status')
-      .eq('id', customerId)
-      .single();
-
-    if (customerError || !customer) {
-      apiLogger.error('[Service Order] Customer not found', { customerId, error: customerError });
-      return NextResponse.json<ServiceOrderResponse>(
-        { success: false, message: 'Customer not found' },
-        { status: 404 }
-      );
-    }
-
-    // === Load Latest Onboarding Submission ===
-    const { data: submission, error: submissionError } = await supabase
-      .from('onboarding_submissions')
-      .select('id, submission_data, submitted_at')
-      .eq('customer_id', customerId)
-      .order('submitted_at', { ascending: false })
-      .limit(1)
-      .single();
-
-    if (submissionError || !submission) {
-      apiLogger.error('[Service Order] No onboarding submission found', { customerId, error: submissionError });
-      return NextResponse.json<ServiceOrderResponse>(
-        { success: false, message: 'No onboarding submission found for this customer' },
-        { status: 404 }
-      );
-    }
-
-    // === Load Customer Service (for monthly price) ===
-    const { data: service, error: serviceError } = await supabase
-      .from('customer_services')
-      .select('monthly_price, activation_date')
-      .eq('customer_id', customerId)
-      .order('activation_date', { ascending: false })
-      .limit(1)
-      .single();
-
-    if (serviceError || !service) {
-      apiLogger.error('[Service Order] No customer service found', { customerId, error: serviceError });
-      return NextResponse.json<ServiceOrderResponse>(
-        { success: false, message: 'No active service found for this customer' },
-        { status: 404 }
-      );
-    }
-
-    // === Extract Data from Submission ===
-    const submissionData = submission.submission_data as any;
-    const step5 = submissionData?.step5 || {};
-    const billingDay = step5.paymentDate || '1';
-    const clinicDetails = customer.clinic_details as any || {};
-
-    // === Acceptance evidence (captured at the Step-5 click-accept) ===
-    const acceptanceRecord = submissionData?.acceptance;
-    let acceptance: Parameters<typeof generateServiceOrderBlob>[0]['acceptance'];
-    if (acceptanceRecord?.accepted_at) {
-      // Link-delivery evidence from the single-use token used at acceptance
-      let linkSentVia: string | undefined;
-      let linkSentAtIso: string | undefined;
-      if (acceptanceRecord.token_id) {
-        const { data: tokenRow } = await supabase
-          .from('onboarding_tokens')
-          .select('sent_via, sent_at')
-          .eq('id', acceptanceRecord.token_id)
-          .maybeSingle();
-        linkSentVia = tokenRow?.sent_via || undefined;
-        linkSentAtIso = tokenRow?.sent_at || undefined;
-      }
-      const digits = (customer.phone || '').replace(/\D/g, '');
-      const maskedPhone =
-        digits.length >= 7 ? `${digits.slice(0, 3)} *** ${digits.slice(-4)}` : undefined;
-
-      acceptance = {
-        acceptedAtIso: acceptanceRecord.accepted_at,
-        ip: acceptanceRecord.ip || undefined,
-        termsVersion: acceptanceRecord.terms_version || undefined,
-        termsHash: acceptanceRecord.terms_hash || undefined,
-        termsSnapshot: Array.isArray(acceptanceRecord.terms_snapshot)
-          ? acceptanceRecord.terms_snapshot
-          : undefined,
-        linkSentVia,
-        linkSentAtIso,
-        maskedPhone,
-        submissionId: submission.id,
-      };
-    }
-
-    // === Generate Service Order PDF ===
-    const pdfBlob = generateServiceOrderBlob({
-      accountNumber: customer.account_number,
-      clinicName: customer.business_name,
-      clinicAddress: clinicDetails.site_address || 'Not provided',
-      clinicProvince: clinicDetails.province || 'Not provided',
-      clinicEmail: customer.email,
-      clinicPhone: customer.phone,
-      monthlyFeeExclVat: service.monthly_price || 450,
-      vatPercentage: 15,
-      billingDay: billingDay as '1' | '15' | '20' | '25',
-      activationDate: service.activation_date || new Date().toISOString(),
-      submittedAt: submission.submitted_at || new Date().toISOString(),
-      acceptance,
-    });
-
-    // Integrity hash of the issued document (proves the stored PDF is untampered)
-    const pdfSha256 = crypto
-      .createHash('sha256')
-      .update(Buffer.from(await pdfBlob.arrayBuffer()))
-      .digest('hex');
-
-    // === Upload PDF to Storage ===
-    // Convert Blob to File for uploadFile API
-    const pdfFile = new File(
-      [pdfBlob],
-      `SO-${customer.account_number}-${Date.now()}.pdf`,
-      { type: 'application/pdf' }
-    );
-
-    const uploadResult = await uploadFile(pdfFile, {
-      bucket: 'kyc-documents',
-      folder: `service-orders/${customerId}`,
-      maxSizeBytes: 5 * 1024 * 1024,
-      allowedTypes: ['application/pdf'],
-      supabaseClient: supabase,
-    });
-
-    if (!uploadResult.success || !uploadResult.path) {
-      apiLogger.error('[Service Order] PDF upload failed', { customerId, error: uploadResult.error });
-      return NextResponse.json<ServiceOrderResponse>(
-        { success: false, message: 'Failed to upload PDF' },
-        { status: 500 }
-      );
-    }
-
-    // === Update Onboarding Submission with PDF Path + integrity hash ===
-    const { error: updateError } = await supabase
-      .from('onboarding_submissions')
-      .update({
-        service_order_pdf_path: uploadResult.path,
-        service_order_issued_at: new Date().toISOString(),
-        submission_data: {
-          ...submissionData,
-          service_order_pdf_sha256: pdfSha256,
-        },
-      })
-      .eq('id', submission.id);
-
-    if (updateError) {
-      apiLogger.error('[Service Order] Failed to update submission', { submissionId: submission.id, error: updateError });
-      return NextResponse.json<ServiceOrderResponse>(
-        { success: false, message: 'Failed to update submission record' },
-        { status: 500 }
-      );
-    }
-
-    // === Send Email (best effort, don't fail the request) ===
-    let emailSent = false;
-    try {
-      const resend = new Resend(process.env.RESEND_API_KEY);
-      const { error: emailError } = await resend.emails.send({
-        from: 'billing@notify.circletel.co.za',
-        to: customer.email,
-        subject: `Your CircleTel Service Order (${customer.account_number})`,
-        html: `
-          <h2>Service Order Issued</h2>
-          <p>Dear ${customer.business_name},</p>
-          <p>Your Service Order has been generated and is attached to this email.</p>
-          <div style="background-color: #f5f5f5; padding: 16px; border-radius: 8px; margin: 16px 0;">
-            <p style="margin: 8px 0;"><strong>Service Order Number:</strong> SO-${customer.account_number}</p>
-            <p style="margin: 8px 0;"><strong>Service:</strong> CircleTel ClinicConnect — Managed Connectivity</p>
-            <p style="margin: 8px 0;"><strong>Monthly Fee:</strong> R${(service.monthly_price || 450).toFixed(2)} ex VAT</p>
-            <p style="margin: 8px 0;"><strong>Billing Day:</strong> ${billingDay === '1' ? '1st' : billingDay === '15' ? '15th' : billingDay === '20' ? '20th' : '25th'}</p>
-          </div>
-          <p>This Service Order is back-to-back with the Master Service Agreement between CircleTel and the Unjani Clinic Network.</p>
-          <p>If you have any questions, please contact our support team at support@circletel.co.za.</p>
-          <p>Regards,<br>CircleTel</p>
-        `,
-      });
-
-      if (!emailError) {
-        emailSent = true;
-      } else {
-        apiLogger.warn('[Service Order] Email send failed but request succeeding', { customerId, error: emailError });
-      }
-    } catch (emailException) {
-      apiLogger.warn('[Service Order] Email exception but request succeeding', { customerId, error: emailException });
-    }
-
-    apiLogger.info('[Service Order] Service Order issued successfully', {
+    const supabase = await createServerClient();
+    const result = await issueServiceOrderForCustomer(supabase, {
       customerId,
-      accountNumber: customer.account_number,
-      pdfPath: uploadResult.path,
-      emailed: emailSent,
+      baseUrl: baseUrlFromRequest(request),
+      issuedBy: authResult.adminUser.email,
+      sendEmail: true,
+    });
+
+    apiLogger.info('[Service Order] issued with signoff link', {
+      customerId,
+      submissionId: result.submissionId,
+      pdfPath: result.pdfPath,
+      emailed: result.emailed,
+      by: authResult.adminUser.email,
     });
 
     return NextResponse.json<ServiceOrderResponse>(
       {
         success: true,
-        pdfPath: uploadResult.path,
-        emailed: emailSent,
-        message: `Service Order issued successfully. Email ${emailSent ? 'sent' : 'could not be sent'}.`,
+        pdfPath: result.pdfPath,
+        emailed: result.emailed,
+        signoffUrl: result.signoffUrl,
+        message: `Service Order issued successfully. Email ${result.emailed ? 'sent' : 'could not be sent'}.`,
       },
       { status: 200 }
     );
   } catch (error) {
-    apiLogger.error('[Service Order] Unexpected error', { error });
+    apiLogger.error('[Service Order] failed', { error });
     return NextResponse.json<ServiceOrderResponse>(
-      { success: false, message: 'Internal server error' },
+      {
+        success: false,
+        message: 'Service Order could not be issued',
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
       { status: 500 }
     );
   }

--- a/app/api/admin/b2b/manual-intake/__tests__/route.test.ts
+++ b/app/api/admin/b2b/manual-intake/__tests__/route.test.ts
@@ -1,0 +1,130 @@
+import { NextRequest } from 'next/server';
+
+import { POST } from '../route';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { svc } from '@/lib/onboarding/onboarding-service';
+import { saveManualB2BIntake } from '@/lib/onboarding/manual-intake';
+
+jest.mock('@/lib/auth/admin-api-auth', () => ({
+  authenticateAdmin: jest.fn(),
+  requirePermission: jest.fn(),
+}));
+
+jest.mock('@/lib/onboarding/onboarding-service', () => ({
+  svc: jest.fn(),
+}));
+
+jest.mock('@/lib/onboarding/manual-intake', () => {
+  const actual = jest.requireActual('@/lib/onboarding/manual-intake');
+  return {
+    ...actual,
+    saveManualB2BIntake: jest.fn(),
+  };
+});
+
+jest.mock('@/lib/logging/logger', () => ({
+  apiLogger: {
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+const mockAuthenticateAdmin = authenticateAdmin as jest.MockedFunction<typeof authenticateAdmin>;
+const mockRequirePermission = requirePermission as jest.MockedFunction<typeof requirePermission>;
+const mockSvc = svc as jest.MockedFunction<typeof svc>;
+const mockSaveManualB2BIntake = saveManualB2BIntake as jest.MockedFunction<typeof saveManualB2BIntake>;
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/admin/b2b/manual-intake', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+const validBody = {
+  segment: 'unjani',
+  business: {
+    businessName: 'Unjani Alexandra Clinic',
+    entityType: 'Private Company',
+    registrationNumber: '2026/123456/07',
+    vatRegistered: false,
+    registeredAddress: '10 Clinic Road, Alexandra',
+  },
+  contact: {
+    contactName: 'Thandi Maseko',
+    email: 'thandi@example.co.za',
+    phone: '0821234567',
+  },
+  site: {
+    clinicName: 'Unjani Alexandra',
+    province: 'Gauteng',
+    siteAddress: '10 Clinic Road, Alexandra',
+  },
+};
+
+describe('POST /api/admin/b2b/manual-intake', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticateAdmin.mockResolvedValue({
+      success: true,
+      user: { id: 'user-1', email: 'admin@circletel.co.za' } as any,
+      adminUser: {
+        id: 'admin-1',
+        email: 'admin@circletel.co.za',
+        role: 'admin',
+      } as any,
+    });
+    mockRequirePermission.mockReturnValue(null);
+    mockSvc.mockReturnValue({ from: jest.fn() } as any);
+    mockSaveManualB2BIntake.mockResolvedValue({
+      customerId: 'customer-1',
+      accountNumber: 'CT-2026-00042',
+      submissionId: 'submission-1',
+      createdCustomer: true,
+      createdSubmission: true,
+    });
+  });
+
+  it('requires customer write or KYC verification permission', async () => {
+    await POST(request(validBody));
+
+    expect(mockRequirePermission).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'admin@circletel.co.za' }),
+      ['customers:write', 'kyc:verify']
+    );
+  });
+
+  it('delegates valid manual intake payloads to the domain service', async () => {
+    const response = await POST(request(validBody));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      intake: {
+        customerId: 'customer-1',
+        accountNumber: 'CT-2026-00042',
+        submissionId: 'submission-1',
+        createdCustomer: true,
+        createdSubmission: true,
+      },
+    });
+    expect(mockSaveManualB2BIntake).toHaveBeenCalledWith(
+      expect.any(Object),
+      validBody,
+      { adminId: 'admin-1', adminEmail: 'admin@circletel.co.za' }
+    );
+  });
+
+  it('rejects malformed payloads before touching Supabase', async () => {
+    const response = await POST(request({ business: { businessName: 'A' } }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('validation_failed');
+    expect(mockSvc).not.toHaveBeenCalled();
+    expect(mockSaveManualB2BIntake).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/admin/b2b/manual-intake/route.ts
+++ b/app/api/admin/b2b/manual-intake/route.ts
@@ -1,0 +1,58 @@
+/**
+ * POST /api/admin/b2b/manual-intake
+ *
+ * Admin-assisted B2B onboarding capture for business details received by email.
+ * Supports creating a new business customer record or updating an existing one.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { svc } from '@/lib/onboarding/onboarding-service';
+import { manualB2BIntakeSchema, saveManualB2BIntake } from '@/lib/onboarding/manual-intake';
+import { apiLogger } from '@/lib/logging/logger';
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticateAdmin(request);
+    if (!auth.success) return auth.response;
+
+    const perm = requirePermission(auth.adminUser, ['customers:write', 'kyc:verify']);
+    if (perm) return perm;
+
+    const body = await request.json();
+    const parsed = manualB2BIntakeSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'validation_failed',
+          issues: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const result = await saveManualB2BIntake(svc(), body, {
+      adminId: auth.adminUser.id ?? auth.user.id,
+      adminEmail: auth.adminUser.email,
+    });
+
+    apiLogger.info('[Manual B2B Intake] captured', {
+      customerId: result.customerId,
+      submissionId: result.submissionId,
+      createdCustomer: result.createdCustomer,
+      by: auth.adminUser.email,
+    });
+
+    return NextResponse.json({ success: true, intake: result });
+  } catch (error) {
+    apiLogger.error('[Manual B2B Intake] failed', { error });
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/b2b/onboarding-pipeline/route.ts
+++ b/app/api/admin/b2b/onboarding-pipeline/route.ts
@@ -27,6 +27,7 @@ interface PipelineClinic {
   vetting_due_date: string | null;
   submitted_at: string | null;
   service_order_issued_at: string | null;
+  service_order_status: 'not_issued' | 'pending_signoff' | 'accepted';
   sla: {
     dueDate: string | null;
     overdue: boolean;
@@ -46,6 +47,7 @@ interface PipelineResponse {
     submitted: number;
     changes_requested: number;
     docs_approved: number;
+    service_order_pending: number;
     billing_ready: number;
     pending: number;
   };
@@ -55,23 +57,25 @@ interface PipelineResponse {
 /**
  * Determine the clinic's current stage in the onboarding pipeline
  *
- * Stages flow: pending → invited → submitted → changes_requested/docs_approved → billing_ready
- * No longer includes mandate_active (billing bypassed eMandate signature via click-wrap).
+ * Stages flow: pending → invited → submitted → changes_requested/docs_approved
+ * → service_order_pending → billing_ready.
  */
 export function determineStage(
   onboarding_status: string | null,
   submission_status: string | null,
   document_vetting_status: string | null,
-  mandate_status: string | null
+  mandate_status: string | null,
+  service_order_status: 'not_issued' | 'pending_signoff' | 'accepted' = 'not_issued'
 ): string {
   // billing_ready takes precedence
   if (onboarding_status === 'billing_ready') {
     return 'billing_ready';
   }
 
-  // docs_approved (vetting approved, bank details on file)
-  // Note: mandate_status is no longer required; we check bank details in the gate
   if (document_vetting_status === 'approved') {
+    if (service_order_status === 'pending_signoff') {
+      return 'service_order_pending';
+    }
     return 'docs_approved';
   }
 
@@ -122,7 +126,9 @@ export async function GET(request: NextRequest) {
           document_vetting_status,
           submitted_at,
           vetting_due_date,
-          service_order_issued_at
+          service_order_issued_at,
+          service_order_pdf_path,
+          submission_data
         ),
         customer_payment_methods!customer_payment_methods_customer_id_fkey (
           id,
@@ -150,6 +156,7 @@ export async function GET(request: NextRequest) {
         submitted: 0,
         changes_requested: 0,
         docs_approved: 0,
+        service_order_pending: 0,
         billing_ready: 0,
         pending: 0,
       },
@@ -175,12 +182,25 @@ export async function GET(request: NextRequest) {
       const province = typeof details.province === 'string' ? details.province : '';
       const nurseName =
         typeof details.nurse_owner_name === 'string' ? details.nurse_owner_name : null;
+      const submissionData =
+        submission?.submission_data && typeof submission.submission_data === 'object'
+          ? (submission.submission_data as Record<string, any>)
+          : {};
+      const serviceOrderAcceptedAt =
+        submissionData.service_order_acceptance?.accepted_at || submissionData.acceptance?.accepted_at;
+      const serviceOrderStatus =
+        serviceOrderAcceptedAt
+          ? 'accepted'
+          : submission?.service_order_issued_at || submission?.service_order_pdf_path
+            ? 'pending_signoff'
+            : 'not_issued';
 
       const stage = determineStage(
         clinic.onboarding_status,
         submission?.status || null,
         submission?.document_vetting_status || null,
-        debitOrderPm?.mandate_status || null
+        debitOrderPm?.mandate_status || null,
+        serviceOrderStatus
       );
 
       // SLA calculation: vetting_due_date (if submitted) vs now
@@ -210,6 +230,7 @@ export async function GET(request: NextRequest) {
         vetting_due_date: submission?.vetting_due_date || null,
         submitted_at: submission?.submitted_at || null,
         service_order_issued_at: submission?.service_order_issued_at || null,
+        service_order_status: serviceOrderStatus,
         sla: {
           dueDate: submission?.vetting_due_date || null,
           overdue: isOverdue,

--- a/app/api/admin/b2b/upload-document/route.ts
+++ b/app/api/admin/b2b/upload-document/route.ts
@@ -23,6 +23,10 @@ export async function POST(request: NextRequest) {
   const customerId = form.get('customerId') as string | null;
   const documentType = form.get('documentType') as string | null;
   const submissionIdIn = (form.get('submissionId') as string | null) || null;
+  const segment = ((form.get('segment') as string | null) || 'unjani').trim() || 'unjani';
+  const emailFrom = ((form.get('emailFrom') as string | null) || '').trim();
+  const emailSubject = ((form.get('emailSubject') as string | null) || '').trim();
+  const emailReceivedAt = ((form.get('emailReceivedAt') as string | null) || '').trim();
   const file = form.get('file') as File | null;
 
   if (!customerId || !documentType || !file) {
@@ -38,6 +42,14 @@ export async function POST(request: NextRequest) {
 
   const supabase = svc();
   const adminEmail = auth.adminUser.email;
+  const emailProvenance =
+    emailFrom || emailSubject || emailReceivedAt
+      ? {
+          from: emailFrom || null,
+          subject: emailSubject || null,
+          received_at: emailReceivedAt || null,
+        }
+      : null;
 
   const { data: customer } = await supabase
     .from('customers')
@@ -66,12 +78,18 @@ export async function POST(request: NextRequest) {
         .from('onboarding_submissions')
         .insert({
           customer_id: customerId,
-          segment: 'unjani',
+          segment,
           status: 'submitted',
           document_vetting_status: 'documents_pending',
           submitted_at: now().toISOString(),
           vetting_due_date: addBusinessDays(now(), 2).toISOString(),
-          submission_data: { manual: true, source: 'admin_email', uploaded_by: adminEmail },
+          submission_data: {
+            manual: true,
+            source: 'admin_email',
+            segment,
+            uploaded_by: adminEmail,
+            ...(emailProvenance ? { email_provenance: emailProvenance } : {}),
+          },
         })
         .select('id')
         .single();
@@ -121,7 +139,12 @@ export async function POST(request: NextRequest) {
       file_type: file.type,
       verification_status: 'pending',
       is_sensitive: true,
-      metadata: { source: 'admin_email', uploaded_by: adminEmail },
+      metadata: {
+        source: 'admin_email',
+        segment,
+        uploaded_by: adminEmail,
+        ...(emailProvenance ? { email_provenance: emailProvenance } : {}),
+      },
     })
     .select('id')
     .single();

--- a/app/api/service-order/__tests__/accept.test.ts
+++ b/app/api/service-order/__tests__/accept.test.ts
@@ -1,0 +1,133 @@
+import { NextRequest } from 'next/server';
+
+import { POST } from '../accept/route';
+import { resolveTokenForPurpose, svc } from '@/lib/onboarding/onboarding-service';
+import { issueServiceOrderForCustomer } from '@/lib/onboarding/service-order-issuer';
+import { maybeMarkBillingReady } from '@/lib/onboarding/billing-ready';
+
+jest.mock('@/lib/onboarding/onboarding-service', () => ({
+  resolveTokenForPurpose: jest.fn(),
+  svc: jest.fn(),
+}));
+
+jest.mock('@/lib/onboarding/service-order-issuer', () => {
+  const actual = jest.requireActual('@/lib/onboarding/service-order-issuer');
+  return {
+    ...actual,
+    issueServiceOrderForCustomer: jest.fn(),
+  };
+});
+
+jest.mock('@/lib/onboarding/billing-ready', () => ({
+  maybeMarkBillingReady: jest.fn(),
+}));
+
+const mockResolveTokenForPurpose = resolveTokenForPurpose as jest.MockedFunction<typeof resolveTokenForPurpose>;
+const mockSvc = svc as jest.MockedFunction<typeof svc>;
+const mockIssueServiceOrderForCustomer = issueServiceOrderForCustomer as jest.MockedFunction<typeof issueServiceOrderForCustomer>;
+const mockMaybeMarkBillingReady = maybeMarkBillingReady as jest.MockedFunction<typeof maybeMarkBillingReady>;
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/service-order/accept', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-forwarded-for': '196.1.2.3',
+      'user-agent': 'Jest Browser',
+    },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+function createSupabaseMock() {
+  const updates: Array<{ table: string; payload: unknown }> = [];
+  const from = jest.fn((table: string) => {
+    const builder: any = {
+      select: jest.fn(() => builder),
+      eq: jest.fn(() => builder),
+      update: jest.fn((payload) => {
+        updates.push({ table, payload });
+        return builder;
+      }),
+      single: jest.fn(() => {
+        if (table === 'onboarding_submissions') {
+          return Promise.resolve({
+            data: {
+              id: 'submission-1',
+              customer_id: 'customer-1',
+              segment: 'enterprise',
+              submission_data: { step5: { paymentDate: '25' } },
+            },
+            error: null,
+          });
+        }
+        return Promise.resolve({ data: null, error: null });
+      }),
+    };
+    return builder;
+  });
+  return { supabase: { from } as any, updates };
+}
+
+describe('POST /api/service-order/accept', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveTokenForPurpose.mockResolvedValue({
+      customerId: 'customer-1',
+      tokenId: 'token-1',
+      purpose: 'service_order_signoff',
+      onboardingSubmissionId: 'submission-1',
+      metadata: {},
+    });
+    mockIssueServiceOrderForCustomer.mockResolvedValue({
+      pdfPath: 'service-orders/customer-1/SO.pdf',
+      pdfSha256: 'hash',
+      submissionId: 'submission-1',
+      emailed: false,
+    });
+    mockMaybeMarkBillingReady.mockResolvedValue(false);
+  });
+
+  it('records service-order acceptance, consumes the token, and regenerates the accepted PDF', async () => {
+    const { supabase, updates } = createSupabaseMock();
+    mockSvc.mockReturnValue(supabase);
+
+    const response = await POST(request({ token: 'plain-token' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      pdfPath: 'service-orders/customer-1/SO.pdf',
+      billingReady: false,
+    });
+    expect(mockResolveTokenForPurpose).toHaveBeenCalledWith('plain-token', 'service_order_signoff');
+
+    const submissionUpdate = updates.find((update) => update.table === 'onboarding_submissions');
+    expect(submissionUpdate?.payload).toEqual(
+      expect.objectContaining({
+        submission_data: expect.objectContaining({
+          service_order_status: 'accepted',
+          service_order_acceptance: expect.objectContaining({
+            ip: '196.1.2.3',
+            user_agent: 'Jest Browser',
+            token_id: 'token-1',
+            terms_version: expect.any(String),
+            terms_hash: expect.any(String),
+            terms_snapshot: expect.any(Array),
+          }),
+        }),
+      })
+    );
+    expect(updates).toContainEqual({
+      table: 'onboarding_tokens',
+      payload: expect.objectContaining({ used_at: expect.any(String) }),
+    });
+    expect(mockIssueServiceOrderForCustomer).toHaveBeenCalledWith(supabase, {
+      customerId: 'customer-1',
+      issuedBy: 'customer_signoff',
+      sendEmail: false,
+    });
+    expect(mockMaybeMarkBillingReady).toHaveBeenCalledWith(supabase, 'customer-1');
+  });
+});

--- a/app/api/service-order/accept/route.ts
+++ b/app/api/service-order/accept/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveTokenForPurpose, svc } from '@/lib/onboarding/onboarding-service';
+import {
+  buildServiceOrderAcceptanceRecord,
+  issueServiceOrderForCustomer,
+} from '@/lib/onboarding/service-order-issuer';
+import { maybeMarkBillingReady } from '@/lib/onboarding/billing-ready';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { token } = (await request.json()) as { token?: string };
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'token_required' }, { status: 400 });
+    }
+
+    const resolved = await resolveTokenForPurpose(token, 'service_order_signoff');
+    if (!resolved) {
+      return NextResponse.json({ success: false, error: 'invalid_or_expired' }, { status: 401 });
+    }
+
+    const supabase = svc();
+    let submissionQuery = supabase
+      .from('onboarding_submissions')
+      .select('id, customer_id, segment, submission_data')
+      .eq('customer_id', resolved.customerId);
+
+    if (resolved.onboardingSubmissionId) {
+      submissionQuery = submissionQuery.eq('id', resolved.onboardingSubmissionId);
+    } else {
+      submissionQuery = submissionQuery
+        .order('submitted_at', { ascending: false, nullsFirst: false })
+        .limit(1);
+    }
+
+    const { data: submission, error: submissionError } = await submissionQuery.single();
+    if (submissionError || !submission) {
+      return NextResponse.json(
+        { success: false, error: 'submission_not_found' },
+        { status: 404 }
+      );
+    }
+
+    const existingData =
+      submission.submission_data && typeof submission.submission_data === 'object'
+        ? submission.submission_data
+        : {};
+    const acceptance = buildServiceOrderAcceptanceRecord({
+      tokenId: resolved.tokenId,
+      ip:
+        request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+        request.headers.get('x-real-ip') ||
+        null,
+      userAgent: request.headers.get('user-agent') || null,
+      segment: submission.segment,
+    });
+
+    const { error: updateError } = await supabase
+      .from('onboarding_submissions')
+      .update({
+        submission_data: {
+          ...existingData,
+          service_order_status: 'accepted',
+          service_order_acceptance: acceptance,
+        },
+      })
+      .eq('id', submission.id);
+    if (updateError) {
+      return NextResponse.json(
+        { success: false, error: updateError.message || 'acceptance_update_failed' },
+        { status: 500 }
+      );
+    }
+
+    await supabase
+      .from('onboarding_tokens')
+      .update({ used_at: new Date().toISOString() })
+      .eq('id', resolved.tokenId);
+
+    const issued = await issueServiceOrderForCustomer(supabase, {
+      customerId: resolved.customerId,
+      issuedBy: 'customer_signoff',
+      sendEmail: false,
+    });
+    const billingReady = await maybeMarkBillingReady(supabase, resolved.customerId);
+
+    return NextResponse.json({
+      success: true,
+      pdfPath: issued.pdfPath,
+      billingReady,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/service-order/[token]/ServiceOrderSignoffClient.tsx
+++ b/app/service-order/[token]/ServiceOrderSignoffClient.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { PiCheckCircleBold, PiFileTextBold, PiSpinnerGapBold } from 'react-icons/pi';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+interface ServiceOrderSignoffClientProps {
+  token: string;
+  businessName: string;
+  accountNumber: string;
+  serviceName: string;
+  monthlyFeeExVat: number;
+  billingDay: string;
+  activationDate: string;
+  terms: string[];
+  serviceReference: string;
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-ZA', {
+    style: 'currency',
+    currency: 'ZAR',
+    minimumFractionDigits: 2,
+  }).format(amount);
+}
+
+export function ServiceOrderSignoffClient({
+  token,
+  businessName,
+  accountNumber,
+  serviceName,
+  monthlyFeeExVat,
+  billingDay,
+  activationDate,
+  terms,
+  serviceReference,
+}: ServiceOrderSignoffClientProps) {
+  const [accepted, setAccepted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [complete, setComplete] = useState(false);
+
+  async function handleAccept() {
+    setSubmitting(true);
+    try {
+      const response = await fetch('/api/service-order/accept', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Service Order signoff failed');
+      }
+      setComplete(true);
+      toast.success('Service Order accepted');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Service Order signoff failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (complete) {
+    return (
+      <Card className="border-green-200 bg-green-50">
+        <CardContent className="space-y-4 pt-6 text-center">
+          <PiCheckCircleBold className="mx-auto h-12 w-12 text-green-600" />
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Service Order Accepted</h1>
+            <p className="mt-2 text-gray-700">
+              CircleTel has recorded the acceptance for {accountNumber}.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <div className="inline-flex items-center gap-2 rounded-md border border-orange-200 bg-orange-50 px-3 py-1 text-sm font-semibold text-[#AE5B16]">
+          <PiFileTextBold className="h-4 w-4" />
+          Service Order
+        </div>
+        <h1 className="text-3xl font-bold text-gray-900 md:text-4xl">{businessName}</h1>
+        <p className="text-gray-600">{accountNumber}</p>
+      </div>
+
+      <Card>
+        <CardContent className="grid gap-4 pt-6 md:grid-cols-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Service</p>
+            <p className="mt-1 font-semibold text-gray-900">{serviceName}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Monthly fee</p>
+            <p className="mt-1 font-semibold text-gray-900">
+              {formatCurrency(monthlyFeeExVat)} ex VAT
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Billing day</p>
+            <p className="mt-1 font-semibold text-gray-900">{billingDay}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Activation date</p>
+            <p className="mt-1 font-semibold text-gray-900">{activationDate}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-4 pt-6">
+          <h2 className="text-xl font-bold text-gray-900">Terms And Conditions</h2>
+          <ol className="space-y-3 text-sm leading-6 text-gray-700">
+            {terms.map((term, index) => (
+              <li key={term} className="grid grid-cols-[28px_minmax(0,1fr)] gap-2">
+                <span className="font-semibold text-gray-500">{index + 1}.</span>
+                <span>{term}</span>
+              </li>
+            ))}
+          </ol>
+          <p className="border-t border-gray-100 pt-4 text-sm text-gray-600">{serviceReference}</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-4 pt-6">
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="service-order-accept"
+              checked={accepted}
+              onCheckedChange={(checked) => setAccepted(checked === true)}
+              className="mt-1"
+            />
+            <Label htmlFor="service-order-accept" className="text-sm leading-6 text-gray-700">
+              I am authorised to accept this Service Order and debit-order mandate for {businessName}.
+            </Label>
+          </div>
+          <Button onClick={handleAccept} disabled={!accepted || submitting} className="w-full sm:w-auto">
+            {submitting ? (
+              <>
+                <PiSpinnerGapBold className="mr-2 h-4 w-4 animate-spin" />
+                Accepting...
+              </>
+            ) : (
+              'Accept Service Order'
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/service-order/[token]/page.tsx
+++ b/app/service-order/[token]/page.tsx
@@ -1,0 +1,120 @@
+import { Navbar } from '@/components/layout/Navbar';
+import { Footer } from '@/components/layout/Footer';
+import { Card, CardContent } from '@/components/ui/card';
+import { resolveTokenForPurpose, svc } from '@/lib/onboarding/onboarding-service';
+import {
+  SERVICE_ORDER_TERMS,
+  getServiceOrderReference,
+  stripHtmlFromTerms,
+} from '@/lib/onboarding/service-order-terms';
+import { ServiceOrderSignoffClient } from './ServiceOrderSignoffClient';
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return 'Not set';
+  return new Date(value).toLocaleDateString('en-ZA', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function billingDayLabel(value: string | null | undefined): string {
+  if (value === '1') return '1st';
+  if (value === '15') return '15th';
+  if (value === '20') return '20th';
+  if (value === '25') return '25th';
+  return value || 'Not set';
+}
+
+function InvalidLink() {
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-[#F9FAFB] px-4 py-12">
+        <div className="mx-auto max-w-2xl">
+          <Card className="border-red-200 bg-red-50">
+            <CardContent className="pt-6">
+              <h1 className="text-2xl font-bold text-gray-900">Service Order Link Unavailable</h1>
+              <p className="mt-2 text-gray-700">
+                This signoff link is invalid, expired, or already used.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+export default async function ServiceOrderSignoffPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const resolved = await resolveTokenForPurpose(token, 'service_order_signoff');
+  if (!resolved) return <InvalidLink />;
+
+  const supabase = svc();
+  const { data: customer } = await supabase
+    .from('customers')
+    .select('id, account_number, business_name, email')
+    .eq('id', resolved.customerId)
+    .single();
+  if (!customer) return <InvalidLink />;
+
+  let submissionQuery = supabase
+    .from('onboarding_submissions')
+    .select('id, segment, submission_data')
+    .eq('customer_id', resolved.customerId);
+  if (resolved.onboardingSubmissionId) {
+    submissionQuery = submissionQuery.eq('id', resolved.onboardingSubmissionId);
+  } else {
+    submissionQuery = submissionQuery
+      .order('submitted_at', { ascending: false, nullsFirst: false })
+      .limit(1);
+  }
+  const { data: submission } = await submissionQuery.single();
+  if (!submission) return <InvalidLink />;
+
+  const { data: service } = await supabase
+    .from('customer_services')
+    .select('monthly_price, activation_date, package_name')
+    .eq('customer_id', resolved.customerId)
+    .order('activation_date', { ascending: false })
+    .limit(1)
+    .single();
+  if (!service) return <InvalidLink />;
+
+  const submissionData = (submission.submission_data ?? {}) as Record<string, any>;
+  const billingDay = submissionData.step5?.paymentDate ?? '1';
+  const segment = submission.segment ?? 'unjani';
+
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-[#F9FAFB] px-4 py-12">
+        <div className="mx-auto max-w-3xl">
+          <ServiceOrderSignoffClient
+            token={token}
+            businessName={customer.business_name}
+            accountNumber={customer.account_number}
+            serviceName={
+              service.package_name ||
+              (segment === 'unjani'
+                ? 'CircleTel ClinicConnect — Managed Connectivity'
+                : 'CircleTel Business Connectivity Service')
+            }
+            monthlyFeeExVat={Number(service.monthly_price ?? 450)}
+            billingDay={billingDayLabel(billingDay)}
+            activationDate={formatDate(service.activation_date)}
+            terms={stripHtmlFromTerms(SERVICE_ORDER_TERMS)}
+            serviceReference={getServiceOrderReference(segment)}
+          />
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { PiArrowsClockwiseBold, PiBellBold, PiBriefcaseBold, PiBuildingsBold, PiCalendarBold, PiCaretDownBold, PiCaretLeftBold, PiCaretRightBold, PiChartBarBold, PiCheckCircleBold, PiClockBold, PiCreditCardBold, PiFileTextBold, PiGearBold, PiGlobeBold, PiGraphBold, PiHandshakeBold, PiImageBold, PiLightningBold, PiLinkBold, PiListBold, PiMapPinBold, PiMapTrifoldBold, PiMegaphoneBold, PiPackageBold, PiPercentBold, PiPlusBold, PiPulseBold, PiRadioBold, PiReceiptBold, PiRocketBold, PiShieldCheckBold, PiShoppingCartBold, PiSidebarSimpleBold, PiSparkleBold, PiSquaresFourBold, PiTargetBold, PiTestTubeBold, PiTrendUpBold, PiTruckBold, PiUserCheckBold, PiUserPlusBold, PiUsersBold, PiWarningCircleBold, PiWifiHighBold, PiWrenchBold } from 'react-icons/pi';
+import { PiArrowsClockwiseBold, PiBellBold, PiBriefcaseBold, PiBuildingsBold, PiCalendarBold, PiCaretDownBold, PiCaretLeftBold, PiCaretRightBold, PiChartBarBold, PiCheckCircleBold, PiClipboardTextBold, PiClockBold, PiCreditCardBold, PiFileTextBold, PiGearBold, PiGlobeBold, PiGraphBold, PiHandshakeBold, PiImageBold, PiLightningBold, PiLinkBold, PiListBold, PiMapPinBold, PiMapTrifoldBold, PiMegaphoneBold, PiPackageBold, PiPercentBold, PiPlusBold, PiPulseBold, PiRadioBold, PiReceiptBold, PiRocketBold, PiShieldCheckBold, PiShoppingCartBold, PiSidebarSimpleBold, PiSparkleBold, PiSquaresFourBold, PiTargetBold, PiTestTubeBold, PiTrendUpBold, PiTruckBold, PiUserCheckBold, PiUserPlusBold, PiUsersBold, PiWarningCircleBold, PiWifiHighBold, PiWrenchBold } from 'react-icons/pi';
 
 import Link from 'next/link';
 import Image from 'next/image';
@@ -142,6 +142,7 @@ const navigationSections: NavSection[] = [
         description: 'Business customer journey',
         children: [
           { name: 'Clinic Onboarding', href: '/admin/unjani/onboarding', icon: PiUserPlusBold },
+          { name: 'Manual Intake', href: '/admin/b2b/manual-intake', icon: PiClipboardTextBold },
           { name: 'Document Vetting', href: '/admin/b2b/vetting', icon: PiUserCheckBold },
           { name: 'All B2B Customers', href: '/admin/b2b-customers', icon: PiBuildingsBold },
           { name: 'Site Details', href: '/admin/b2b-customers/site-details', icon: PiMapPinBold },

--- a/components/admin/onboarding/UploadDocumentModal.tsx
+++ b/components/admin/onboarding/UploadDocumentModal.tsx
@@ -10,6 +10,8 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   DOC_TYPE_OPTIONS,
   ALLOWED_FILE_TYPES,
@@ -37,12 +39,20 @@ export function UploadDocumentModal({
   onUploaded,
 }: UploadDocumentModalProps) {
   const [docType, setDocType] = useState<DocType>('company_registration');
+  const [segment, setSegment] = useState('unjani');
+  const [emailFrom, setEmailFrom] = useState('');
+  const [emailSubject, setEmailSubject] = useState('');
+  const [emailReceivedAt, setEmailReceivedAt] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploaded, setUploaded] = useState<{ type: string; name: string }[]>([]);
 
   const reset = () => {
     setDocType('company_registration');
+    setSegment('unjani');
+    setEmailFrom('');
+    setEmailSubject('');
+    setEmailReceivedAt('');
     setFile(null);
     setUploaded([]);
   };
@@ -65,6 +75,10 @@ export function UploadDocumentModal({
       const fd = new FormData();
       fd.append('customerId', customerId);
       fd.append('documentType', docType);
+      fd.append('segment', segment);
+      if (emailFrom.trim()) fd.append('emailFrom', emailFrom.trim());
+      if (emailSubject.trim()) fd.append('emailSubject', emailSubject.trim());
+      if (emailReceivedAt.trim()) fd.append('emailReceivedAt', emailReceivedAt.trim());
       if (submissionId) fd.append('submissionId', submissionId);
       fd.append('file', file);
       const res = await fetch('/api/admin/b2b/upload-document', {
@@ -101,22 +115,78 @@ export function UploadDocumentModal({
           <DialogTitle>Upload documents — {clinicName}</DialogTitle>
         </DialogHeader>
 
-        <p className="text-sm text-gray-500">
-          For documents received by email. Pick a type, choose the file, and upload. Repeat for each file.
-        </p>
-
         <div className="space-y-3">
-          <select
-            value={docType}
-            onChange={(e) => setDocType(e.target.value as DocType)}
-            className="w-full rounded border border-gray-300 px-2 py-2 text-sm"
-          >
-            {DOC_TYPE_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>
-                {o.label}
-              </option>
-            ))}
-          </select>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="upload-document-type" className="text-xs font-semibold text-gray-500">
+                Document type
+              </Label>
+              <select
+                id="upload-document-type"
+                value={docType}
+                onChange={(e) => setDocType(e.target.value as DocType)}
+                className="h-10 w-full rounded-md border border-gray-300 px-2 py-2 text-sm"
+              >
+                {DOC_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="upload-segment" className="text-xs font-semibold text-gray-500">
+                Segment
+              </Label>
+              <select
+                id="upload-segment"
+                value={segment}
+                onChange={(e) => setSegment(e.target.value)}
+                className="h-10 w-full rounded-md border border-gray-300 px-2 py-2 text-sm"
+              >
+                <option value="unjani">Unjani</option>
+                <option value="smb">SMB</option>
+                <option value="edu">Education</option>
+                <option value="enterprise">Enterprise</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="upload-email-from" className="text-xs font-semibold text-gray-500">
+              Email from
+            </Label>
+            <Input
+              id="upload-email-from"
+              type="email"
+              value={emailFrom}
+              onChange={(event) => setEmailFrom(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="upload-email-subject" className="text-xs font-semibold text-gray-500">
+              Email subject
+            </Label>
+            <Input
+              id="upload-email-subject"
+              value={emailSubject}
+              onChange={(event) => setEmailSubject(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="upload-email-received-at" className="text-xs font-semibold text-gray-500">
+              Email received
+            </Label>
+            <Input
+              id="upload-email-received-at"
+              type="datetime-local"
+              value={emailReceivedAt}
+              onChange={(event) => setEmailReceivedAt(event.target.value)}
+            />
+          </div>
 
           <input
             type="file"

--- a/docs/onboarding/ADMIN_ASSISTED_B2B_ONBOARDING.md
+++ b/docs/onboarding/ADMIN_ASSISTED_B2B_ONBOARDING.md
@@ -1,0 +1,47 @@
+# Admin-Assisted B2B Onboarding
+
+Last updated: 2026-06-30
+
+## Admin Entry Points
+
+- Manual intake: `/admin/b2b/manual-intake`
+- Onboarding pipeline: `/admin/unjani/onboarding`
+- Document vetting: `/admin/b2b/vetting`
+
+Manual intake can create a new `customers` business record or update an existing B2B customer. It captures business details, site/contact details, the active billable service, and optional debit-order banking details received by email.
+
+## Document Intake
+
+Admin document upload now stores email provenance:
+
+- `segment`
+- email sender
+- email subject
+- email received timestamp
+- uploading admin email
+
+The provenance is stored on `kyc_documents.metadata`. When the upload creates a manual onboarding shell, the same provenance is also stored in `onboarding_submissions.submission_data.email_provenance`.
+
+## Service Order Signoff
+
+Issuing a Service Order from admin now:
+
+- generates and stores the PDF in the `kyc-documents` storage bucket
+- records `service_order_pdf_path`, `service_order_issued_at`, and `service_order_pdf_sha256`
+- creates a purpose-scoped `onboarding_tokens` row with `purpose = 'service_order_signoff'`
+- emails the customer a signoff link at `/service-order/{token}`
+- attaches the generated Service Order PDF to the email
+
+Customer acceptance is recorded by `POST /api/service-order/accept` in `onboarding_submissions.submission_data.service_order_acceptance`. The accepted PDF is regenerated with acceptance evidence after signoff.
+
+## Billing-Ready Gate
+
+`maybeMarkBillingReady` now requires all of the following:
+
+- latest onboarding submission has `document_vetting_status = 'approved'`
+- Service Order PDF path exists
+- Service Order acceptance evidence exists
+- customer has an active service
+- active debit-order payment method has both `account_number` and `branch_code`
+
+Pending Netcash mandate status does not block billing-ready if the customer has accepted the Service Order debit-order mandate.

--- a/lib/contracts/service-order-pdf.ts
+++ b/lib/contracts/service-order-pdf.ts
@@ -163,6 +163,9 @@ export interface ServiceOrderInput {
   clinicProvince: string;
   clinicEmail: string;
   clinicPhone?: string;
+  customerLabel?: string;
+  serviceName?: string;
+  serviceReference?: string;
   monthlyFeeExclVat: number;
   vatPercentage: number; // Usually 15
   billingDay: '1' | '15' | '20' | '25';
@@ -266,11 +269,12 @@ export function generateServiceOrderPdf(input: ServiceOrderInput): jsPDF {
 
   yPos += 15;
 
-  // === CLINIC DETAILS ===
-  let clinicY = addSectionHeader(doc, 'CLINIC DETAILS', leftCol, yPos, colWidth);
+  // === CUSTOMER DETAILS ===
+  const customerLabel = input.customerLabel ?? 'CLINIC';
+  let clinicY = addSectionHeader(doc, `${customerLabel.toUpperCase()} DETAILS`, leftCol, yPos, colWidth);
 
   const clinicFields = [
-    ['Clinic Name:', input.clinicName],
+    [`${customerLabel} Name:`, input.clinicName],
     ['Account Number:', input.accountNumber],
     ['Address:', input.clinicAddress],
     ['Province:', input.clinicProvince],
@@ -300,7 +304,7 @@ export function generateServiceOrderPdf(input: ServiceOrderInput): jsPDF {
   doc.setTextColor(...COLORS.secondaryText);
   doc.text('Service:', leftCol, serviceY);
   doc.setTextColor(...COLORS.darkText);
-  doc.text('CircleTel ClinicConnect — Managed Connectivity', leftCol + 50, serviceY);
+  doc.text(input.serviceName ?? 'CircleTel ClinicConnect — Managed Connectivity', leftCol + 50, serviceY);
   serviceY += 8;
 
   // Billing day
@@ -346,7 +350,7 @@ export function generateServiceOrderPdf(input: ServiceOrderInput): jsPDF {
   doc.setFontSize(9);
   doc.setFont('helvetica', 'normal');
   doc.setTextColor(...COLORS.secondaryText);
-  const msaLines = doc.splitTextToSize(SERVICE_ORDER_MSA_REFERENCE, colWidth);
+  const msaLines = doc.splitTextToSize(input.serviceReference ?? SERVICE_ORDER_MSA_REFERENCE, colWidth);
   doc.text(msaLines, leftCol, yPos);
   yPos += 4 * msaLines.length + 4;
 
@@ -429,8 +433,8 @@ export function generateServiceOrderPdf(input: ServiceOrderInput): jsPDF {
       `Transactions Act 25 of 2002.${linkSentence}${ipSentence} No manual signature is required.`;
   } else {
     acceptanceText =
-      `This Service Order was accepted electronically by the clinic on ${formatDate(input.submittedAt)} ` +
-      `via the CircleTel onboarding portal (click-accept). No manual signature is required.`;
+      `This Service Order is pending electronic acceptance by the customer. ` +
+      `No debit-order billing readiness should be granted until the acceptance record is captured.`;
   }
   const acceptanceLines = doc.splitTextToSize(acceptanceText, colWidth);
   doc.text(acceptanceLines, leftCol, yPos);

--- a/lib/onboarding/__tests__/billing-ready.test.ts
+++ b/lib/onboarding/__tests__/billing-ready.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for maybeMarkBillingReady
- * Verifies the new gate: vetting approved + active service + bank details (drop signature)
+ * Verifies the gate: vetting approved + service order accepted + active service + bank details.
  */
 
 import { maybeMarkBillingReady } from '../billing-ready';
@@ -96,7 +96,16 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
                       error: null,
                     }),
                   }),
@@ -137,7 +146,16 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
                       error: null,
                     }),
                   }),
@@ -198,7 +216,7 @@ describe('maybeMarkBillingReady', () => {
     expect(result).toBe(false);
   });
 
-  it('returns true when vetting approved + active service + bank details present', async () => {
+  it('returns false when service order has not been accepted', async () => {
     const supabase = {
       from: jest.fn((table) => {
         if (table === 'onboarding_submissions') {
@@ -208,7 +226,12 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {},
+                      },
                       error: null,
                     }),
                   }),
@@ -275,10 +298,10 @@ describe('maybeMarkBillingReady', () => {
     } as any as SupabaseClient;
 
     const result = await maybeMarkBillingReady(supabase, 'customer-123');
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
-  it('returns true even when mandate_status is pending (drops signature requirement)', async () => {
+  it('returns true when vetting approved + accepted service order + active service + bank details present', async () => {
     const supabase = {
       from: jest.fn((table) => {
         if (table === 'onboarding_submissions') {
@@ -288,7 +311,107 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
+                      error: null,
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'customer_services') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  maybeSingle: jest.fn().mockResolvedValue({
+                    data: { id: 'svc-1', status: 'active' },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'customer_payment_methods') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest
+                .fn()
+                .mockReturnValue({
+                  eq: jest
+                    .fn()
+                    .mockReturnValue({
+                      eq: jest.fn().mockResolvedValue({
+                        data: [
+                          {
+                            id: 'pm-1',
+                            is_active: true,
+                            method_type: 'debit_order',
+                            mandate_status: 'pending',
+                            encrypted_details: {
+                              account_holder_name: 'Test Clinic',
+                              account_type: 'Cheque',
+                              account_number: '62836392449',
+                              branch_code: '250655',
+                              verified: false,
+                            },
+                          },
+                        ],
+                        error: null,
+                      }),
+                    }),
+                }),
+            }),
+          };
+        }
+        if (table === 'customers') {
+          return {
+            update: jest
+              .fn()
+              .mockReturnValue({
+                eq: jest.fn().mockResolvedValue({ error: null }),
+              }),
+          };
+        }
+        return { select: jest.fn() };
+      }),
+    } as any as SupabaseClient;
+
+    const result = await maybeMarkBillingReady(supabase, 'customer-123');
+    expect(result).toBe(true);
+  });
+
+  it('returns true even when mandate_status is pending if the service order was accepted', async () => {
+    const supabase = {
+      from: jest.fn((table) => {
+        if (table === 'onboarding_submissions') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                order: jest.fn().mockReturnValue({
+                  limit: jest.fn().mockReturnValue({
+                    maybeSingle: jest.fn().mockResolvedValue({
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
                       error: null,
                     }),
                   }),
@@ -370,7 +493,16 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
                       error: null,
                     }),
                   }),

--- a/lib/onboarding/__tests__/manual-intake.test.ts
+++ b/lib/onboarding/__tests__/manual-intake.test.ts
@@ -1,0 +1,174 @@
+import { saveManualB2BIntake } from '../manual-intake';
+
+type Operation = {
+  table: string;
+  action: 'insert' | 'update' | 'select';
+  payload?: unknown;
+  filters: Array<{ column: string; value: unknown }>;
+};
+
+function createMockSupabase() {
+  const operations: Operation[] = [];
+
+  const responseFor = (table: string, action: string) => {
+    if (table === 'customers' && action === 'single') {
+      return Promise.resolve({
+        data: { id: 'customer-1', account_number: 'CT-2026-00042' },
+        error: null,
+      });
+    }
+    if (table === 'onboarding_submissions' && action === 'maybeSingle') {
+      return Promise.resolve({ data: null, error: null });
+    }
+    if (table === 'onboarding_submissions' && action === 'single') {
+      return Promise.resolve({ data: { id: 'submission-1' }, error: null });
+    }
+    if (table === 'customer_services' && action === 'single') {
+      return Promise.resolve({ data: { id: 'service-1' }, error: null });
+    }
+    if (table === 'customer_payment_methods' && action === 'maybeSingle') {
+      return Promise.resolve({ data: null, error: null });
+    }
+    if (table === 'customer_payment_methods' && action === 'single') {
+      return Promise.resolve({ data: { id: 'payment-method-1' }, error: null });
+    }
+    return Promise.resolve({ data: null, error: null });
+  };
+
+  const from = jest.fn((table: string) => {
+    const state: Operation = { table, action: 'select', filters: [] };
+    const builder: any = {
+      insert: jest.fn((payload) => {
+        state.action = 'insert';
+        state.payload = payload;
+        operations.push(state);
+        return builder;
+      }),
+      update: jest.fn((payload) => {
+        state.action = 'update';
+        state.payload = payload;
+        operations.push(state);
+        return builder;
+      }),
+      select: jest.fn(() => {
+        if (!operations.includes(state)) operations.push(state);
+        return builder;
+      }),
+      eq: jest.fn((column, value) => {
+        state.filters.push({ column, value });
+        return builder;
+      }),
+      order: jest.fn(() => builder),
+      limit: jest.fn(() => builder),
+      maybeSingle: jest.fn(() => responseFor(table, 'maybeSingle')),
+      single: jest.fn(() => responseFor(table, 'single')),
+    };
+    return builder;
+  });
+
+  return { supabase: { from } as any, operations };
+}
+
+describe('saveManualB2BIntake', () => {
+  it('creates a business customer, submission, active service, and debit-order payment method', async () => {
+    const { supabase, operations } = createMockSupabase();
+
+    const result = await saveManualB2BIntake(
+      supabase,
+      {
+        segment: 'unjani',
+        business: {
+          businessName: 'Unjani Alexandra Clinic',
+          entityType: 'Private Company',
+          registrationNumber: '2026/123456/07',
+          vatRegistered: true,
+          vatNumber: '4123456789',
+          registeredAddress: '10 Clinic Road, Alexandra',
+        },
+        contact: {
+          contactName: 'Thandi Maseko',
+          email: 'thandi@example.co.za',
+          phone: '0821234567',
+        },
+        site: {
+          clinicName: 'Unjani Alexandra',
+          province: 'Gauteng',
+          siteAddress: '10 Clinic Road, Alexandra',
+        },
+        service: {
+          packageName: 'CircleTel ClinicConnect',
+          serviceType: 'managed_connectivity',
+          monthlyPrice: 450,
+          activationDate: '2026-07-01',
+          billingDay: '25',
+        },
+        debitOrder: {
+          accountHolderName: 'Unjani Alexandra Clinic',
+          bankName: 'FNB',
+          accountType: 'Cheque',
+          accountNumber: '1234567890',
+          branchCode: '250655',
+        },
+      },
+      { adminId: 'admin-1', adminEmail: 'admin@example.co.za' }
+    );
+
+    expect(result).toEqual({
+      customerId: 'customer-1',
+      accountNumber: 'CT-2026-00042',
+      submissionId: 'submission-1',
+      createdCustomer: true,
+      createdSubmission: true,
+      serviceId: 'service-1',
+      paymentMethodId: 'payment-method-1',
+    });
+
+    const customerInsert = operations.find(
+      (op) => op.table === 'customers' && op.action === 'insert'
+    );
+    expect(customerInsert?.payload).toEqual(
+      expect.objectContaining({
+        account_type: 'business',
+        business_name: 'Unjani Alexandra Clinic',
+        email: 'thandi@example.co.za',
+        phone: '0821234567',
+        onboarding_status: 'submitted',
+      })
+    );
+
+    const submissionInsert = operations.find(
+      (op) => op.table === 'onboarding_submissions' && op.action === 'insert'
+    );
+    expect(submissionInsert?.payload).toEqual(
+      expect.objectContaining({
+        customer_id: 'customer-1',
+        segment: 'unjani',
+        status: 'submitted',
+        document_vetting_status: 'documents_pending',
+        submission_data: expect.objectContaining({
+          capture_method: 'admin_manual_intake',
+          captured_by: 'admin@example.co.za',
+          step3: expect.objectContaining({ accNumber: '****7890' }),
+        }),
+      })
+    );
+
+    const paymentInsert = operations.find(
+      (op) => op.table === 'customer_payment_methods' && op.action === 'insert'
+    );
+    expect(paymentInsert?.payload).toEqual(
+      expect.objectContaining({
+        customer_id: 'customer-1',
+        onboarding_submission_id: 'submission-1',
+        method_type: 'debit_order',
+        display_name: 'Debit Order - FNB ****7890',
+        encrypted_details: expect.objectContaining({
+          account_number: '1234567890',
+          branch_code: '250655',
+          verified: false,
+        }),
+        mandate_status: 'pending',
+      })
+    );
+  });
+});

--- a/lib/onboarding/__tests__/onboarding-service-token-purpose.test.ts
+++ b/lib/onboarding/__tests__/onboarding-service-token-purpose.test.ts
@@ -1,0 +1,100 @@
+import { createClient } from '@supabase/supabase-js';
+import { hashToken } from '../token-service';
+import { issueToken, resolveTokenForPurpose } from '../onboarding-service';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(),
+}));
+
+const mockedCreateClient = createClient as jest.Mock;
+
+describe('onboarding token purpose handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+  });
+
+  it('stores service-order signoff token purpose and metadata when issuing a token', async () => {
+    const insert = jest.fn().mockResolvedValue({ error: null });
+    mockedCreateClient.mockReturnValue({
+      from: jest.fn().mockReturnValue({ insert }),
+    });
+
+    const token = await issueToken('customer-1', 'email', {
+      purpose: 'service_order_signoff',
+      onboardingSubmissionId: 'submission-1',
+      metadata: { issued_by: 'admin-1' },
+    });
+
+    expect(token).toEqual(expect.any(String));
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer_id: 'customer-1',
+        token_hash: hashToken(token),
+        sent_via: 'email',
+        purpose: 'service_order_signoff',
+        onboarding_submission_id: 'submission-1',
+        metadata: { issued_by: 'admin-1' },
+      })
+    );
+  });
+
+  it('resolves only matching-purpose active tokens', async () => {
+    const maybeSingle = jest.fn().mockResolvedValue({
+      data: {
+        id: 'token-1',
+        customer_id: 'customer-1',
+        onboarding_submission_id: 'submission-1',
+        purpose: 'service_order_signoff',
+        metadata: { service_order_pdf_path: 'service-orders/order.pdf' },
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        used_at: null,
+      },
+      error: null,
+    });
+    const eq = jest.fn().mockReturnValue({ maybeSingle });
+    mockedCreateClient.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({ eq }),
+      }),
+    });
+
+    const result = await resolveTokenForPurpose('plain-token', 'service_order_signoff');
+
+    expect(eq).toHaveBeenCalledWith('token_hash', hashToken('plain-token'));
+    expect(result).toEqual({
+      customerId: 'customer-1',
+      tokenId: 'token-1',
+      purpose: 'service_order_signoff',
+      onboardingSubmissionId: 'submission-1',
+      metadata: { service_order_pdf_path: 'service-orders/order.pdf' },
+    });
+  });
+
+  it('returns null when the token purpose does not match the requested purpose', async () => {
+    const maybeSingle = jest.fn().mockResolvedValue({
+      data: {
+        id: 'token-1',
+        customer_id: 'customer-1',
+        onboarding_submission_id: null,
+        purpose: 'onboarding',
+        metadata: {},
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        used_at: null,
+      },
+      error: null,
+    });
+    mockedCreateClient.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({ maybeSingle }),
+        }),
+      }),
+    });
+
+    const result = await resolveTokenForPurpose('plain-token', 'service_order_signoff');
+
+    expect(result).toBeNull();
+  });
+});

--- a/lib/onboarding/__tests__/service-order-issuer.test.ts
+++ b/lib/onboarding/__tests__/service-order-issuer.test.ts
@@ -1,0 +1,135 @@
+import { Resend } from 'resend';
+import { issueToken } from '../onboarding-service';
+import { issueServiceOrderForCustomer } from '../service-order-issuer';
+import { uploadFile } from '@/lib/storage/supabase-upload';
+import { generateServiceOrderBlob } from '@/lib/contracts/service-order-pdf';
+
+jest.mock('resend', () => ({
+  Resend: jest.fn(),
+}));
+
+jest.mock('../onboarding-service', () => ({
+  issueToken: jest.fn(),
+}));
+
+jest.mock('@/lib/storage/supabase-upload', () => ({
+  uploadFile: jest.fn(),
+}));
+
+jest.mock('@/lib/contracts/service-order-pdf', () => ({
+  generateServiceOrderBlob: jest.fn(),
+}));
+
+const mockIssueToken = issueToken as jest.MockedFunction<typeof issueToken>;
+const mockUploadFile = uploadFile as jest.MockedFunction<typeof uploadFile>;
+const mockGenerateServiceOrderBlob = generateServiceOrderBlob as jest.MockedFunction<typeof generateServiceOrderBlob>;
+const mockResend = Resend as jest.Mock;
+
+function createSupabaseMock() {
+  const updates: unknown[] = [];
+  const from = jest.fn((table: string) => {
+    const builder: any = {
+      select: jest.fn(() => builder),
+      eq: jest.fn(() => builder),
+      order: jest.fn(() => builder),
+      limit: jest.fn(() => builder),
+      update: jest.fn((payload) => {
+        updates.push(payload);
+        return builder;
+      }),
+      single: jest.fn(() => {
+        if (table === 'customers') {
+          return Promise.resolve({
+            data: {
+              id: 'customer-1',
+              account_number: 'CT-2026-00042',
+              business_name: 'Future Business Client',
+              email: 'client@example.co.za',
+              phone: '0821234567',
+              clinic_details: {
+                province: 'Gauteng',
+                site_address: '10 Business Road',
+              },
+            },
+            error: null,
+          });
+        }
+        if (table === 'onboarding_submissions') {
+          return Promise.resolve({
+            data: {
+              id: 'submission-1',
+              segment: 'enterprise',
+              submitted_at: '2026-06-30T09:00:00.000Z',
+              submission_data: {
+                step5: { paymentDate: '25' },
+              },
+            },
+            error: null,
+          });
+        }
+        if (table === 'customer_services') {
+          return Promise.resolve({
+            data: {
+              monthly_price: 450,
+              activation_date: '2026-07-01',
+            },
+            error: null,
+          });
+        }
+        return Promise.resolve({ data: null, error: null });
+      }),
+    };
+    return builder;
+  });
+  return { supabase: { from } as any, updates };
+}
+
+describe('issueServiceOrderForCustomer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateServiceOrderBlob.mockReturnValue(
+      new Blob(['pdf-bytes'], { type: 'application/pdf' })
+    );
+    mockIssueToken.mockResolvedValue('sign-token');
+    mockUploadFile.mockResolvedValue({
+      success: true,
+      path: 'service-orders/customer-1/SO-CT-2026-00042.pdf',
+    } as any);
+  });
+
+  it('emails a signoff link and attaches the generated service order PDF', async () => {
+    const send = jest.fn().mockResolvedValue({ error: null });
+    mockResend.mockImplementation(() => ({ emails: { send } }));
+    const { supabase } = createSupabaseMock();
+
+    const result = await issueServiceOrderForCustomer(supabase, {
+      customerId: 'customer-1',
+      baseUrl: 'https://circletel.co.za',
+      issuedBy: 'admin@example.co.za',
+      sendEmail: true,
+    });
+
+    expect(result.signoffUrl).toBe('https://circletel.co.za/service-order/sign-token');
+    expect(mockIssueToken).toHaveBeenCalledWith('customer-1', 'email', {
+      purpose: 'service_order_signoff',
+      onboardingSubmissionId: 'submission-1',
+      metadata: expect.objectContaining({
+        service_order_pdf_path: 'service-orders/customer-1/SO-CT-2026-00042.pdf',
+        issued_by: 'admin@example.co.za',
+      }),
+    });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'client@example.co.za',
+        html: expect.stringContaining('https://circletel.co.za/service-order/sign-token'),
+        attachments: [
+          expect.objectContaining({
+            filename: 'SO-CT-2026-00042.pdf',
+            content: expect.any(Buffer),
+            contentType: 'application/pdf',
+          }),
+        ],
+      })
+    );
+  });
+});

--- a/lib/onboarding/billing-ready.ts
+++ b/lib/onboarding/billing-ready.ts
@@ -2,19 +2,18 @@
  * Billing-ready status computation
  * Sets customers.onboarding_status = 'billing_ready' when:
  * - Latest onboarding_submissions.document_vetting_status === 'approved'
+ * - Service Order PDF has been issued and accepted by the customer
  * - At least one customer_services row with status='active'
  * - An active customer_payment_methods (method_type='debit_order', is_active=true)
  *   with encrypted_details containing BOTH account_number AND branch_code
- *
- * (Drops the signature requirement: mandate_status active + verified)
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 /**
- * Check if an onboarding submission's documents are approved, the customer
- * has an active service, and valid bank details on file. If all conditions met,
- * mark the customer billing_ready.
+ * Check if an onboarding submission's documents are approved, the customer has
+ * accepted the Service Order, has an active service, and valid bank details on
+ * file. If all conditions are met, mark the customer billing_ready.
  *
  * Returns true if status was flipped to billing_ready, false otherwise.
  * Safe to call repeatedly — idempotent.
@@ -26,7 +25,7 @@ export async function maybeMarkBillingReady(
   // 1. Get the latest submission for this customer
   const { data: submission, error: subError } = await supabase
     .from('onboarding_submissions')
-    .select('id, document_vetting_status')
+    .select('id, document_vetting_status, service_order_pdf_path, submission_data')
     .eq('customer_id', customerId)
     .order('submitted_at', { ascending: false })
     .limit(1)
@@ -36,6 +35,15 @@ export async function maybeMarkBillingReady(
 
   // Docs must be approved
   if (submission.document_vetting_status !== 'approved') return false;
+
+  const submissionData =
+    submission.submission_data && typeof submission.submission_data === 'object'
+      ? (submission.submission_data as Record<string, any>)
+      : {};
+  const serviceOrderAcceptedAt =
+    submissionData.service_order_acceptance?.accepted_at || submissionData.acceptance?.accepted_at;
+
+  if (!submission.service_order_pdf_path || !serviceOrderAcceptedAt) return false;
 
   // 2. Check for at least one active service
   const { data: activeService } = await supabase

--- a/lib/onboarding/manual-intake.ts
+++ b/lib/onboarding/manual-intake.ts
@@ -1,0 +1,369 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+import { addBusinessDays, now } from '@/lib/dates';
+
+const billingDaySchema = z.enum(['1', '15', '20', '25']);
+
+export const manualB2BIntakeSchema = z.object({
+  customerId: z.string().uuid().optional(),
+  submissionId: z.string().uuid().optional(),
+  segment: z.string().min(2).default('unjani'),
+  business: z.object({
+    businessName: z.string().min(2),
+    entityType: z.string().min(2),
+    registrationNumber: z.string().min(2),
+    vatRegistered: z.boolean().default(false),
+    vatNumber: z.string().optional().nullable(),
+    registeredAddress: z.string().min(5),
+  }),
+  contact: z.object({
+    contactName: z.string().min(2),
+    email: z.string().email(),
+    phone: z.string().min(9),
+  }),
+  site: z.object({
+    clinicName: z.string().min(2).optional(),
+    province: z.string().min(2).optional(),
+    siteAddress: z.string().min(5).optional(),
+    lat: z.string().optional().nullable(),
+    lng: z.string().optional().nullable(),
+  }).default({}),
+  service: z.object({
+    serviceId: z.string().uuid().optional(),
+    packageName: z.string().min(2).default('CircleTel ClinicConnect'),
+    serviceType: z.string().min(2).default('managed_connectivity'),
+    productCategory: z.string().min(2).default('business_connectivity'),
+    monthlyPrice: z.coerce.number().nonnegative().default(450),
+    activationDate: z.string().optional().nullable(),
+    billingDay: billingDaySchema.default('1'),
+    providerName: z.string().optional().nullable(),
+  }).optional(),
+  debitOrder: z.object({
+    paymentMethodId: z.string().uuid().optional(),
+    accountHolderName: z.string().min(2),
+    bankName: z.string().min(2),
+    accountType: z.string().min(2),
+    accountNumber: z.string().min(6),
+    branchCode: z.string().min(5),
+  }).optional(),
+});
+
+export type ManualB2BIntakeInput = z.infer<typeof manualB2BIntakeSchema>;
+
+export interface ManualB2BIntakeAdmin {
+  adminId: string;
+  adminEmail: string;
+}
+
+export interface ManualB2BIntakeResult {
+  customerId: string;
+  accountNumber: string | null;
+  submissionId: string;
+  createdCustomer: boolean;
+  createdSubmission: boolean;
+  serviceId?: string;
+  paymentMethodId?: string;
+}
+
+function splitContactName(name: string): { firstName: string; lastName: string } {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { firstName: 'Business', lastName: 'Contact' };
+  if (parts.length === 1) return { firstName: parts[0], lastName: 'Contact' };
+  return { firstName: parts[0], lastName: parts.slice(1).join(' ') };
+}
+
+function maskAccountNumber(accountNumber: string): string {
+  return `****${accountNumber.slice(-4)}`;
+}
+
+function errorMessage(error: { message?: string } | null | undefined, fallback: string): string {
+  return error?.message || fallback;
+}
+
+function buildClinicDetails(input: ManualB2BIntakeInput) {
+  return {
+    clinic_name: input.site.clinicName ?? input.business.businessName,
+    province: input.site.province ?? null,
+    nurse_owner_name: input.contact.contactName,
+    site_address: input.site.siteAddress ?? input.business.registeredAddress,
+    lat: input.site.lat ?? null,
+    lng: input.site.lng ?? null,
+    capture_method: 'admin_manual_intake',
+  };
+}
+
+function buildSubmissionData(
+  input: ManualB2BIntakeInput,
+  admin: ManualB2BIntakeAdmin,
+  capturedAt: string
+) {
+  const billingDay = input.service?.billingDay ?? '1';
+  return {
+    capture_method: 'admin_manual_intake',
+    source: 'email',
+    captured_by: admin.adminEmail,
+    captured_by_id: admin.adminId,
+    captured_at: capturedAt,
+    step1: {
+      clinicName: input.site.clinicName ?? input.business.businessName,
+      province: input.site.province ?? '',
+      contact: input.contact.contactName,
+      phone: input.contact.phone,
+      email: input.contact.email,
+      siteAddress: input.site.siteAddress ?? input.business.registeredAddress,
+      lat: input.site.lat ?? undefined,
+      lng: input.site.lng ?? undefined,
+    },
+    step2: {
+      entityName: input.business.businessName,
+      entityType: input.business.entityType,
+      regNumber: input.business.registrationNumber,
+      vat: input.business.vatRegistered ? 'Yes' : 'No',
+      vatNumber: input.business.vatNumber ?? undefined,
+      regAddress: input.business.registeredAddress,
+    },
+    step3: input.debitOrder
+      ? {
+          accHolder: input.debitOrder.accountHolderName,
+          bank: input.debitOrder.bankName,
+          accType: input.debitOrder.accountType,
+          accNumber: maskAccountNumber(input.debitOrder.accountNumber),
+          branchCode: input.debitOrder.branchCode,
+          mandate: true,
+        }
+      : undefined,
+    step5: {
+      paymentDate: billingDay,
+      soAccept: false,
+    },
+    manual_intake: {
+      segment: input.segment,
+      service_captured: Boolean(input.service),
+      debit_order_captured: Boolean(input.debitOrder),
+      service_order_signoff_status: 'pending',
+    },
+  };
+}
+
+export async function saveManualB2BIntake(
+  supabase: SupabaseClient,
+  rawInput: unknown,
+  admin: ManualB2BIntakeAdmin
+): Promise<ManualB2BIntakeResult> {
+  const input = manualB2BIntakeSchema.parse(rawInput);
+  const capturedAt = now().toISOString();
+  const clinicDetails = buildClinicDetails(input);
+  const { firstName, lastName } = splitContactName(input.contact.contactName);
+
+  const customerPayload = {
+    first_name: firstName,
+    last_name: lastName,
+    email: input.contact.email,
+    phone: input.contact.phone,
+    account_type: 'business',
+    status: 'active',
+    account_status: 'active',
+    business_name: input.business.businessName,
+    business_registration: input.business.registrationNumber,
+    tax_number: input.business.vatRegistered ? input.business.vatNumber ?? null : null,
+    onboarding_status: 'submitted',
+    clinic_details: clinicDetails,
+  };
+
+  let customerId = input.customerId;
+  let accountNumber: string | null = null;
+  let createdCustomer = false;
+
+  if (customerId) {
+    const { data, error } = await supabase
+      .from('customers')
+      .update(customerPayload)
+      .eq('id', customerId)
+      .select('id, account_number')
+      .single();
+    if (error || !data) {
+      throw new Error(errorMessage(error, 'Failed to update business customer'));
+    }
+    accountNumber = data.account_number ?? null;
+  } else {
+    const { data, error } = await supabase
+      .from('customers')
+      .insert(customerPayload)
+      .select('id, account_number')
+      .single();
+    if (error || !data) {
+      throw new Error(errorMessage(error, 'Failed to create business customer'));
+    }
+    customerId = data.id;
+    accountNumber = data.account_number ?? null;
+    createdCustomer = true;
+  }
+
+  const submissionData = buildSubmissionData(input, admin, capturedAt);
+  let submissionId = input.submissionId;
+  let createdSubmission = false;
+
+  if (!submissionId) {
+    const { data: existing, error: existingError } = await supabase
+      .from('onboarding_submissions')
+      .select('id')
+      .eq('customer_id', customerId)
+      .order('submitted_at', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (existingError) {
+      throw new Error(errorMessage(existingError, 'Failed to find onboarding submission'));
+    }
+    submissionId = existing?.id;
+  }
+
+  const submissionPayload = {
+    customer_id: customerId,
+    segment: input.segment,
+    status: 'submitted',
+    document_vetting_status: 'documents_pending',
+    submitted_at: capturedAt,
+    vetting_due_date: addBusinessDays(now(), 2).toISOString(),
+    submission_data: submissionData,
+  };
+
+  if (submissionId) {
+    const { error } = await supabase
+      .from('onboarding_submissions')
+      .update(submissionPayload)
+      .eq('id', submissionId);
+    if (error) {
+      throw new Error(errorMessage(error, 'Failed to update onboarding submission'));
+    }
+  } else {
+    const { data, error } = await supabase
+      .from('onboarding_submissions')
+      .insert(submissionPayload)
+      .select('id')
+      .single();
+    if (error || !data) {
+      throw new Error(errorMessage(error, 'Failed to create onboarding submission'));
+    }
+    submissionId = data.id;
+    createdSubmission = true;
+  }
+
+  let serviceId: string | undefined;
+  if (input.service) {
+    const servicePayload = {
+      customer_id: customerId,
+      package_name: input.service.packageName,
+      service_type: input.service.serviceType,
+      product_category: input.service.productCategory,
+      monthly_price: input.service.monthlyPrice,
+      setup_fee: 0,
+      status: 'active',
+      active: true,
+      installation_address: input.site.siteAddress ?? input.business.registeredAddress,
+      activation_date: input.service.activationDate ?? capturedAt.slice(0, 10),
+      provider_name: input.service.providerName ?? null,
+      contract_months: 0,
+      billing_day: Number(input.service.billingDay),
+    };
+    if (input.service.serviceId) {
+      const { error } = await supabase
+        .from('customer_services')
+        .update(servicePayload)
+        .eq('id', input.service.serviceId);
+      if (error) {
+        throw new Error(errorMessage(error, 'Failed to update active service'));
+      }
+      serviceId = input.service.serviceId;
+    } else {
+      const { data, error } = await supabase
+        .from('customer_services')
+        .insert(servicePayload)
+        .select('id')
+        .single();
+      if (error || !data) {
+        throw new Error(errorMessage(error, 'Failed to create active service'));
+      }
+      serviceId = data.id;
+    }
+  }
+
+  let paymentMethodId: string | undefined;
+  if (input.debitOrder) {
+    const paymentPayload = {
+      customer_id: customerId,
+      onboarding_submission_id: submissionId,
+      method_type: 'debit_order',
+      display_name: `Debit Order - ${input.debitOrder.bankName} ${maskAccountNumber(input.debitOrder.accountNumber)}`,
+      last_four: input.debitOrder.accountNumber.slice(-4),
+      encrypted_details: {
+        bank_name: input.debitOrder.bankName,
+        account_holder_name: input.debitOrder.accountHolderName,
+        account_type: input.debitOrder.accountType,
+        account_number: input.debitOrder.accountNumber,
+        branch_code: input.debitOrder.branchCode,
+        verified: false,
+        source: 'admin_manual_intake',
+      },
+      mandate_status: 'pending',
+      is_primary: true,
+      is_active: true,
+    };
+
+    if (input.debitOrder.paymentMethodId) {
+      const { error } = await supabase
+        .from('customer_payment_methods')
+        .update(paymentPayload)
+        .eq('id', input.debitOrder.paymentMethodId);
+      if (error) {
+        throw new Error(errorMessage(error, 'Failed to update debit-order payment method'));
+      }
+      paymentMethodId = input.debitOrder.paymentMethodId;
+    } else {
+      const { data: existingPm, error: existingPmError } = await supabase
+        .from('customer_payment_methods')
+        .select('id')
+        .eq('onboarding_submission_id', submissionId)
+        .eq('method_type', 'debit_order')
+        .maybeSingle();
+      if (existingPmError) {
+        throw new Error(errorMessage(existingPmError, 'Failed to find debit-order payment method'));
+      }
+
+      if (existingPm?.id) {
+        const { error } = await supabase
+          .from('customer_payment_methods')
+          .update(paymentPayload)
+          .eq('id', existingPm.id);
+        if (error) {
+          throw new Error(errorMessage(error, 'Failed to update debit-order payment method'));
+        }
+        paymentMethodId = existingPm.id;
+      } else {
+        const { data, error } = await supabase
+          .from('customer_payment_methods')
+          .insert(paymentPayload)
+          .select('id')
+          .single();
+        if (error || !data) {
+          throw new Error(errorMessage(error, 'Failed to create debit-order payment method'));
+        }
+        paymentMethodId = data.id;
+      }
+    }
+  }
+
+  if (!customerId || !submissionId) {
+    throw new Error('Manual intake did not produce a customer and submission');
+  }
+
+  return {
+    customerId,
+    accountNumber,
+    submissionId,
+    createdCustomer,
+    createdSubmission,
+    serviceId,
+    paymentMethodId,
+  };
+}

--- a/lib/onboarding/onboarding-service.ts
+++ b/lib/onboarding/onboarding-service.ts
@@ -1,6 +1,22 @@
 import { createClient } from '@supabase/supabase-js';
 import { generateToken, hashToken, tokenExpiry } from './token-service';
 
+export type OnboardingTokenPurpose = 'onboarding' | 'service_order_signoff';
+
+export interface IssueTokenOptions {
+  purpose?: OnboardingTokenPurpose;
+  onboardingSubmissionId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ResolvedPurposeToken {
+  customerId: string;
+  tokenId: string;
+  purpose: OnboardingTokenPurpose;
+  onboardingSubmissionId: string | null;
+  metadata: Record<string, unknown>;
+}
+
 export function svc() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -14,7 +30,11 @@ export function buildMagicLinkUrl(base: string, token: string): string {
 }
 
 /** Issue a fresh single-use token for a customer; returns the plaintext token. */
-export async function issueToken(customerId: string, sentVia: string): Promise<string> {
+export async function issueToken(
+  customerId: string,
+  sentVia: string,
+  options: IssueTokenOptions = {}
+): Promise<string> {
   const supabase = svc();
   const token = generateToken();
   const { error } = await supabase.from('onboarding_tokens').insert({
@@ -23,6 +43,9 @@ export async function issueToken(customerId: string, sentVia: string): Promise<s
     expires_at: tokenExpiry(),
     sent_via: sentVia,
     sent_at: new Date().toISOString(),
+    purpose: options.purpose ?? 'onboarding',
+    onboarding_submission_id: options.onboardingSubmissionId ?? null,
+    metadata: options.metadata ?? {},
   });
   if (error) throw new Error(`Failed to issue token: ${error.message}`);
   return token;
@@ -30,16 +53,33 @@ export async function issueToken(customerId: string, sentVia: string): Promise<s
 
 /** Resolve a plaintext token to a customer id, enforcing expiry + single use. */
 export async function resolveToken(token: string): Promise<{ customerId: string; tokenId: string } | null> {
+  const resolved = await resolveTokenForPurpose(token, 'onboarding');
+  if (!resolved) return null;
+  return { customerId: resolved.customerId, tokenId: resolved.tokenId };
+}
+
+/** Resolve a plaintext token for a specific purpose, enforcing expiry + single use. */
+export async function resolveTokenForPurpose(
+  token: string,
+  purpose: OnboardingTokenPurpose
+): Promise<ResolvedPurposeToken | null> {
   const supabase = svc();
   const { data, error } = await supabase
     .from('onboarding_tokens')
-    .select('id, customer_id, expires_at, used_at')
+    .select('id, customer_id, onboarding_submission_id, purpose, metadata, expires_at, used_at')
     .eq('token_hash', hashToken(token))
     .maybeSingle();
   if (error || !data) return null;
   if (data.used_at) return null;
   if (new Date(data.expires_at).getTime() < Date.now()) return null;
-  return { customerId: data.customer_id, tokenId: data.id };
+  if (data.purpose !== purpose) return null;
+  return {
+    customerId: data.customer_id,
+    tokenId: data.id,
+    purpose: data.purpose,
+    onboardingSubmissionId: data.onboarding_submission_id ?? null,
+    metadata: data.metadata ?? {},
+  };
 }
 
 /** Pre-fill payload for the wizard from the existing customer record. */

--- a/lib/onboarding/service-order-issuer.ts
+++ b/lib/onboarding/service-order-issuer.ts
@@ -1,0 +1,297 @@
+import crypto from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { Resend } from 'resend';
+import { generateServiceOrderBlob, type ServiceOrderInput } from '@/lib/contracts/service-order-pdf';
+import { uploadFile } from '@/lib/storage/supabase-upload';
+import { issueToken } from './onboarding-service';
+import {
+  SERVICE_ORDER_TERMS,
+  SERVICE_ORDER_TERMS_TITLE,
+  SERVICE_ORDER_TERMS_VERSION,
+  getServiceOrderReference,
+  stripHtmlFromTerms,
+} from './service-order-terms';
+
+interface ServiceOrderIssuerOptions {
+  customerId: string;
+  baseUrl?: string;
+  issuedBy: string;
+  sendEmail?: boolean;
+}
+
+export interface ServiceOrderIssueResult {
+  pdfPath: string;
+  pdfSha256: string;
+  submissionId: string;
+  emailed: boolean;
+  signoffUrl?: string;
+}
+
+interface CustomerRow {
+  id: string;
+  account_number: string;
+  business_name: string;
+  email: string;
+  phone: string | null;
+  clinic_details: Record<string, unknown> | null;
+}
+
+interface SubmissionRow {
+  id: string;
+  segment: string | null;
+  submitted_at: string | null;
+  submission_data: Record<string, any> | null;
+}
+
+interface ServiceRow {
+  monthly_price: number | null;
+  activation_date: string | null;
+  package_name?: string | null;
+  service_type?: string | null;
+}
+
+function cleanBaseUrl(baseUrl?: string): string {
+  return (baseUrl || process.env.NEXT_PUBLIC_BASE_URL || 'https://www.circletel.co.za').replace(/\/+$/, '');
+}
+
+export function buildServiceOrderSignoffUrl(baseUrl: string, token: string): string {
+  return `${cleanBaseUrl(baseUrl)}/service-order/${token}`;
+}
+
+function termsHash(reference: string): string {
+  const canonical = JSON.stringify([
+    SERVICE_ORDER_TERMS_TITLE,
+    ...SERVICE_ORDER_TERMS,
+    reference,
+  ]);
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+function buildAcceptance(
+  submission: SubmissionRow,
+  customer: CustomerRow
+): ServiceOrderInput['acceptance'] | undefined {
+  const submissionData = submission.submission_data ?? {};
+  const acceptanceRecord = submissionData.service_order_acceptance ?? submissionData.acceptance;
+  if (!acceptanceRecord?.accepted_at) return undefined;
+
+  const digits = (customer.phone || '').replace(/\D/g, '');
+  const maskedPhone =
+    digits.length >= 7 ? `${digits.slice(0, 3)} *** ${digits.slice(-4)}` : undefined;
+
+  return {
+    acceptedAtIso: acceptanceRecord.accepted_at,
+    ip: acceptanceRecord.ip || undefined,
+    termsVersion: acceptanceRecord.terms_version || undefined,
+    termsHash: acceptanceRecord.terms_hash || undefined,
+    termsSnapshot: Array.isArray(acceptanceRecord.terms_snapshot)
+      ? acceptanceRecord.terms_snapshot
+      : undefined,
+    linkSentVia: acceptanceRecord.link_sent_via || undefined,
+    linkSentAtIso: acceptanceRecord.link_sent_at || undefined,
+    maskedPhone,
+    submissionId: submission.id,
+  };
+}
+
+function buildPdfInput(
+  customer: CustomerRow,
+  submission: SubmissionRow,
+  service: ServiceRow
+): ServiceOrderInput {
+  const submissionData = submission.submission_data ?? {};
+  const step5 = submissionData.step5 ?? {};
+  const clinicDetails = customer.clinic_details ?? {};
+  const segment = submission.segment ?? 'unjani';
+  const customerLabel = segment === 'unjani' ? 'Clinic' : 'Business';
+  const serviceReference = getServiceOrderReference(segment);
+  const serviceName =
+    service.package_name ||
+    (segment === 'unjani'
+      ? 'CircleTel ClinicConnect — Managed Connectivity'
+      : 'CircleTel Business Connectivity Service');
+
+  return {
+    accountNumber: customer.account_number,
+    clinicName: customer.business_name,
+    clinicAddress:
+      String(clinicDetails.site_address || submissionData.step1?.siteAddress || 'Not provided'),
+    clinicProvince: String(clinicDetails.province || submissionData.step1?.province || 'Not provided'),
+    clinicEmail: customer.email,
+    clinicPhone: customer.phone || undefined,
+    customerLabel,
+    serviceName,
+    serviceReference,
+    monthlyFeeExclVat: Number(service.monthly_price ?? 450),
+    vatPercentage: 15,
+    billingDay: (step5.paymentDate || '1') as '1' | '15' | '20' | '25',
+    activationDate: service.activation_date || new Date().toISOString(),
+    submittedAt: submission.submitted_at || new Date().toISOString(),
+    acceptance: buildAcceptance(submission, customer),
+  };
+}
+
+function serviceOrderEmailHtml(input: {
+  customer: CustomerRow;
+  accountNumber: string;
+  monthlyFee: number;
+  signoffUrl: string;
+}) {
+  return `
+    <h2>CircleTel Service Order</h2>
+    <p>Dear ${input.customer.business_name},</p>
+    <p>Your Service Order is ready for sign-off.</p>
+    <div style="background-color:#f5f5f5;padding:16px;border-radius:8px;margin:16px 0;">
+      <p style="margin:8px 0;"><strong>Account Number:</strong> ${input.accountNumber}</p>
+      <p style="margin:8px 0;"><strong>Monthly Fee:</strong> R${input.monthlyFee.toFixed(2)} ex VAT</p>
+    </div>
+    <p><a href="${input.signoffUrl}" style="display:inline-block;background:#E87A1E;color:#ffffff;padding:12px 18px;border-radius:6px;text-decoration:none;font-weight:700;">Review and sign off</a></p>
+    <p>The generated PDF is attached for your records.</p>
+    <p>Regards,<br>CircleTel</p>
+  `;
+}
+
+export async function issueServiceOrderForCustomer(
+  supabase: SupabaseClient,
+  options: ServiceOrderIssuerOptions
+): Promise<ServiceOrderIssueResult> {
+  const { data: customer, error: customerError } = await supabase
+    .from('customers')
+    .select('id, account_number, business_name, email, phone, clinic_details')
+    .eq('id', options.customerId)
+    .single();
+  if (customerError || !customer) {
+    throw new Error(customerError?.message || 'Customer not found');
+  }
+
+  const { data: submission, error: submissionError } = await supabase
+    .from('onboarding_submissions')
+    .select('id, segment, submission_data, submitted_at')
+    .eq('customer_id', options.customerId)
+    .order('submitted_at', { ascending: false })
+    .limit(1)
+    .single();
+  if (submissionError || !submission) {
+    throw new Error(submissionError?.message || 'No onboarding submission found for this customer');
+  }
+
+  const { data: service, error: serviceError } = await supabase
+    .from('customer_services')
+    .select('monthly_price, activation_date, package_name, service_type')
+    .eq('customer_id', options.customerId)
+    .order('activation_date', { ascending: false })
+    .limit(1)
+    .single();
+  if (serviceError || !service) {
+    throw new Error(serviceError?.message || 'No active service found for this customer');
+  }
+
+  const customerRow = customer as CustomerRow;
+  const submissionRow = submission as SubmissionRow;
+  const serviceRow = service as ServiceRow;
+  const pdfInput = buildPdfInput(customerRow, submissionRow, serviceRow);
+  const pdfBlob = generateServiceOrderBlob(pdfInput);
+  const pdfBuffer = Buffer.from(await pdfBlob.arrayBuffer());
+  const pdfSha256 = crypto.createHash('sha256').update(pdfBuffer).digest('hex');
+  const filename = `SO-${customerRow.account_number}.pdf`;
+
+  const pdfFile = new File([pdfBlob], `${filename.replace(/\.pdf$/, '')}-${Date.now()}.pdf`, {
+    type: 'application/pdf',
+  });
+  const uploadResult = await uploadFile(pdfFile, {
+    bucket: 'kyc-documents',
+    folder: `service-orders/${options.customerId}`,
+    maxSizeBytes: 5 * 1024 * 1024,
+    allowedTypes: ['application/pdf'],
+    supabaseClient: supabase,
+  });
+  if (!uploadResult.success || !uploadResult.path) {
+    throw new Error(uploadResult.error || 'Failed to upload service order PDF');
+  }
+
+  const existingSubmissionData = submissionRow.submission_data ?? {};
+  const accepted = Boolean(existingSubmissionData.service_order_acceptance?.accepted_at || existingSubmissionData.acceptance?.accepted_at);
+  const issuedAt = new Date().toISOString();
+  const { error: updateError } = await supabase
+    .from('onboarding_submissions')
+    .update({
+      service_order_pdf_path: uploadResult.path,
+      service_order_issued_at: issuedAt,
+      submission_data: {
+        ...existingSubmissionData,
+        service_order_pdf_sha256: pdfSha256,
+        service_order_status: accepted ? 'accepted' : 'pending_signoff',
+        service_order_issued_by: options.issuedBy,
+        service_order_issued_at: issuedAt,
+      },
+    })
+    .eq('id', submissionRow.id);
+  if (updateError) {
+    throw new Error(updateError.message || 'Failed to update submission service order');
+  }
+
+  let emailed = false;
+  let signoffUrl: string | undefined;
+  if (options.sendEmail !== false) {
+    const token = await issueToken(options.customerId, 'email', {
+      purpose: 'service_order_signoff',
+      onboardingSubmissionId: submissionRow.id,
+      metadata: {
+        service_order_pdf_path: uploadResult.path,
+        issued_by: options.issuedBy,
+      },
+    });
+    signoffUrl = buildServiceOrderSignoffUrl(cleanBaseUrl(options.baseUrl), token);
+    const resend = new Resend(process.env.RESEND_API_KEY);
+    const { error: emailError } = await resend.emails.send({
+      from: 'billing@notify.circletel.co.za',
+      to: customerRow.email,
+      subject: `CircleTel Service Order ${customerRow.account_number}`,
+      html: serviceOrderEmailHtml({
+        customer: customerRow,
+        accountNumber: customerRow.account_number,
+        monthlyFee: Number(serviceRow.monthly_price ?? 450),
+        signoffUrl,
+      }),
+      attachments: [
+        {
+          filename,
+          content: pdfBuffer,
+          contentType: 'application/pdf',
+        },
+      ],
+    });
+    if (emailError) {
+      throw new Error(emailError.message || 'Failed to send service order email');
+    }
+    emailed = true;
+  }
+
+  return {
+    pdfPath: uploadResult.path,
+    pdfSha256,
+    submissionId: submissionRow.id,
+    emailed,
+    signoffUrl,
+  };
+}
+
+export function buildServiceOrderAcceptanceRecord(input: {
+  tokenId: string;
+  ip: string | null;
+  userAgent: string | null;
+  segment?: string | null;
+}) {
+  const acceptedAt = new Date().toISOString();
+  const reference = getServiceOrderReference(input.segment);
+  return {
+    accepted_at: acceptedAt,
+    ip: input.ip,
+    user_agent: input.userAgent,
+    token_id: input.tokenId,
+    terms_version: SERVICE_ORDER_TERMS_VERSION,
+    terms_hash: termsHash(reference),
+    terms_snapshot: stripHtmlFromTerms(SERVICE_ORDER_TERMS),
+    service_reference: reference,
+  };
+}

--- a/lib/onboarding/service-order-terms.ts
+++ b/lib/onboarding/service-order-terms.ts
@@ -84,8 +84,15 @@ export function convertTermsToPlainText(terms: string[]): string[] {
 export const SERVICE_ORDER_MSA_REFERENCE =
   'This Service Order is issued back-to-back with, and incorporates by reference, the Unjani Master Service Agreement between CircleTel and the Unjani Clinic Network.';
 
+export const SERVICE_ORDER_STANDARD_REFERENCE =
+  'This Service Order is issued under CircleTel standard business service terms and the customer-specific commercial terms recorded in this Service Order.';
+
 /**
  * MSA reference text (shown in UI)
  */
 export const SERVICE_ORDER_MSA_REFERENCE_UI =
   'These terms are back-to-back with the Master Service Agreement between CircleTel and Unjani Clinics NPC (the "MSA"). In the event of any conflict, the MSA prevails.';
+
+export function getServiceOrderReference(segment?: string | null): string {
+  return segment === 'unjani' ? SERVICE_ORDER_MSA_REFERENCE : SERVICE_ORDER_STANDARD_REFERENCE;
+}

--- a/memory-os/long-term/agent-context.md
+++ b/memory-os/long-term/agent-context.md
@@ -49,6 +49,11 @@ Format:
 - **Why:** The app currently has an existing hydration mismatch around `#zcb-banner`; admin header notifications can also crash local stubbed checks if `/api/notifications` does not return `data` plus `pagination.unread_count`.
 - **Workaround:** For layout-only checks, stub `/api/notifications` as `{ success: true, data: [], pagination: { total: 0, limit: 10, offset: 0, unread_count: 0 } }` and hide/remove `nextjs-portal` overlay nodes before screenshots.
 
+### 2026-06-30: Admin-Assisted B2B Onboarding Gate
+- **What:** Admins can create/update B2B customers from emailed onboarding packs at `/admin/b2b/manual-intake`; uploaded emailed docs can carry sender/subject/received-at provenance.
+- **Why:** Unjani and future B2B customers may send onboarding documents by email instead of completing the self-service wizard.
+- **Workaround:** Do not mark a B2B customer `billing_ready` from docs + bank details alone. `maybeMarkBillingReady` now also requires an issued Service Order PDF and `submission_data.service_order_acceptance.accepted_at` (or legacy `acceptance.accepted_at`). Service Order signoff tokens use `onboarding_tokens.purpose = 'service_order_signoff'` and resolve at `/service-order/{token}`.
+
 ## Agent-Discovered Patterns
 
 _Patterns discovered by agents while working in this codebase._

--- a/supabase/migrations/20260630090000_onboarding_token_purpose.sql
+++ b/supabase/migrations/20260630090000_onboarding_token_purpose.sql
@@ -1,0 +1,26 @@
+-- Purpose-scope onboarding tokens so signoff links cannot be used as wizard links.
+
+ALTER TABLE onboarding_tokens
+  ADD COLUMN IF NOT EXISTS purpose text NOT NULL DEFAULT 'onboarding';
+
+ALTER TABLE onboarding_tokens
+  ADD COLUMN IF NOT EXISTS onboarding_submission_id uuid REFERENCES onboarding_submissions(id) ON DELETE SET NULL;
+
+ALTER TABLE onboarding_tokens
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+DO $$
+BEGIN
+  ALTER TABLE onboarding_tokens
+    ADD CONSTRAINT onboarding_tokens_purpose_check
+    CHECK (purpose IN ('onboarding', 'service_order_signoff'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_tokens_purpose_hash
+  ON onboarding_tokens(purpose, token_hash);
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_tokens_submission
+  ON onboarding_tokens(onboarding_submission_id)
+  WHERE onboarding_submission_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- Add admin manual intake for B2B/Unjani customers, including create-customer flow and uploaded email document provenance.
- Add service-order signoff token flow, PDF issuance/acceptance, and billing-ready gating on accepted service order plus bank details.
- Add admin pipeline visibility, navigation, documentation, migration, and focused tests.

## Test Plan
- npx jest lib/onboarding/__tests__/onboarding-service-token-purpose.test.ts lib/onboarding/__tests__/manual-intake.test.ts lib/onboarding/__tests__/service-order-issuer.test.ts lib/onboarding/__tests__/billing-ready.test.ts app/api/admin/b2b/manual-intake/__tests__/route.test.ts app/api/admin/b2b/__tests__/upload-document.test.ts app/api/service-order/__tests__/accept.test.ts app/api/admin/b2b/__tests__/onboarding-pipeline.test.ts --runInBand
- git diff --check
- pre-push hook: no type errors in pushed files