### PR TITLE
feat(offers): public storefront read — /offers list + detail, JSON-LD, VAT (Plan 2)

### DIFF
--- a/__mocks__/empty-module.js
+++ b/__mocks__/empty-module.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/__mocks__/lib/offers/public-read.js
+++ b/__mocks__/lib/offers/public-read.js
@@ -1,0 +1,3 @@
+module.exports = {
+  listPublicOffers: jest.fn(() => Promise.resolve([])),
+};

--- a/__tests__/app/api/offers/detail-route.test.ts
+++ b/__tests__/app/api/offers/detail-route.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { NextRequest } from 'next/server';
+
+// ts-jest does not reliably hoist and bind factory mocks with @/-aliased ESM-interop modules.
+// Use jest.resetModules() + dynamic import() in beforeEach to ensure a fresh, correctly-bound mock per test.
+jest.mock('@/lib/offers/public-read');
+
+describe('GET /api/offers/[slug]', () => {
+  let getPublicOfferBySlug: any;
+  let GET: any;
+  const ctx = (slug: string) => ({ params: Promise.resolve({ slug }) });
+  const req = new NextRequest(new URL('http://localhost/api/offers/x'));
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    const publicRead = await import('@/lib/offers/public-read');
+    getPublicOfferBySlug = publicRead.getPublicOfferBySlug;
+
+    const route = await import('@/app/api/offers/[slug]/route');
+    GET = route.GET;
+  });
+
+  it('returns the offer when found', async () => {
+    jest.mocked(getPublicOfferBySlug).mockResolvedValueOnce({ slug: 'sky-50', priceInclVat: 2183.85 });
+    const res = await GET(req, ctx('sky-50'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ offer: { slug: 'sky-50', priceInclVat: 2183.85 } });
+  });
+
+  it('404s when not found / excluded', async () => {
+    jest.mocked(getPublicOfferBySlug).mockResolvedValueOnce(null);
+    const res = await GET(req, ctx('nope'));
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/app/api/offers/list-route.test.ts
+++ b/__tests__/app/api/offers/list-route.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { NextRequest } from 'next/server';
 
+// ts-jest does not reliably hoist and bind factory mocks with @/-aliased ESM-interop modules.
+// Use jest.resetModules() + dynamic import() in beforeEach to ensure a fresh, correctly-bound mock per test.
 jest.mock('@/lib/offers/public-read');
 
 describe('GET /api/offers', () => {
@@ -20,20 +22,21 @@ describe('GET /api/offers', () => {
   });
 
   it('returns offers for a valid segment', async () => {
-    (listPublicOffers as any).mockResolvedValueOnce([{ slug: 's', priceInclVat: 100 }]);
+    jest.mocked(listPublicOffers).mockResolvedValueOnce([{ slug: 's', priceInclVat: 100 }]);
     const res = await GET(req('/api/offers?segment=consumer'));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ offers: [{ slug: 's', priceInclVat: 100 }] });
   });
 
   it('defaults to segment=all when omitted', async () => {
-    (listPublicOffers as any).mockResolvedValueOnce([]);
+    jest.mocked(listPublicOffers).mockResolvedValueOnce([]);
     await GET(req('/api/offers'));
-    expect((listPublicOffers as any)).toHaveBeenCalledWith('all');
+    expect(jest.mocked(listPublicOffers)).toHaveBeenCalledWith('all');
   });
 
   it('400s on an invalid segment', async () => {
     const res = await GET(req('/api/offers?segment=bogus'));
     expect(res.status).toBe(400);
+    expect(jest.mocked(listPublicOffers)).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/app/api/offers/list-route.test.ts
+++ b/__tests__/app/api/offers/list-route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/offers/public-read');
+
+describe('GET /api/offers', () => {
+  let listPublicOffers: any;
+  let GET: any;
+  const req = (url: string) => new NextRequest(new URL(url, 'http://localhost'));
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    const publicRead = await import('@/lib/offers/public-read');
+    listPublicOffers = publicRead.listPublicOffers;
+
+    const route = await import('@/app/api/offers/route');
+    GET = route.GET;
+  });
+
+  it('returns offers for a valid segment', async () => {
+    (listPublicOffers as any).mockResolvedValueOnce([{ slug: 's', priceInclVat: 100 }]);
+    const res = await GET(req('/api/offers?segment=consumer'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ offers: [{ slug: 's', priceInclVat: 100 }] });
+  });
+
+  it('defaults to segment=all when omitted', async () => {
+    (listPublicOffers as any).mockResolvedValueOnce([]);
+    await GET(req('/api/offers'));
+    expect((listPublicOffers as any)).toHaveBeenCalledWith('all');
+  });
+
+  it('400s on an invalid segment', async () => {
+    const res = await GET(req('/api/offers?segment=bogus'));
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/app/contact-offer-prefill.test.ts
+++ b/__tests__/app/contact-offer-prefill.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from '@jest/globals';
+import { offerEnquiryPrefix } from '@/app/contact/page';
+
+describe('contact page offer prefill helper', () => {
+  it('builds offer enquiry prefix with subject and offer', () => {
+    const result = offerEnquiryPrefix('SkyFibre Home 50', 'skyfibre-home-50');
+    expect(result).toContain('Enquiry about: SkyFibre Home 50');
+    expect(result).toContain('Offer reference: skyfibre-home-50');
+  });
+
+  it('returns empty string when subject is null', () => {
+    const result = offerEnquiryPrefix(null, 'skyfibre-home-50');
+    expect(result).toBe('');
+  });
+
+  it('includes offer reference only when both subject and offer are present', () => {
+    const result = offerEnquiryPrefix('Product Name', 'ref-123');
+    expect(result).toContain('Enquiry about: Product Name');
+    expect(result).toContain('Offer reference: ref-123');
+  });
+
+  it('omits offer reference when offer is null but subject exists', () => {
+    const result = offerEnquiryPrefix('Product Name', null);
+    expect(result).toContain('Enquiry about: Product Name');
+    expect(result).not.toContain('Offer reference');
+    expect(result).toBe('Enquiry about: Product Name\n\n');
+  });
+
+  it('returns empty string when both are null', () => {
+    const result = offerEnquiryPrefix(null, null);
+    expect(result).toBe('');
+  });
+});

--- a/__tests__/app/coverage-check-offer.test.ts
+++ b/__tests__/app/coverage-check-offer.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from '@jest/globals';
+import CoverageCheckPage from '@/app/coverage-check/page';
+
+// Extract URL from Next.js redirect error digest format: "NEXT_REDIRECT;replace;/<url>;307;"
+function extractRedirectUrl(error: unknown): string | null {
+  if (error instanceof Error && error.message === 'NEXT_REDIRECT') {
+    const digest = (error as any).digest;
+    if (typeof digest === 'string' && digest.startsWith('NEXT_REDIRECT;')) {
+      // Format: "NEXT_REDIRECT;replace;/<url>;307;"
+      const parts = digest.split(';');
+      return parts[2] || null;
+    }
+  }
+  return null;
+}
+
+describe('coverage-check offer attribution', () => {
+  it('carries ?offer through to the homepage coverage checker', async () => {
+    let redirectUrl: string | null = null;
+    try {
+      await CoverageCheckPage({ searchParams: Promise.resolve({ offer: 'sky-50' }) });
+    } catch (error) {
+      redirectUrl = extractRedirectUrl(error);
+    }
+    expect(redirectUrl).toBe('/?offer=sky-50');
+  });
+
+  it('still maps a plan alias when present (no regression)', async () => {
+    let redirectUrl: string | null = null;
+    try {
+      await CoverageCheckPage({ searchParams: Promise.resolve({ plan: 'plus' }) });
+    } catch (error) {
+      redirectUrl = extractRedirectUrl(error);
+    }
+    expect(redirectUrl).toBe('/packages?plan=skyfibre-home-plus');
+  });
+
+  it('falls back to homepage with neither param', async () => {
+    let redirectUrl: string | null = null;
+    try {
+      await CoverageCheckPage({ searchParams: Promise.resolve({}) });
+    } catch (error) {
+      redirectUrl = extractRedirectUrl(error);
+    }
+    expect(redirectUrl).toBe('/');
+  });
+});

--- a/__tests__/app/home-offer-attribution.test.ts
+++ b/__tests__/app/home-offer-attribution.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from '@jest/globals';
+import { offerSlugFromParams } from '@/app/(marketing)/page';
+
+describe('home offer attribution helper', () => {
+  it('extracts offer slug from URLSearchParams', () => {
+    const params = new URLSearchParams('offer=skyfibre-home-50');
+    expect(offerSlugFromParams(params)).toBe('skyfibre-home-50');
+  });
+
+  it('returns null when offer param is missing', () => {
+    const params = new URLSearchParams('');
+    expect(offerSlugFromParams(params)).toBeNull();
+  });
+
+  it('returns null when other params are present but not offer', () => {
+    const params = new URLSearchParams('segment=business&other=value');
+    expect(offerSlugFromParams(params)).toBeNull();
+  });
+});

--- a/__tests__/app/offers/detail-page.test.tsx
+++ b/__tests__/app/offers/detail-page.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('@/components/layout/Navbar', () => ({ Navbar: () => null }));
+jest.mock('@/components/layout/Footer', () => ({ Footer: () => null }));
+// next/link uses useContext internally. Under jest.resetModules() (needed to bind the
+// @/-aliased public-read automock) the page tree loads a SECOND React instance while the
+// top-level renderToString holds the first → "Invalid hook call". Mocking Link to a plain
+// anchor removes the only hook-bearing node from the render; the CTA href is still asserted.
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+}));
+
+// mock-prefixed name is hoisting-safe inside the factory.
+const mockNotFound = jest.fn(() => {
+  throw new Error('NEXT_NOT_FOUND');
+});
+jest.mock('next/navigation', () => ({ notFound: () => mockNotFound() }));
+
+// Bare automock + jest.resetModules() + dynamic import binds the @/-aliased mock reliably
+// under this repo's ts-jest config (a top-level factory mock does not bind here). The page
+// renders no hook component, so resetModules is safe. offerProductJsonLd is left REAL so the
+// rendered Product JSON-LD is exercised for leaks at the page level.
+jest.mock('@/lib/offers/public-read');
+
+const INTERNAL_FIELDS = [
+  'total_cost', 'margin_pct', 'guardrail_status', 'cost_buildup', 'source_uid',
+  'source_type', 'source_id', 'unit_cost', 'unit_price', 'resolved_price', 'priceExclVat',
+];
+
+describe('/offers/[slug] detail page', () => {
+  let getPublicOfferBySlug: any;
+  let OfferDetailPage: any;
+  let renderToString: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockNotFound.mockImplementation(() => {
+      throw new Error('NEXT_NOT_FOUND');
+    });
+
+    // Import renderToString from the post-reset registry so it shares the same React
+    // instance as the dynamically-imported page tree (avoids the dual-React dispatcher mismatch).
+    ({ renderToString } = await import('react-dom/server'));
+
+    const publicRead = await import('@/lib/offers/public-read');
+    getPublicOfferBySlug = publicRead.getPublicOfferBySlug;
+
+    const page = await import('@/app/offers/[slug]/page');
+    OfferDetailPage = page.default;
+  });
+
+  it('renders price + VAT label + CTA + real Product JSON-LD, leaks nothing', async () => {
+    jest.mocked(getPublicOfferBySlug).mockResolvedValue({
+      slug: 'sky-50', title: 'SkyFibre 50', customerType: 'consumer',
+      priceInclVat: 2183.85, vatRate: 0.15, vatLabel: 'incl. VAT',
+      description: 'Fast and reliable 50Mbps connection',
+    } as any);
+
+    const html = renderToString(
+      await OfferDetailPage({ params: Promise.resolve({ slug: 'sky-50' }) }),
+    );
+
+    expect(html).toContain('incl. VAT');
+    expect(html).toContain('/coverage-check?offer=sky-50');
+    expect(html).toContain('application/ld+json');
+    expect(html).toContain('Product'); // real offerProductJsonLd output
+    expect(html).toContain('SkyFibre 50');
+    for (const k of INTERNAL_FIELDS) {
+      expect(html).not.toContain(k);
+    }
+  });
+
+  it('calls notFound() when the offer is missing', async () => {
+    jest.mocked(getPublicOfferBySlug).mockResolvedValue(null);
+    await expect(
+      OfferDetailPage({ params: Promise.resolve({ slug: 'nope' }) }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+});

--- a/__tests__/app/offers/list-page.test.tsx
+++ b/__tests__/app/offers/list-page.test.tsx
@@ -1,8 +1,13 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { renderToString } from 'react-dom/server';
 
-// ts-jest does not reliably hoist and bind factory mocks with @/-aliased ESM-interop modules.
-// Use jest.resetModules() + dynamic import() in beforeEach to ensure a fresh, correctly-bound mock per test.
+// Renders the REAL OfferTabs -> OfferCard tree and the REAL ItemList JSON-LD: only the
+// data source (public-read) and the isolated layout chrome (Navbar/Footer) are mocked, so
+// the leak assertions below exercise the actual rendered component output, not stubs.
+// NOTE: do NOT add jest.resetModules() here — with the real OfferTabs ('use client' + useState)
+// rendered under the top-level renderToString, a module reset loads a second React instance
+// and React throws "Invalid hook call" from the dispatcher mismatch. clearAllMocks is enough;
+// the bare automock of public-read binds correctly through the dynamic import without a reset.
 jest.mock('@/lib/offers/public-read');
 jest.mock('@/components/layout/Navbar', () => ({ Navbar: () => null }));
 jest.mock('@/components/layout/Footer', () => ({ Footer: () => null }));
@@ -29,9 +34,15 @@ describe('/offers list page', () => {
     const ui = await OffersPage();
     const html = renderToString(ui);
 
+    // Real OfferCard markup (initial 'consumer' tab shows the consumer offer).
     expect(html).toContain('incl. VAT');
     expect(html).toContain('SkyFibre 50');
-    for (const k of ['total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'resolved_price']) {
+    // Real ItemList JSON-LD <script> rendered by the page (offersItemListJsonLd is not mocked).
+    expect(html).toContain('application/ld+json');
+    expect(html).toContain('ItemList');
+    // Full never-expose set must be absent from the real rendered tree AND the JSON-LD.
+    for (const k of ['total_cost', 'margin_pct', 'guardrail_status', 'cost_buildup',
+      'source_uid', 'source_type', 'source_id', 'unit_cost', 'unit_price', 'resolved_price', 'priceExclVat']) {
       expect(html).not.toContain(k);
     }
   });

--- a/__tests__/app/offers/list-page.test.tsx
+++ b/__tests__/app/offers/list-page.test.tsx
@@ -1,29 +1,15 @@
+import React from 'react';
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { renderToString } from 'react-dom/server';
 
 // ts-jest does not reliably hoist and bind factory mocks with @/-aliased ESM-interop modules.
 // Use jest.resetModules() + dynamic import() in beforeEach to ensure a fresh, correctly-bound mock per test.
 jest.mock('@/lib/offers/public-read');
-jest.mock('@/lib/offers/offer-jsonld');
 jest.mock('@/components/layout/Navbar', () => ({ Navbar: () => null }));
 jest.mock('@/components/layout/Footer', () => ({ Footer: () => null }));
-jest.mock('@/components/offers/OfferTabs', () => ({
-  OfferTabs: ({ offers }: { offers: any[] }) => (
-    <>
-      {offers.map((o) => (
-        <div key={o.slug}>
-          <h3>{o.title}</h3>
-          <span>{o.vatLabel}</span>
-          <span>{o.priceInclVat}</span>
-        </div>
-      ))}
-    </>
-  ),
-}));
 
 describe('/offers list page', () => {
   let listPublicOffers: any;
-  let offersItemListJsonLd: any;
   let OffersPage: any;
 
   beforeEach(async () => {
@@ -37,10 +23,6 @@ describe('/offers list page', () => {
       { slug: 'biz-100', title: 'Business 100', customerType: 'business', priceInclVat: 5000, vatRate: 0.15, vatLabel: 'incl. VAT' },
     ]);
 
-    const jsonld = await import('@/lib/offers/offer-jsonld');
-    offersItemListJsonLd = jsonld.offersItemListJsonLd;
-    jest.mocked(offersItemListJsonLd).mockReturnValue({} as any);
-
     const page = await import('@/app/offers/page');
     OffersPage = page.default;
   });
@@ -48,6 +30,7 @@ describe('/offers list page', () => {
   it('renders VAT-labelled prices and no internal fields', async () => {
     const ui = await OffersPage();
     const html = renderToString(ui);
+
     expect(html).toContain('incl. VAT');
     expect(html).toContain('SkyFibre 50');
     for (const k of ['total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'resolved_price']) {

--- a/__tests__/app/offers/list-page.test.tsx
+++ b/__tests__/app/offers/list-page.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { renderToString } from 'react-dom/server';
 
@@ -13,7 +12,6 @@ describe('/offers list page', () => {
   let OffersPage: any;
 
   beforeEach(async () => {
-    jest.resetModules();
     jest.clearAllMocks();
 
     const publicRead = await import('@/lib/offers/public-read');

--- a/__tests__/app/offers/list-page.test.tsx
+++ b/__tests__/app/offers/list-page.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { renderToString } from 'react-dom/server';
+
+// ts-jest does not reliably hoist and bind factory mocks with @/-aliased ESM-interop modules.
+// Use jest.resetModules() + dynamic import() in beforeEach to ensure a fresh, correctly-bound mock per test.
+jest.mock('@/lib/offers/public-read');
+jest.mock('@/lib/offers/offer-jsonld');
+jest.mock('@/components/layout/Navbar', () => ({ Navbar: () => null }));
+jest.mock('@/components/layout/Footer', () => ({ Footer: () => null }));
+jest.mock('@/components/offers/OfferTabs', () => ({
+  OfferTabs: ({ offers }: { offers: any[] }) => (
+    <>
+      {offers.map((o) => (
+        <div key={o.slug}>
+          <h3>{o.title}</h3>
+          <span>{o.vatLabel}</span>
+          <span>{o.priceInclVat}</span>
+        </div>
+      ))}
+    </>
+  ),
+}));
+
+describe('/offers list page', () => {
+  let listPublicOffers: any;
+  let offersItemListJsonLd: any;
+  let OffersPage: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    const publicRead = await import('@/lib/offers/public-read');
+    listPublicOffers = publicRead.listPublicOffers;
+    jest.mocked(listPublicOffers).mockResolvedValue([
+      { slug: 'sky-50', title: 'SkyFibre 50', customerType: 'consumer', priceInclVat: 2183.85, vatRate: 0.15, vatLabel: 'incl. VAT' },
+      { slug: 'biz-100', title: 'Business 100', customerType: 'business', priceInclVat: 5000, vatRate: 0.15, vatLabel: 'incl. VAT' },
+    ]);
+
+    const jsonld = await import('@/lib/offers/offer-jsonld');
+    offersItemListJsonLd = jsonld.offersItemListJsonLd;
+    jest.mocked(offersItemListJsonLd).mockReturnValue({} as any);
+
+    const page = await import('@/app/offers/page');
+    OffersPage = page.default;
+  });
+
+  it('renders VAT-labelled prices and no internal fields', async () => {
+    const ui = await OffersPage();
+    const html = renderToString(ui);
+    expect(html).toContain('incl. VAT');
+    expect(html).toContain('SkyFibre 50');
+    for (const k of ['total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'resolved_price']) {
+      expect(html).not.toContain(k);
+    }
+  });
+});

--- a/__tests__/lib/billing/vat.test.ts
+++ b/__tests__/lib/billing/vat.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from '@jest/globals';
+import { VAT_RATE, addVat } from '@/lib/billing/vat';
+
+describe('vat helper', () => {
+  it('VAT_RATE is 0.15', () => {
+    expect(VAT_RATE).toBe(0.15);
+  });
+  it('addVat grosses up ex-VAT to incl-VAT, rounded to 2dp', () => {
+    expect(addVat(1899)).toBe(2183.85);   // 1899 * 1.15 = 2183.85
+    expect(addVat(499)).toBe(573.85);     // 499 * 1.15 = 573.85
+    expect(addVat(0)).toBe(0);
+  });
+  it('rounds half-cent correctly', () => {
+    expect(addVat(100.005)).toBe(115.01); // 100.005*1.15=115.00575 -> 115.01
+  });
+});

--- a/__tests__/lib/offers/offer-jsonld.test.ts
+++ b/__tests__/lib/offers/offer-jsonld.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from '@jest/globals';
+import { offerProductJsonLd, offersItemListJsonLd } from '@/lib/offers/offer-jsonld';
+
+const base = { slug: 'sky-50', title: 'SkyFibre 50', customerType: 'consumer' as const,
+  priceInclVat: 2183.85, vatRate: 0.15, vatLabel: 'incl. VAT' };
+
+describe('offer JSON-LD', () => {
+  it('Product uses the VAT-inclusive price and ZAR', () => {
+    const ld = offerProductJsonLd(base) as any;
+    expect(ld['@type']).toBe('Product');
+    expect(ld.offers.price).toBe(2183.85);
+    expect(ld.offers.priceCurrency).toBe('ZAR');
+    expect(ld.offers.url).toBe('https://www.circletel.co.za/offers/sky-50');
+  });
+
+  it('omits image/description when absent and includes them when present', () => {
+    expect(offerProductJsonLd(base) as any).not.toHaveProperty('image');
+    const ld = offerProductJsonLd({ ...base, image: 'http://i/x.jpg', description: 'fast' }) as any;
+    expect(ld.image).toBe('http://i/x.jpg');
+    expect(ld.description).toBe('fast');
+  });
+
+  it('never leaks internal fields', () => {
+    const s = JSON.stringify(offerProductJsonLd({ ...base, description: 'fast' }));
+    for (const k of ['resolved_price', 'total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'priceExclVat']) {
+      expect(s).not.toContain(k);
+    }
+  });
+
+  it('ItemList references each detail URL', () => {
+    const ld = offersItemListJsonLd([base]) as any;
+    expect(ld['@type']).toBe('ItemList');
+    expect(ld.itemListElement[0].url).toBe('https://www.circletel.co.za/offers/sky-50');
+  });
+});

--- a/__tests__/lib/offers/offer-jsonld.test.ts
+++ b/__tests__/lib/offers/offer-jsonld.test.ts
@@ -22,7 +22,7 @@ describe('offer JSON-LD', () => {
 
   it('never leaks internal fields', () => {
     const s = JSON.stringify(offerProductJsonLd({ ...base, description: 'fast' }));
-    for (const k of ['resolved_price', 'total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'priceExclVat']) {
+    for (const k of ['resolved_price', 'total_cost', 'margin_pct', 'guardrail_status', 'cost_buildup', 'source_uid', 'source_type', 'source_id', 'unit_cost', 'unit_price', 'priceExclVat']) {
       expect(s).not.toContain(k);
     }
   });

--- a/__tests__/lib/offers/public-read-db.test.ts
+++ b/__tests__/lib/offers/public-read-db.test.ts
@@ -1,0 +1,67 @@
+import { getPublicOfferBySlug, listPublicOffers } from '@/lib/offers/public-read'
+
+function makeClient(result: { data: any; error: any }) {
+  const createBuilder = () => {
+    const builder: any = {
+      select: () => createBuilder(),
+      eq: () => createBuilder(),
+      order: () => createBuilder(),
+      then: (onfulfilled: any, onrejected?: any) => Promise.resolve(result).then(onfulfilled, onrejected),
+    };
+    return builder;
+  };
+  return { from: () => createBuilder() };
+}
+
+const sp = (over: any = {}) => ({
+  slug: 'sky-50', title: 'SkyFibre 50', customer_type: 'consumer',
+  source_uid: 'service_packages:a', media: {},
+  offer_pricing_snapshot: { resolved_price: 1899 },
+  offer_components: [{ role: 'primary', source_type: 'service_package' }],
+  ...over,
+});
+
+jest.mock('@/lib/supabase/server', () => ({ createClient: jest.fn() }))
+import { createClient } from '@/lib/supabase/server'
+
+describe('public-read DB functions', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('listPublicOffers maps + drops excluded sources', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({
+      data: [sp(), sp({ slug: 'admin-1', source_uid: 'admin_products:x' })], error: null,
+    }))
+    const offers = await listPublicOffers('all');
+    expect(offers).toHaveLength(1);
+    expect(offers[0]).toMatchObject({ slug: 'sky-50', priceInclVat: 2183.85, vatLabel: 'incl. VAT' });
+  });
+
+  it('listPublicOffers filters by segment (business excludes consumer-only)', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({
+      data: [sp({ slug: 'c', customer_type: 'consumer' }), sp({ slug: 'b', customer_type: 'business' }), sp({ slug: 'x', customer_type: 'both' })],
+      error: null,
+    }))
+    const slugs = (await listPublicOffers('business')).map((o) => o.slug);
+    expect(slugs).toEqual(['b', 'x']);
+  });
+
+  it('listPublicOffers returns [] on db error', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: null, error: { message: 'boom' } }))
+    expect(await listPublicOffers()).toEqual([]);
+  });
+
+  it('getPublicOfferBySlug returns the mapped offer', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: [sp()], error: null }))
+    expect(await getPublicOfferBySlug('sky-50')).toMatchObject({ slug: 'sky-50', priceInclVat: 2183.85 });
+  });
+
+  it('getPublicOfferBySlug returns null for an excluded source', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: [sp({ source_uid: 'admin_products:x' })], error: null }))
+    expect(await getPublicOfferBySlug('admin-1')).toBeNull();
+  });
+
+  it('getPublicOfferBySlug returns null when not found', async () => {
+    ;(createClient as jest.Mock).mockResolvedValue(makeClient({ data: [], error: null }))
+    expect(await getPublicOfferBySlug('nope')).toBeNull();
+  });
+});

--- a/__tests__/lib/offers/public-read-map.test.ts
+++ b/__tests__/lib/offers/public-read-map.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from '@jest/globals';
+import { mapOfferRow, type OfferReadRow } from '@/lib/offers/public-read';
+
+function row(over: Partial<OfferReadRow> = {}): OfferReadRow {
+  return {
+    slug: 'skyfibre-home-50',
+    title: 'SkyFibre Home 50/50',
+    customer_type: 'consumer',
+    source_uid: 'service_packages:abc',
+    media: {},
+    offer_pricing_snapshot: { resolved_price: 1899 },
+    offer_components: [{ role: 'primary', source_type: 'service_package' }],
+    ...over,
+  };
+}
+
+describe('mapOfferRow — sanitization + VAT + guard', () => {
+  it('maps a service-package offer to a VAT-inclusive public DTO', () => {
+    const r = mapOfferRow(row());
+    expect(r).toEqual({
+      slug: 'skyfibre-home-50',
+      title: 'SkyFibre Home 50/50',
+      customerType: 'consumer',
+      priceInclVat: 2183.85,
+      vatRate: 0.15,
+      vatLabel: 'incl. VAT',
+    });
+  });
+
+  it('never includes cost/margin/provenance keys', () => {
+    const r = mapOfferRow(row()) as Record<string, unknown>;
+    for (const k of ['resolved_price', 'priceExclVat', 'total_cost', 'margin_pct',
+      'cost_buildup', 'guardrail_status', 'source_uid', 'source_type', 'source_id']) {
+      expect(r).not.toHaveProperty(k);
+    }
+  });
+
+  it('whitelists only media.description and media.image strings', () => {
+    const r = mapOfferRow(row({ media: { description: 'Fast fibre', image: 'http://img/x.jpg', secret: 'NO', cost: 123 } }))!;
+    expect(r.description).toBe('Fast fibre');
+    expect(r.image).toBe('http://img/x.jpg');
+    expect(r as Record<string, unknown>).not.toHaveProperty('secret');
+    expect(r as Record<string, unknown>).not.toHaveProperty('cost');
+  });
+
+  it('omits description/image when media is empty or non-string', () => {
+    const r = mapOfferRow(row({ media: { description: 42 as unknown as string } }))!;
+    expect(r.description).toBeUndefined();
+    expect(r.image).toBeUndefined();
+  });
+
+  it('returns null when source_uid is not a service_packages: row (admin_products excluded)', () => {
+    expect(mapOfferRow(row({ source_uid: 'admin_products:xyz' }))).toBeNull();
+    expect(mapOfferRow(row({ source_uid: 'mtn_dealer_products:1' }))).toBeNull();
+  });
+
+  it('returns null when the primary component is not source_type service_package', () => {
+    expect(mapOfferRow(row({ offer_components: [{ role: 'primary', source_type: 'hardware' }] }))).toBeNull();
+  });
+
+  it('tolerates the snapshot arriving as a single-element array', () => {
+    const r = mapOfferRow(row({ offer_pricing_snapshot: [{ resolved_price: 1899 }] as unknown as OfferReadRow['offer_pricing_snapshot'] }))!;
+    expect(r.priceInclVat).toBe(2183.85);
+  });
+
+  it('returns null when no snapshot price exists', () => {
+    expect(mapOfferRow(row({ offer_pricing_snapshot: null as unknown as OfferReadRow['offer_pricing_snapshot'] }))).toBeNull();
+  });
+});

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -12,6 +12,11 @@ function isValidSegment(value: string | null): value is SegmentType {
   return value !== null && VALID_SEGMENTS.includes(value as SegmentType);
 }
 
+// Pure helper to extract offer slug from URLSearchParams
+export function offerSlugFromParams(params: URLSearchParams): string | null {
+  return params.get('offer');
+}
+
 export default function Home() {
   const searchParams = useSearchParams();
   const [isRedirecting, setIsRedirecting] = useState(false);
@@ -28,6 +33,12 @@ export default function Home() {
       setActiveSegment(urlSegment);
     }
   }, [searchParams, activeSegment]);
+
+  // Carry offer attribution from /offers CTAs (read-only Plan 2: client-side only, no DB write).
+  useEffect(() => {
+    const offer = offerSlugFromParams(searchParams);
+    if (offer) sessionStorage.setItem('circletel_offer_slug', offer);
+  }, [searchParams]);
 
   // Update URL when segment changes
   const handleSegmentChange = useCallback((segment: SegmentType) => {

--- a/app/api/offers/[slug]/route.ts
+++ b/app/api/offers/[slug]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPublicOfferBySlug } from '@/lib/offers/public-read';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await context.params;
+  const offer = await getPublicOfferBySlug(slug);
+  if (!offer) {
+    return NextResponse.json({ error: 'offer not found' }, { status: 404 });
+  }
+  return NextResponse.json({ offer });
+}

--- a/app/api/offers/route.ts
+++ b/app/api/offers/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { listPublicOffers, type OfferSegment } from '@/lib/offers/public-read';
+
+const VALID: OfferSegment[] = ['consumer', 'business', 'all'];
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const raw = searchParams.get('segment') ?? 'all';
+  if (!VALID.includes(raw as OfferSegment)) {
+    return NextResponse.json({ error: `invalid segment: ${raw}` }, { status: 400 });
+  }
+  const offers = await listPublicOffers(raw as OfferSegment);
+  return NextResponse.json({ offers });
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -3,6 +3,14 @@ import { PiCalendarBold, PiChatCircleBold, PiCheckBold, PiCheckCircleBold, PiClo
 
 import React, { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
+
+// Pure helper to build offer enquiry message prefix
+export function offerEnquiryPrefix(subject: string | null, offer: string | null): string {
+  if (!subject) return '';
+  let s = `Enquiry about: ${subject}\n`;
+  if (offer) s += `Offer reference: ${offer}\n`;
+  return s + '\n';
+}
 import { Footer } from '@/components/layout/Footer';
 import { Navbar } from '@/components/layout/Navbar';
 import ContactHero from '@/components/contact/ContactHero';
@@ -36,16 +44,21 @@ const Contact = () => {
     message: '',
   });
 
-  // Pre-fill form with URL parameters (from coverage check)
+  // Pre-fill form with URL parameters (from coverage check and offers)
   useEffect(() => {
     const address = searchParams.get('address');
     const coverage = searchParams.get('coverage');
     const serviceType = searchParams.get('service');
     const speeds = searchParams.get('speeds');
     const nearest = searchParams.get('nearest');
+    const subject = searchParams.get('subject');
+    const offer = searchParams.get('offer');
 
-    if (address || coverage || serviceType || speeds || nearest) {
+    if (address || coverage || serviceType || speeds || nearest || subject || offer) {
       let message = '';
+
+      // Prepend offer enquiry information (before coverage check details)
+      message += offerEnquiryPrefix(subject, offer);
 
       if (address) {
         message += `I'm interested in connectivity for the following address:\n${address}\n\n`;

--- a/app/coverage-check/page.tsx
+++ b/app/coverage-check/page.tsx
@@ -15,15 +15,21 @@ const PLAN_ALIASES: Record<string, string> = {
 };
 
 interface CoverageCheckPageProps {
-  searchParams: Promise<{ plan?: string }>;
+  searchParams: Promise<{ plan?: string; offer?: string }>;
 }
 
 export default async function CoverageCheckPage({ searchParams }: CoverageCheckPageProps) {
-  const { plan } = await searchParams;
+  const { plan, offer } = await searchParams;
   const planId = plan ? PLAN_ALIASES[plan.toLowerCase()] ?? plan : null;
 
   if (planId) {
     redirect(`/packages?plan=${planId}`);
+  }
+
+  // Offer-sourced visitors have no lead yet — send them to the homepage coverage
+  // checker, preserving the offer slug for attribution.
+  if (offer) {
+    redirect(`/?offer=${encodeURIComponent(offer)}`);
   }
 
   redirect('/');

--- a/app/offers/[slug]/page.tsx
+++ b/app/offers/[slug]/page.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Navbar } from '@/components/layout/Navbar';
+import { Footer } from '@/components/layout/Footer';
+import { getPublicOfferBySlug, listPublicOffers } from '@/lib/offers/public-read';
+import { offerProductJsonLd } from '@/lib/offers/offer-jsonld';
+
+export const revalidate = 300;
+
+export async function generateStaticParams() {
+  const offers = await listPublicOffers('all');
+  return offers.map((o) => ({ slug: o.slug }));
+}
+
+export default async function OfferDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const offer = await getPublicOfferBySlug(slug);
+  if (!offer) notFound();
+
+  const jsonLd = offerProductJsonLd(offer);
+  const ctaHref = `/coverage-check?offer=${encodeURIComponent(offer.slug)}`;
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="container mx-auto px-4 py-16">
+        <h1 className="text-4xl font-bold text-circleTel-navy">{offer.title}</h1>
+        {offer.description && (
+          <p className="mt-4 max-w-2xl text-circleTel-secondaryNeutral">{offer.description}</p>
+        )}
+        <div className="mt-6">
+          <span className="text-4xl font-bold text-circleTel-orange">
+            R{offer.priceInclVat.toLocaleString('en-ZA', { minimumFractionDigits: 2 })}
+          </span>
+          <span className="ml-2 text-sm text-circleTel-secondaryNeutral">{offer.vatLabel}</span>
+        </div>
+        <Link
+          href={ctaHref}
+          className="mt-8 inline-block rounded-lg bg-circleTel-orange px-6 py-3 font-semibold text-white hover:bg-circleTel-orange-dark"
+        >
+          Check availability
+        </Link>
+      </main>
+      <Footer />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+    </div>
+  );
+}

--- a/app/offers/page.tsx
+++ b/app/offers/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from 'next';
+import { Navbar } from '@/components/layout/Navbar';
+import { Footer } from '@/components/layout/Footer';
+import { OfferTabs } from '@/components/offers/OfferTabs';
+import { listPublicOffers } from '@/lib/offers/public-read';
+import { offersItemListJsonLd } from '@/lib/offers/offer-jsonld';
+
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: 'Plans & Pricing | CircleTel',
+  description: 'Browse CircleTel connectivity plans with transparent, VAT-inclusive pricing.',
+};
+
+export default async function OffersPage() {
+  const offers = await listPublicOffers('all');
+  const jsonLd = offersItemListJsonLd(offers);
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="container mx-auto px-4 py-16">
+        <h1 className="mb-2 text-center text-4xl font-bold text-circleTel-navy">
+          Plans &amp; <span className="text-circleTel-orange">Pricing</span>
+        </h1>
+        <p className="mb-12 text-center text-circleTel-secondaryNeutral">
+          Transparent pricing, VAT included. No surprises.
+        </p>
+        <OfferTabs offers={offers} />
+      </main>
+      <Footer />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+    </div>
+  );
+}

--- a/components/home/HomeLanding20260607.tsx
+++ b/components/home/HomeLanding20260607.tsx
@@ -220,6 +220,10 @@ export function HomeLanding20260607({
           address: nextAddress.trim(),
           coordinates: nextCoordinates,
           coverageType,
+          // Forward-prep: lead API ignores this today (Plan 3 persists it). Carry is sessionStorage.
+          offerSlug: typeof window !== 'undefined'
+            ? sessionStorage.getItem('circletel_offer_slug') ?? undefined
+            : undefined,
         }),
       });
 

--- a/components/offers/OfferCard.tsx
+++ b/components/offers/OfferCard.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import type { PublicOffer } from '@/lib/types/offer';
+
+export function OfferCard({ offer }: { offer: PublicOffer }) {
+  return (
+    <div className="rounded-xl border-2 border-circleTel-lightNeutral p-6 hover:border-circleTel-orange transition-colors">
+      <h3 className="text-lg font-bold text-circleTel-navy">{offer.title}</h3>
+      {offer.description && (
+        <p className="mt-2 text-sm text-circleTel-secondaryNeutral">{offer.description}</p>
+      )}
+      <div className="mt-4">
+        <span className="text-3xl font-bold text-circleTel-orange">
+          R{offer.priceInclVat.toLocaleString('en-ZA', { minimumFractionDigits: 2 })}
+        </span>
+        <span className="ml-2 text-xs text-circleTel-secondaryNeutral">{offer.vatLabel}</span>
+      </div>
+      <Link
+        href={`/offers/${offer.slug}`}
+        className="mt-6 inline-block rounded-lg bg-circleTel-orange px-5 py-2 text-white hover:bg-circleTel-orange-dark"
+      >
+        View details
+      </Link>
+    </div>
+  );
+}

--- a/components/offers/OfferTabs.tsx
+++ b/components/offers/OfferTabs.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { useState } from 'react';
+import type { PublicOffer } from '@/lib/types/offer';
+import { OfferCard } from './OfferCard';
+
+type Segment = 'consumer' | 'business';
+
+export function OfferTabs({ offers }: { offers: PublicOffer[] }) {
+  const [segment, setSegment] = useState<Segment>('consumer');
+  const visible = offers.filter((o) =>
+    segment === 'consumer'
+      ? o.customerType === 'consumer' || o.customerType === 'both'
+      : o.customerType === 'business' || o.customerType === 'both',
+  );
+
+  return (
+    <div>
+      <div className="mb-8 flex justify-center gap-2">
+        {(['consumer', 'business'] as Segment[]).map((s) => (
+          <button
+            key={s}
+            onClick={() => setSegment(s)}
+            className={`rounded-full px-6 py-2 text-sm font-semibold capitalize ${
+              segment === s ? 'bg-circleTel-navy text-white' : 'bg-circleTel-lightNeutral text-circleTel-navy'
+            }`}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        {visible.map((o) => (
+          <OfferCard key={o.slug} offer={o} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-06-28-offer-storefront-read.md
+++ b/docs/superpowers/plans/2026-06-28-offer-storefront-read.md
@@ -1,0 +1,1415 @@
+# Offer Storefront Read (`/offers`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a public, snapshot-fed product catalogue at `/offers` (list + per-offer detail) with VAT-inclusive pricing and JSON-LD structured data, reading the Offer Spine produced in Phase 0.
+
+**Architecture:** A single `server-only` read module (`lib/offers/public-read.ts`) is the sole sanitization + VAT boundary: it reads `offers ⋈ offer_pricing_snapshot ⋈ offer_components` via the service-role client, applies a service-package-only VAT-basis guard, and emits VAT-inclusive public DTOs that never carry cost/margin/provenance. API route handlers and statically-rendered (ISR) pages consume only that module; the list page filters consumer/business client-side to stay static.
+
+**Tech Stack:** Next.js 15 (App Router, async params, ISR), TypeScript (strict), Supabase (`@/lib/supabase/server`), Jest + ts-jest, Tailwind, `server-only`.
+
+**Spec:** `docs/superpowers/specs/2026-06-28-offer-storefront-read-design.md`
+
+## Global Constraints
+
+- **Read-only.** No write paths, migrations, cart, or checkout. No new DB columns.
+- **VAT:** `offer_pricing_snapshot.resolved_price` is **ex-VAT**. The public surface exposes **only** `priceInclVat` (= `round(resolved_price * 1.15 * 100)/100`), `vatRate` (`0.15`), `vatLabel` (`"incl. VAT"`). Never expose `priceExclVat` / raw `resolved_price`.
+- **VAT-basis guard:** Only offers with `offers.source_uid` starting `service_packages:` **and** a primary `offer_components.source_type = 'service_package'` may be exposed. All other sources are logged and excluded (`admin_products:*` also maps to `source_type='service_package'`, so the `source_uid` prefix is the real proof).
+- **Never expose:** `cost_buildup`, `total_cost`, `margin_pct`, `guardrail_status`, `source_uid`, `source_type`, `source_id`, component `unit_cost`/`unit_price`, or the raw `media` blob (whitelist `media.description` + `media.image` strings only).
+- **`lib/offers/public-read.ts` first line is `import 'server-only'`.** It must never be imported by a client component.
+- **Next.js 15 API routes:** `context: { params: Promise<{ slug: string }> }`, `const { slug } = await context.params`.
+- **Pages are static + ISR** (`export const revalidate = 300`). The list page takes **no `searchParams`** (tabs are client-side).
+- **Run scripts** with `set -a && source .env.local && set +a && npx tsx <script>`.
+- Test runner: `npx jest <path>`. Tests use `@jest/globals` + path alias `@/`.
+
+---
+
+### Task 1: VAT helper (`lib/billing/vat.ts`)
+
+**Files:**
+- Create: `lib/billing/vat.ts`
+- Test: `__tests__/lib/billing/vat.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `export const VAT_RATE = 0.15`; `export function addVat(excl: number): number` (rounds to 2 decimals).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// __tests__/lib/billing/vat.test.ts
+import { describe, it, expect } from '@jest/globals';
+import { VAT_RATE, addVat } from '@/lib/billing/vat';
+
+describe('vat helper', () => {
+  it('VAT_RATE is 0.15', () => {
+    expect(VAT_RATE).toBe(0.15);
+  });
+  it('addVat grosses up ex-VAT to incl-VAT, rounded to 2dp', () => {
+    expect(addVat(1899)).toBe(2183.85);   // 1899 * 1.15 = 2183.85
+    expect(addVat(499)).toBe(573.85);     // 499 * 1.15 = 573.85
+    expect(addVat(0)).toBe(0);
+  });
+  it('rounds half-cent correctly', () => {
+    expect(addVat(100.005)).toBe(115.01); // 100.005*1.15=115.00575 -> 115.01
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/lib/billing/vat.test.ts`
+Expected: FAIL — `Cannot find module '@/lib/billing/vat'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// lib/billing/vat.ts
+export const VAT_RATE = 0.15;
+
+/** Gross an ex-VAT ZAR amount up to VAT-inclusive, rounded to 2 decimals. */
+export function addVat(excl: number): number {
+  return Math.round(excl * (1 + VAT_RATE) * 100) / 100;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest __tests__/lib/billing/vat.test.ts`
+Expected: PASS (4 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/billing/vat.ts __tests__/lib/billing/vat.test.ts
+git commit -m "feat(billing): shared VAT_RATE + addVat helper"
+```
+
+---
+
+### Task 2: Public-read setup + sanitization mapper (`lib/offers/public-read.ts` core)
+
+This task adds the `server-only` dependency + jest mapping, the public DTO types, and the **pure** `mapOfferRow` function — the single security boundary. No DB access yet.
+
+**Files:**
+- Modify: `package.json` (add `server-only` dependency), `jest.config.js` (map `^server-only$`)
+- Create: `__mocks__/empty-module.js`
+- Modify: `lib/types/offer.ts` (append public DTO types)
+- Create: `lib/offers/public-read.ts` (import + types re-export + `mapOfferRow`)
+- Test: `__tests__/lib/offers/public-read-map.test.ts`
+
+**Interfaces:**
+- Consumes: `addVat`, `VAT_RATE` from Task 1.
+- Produces:
+  - `interface PublicOffer { slug: string; title: string; customerType: 'consumer'|'business'|'both'; priceInclVat: number; vatRate: number; vatLabel: string; description?: string; image?: string }`
+  - `interface PublicOfferDetail extends PublicOffer {}` (same shape in Plan 2)
+  - `interface OfferReadRow` (raw row shape from the query — see Step 4)
+  - `export function mapOfferRow(row: OfferReadRow): PublicOffer | null` (returns `null` when the VAT-basis guard fails)
+
+- [ ] **Step 1: Add `server-only` dependency and jest mapping**
+
+Run:
+```bash
+npm install server-only
+```
+Then create the jest stub and map it.
+
+```javascript
+// __mocks__/empty-module.js
+module.exports = {};
+```
+
+In `jest.config.js`, add the `server-only` mapping inside the existing `moduleNameMapper` (which currently only has `'^@/(.*)$'`):
+
+```javascript
+  moduleNameMapper: {
+    '^server-only$': '<rootDir>/__mocks__/empty-module.js',
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+```
+
+- [ ] **Step 2: Verify existing tests still pass with the new mapping**
+
+Run: `npx jest __tests__/lib/offers/`
+Expected: PASS (the Phase 0 offers tests — pricing-resolver, staleness, publisher — still green; mapping change is inert for them).
+
+- [ ] **Step 3: Append public DTO types to `lib/types/offer.ts`**
+
+Append at the end of `lib/types/offer.ts`:
+
+```typescript
+/** Public, sanitized offer for the storefront (no cost/margin/provenance). */
+export interface PublicOffer {
+  slug: string;
+  title: string;
+  customerType: OfferCustomerType;
+  priceInclVat: number;   // ZAR incl. 15% VAT — the only price ever shown
+  vatRate: number;        // 0.15
+  vatLabel: string;       // "incl. VAT"
+  description?: string;   // from media.description (string) only
+  image?: string;         // from media.image (string) only
+}
+
+/** Detail-page shape — identical to PublicOffer in Plan 2. */
+export type PublicOfferDetail = PublicOffer;
+```
+
+- [ ] **Step 4: Write the failing test for the mapper**
+
+```typescript
+// __tests__/lib/offers/public-read-map.test.ts
+import { describe, it, expect } from '@jest/globals';
+import { mapOfferRow, type OfferReadRow } from '@/lib/offers/public-read';
+
+function row(over: Partial<OfferReadRow> = {}): OfferReadRow {
+  return {
+    slug: 'skyfibre-home-50',
+    title: 'SkyFibre Home 50/50',
+    customer_type: 'consumer',
+    source_uid: 'service_packages:abc',
+    media: {},
+    offer_pricing_snapshot: { resolved_price: 1899 },
+    offer_components: [{ role: 'primary', source_type: 'service_package' }],
+    ...over,
+  };
+}
+
+describe('mapOfferRow — sanitization + VAT + guard', () => {
+  it('maps a service-package offer to a VAT-inclusive public DTO', () => {
+    const r = mapOfferRow(row());
+    expect(r).toEqual({
+      slug: 'skyfibre-home-50',
+      title: 'SkyFibre Home 50/50',
+      customerType: 'consumer',
+      priceInclVat: 2183.85,
+      vatRate: 0.15,
+      vatLabel: 'incl. VAT',
+    });
+  });
+
+  it('never includes cost/margin/provenance keys', () => {
+    const r = mapOfferRow(row()) as Record<string, unknown>;
+    for (const k of ['resolved_price', 'priceExclVat', 'total_cost', 'margin_pct',
+      'cost_buildup', 'guardrail_status', 'source_uid', 'source_type', 'source_id']) {
+      expect(r).not.toHaveProperty(k);
+    }
+  });
+
+  it('whitelists only media.description and media.image strings', () => {
+    const r = mapOfferRow(row({ media: { description: 'Fast fibre', image: 'http://img/x.jpg', secret: 'NO', cost: 123 } }))!;
+    expect(r.description).toBe('Fast fibre');
+    expect(r.image).toBe('http://img/x.jpg');
+    expect(r as Record<string, unknown>).not.toHaveProperty('secret');
+    expect(r as Record<string, unknown>).not.toHaveProperty('cost');
+  });
+
+  it('omits description/image when media is empty or non-string', () => {
+    const r = mapOfferRow(row({ media: { description: 42 as unknown as string } }))!;
+    expect(r.description).toBeUndefined();
+    expect(r.image).toBeUndefined();
+  });
+
+  it('returns null when source_uid is not a service_packages: row (admin_products excluded)', () => {
+    expect(mapOfferRow(row({ source_uid: 'admin_products:xyz' }))).toBeNull();
+    expect(mapOfferRow(row({ source_uid: 'mtn_dealer_products:1' }))).toBeNull();
+  });
+
+  it('returns null when the primary component is not source_type service_package', () => {
+    expect(mapOfferRow(row({ offer_components: [{ role: 'primary', source_type: 'hardware' }] }))).toBeNull();
+  });
+
+  it('tolerates the snapshot arriving as a single-element array', () => {
+    const r = mapOfferRow(row({ offer_pricing_snapshot: [{ resolved_price: 1899 }] as unknown as OfferReadRow['offer_pricing_snapshot'] }))!;
+    expect(r.priceInclVat).toBe(2183.85);
+  });
+
+  it('returns null when no snapshot price exists', () => {
+    expect(mapOfferRow(row({ offer_pricing_snapshot: null as unknown as OfferReadRow['offer_pricing_snapshot'] }))).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 5: Run test to verify it fails**
+
+Run: `npx jest __tests__/lib/offers/public-read-map.test.ts`
+Expected: FAIL — `Cannot find module '@/lib/offers/public-read'`.
+
+- [ ] **Step 6: Write the mapper implementation**
+
+```typescript
+// lib/offers/public-read.ts
+import 'server-only';
+import { addVat, VAT_RATE } from '@/lib/billing/vat';
+import type { PublicOffer, OfferCustomerType } from '@/lib/types/offer';
+import { apiLogger } from '@/lib/logging/logger';
+
+export type { PublicOffer, PublicOfferDetail } from '@/lib/types/offer';
+
+/** Raw row shape returned by the storefront query (see listPublicOffers). */
+export interface OfferReadRow {
+  slug: string;
+  title: string;
+  customer_type: OfferCustomerType;
+  source_uid: string | null;
+  media: Record<string, unknown> | null;
+  offer_pricing_snapshot:
+    | { resolved_price: number }
+    | { resolved_price: number }[]
+    | null;
+  offer_components: { role: string; source_type: string }[] | null;
+}
+
+const VAT_LABEL = 'incl. VAT';
+
+function firstSnapshot(s: OfferReadRow['offer_pricing_snapshot']): { resolved_price: number } | null {
+  if (!s) return null;
+  return Array.isArray(s) ? (s[0] ?? null) : s;
+}
+
+function whitelistedString(media: Record<string, unknown> | null, key: string): string | undefined {
+  const v = media?.[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Pure sanitization + VAT + VAT-basis guard. Returns null when the offer is not
+ * a service_packages-sourced row (the only ex-VAT basis we may expose) or has no price.
+ */
+export function mapOfferRow(row: OfferReadRow): PublicOffer | null {
+  // VAT-basis guard: source_uid prefix is the source-table proof; component type alone
+  // is insufficient (admin_products also maps to source_type 'service_package').
+  const fromServicePackages = (row.source_uid ?? '').startsWith('service_packages:');
+  const primary = (row.offer_components ?? []).find((c) => c.role === 'primary');
+  const primaryIsServicePackage = primary?.source_type === 'service_package';
+  if (!fromServicePackages || !primaryIsServicePackage) {
+    apiLogger.warn('[offers/public-read] excluded non-service_package offer', { slug: row.slug, sourceUid: row.source_uid });
+    return null;
+  }
+
+  const snap = firstSnapshot(row.offer_pricing_snapshot);
+  if (!snap || typeof snap.resolved_price !== 'number') return null;
+
+  const description = whitelistedString(row.media, 'description');
+  const image = whitelistedString(row.media, 'image');
+
+  return {
+    slug: row.slug,
+    title: row.title,
+    customerType: row.customer_type,
+    priceInclVat: addVat(snap.resolved_price),
+    vatRate: VAT_RATE,
+    vatLabel: VAT_LABEL,
+    ...(description ? { description } : {}),
+    ...(image ? { image } : {}),
+  };
+}
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `npx jest __tests__/lib/offers/public-read-map.test.ts`
+Expected: PASS (8 assertions).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add package.json package-lock.json jest.config.js __mocks__/empty-module.js lib/types/offer.ts lib/offers/public-read.ts __tests__/lib/offers/public-read-map.test.ts
+git commit -m "feat(offers): public-read sanitization mapper + server-only + DTO types"
+```
+
+---
+
+### Task 3: Public-read DB functions (`listPublicOffers`, `getPublicOfferBySlug`)
+
+**Files:**
+- Modify: `lib/offers/public-read.ts` (append DB functions)
+- Test: `__tests__/lib/offers/public-read-db.test.ts`
+
+**Interfaces:**
+- Consumes: `mapOfferRow`, `OfferReadRow` (Task 2); `createClient` from `@/lib/supabase/server`.
+- Produces:
+  - `export type OfferSegment = 'consumer' | 'business' | 'all'`
+  - `export async function listPublicOffers(segment?: OfferSegment): Promise<PublicOffer[]>`
+  - `export async function getPublicOfferBySlug(slug: string): Promise<PublicOfferDetail | null>`
+  - `export const OFFER_SELECT` (the PostgREST select string, exported for reuse/tests)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// __tests__/lib/offers/public-read-db.test.ts
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('@/lib/supabase/server', () => ({ createClient: jest.fn() }));
+import { createClient } from '@/lib/supabase/server';
+import { listPublicOffers, getPublicOfferBySlug } from '@/lib/offers/public-read';
+
+function makeClient(result: { data: any; error: any }) {
+  const builder: any = {
+    select: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    then: (ok: any, err?: any) => Promise.resolve(result).then(ok, err),
+  };
+  return { from: () => builder };
+}
+
+const sp = (over: any = {}) => ({
+  slug: 'sky-50', title: 'SkyFibre 50', customer_type: 'consumer',
+  source_uid: 'service_packages:a', media: {},
+  offer_pricing_snapshot: { resolved_price: 1899 },
+  offer_components: [{ role: 'primary', source_type: 'service_package' }],
+  ...over,
+});
+
+describe('public-read DB functions', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('listPublicOffers maps + drops excluded sources', async () => {
+    (createClient as jest.Mock).mockResolvedValue(makeClient({
+      data: [sp(), sp({ slug: 'admin-1', source_uid: 'admin_products:x' })], error: null,
+    }));
+    const offers = await listPublicOffers('all');
+    expect(offers).toHaveLength(1);
+    expect(offers[0]).toMatchObject({ slug: 'sky-50', priceInclVat: 2183.85, vatLabel: 'incl. VAT' });
+  });
+
+  it('listPublicOffers filters by segment (business excludes consumer-only)', async () => {
+    (createClient as jest.Mock).mockResolvedValue(makeClient({
+      data: [sp({ slug: 'c', customer_type: 'consumer' }), sp({ slug: 'b', customer_type: 'business' }), sp({ slug: 'x', customer_type: 'both' })],
+      error: null,
+    }));
+    const slugs = (await listPublicOffers('business')).map((o) => o.slug);
+    expect(slugs).toEqual(['b', 'x']);
+  });
+
+  it('listPublicOffers returns [] on db error', async () => {
+    (createClient as jest.Mock).mockResolvedValue(makeClient({ data: null, error: { message: 'boom' } }));
+    expect(await listPublicOffers()).toEqual([]);
+  });
+
+  it('getPublicOfferBySlug returns the mapped offer', async () => {
+    (createClient as jest.Mock).mockResolvedValue(makeClient({ data: [sp()], error: null }));
+    expect(await getPublicOfferBySlug('sky-50')).toMatchObject({ slug: 'sky-50', priceInclVat: 2183.85 });
+  });
+
+  it('getPublicOfferBySlug returns null for an excluded source', async () => {
+    (createClient as jest.Mock).mockResolvedValue(makeClient({ data: [sp({ source_uid: 'admin_products:x' })], error: null }));
+    expect(await getPublicOfferBySlug('admin-1')).toBeNull();
+  });
+
+  it('getPublicOfferBySlug returns null when not found', async () => {
+    (createClient as jest.Mock).mockResolvedValue(makeClient({ data: [], error: null }));
+    expect(await getPublicOfferBySlug('nope')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/lib/offers/public-read-db.test.ts`
+Expected: FAIL — `listPublicOffers is not a function`.
+
+- [ ] **Step 3: Append DB functions to `lib/offers/public-read.ts`**
+
+```typescript
+// --- append to lib/offers/public-read.ts ---
+import { createClient } from '@/lib/supabase/server';
+import type { PublicOfferDetail } from '@/lib/types/offer';
+
+export type OfferSegment = 'consumer' | 'business' | 'all';
+
+/** PostgREST select: offer + its snapshot (inner) + components, public-safe columns only. */
+export const OFFER_SELECT =
+  'slug,title,customer_type,source_uid,media,' +
+  'offer_pricing_snapshot!inner(resolved_price),' +
+  'offer_components(role,source_type)';
+
+function matchesSegment(customerType: string, segment: OfferSegment): boolean {
+  if (segment === 'all') return true;
+  if (segment === 'consumer') return customerType === 'consumer' || customerType === 'both';
+  return customerType === 'business' || customerType === 'both';
+}
+
+export async function listPublicOffers(segment: OfferSegment = 'all'): Promise<PublicOffer[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('offers')
+    .select(OFFER_SELECT)
+    .eq('status', 'active')
+    .eq('lifecycle_state', 'active');
+
+  if (error || !data) {
+    if (error) apiLogger.error('[offers/public-read] list failed', { error: error.message });
+    return [];
+  }
+
+  return (data as unknown as OfferReadRow[])
+    .filter((r) => matchesSegment(r.customer_type, segment))
+    .map(mapOfferRow)
+    .filter((o): o is PublicOffer => o !== null);
+}
+
+export async function getPublicOfferBySlug(slug: string): Promise<PublicOfferDetail | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('offers')
+    .select(OFFER_SELECT)
+    .eq('status', 'active')
+    .eq('lifecycle_state', 'active')
+    .eq('slug', slug);
+
+  if (error || !data || data.length === 0) {
+    if (error) apiLogger.error('[offers/public-read] detail failed', { error: error.message, slug });
+    return null;
+  }
+  return mapOfferRow((data as unknown as OfferReadRow[])[0]);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest __tests__/lib/offers/public-read-db.test.ts`
+Expected: PASS (6 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/offers/public-read.ts __tests__/lib/offers/public-read-db.test.ts
+git commit -m "feat(offers): listPublicOffers + getPublicOfferBySlug (service-role read)"
+```
+
+---
+
+### Task 4: List API route (`GET /api/offers`)
+
+**Files:**
+- Create: `app/api/offers/route.ts`
+- Test: `__tests__/app/api/offers/list-route.test.ts`
+
+**Interfaces:**
+- Consumes: `listPublicOffers`, `OfferSegment` (Task 3).
+- Produces: `GET` handler → `{ offers: PublicOffer[] }` (200), or `{ error }` (400 on invalid segment).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// __tests__/app/api/offers/list-route.test.ts
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('@/lib/offers/public-read', () => ({
+  listPublicOffers: jest.fn(),
+}));
+import { listPublicOffers } from '@/lib/offers/public-read';
+import { GET } from '@/app/api/offers/route';
+import { NextRequest } from 'next/server';
+
+const req = (url: string) => new NextRequest(new URL(url, 'http://localhost'));
+
+describe('GET /api/offers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns offers for a valid segment', async () => {
+    (listPublicOffers as jest.Mock).mockResolvedValue([{ slug: 's', priceInclVat: 100 }]);
+    const res = await GET(req('/api/offers?segment=consumer'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ offers: [{ slug: 's', priceInclVat: 100 }] });
+    expect(listPublicOffers).toHaveBeenCalledWith('consumer');
+  });
+
+  it('defaults to segment=all when omitted', async () => {
+    (listPublicOffers as jest.Mock).mockResolvedValue([]);
+    await GET(req('/api/offers'));
+    expect(listPublicOffers).toHaveBeenCalledWith('all');
+  });
+
+  it('400s on an invalid segment', async () => {
+    const res = await GET(req('/api/offers?segment=bogus'));
+    expect(res.status).toBe(400);
+    expect(listPublicOffers).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/app/api/offers/list-route.test.ts`
+Expected: FAIL — `Cannot find module '@/app/api/offers/route'`.
+
+- [ ] **Step 3: Write the route**
+
+```typescript
+// app/api/offers/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { listPublicOffers, type OfferSegment } from '@/lib/offers/public-read';
+
+const VALID: OfferSegment[] = ['consumer', 'business', 'all'];
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const raw = searchParams.get('segment') ?? 'all';
+  if (!VALID.includes(raw as OfferSegment)) {
+    return NextResponse.json({ error: `invalid segment: ${raw}` }, { status: 400 });
+  }
+  const offers = await listPublicOffers(raw as OfferSegment);
+  return NextResponse.json({ offers });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest __tests__/app/api/offers/list-route.test.ts`
+Expected: PASS (3 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/offers/route.ts __tests__/app/api/offers/list-route.test.ts
+git commit -m "feat(offers): GET /api/offers list endpoint"
+```
+
+---
+
+### Task 5: Detail API route (`GET /api/offers/[slug]`)
+
+**Files:**
+- Create: `app/api/offers/[slug]/route.ts`
+- Test: `__tests__/app/api/offers/detail-route.test.ts`
+
+**Interfaces:**
+- Consumes: `getPublicOfferBySlug` (Task 3).
+- Produces: `GET` handler → `{ offer }` (200) or `{ error }` (404).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// __tests__/app/api/offers/detail-route.test.ts
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('@/lib/offers/public-read', () => ({ getPublicOfferBySlug: jest.fn() }));
+import { getPublicOfferBySlug } from '@/lib/offers/public-read';
+import { GET } from '@/app/api/offers/[slug]/route';
+import { NextRequest } from 'next/server';
+
+const ctx = (slug: string) => ({ params: Promise.resolve({ slug }) });
+const req = new NextRequest(new URL('http://localhost/api/offers/x'));
+
+describe('GET /api/offers/[slug]', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns the offer when found', async () => {
+    (getPublicOfferBySlug as jest.Mock).mockResolvedValue({ slug: 'sky-50', priceInclVat: 2183.85 });
+    const res = await GET(req, ctx('sky-50'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ offer: { slug: 'sky-50', priceInclVat: 2183.85 } });
+  });
+
+  it('404s when not found / excluded', async () => {
+    (getPublicOfferBySlug as jest.Mock).mockResolvedValue(null);
+    const res = await GET(req, ctx('nope'));
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/app/api/offers/detail-route.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the route**
+
+```typescript
+// app/api/offers/[slug]/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { getPublicOfferBySlug } from '@/lib/offers/public-read';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await context.params;
+  const offer = await getPublicOfferBySlug(slug);
+  if (!offer) {
+    return NextResponse.json({ error: 'offer not found' }, { status: 404 });
+  }
+  return NextResponse.json({ offer });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest __tests__/app/api/offers/detail-route.test.ts`
+Expected: PASS (2 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/offers/[slug]/route.ts __tests__/app/api/offers/detail-route.test.ts
+git commit -m "feat(offers): GET /api/offers/[slug] detail endpoint"
+```
+
+---
+
+### Task 6: JSON-LD builders (`lib/offers/offer-jsonld.ts`)
+
+Pure builders so JSON-LD is unit-testable and reused by both pages. Keeps the "no ex-VAT, no leakage in structured data" guarantee in a tested function.
+
+**Files:**
+- Create: `lib/offers/offer-jsonld.ts`
+- Test: `__tests__/lib/offers/offer-jsonld.test.ts`
+
+**Interfaces:**
+- Consumes: `PublicOffer`, `PublicOfferDetail` (Task 2).
+- Produces:
+  - `export const OFFERS_BASE_URL = 'https://www.circletel.co.za'`
+  - `export function offerProductJsonLd(o: PublicOfferDetail): object`
+  - `export function offersItemListJsonLd(offers: PublicOffer[]): object`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// __tests__/lib/offers/offer-jsonld.test.ts
+import { describe, it, expect } from '@jest/globals';
+import { offerProductJsonLd, offersItemListJsonLd } from '@/lib/offers/offer-jsonld';
+
+const base = { slug: 'sky-50', title: 'SkyFibre 50', customerType: 'consumer' as const,
+  priceInclVat: 2183.85, vatRate: 0.15, vatLabel: 'incl. VAT' };
+
+describe('offer JSON-LD', () => {
+  it('Product uses the VAT-inclusive price and ZAR', () => {
+    const ld = offerProductJsonLd(base) as any;
+    expect(ld['@type']).toBe('Product');
+    expect(ld.offers.price).toBe(2183.85);
+    expect(ld.offers.priceCurrency).toBe('ZAR');
+    expect(ld.offers.url).toBe('https://www.circletel.co.za/offers/sky-50');
+  });
+
+  it('omits image/description when absent and includes them when present', () => {
+    expect(offerProductJsonLd(base) as any).not.toHaveProperty('image');
+    const ld = offerProductJsonLd({ ...base, image: 'http://i/x.jpg', description: 'fast' }) as any;
+    expect(ld.image).toBe('http://i/x.jpg');
+    expect(ld.description).toBe('fast');
+  });
+
+  it('never leaks internal fields', () => {
+    const s = JSON.stringify(offerProductJsonLd({ ...base, description: 'fast' }));
+    for (const k of ['resolved_price', 'total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'priceExclVat']) {
+      expect(s).not.toContain(k);
+    }
+  });
+
+  it('ItemList references each detail URL', () => {
+    const ld = offersItemListJsonLd([base]) as any;
+    expect(ld['@type']).toBe('ItemList');
+    expect(ld.itemListElement[0].url).toBe('https://www.circletel.co.za/offers/sky-50');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/lib/offers/offer-jsonld.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the builders**
+
+```typescript
+// lib/offers/offer-jsonld.ts
+import type { PublicOffer, PublicOfferDetail } from '@/lib/types/offer';
+
+export const OFFERS_BASE_URL = 'https://www.circletel.co.za';
+
+export function offerProductJsonLd(o: PublicOfferDetail): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: o.title,
+    ...(o.image ? { image: o.image } : {}),
+    ...(o.description ? { description: o.description } : {}),
+    offers: {
+      '@type': 'Offer',
+      price: o.priceInclVat,
+      priceCurrency: 'ZAR',
+      availability: 'https://schema.org/InStock',
+      url: `${OFFERS_BASE_URL}/offers/${o.slug}`,
+    },
+  };
+}
+
+export function offersItemListJsonLd(offers: PublicOffer[]): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement: offers.map((o, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: o.title,
+      url: `${OFFERS_BASE_URL}/offers/${o.slug}`,
+    })),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest __tests__/lib/offers/offer-jsonld.test.ts`
+Expected: PASS (4 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/offers/offer-jsonld.ts __tests__/lib/offers/offer-jsonld.test.ts
+git commit -m "feat(offers): JSON-LD builders (Product + ItemList, VAT-inclusive)"
+```
+
+---
+
+### Task 7: List page + client tabs (`/offers`)
+
+**Files:**
+- Create: `components/offers/OfferCard.tsx` (presentational), `components/offers/OfferTabs.tsx` (client filter)
+- Create: `app/offers/page.tsx` (static server component, ISR)
+- Test: `__tests__/app/offers/list-page.test.tsx`
+
+**Interfaces:**
+- Consumes: `listPublicOffers` (Task 3), `offersItemListJsonLd` (Task 6), `PublicOffer`.
+- Produces: rendered `/offers` HTML with VAT-labelled prices, tabs, and an ItemList JSON-LD `<script>`.
+
+- [ ] **Step 1: Write the failing rendered-leakage test**
+
+```typescript
+// __tests__/app/offers/list-page.test.tsx
+import { describe, it, expect, jest } from '@jest/globals';
+import { render } from '@testing-library/react';
+
+jest.mock('@/lib/offers/public-read', () => ({
+  listPublicOffers: jest.fn().mockResolvedValue([
+    { slug: 'sky-50', title: 'SkyFibre 50', customerType: 'consumer', priceInclVat: 2183.85, vatRate: 0.15, vatLabel: 'incl. VAT' },
+    { slug: 'biz-100', title: 'Business 100', customerType: 'business', priceInclVat: 5000, vatRate: 0.15, vatLabel: 'incl. VAT' },
+  ]),
+}));
+import OffersPage from '@/app/offers/page';
+
+describe('/offers list page', () => {
+  it('renders VAT-labelled prices and no internal fields', async () => {
+    const ui = await OffersPage();
+    const { container } = render(ui);
+    const html = container.innerHTML;
+    expect(html).toContain('incl. VAT');
+    expect(html).toContain('SkyFibre 50');
+    for (const k of ['total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'resolved_price']) {
+      expect(html).not.toContain(k);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/app/offers/list-page.test.tsx`
+Expected: FAIL — `Cannot find module '@/app/offers/page'`.
+
+- [ ] **Step 3: Write `OfferCard.tsx`**
+
+```tsx
+// components/offers/OfferCard.tsx
+import Link from 'next/link';
+import type { PublicOffer } from '@/lib/types/offer';
+
+export function OfferCard({ offer }: { offer: PublicOffer }) {
+  return (
+    <div className="rounded-xl border-2 border-circleTel-lightNeutral p-6 hover:border-circleTel-orange transition-colors">
+      <h3 className="text-lg font-bold text-circleTel-navy">{offer.title}</h3>
+      {offer.description && (
+        <p className="mt-2 text-sm text-circleTel-secondaryNeutral">{offer.description}</p>
+      )}
+      <div className="mt-4">
+        <span className="text-3xl font-bold text-circleTel-orange">
+          R{offer.priceInclVat.toLocaleString('en-ZA', { minimumFractionDigits: 2 })}
+        </span>
+        <span className="ml-2 text-xs text-circleTel-secondaryNeutral">{offer.vatLabel}</span>
+      </div>
+      <Link
+        href={`/offers/${offer.slug}`}
+        className="mt-6 inline-block rounded-lg bg-circleTel-orange px-5 py-2 text-white hover:bg-circleTel-orange-dark"
+      >
+        View details
+      </Link>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Write `OfferTabs.tsx` (client)**
+
+```tsx
+// components/offers/OfferTabs.tsx
+'use client';
+import { useState } from 'react';
+import type { PublicOffer } from '@/lib/types/offer';
+import { OfferCard } from './OfferCard';
+
+type Segment = 'consumer' | 'business';
+
+export function OfferTabs({ offers }: { offers: PublicOffer[] }) {
+  const [segment, setSegment] = useState<Segment>('consumer');
+  const visible = offers.filter((o) =>
+    segment === 'consumer'
+      ? o.customerType === 'consumer' || o.customerType === 'both'
+      : o.customerType === 'business' || o.customerType === 'both',
+  );
+
+  return (
+    <div>
+      <div className="mb-8 flex justify-center gap-2">
+        {(['consumer', 'business'] as Segment[]).map((s) => (
+          <button
+            key={s}
+            onClick={() => setSegment(s)}
+            className={`rounded-full px-6 py-2 text-sm font-semibold capitalize ${
+              segment === s ? 'bg-circleTel-navy text-white' : 'bg-circleTel-lightNeutral text-circleTel-navy'
+            }`}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        {visible.map((o) => (
+          <OfferCard key={o.slug} offer={o} />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Write `app/offers/page.tsx`**
+
+```tsx
+// app/offers/page.tsx
+import type { Metadata } from 'next';
+import { Navbar } from '@/components/layout/Navbar';
+import { Footer } from '@/components/layout/Footer';
+import { OfferTabs } from '@/components/offers/OfferTabs';
+import { listPublicOffers } from '@/lib/offers/public-read';
+import { offersItemListJsonLd } from '@/lib/offers/offer-jsonld';
+
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: 'Plans & Pricing | CircleTel',
+  description: 'Browse CircleTel connectivity plans with transparent, VAT-inclusive pricing.',
+};
+
+export default async function OffersPage() {
+  const offers = await listPublicOffers('all');
+  const jsonLd = offersItemListJsonLd(offers);
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="container mx-auto px-4 py-16">
+        <h1 className="mb-2 text-center text-4xl font-bold text-circleTel-navy">
+          Plans &amp; <span className="text-circleTel-orange">Pricing</span>
+        </h1>
+        <p className="mb-12 text-center text-circleTel-secondaryNeutral">
+          Transparent pricing, VAT included. No surprises.
+        </p>
+        <OfferTabs offers={offers} />
+      </main>
+      <Footer />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npx jest __tests__/app/offers/list-page.test.tsx`
+Expected: PASS. If `Navbar`/`Footer` pull browser-only deps that break jsdom, mock them at the top of the test: `jest.mock('@/components/layout/Navbar', () => ({ Navbar: () => null })); jest.mock('@/components/layout/Footer', () => ({ Footer: () => null }));`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/offers/OfferCard.tsx components/offers/OfferTabs.tsx app/offers/page.tsx __tests__/app/offers/list-page.test.tsx
+git commit -m "feat(offers): /offers list page with consumer/business tabs + ItemList JSON-LD"
+```
+
+---
+
+### Task 8: Detail page (`/offers/[slug]`)
+
+**Files:**
+- Create: `app/offers/[slug]/page.tsx`
+- Test: `__tests__/app/offers/detail-page.test.tsx`
+
+**Interfaces:**
+- Consumes: `getPublicOfferBySlug`, `listPublicOffers` (Task 3), `offerProductJsonLd` (Task 6).
+- Produces: rendered detail HTML with VAT-labelled price, CTA, Product JSON-LD; `notFound()` on miss.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// __tests__/app/offers/detail-page.test.tsx
+import { describe, it, expect, jest } from '@jest/globals';
+import { render } from '@testing-library/react';
+
+jest.mock('@/components/layout/Navbar', () => ({ Navbar: () => null }));
+jest.mock('@/components/layout/Footer', () => ({ Footer: () => null }));
+// Jest hoists jest.mock() above imports; a factory may only reference `mock`-prefixed vars.
+const mockNotFound = jest.fn(() => { throw new Error('NEXT_NOT_FOUND'); });
+jest.mock('next/navigation', () => ({ notFound: () => mockNotFound() }));
+jest.mock('@/lib/offers/public-read', () => ({
+  getPublicOfferBySlug: jest.fn(),
+  listPublicOffers: jest.fn().mockResolvedValue([]),
+}));
+import { getPublicOfferBySlug } from '@/lib/offers/public-read';
+import OfferDetailPage from '@/app/offers/[slug]/page';
+
+describe('/offers/[slug] detail page', () => {
+  it('renders price + VAT label + CTA, leaks nothing', async () => {
+    (getPublicOfferBySlug as jest.Mock).mockResolvedValue({
+      slug: 'sky-50', title: 'SkyFibre 50', customerType: 'consumer', priceInclVat: 2183.85, vatRate: 0.15, vatLabel: 'incl. VAT',
+    });
+    const ui = await OfferDetailPage({ params: Promise.resolve({ slug: 'sky-50' }) });
+    const html = render(ui).container.innerHTML;
+    expect(html).toContain('incl. VAT');
+    expect(html).toContain('/coverage-check?offer=sky-50');
+    for (const k of ['total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'resolved_price']) {
+      expect(html).not.toContain(k);
+    }
+  });
+
+  it('calls notFound() when the offer is missing', async () => {
+    (getPublicOfferBySlug as jest.Mock).mockResolvedValue(null);
+    await expect(OfferDetailPage({ params: Promise.resolve({ slug: 'nope' }) })).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/app/offers/detail-page.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write `app/offers/[slug]/page.tsx`**
+
+```tsx
+// app/offers/[slug]/page.tsx
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Navbar } from '@/components/layout/Navbar';
+import { Footer } from '@/components/layout/Footer';
+import { getPublicOfferBySlug, listPublicOffers } from '@/lib/offers/public-read';
+import { offerProductJsonLd } from '@/lib/offers/offer-jsonld';
+
+export const revalidate = 300;
+
+export async function generateStaticParams() {
+  const offers = await listPublicOffers('all');
+  return offers.map((o) => ({ slug: o.slug }));
+}
+
+export default async function OfferDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const offer = await getPublicOfferBySlug(slug);
+  if (!offer) notFound();
+
+  const jsonLd = offerProductJsonLd(offer);
+  const ctaHref = `/coverage-check?offer=${encodeURIComponent(offer.slug)}`;
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="container mx-auto px-4 py-16">
+        <h1 className="text-4xl font-bold text-circleTel-navy">{offer.title}</h1>
+        {offer.description && (
+          <p className="mt-4 max-w-2xl text-circleTel-secondaryNeutral">{offer.description}</p>
+        )}
+        <div className="mt-6">
+          <span className="text-4xl font-bold text-circleTel-orange">
+            R{offer.priceInclVat.toLocaleString('en-ZA', { minimumFractionDigits: 2 })}
+          </span>
+          <span className="ml-2 text-sm text-circleTel-secondaryNeutral">{offer.vatLabel}</span>
+        </div>
+        <Link
+          href={ctaHref}
+          className="mt-8 inline-block rounded-lg bg-circleTel-orange px-6 py-3 font-semibold text-white hover:bg-circleTel-orange-dark"
+        >
+          Check availability
+        </Link>
+      </main>
+      <Footer />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest __tests__/app/offers/detail-page.test.tsx`
+Expected: PASS (2 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/offers/[slug]/page.tsx __tests__/app/offers/detail-page.test.tsx
+git commit -m "feat(offers): /offers/[slug] detail page + Product JSON-LD + coverage CTA"
+```
+
+---
+
+### Task 9: CTA receivers — `coverage-check` + homepage attribution + `contact` consume `offer`
+
+**Attribution model (decided):** `Plan 2 is read-only` — no new DB column. The offer slug is carried
+**client-side via `sessionStorage`**: `/coverage-check?offer=<slug>` redirects to `/?offer=<slug>`; the
+homepage reads `?offer=` and persists it to `sessionStorage['circletel_offer_slug']`; `runCoverageCheck`
+forwards it in the lead POST body as `offerSlug`. The lead API (`app/api/coverage/lead/route.ts:9`)
+destructures only `{ address, coordinates, coverageType }`, so the extra `offerSlug` key is **silently
+ignored today** — it is forward-prep that Plan 3 will persist. The durable carry is the `sessionStorage`
+value, which any downstream step (packages page, order) can read. DB-level attribution + package
+pre-select are deferred to Plan 3.
+
+**Files:**
+- Modify: `app/coverage-check/page.tsx` (carry `offer` through the redirect)
+- Modify: `app/(marketing)/page.tsx` (read `?offer=`, persist to `sessionStorage`)
+- Modify: `components/home/HomeLanding20260607.tsx:216-224` (forward `offerSlug` in the lead POST body)
+- Modify: `app/contact/page.tsx:40-74` (read `subject`/`offer` into the prefilled message)
+- Test: `__tests__/app/coverage-check-offer.test.ts`, `__tests__/app/home-offer-attribution.test.tsx`, `__tests__/app/contact-offer-prefill.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `/coverage-check?offer=<slug>` → redirect `/?offer=<slug>`; homepage writes
+  `sessionStorage['circletel_offer_slug']`; `/contact?subject=&offer=` prefills the message.
+
+- [ ] **Step 1: Write the failing test for coverage-check**
+
+```typescript
+// __tests__/app/coverage-check-offer.test.ts
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// Jest hoists jest.mock() above imports; a factory may only reference `mock`-prefixed vars.
+const mockRedirect = jest.fn((url: string) => { throw new Error(`REDIRECT:${url}`); });
+jest.mock('next/navigation', () => ({ redirect: (u: string) => mockRedirect(u) }));
+import CoverageCheckPage from '@/app/coverage-check/page';
+
+describe('coverage-check offer attribution', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('carries ?offer through to the homepage coverage checker', async () => {
+    await expect(
+      CoverageCheckPage({ searchParams: Promise.resolve({ offer: 'sky-50' }) }),
+    ).rejects.toThrow('REDIRECT:/?offer=sky-50');
+  });
+
+  it('still maps a plan alias when present (no regression)', async () => {
+    await expect(
+      CoverageCheckPage({ searchParams: Promise.resolve({ plan: 'plus' }) }),
+    ).rejects.toThrow('REDIRECT:/packages?plan=skyfibre-home-plus');
+  });
+
+  it('falls back to homepage with neither param', async () => {
+    await expect(
+      CoverageCheckPage({ searchParams: Promise.resolve({}) }),
+    ).rejects.toThrow('REDIRECT:/');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/app/coverage-check-offer.test.ts`
+Expected: FAIL — the `offer` case redirects to `/`, not `/?offer=sky-50` (and the `searchParams` type lacks `offer`).
+
+- [ ] **Step 3: Update `app/coverage-check/page.tsx`**
+
+Replace the `CoverageCheckPageProps` interface and component body:
+
+```tsx
+interface CoverageCheckPageProps {
+  searchParams: Promise<{ plan?: string; offer?: string }>;
+}
+
+export default async function CoverageCheckPage({ searchParams }: CoverageCheckPageProps) {
+  const { plan, offer } = await searchParams;
+  const planId = plan ? PLAN_ALIASES[plan.toLowerCase()] ?? plan : null;
+
+  if (planId) {
+    redirect(`/packages?plan=${planId}`);
+  }
+
+  // Offer-sourced visitors have no lead yet — send them to the homepage coverage
+  // checker, preserving the offer slug for attribution.
+  if (offer) {
+    redirect(`/?offer=${encodeURIComponent(offer)}`);
+  }
+
+  redirect('/');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest __tests__/app/coverage-check-offer.test.ts`
+Expected: PASS (3 assertions).
+
+- [ ] **Step 5: Write the failing homepage attribution test**
+
+`app/(marketing)/page.tsx` currently reads only `?segment`. This test pins that an `?offer=` param is
+persisted to `sessionStorage` on mount. `HomeLanding20260607` is mocked to `null` (it pulls Google Maps
+and other browser-only deps that are irrelevant here and heavy under jsdom).
+
+```tsx
+// __tests__/app/home-offer-attribution.test.tsx
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { render } from '@testing-library/react';
+
+const params = new URLSearchParams('offer=skyfibre-home-50');
+jest.mock('next/navigation', () => ({ useSearchParams: () => params }));
+jest.mock('@/components/home/HomeLanding20260607', () => ({ HomeLanding20260607: () => null }));
+import Home from '@/app/(marketing)/page';
+
+describe('homepage offer attribution', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('persists ?offer= to sessionStorage on mount', () => {
+    render(<Home />);
+    expect(sessionStorage.getItem('circletel_offer_slug')).toBe('skyfibre-home-50');
+  });
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `npx jest __tests__/app/home-offer-attribution.test.tsx`
+Expected: FAIL — `sessionStorage` has no `circletel_offer_slug` (the page ignores `offer`).
+
+- [ ] **Step 7: Persist `offer` on the homepage and forward it in the lead POST**
+
+In `app/(marketing)/page.tsx`, add an effect that reads `?offer=` and stashes it (place it alongside the
+existing segment-sync `useEffect`, after line 30):
+
+```typescript
+  // Carry offer attribution from /offers CTAs (read-only Plan 2: client-side only, no DB write).
+  useEffect(() => {
+    const offer = searchParams.get('offer');
+    if (offer) sessionStorage.setItem('circletel_offer_slug', offer);
+  }, [searchParams]);
+```
+
+In `components/home/HomeLanding20260607.tsx`, forward the stored slug in the existing
+`runCoverageCheck` POST body (the `fetch('/api/coverage/lead', ...)` call at line 216). Change the body to:
+
+```typescript
+        body: JSON.stringify({
+          address: nextAddress.trim(),
+          coordinates: nextCoordinates,
+          coverageType,
+          // Forward-prep: lead API ignores this today (Plan 3 persists it). Carry is sessionStorage.
+          offerSlug: typeof window !== 'undefined'
+            ? sessionStorage.getItem('circletel_offer_slug') ?? undefined
+            : undefined,
+        }),
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `npx jest __tests__/app/home-offer-attribution.test.tsx`
+Expected: PASS (1 assertion).
+
+- [ ] **Step 9: Write the failing contact-page prefill test**
+
+The existing prefill `useEffect` (`app/contact/page.tsx:40-74`) **only enters the message block** when
+a coverage param is present — its guard is `if (address || coverage || serviceType || speeds || nearest)`.
+A `?subject=&offer=` URL therefore prefills nothing today. This test pins the desired behaviour first.
+
+```tsx
+// __tests__/app/contact-offer-prefill.test.tsx
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, waitFor } from '@testing-library/react';
+
+// Drive the page's useSearchParams() from a controllable params object.
+const params = new URLSearchParams('subject=SkyFibre%20Home%2050&offer=skyfibre-home-50');
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => params,
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+import ContactPage from '@/app/contact/page';
+
+describe('contact page offer prefill', () => {
+  it('prefills the message from subject + offer params', async () => {
+    const { findByDisplayValue } = render(<ContactPage />);
+    const textarea = await findByDisplayValue(/Enquiry about: SkyFibre Home 50/);
+    expect((textarea as HTMLTextAreaElement).value).toContain('Offer reference: skyfibre-home-50');
+  });
+});
+```
+
+> If `ContactPage` pulls layout/browser-only modules that break under jsdom, mock them at the top of
+> the test the same way Tasks 7/8 mock `Navbar`/`Footer`. The `message` textarea must have `id="message"`
+> and `value={formData.message}` (it already does) for `findByDisplayValue` to match.
+
+- [ ] **Step 10: Run test to verify it fails**
+
+Run: `npx jest __tests__/app/contact-offer-prefill.test.tsx`
+Expected: FAIL — the textarea value is empty because the guard never lets `subject`/`offer` through.
+
+- [ ] **Step 11: Update `app/contact/page.tsx` (read params + widen the guard)**
+
+In the prefill `useEffect`, add the two reads alongside the existing `searchParams.get(...)` calls
+(after the `nearest` line at `app/contact/page.tsx:45`):
+
+```typescript
+    const subject = searchParams.get('subject');
+    const offer = searchParams.get('offer');
+```
+
+Widen the guard at `app/contact/page.tsx:47` so offer-sourced visitors enter the block:
+
+```typescript
+    if (address || coverage || serviceType || speeds || nearest || subject || offer) {
+```
+
+Prepend the subject/offer lines to `message` — **before** the existing `if (address)` block (so it
+leads the prefilled message):
+
+```typescript
+      if (subject) {
+        message += `Enquiry about: ${subject}\n`;
+        if (offer) message += `Offer reference: ${offer}\n`;
+        message += '\n';
+      }
+```
+
+- [ ] **Step 12: Run the contact test to verify it passes**
+
+Run: `npx jest __tests__/app/contact-offer-prefill.test.tsx`
+Expected: PASS (1 assertion).
+
+- [ ] **Step 13: Verify the whole `__tests__/app/` suite is green + scoped type-check**
+
+Run: `npx jest __tests__/app/`
+Expected: PASS (coverage-check, homepage attribution, contact, offers pages). Then
+`npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "contact/page|coverage-check/page|\\(marketing\\)/page|HomeLanding20260607|offers" || echo "no new type errors in changed files"`.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add app/coverage-check/page.tsx "app/(marketing)/page.tsx" \
+  components/home/HomeLanding20260607.tsx app/contact/page.tsx \
+  __tests__/app/coverage-check-offer.test.ts __tests__/app/home-offer-attribution.test.tsx \
+  __tests__/app/contact-offer-prefill.test.tsx
+git commit -m "feat(offers): offer attribution — coverage-check redirect, sessionStorage carry, contact prefill"
+```
+
+---
+
+### Task 10: Live verification script (via the real HTTP routes)
+
+Manual, run-once against a running server (local `dev:memory`, or prod). Not a unit test.
+
+> **Why HTTP, not a direct import:** `lib/offers/public-read.ts` starts with `import 'server-only'`,
+> whose package entry throws unless resolved under Next's `react-server` export condition. A plain
+> `npx tsx scripts/...ts` does **not** set that condition, so importing the read layer (directly or
+> transitively) crashes the script. Hitting `GET /api/offers` / `GET /api/offers/[slug]` exercises the
+> same code path inside the Next runtime (where `server-only` is satisfied) and verifies the real
+> public surface end-to-end. No `server-only` import appears in this script.
+
+**Files:**
+- Create: `scripts/offers/verify-storefront.ts`
+
+**Interfaces:**
+- Consumes: the deployed/local `GET /api/offers` and `GET /api/offers/[slug]` (Tasks 4, 5). No module imports from `lib/offers/*`.
+
+- [ ] **Step 1: Write the script (fetch-based, no `server-only` import)**
+
+```typescript
+// scripts/offers/verify-storefront.ts
+// Run against a RUNNING server. Override with OFFERS_VERIFY_BASE_URL (e.g. https://www.circletel.co.za).
+const BASE = process.env.OFFERS_VERIFY_BASE_URL ?? 'http://localhost:3000';
+const FORBIDDEN = ['resolved_price', 'priceExclVat', 'total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'source_type'];
+
+function assertNoLeak(label: string, payload: string) {
+  for (const k of FORBIDDEN) {
+    if (payload.includes(k)) throw new Error(`LEAK: forbidden key "${k}" present in ${label}`);
+  }
+}
+
+async function getJson(path: string): Promise<{ status: number; text: string; json: any }> {
+  const res = await fetch(`${BASE}${path}`);
+  const text = await res.text();
+  return { status: res.status, text, json: text ? JSON.parse(text) : null };
+}
+
+async function main() {
+  const list = await getJson('/api/offers?segment=all');
+  if (list.status !== 200) throw new Error(`GET /api/offers -> ${list.status}`);
+  const offers = list.json.offers as Array<{ slug: string; priceInclVat: number; vatLabel: string }>;
+  console.log(`GET /api/offers -> 200, ${offers.length} offer(s)`);
+  if (offers.length === 0) throw new Error('No public offers — publish at least one active service_packages offer first');
+  assertNoLeak('list response', list.text);
+
+  const first = offers[0];
+  if (typeof first.priceInclVat !== 'number' || first.vatLabel !== 'incl. VAT') {
+    throw new Error('VAT contract violated on list output');
+  }
+
+  const detail = await getJson(`/api/offers/${encodeURIComponent(first.slug)}`);
+  if (detail.status !== 200) throw new Error(`GET /api/offers/${first.slug} -> ${detail.status}`);
+  assertNoLeak('detail response', detail.text);
+  console.log('Detail:', JSON.stringify(detail.json.offer, null, 2));
+
+  // Negative check: an unknown slug must 404, not leak.
+  const missing = await getJson('/api/offers/__definitely_not_a_real_slug__');
+  if (missing.status !== 404) throw new Error(`expected 404 for unknown slug, got ${missing.status}`);
+
+  console.log('VERIFY OK — VAT-inclusive, no leakage, 404 on unknown');
+}
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+- [ ] **Step 2: Run it against a running server**
+
+Start the server in one shell (`npm run dev:memory`), then in another:
+```bash
+npx tsx scripts/offers/verify-storefront.ts
+# or against prod once deployed:
+OFFERS_VERIFY_BASE_URL=https://www.circletel.co.za npx tsx scripts/offers/verify-storefront.ts
+```
+Expected: prints `GET /api/offers -> 200, N offer(s)`, a detail blob with `priceInclVat` and **no** cost
+keys, and `VERIFY OK`. (Requires at least one active `service_packages` offer published into the spine —
+use the existing admin publish-all path if the table is empty.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/offers/verify-storefront.ts
+git commit -m "test(offers): live storefront verification via HTTP routes (VAT + no-leakage)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §4.1 VAT contract → Task 1 (helper) + Task 2 (mapper applies it, exposes incl-VAT only) ✅
+- §4.1 VAT-basis guard (`service_packages:` prefix + primary component) → Task 2 (`mapOfferRow`) + Task 3 (drops excluded) ✅
+- §4.2 field policy / media whitelist / no leakage → Task 2 tests ✅
+- §4 server-only → Task 2 Step 1 + file header ✅
+- §5 API list + detail (400/404, async params) → Tasks 4, 5 ✅
+- §6 static list + client tabs, detail page, concrete CTA URLs → Tasks 7, 8 ✅
+- §6 CTA receivers / offer attribution → Task 9 — resolved as **sessionStorage carry** (read-only Plan 2: `/coverage-check?offer=` → `/?offer=` → homepage persists `circletel_offer_slug`; lead API ignores the forwarded `offerSlug` until Plan 3). DB persist + package pre-select explicitly deferred to Plan 3 (§11). ✅
+- §7 JSON-LD (Product + ItemList, VAT-incl, no leak) → Task 6 + rendered checks in 7, 8 ✅
+- §8 ISR (`revalidate=300`, no searchParams) → Tasks 7, 8 ✅
+- §9 staleness de-scoped → no task (correct) ✅
+- §10 testing incl. rendered HTML/JSON-LD leakage + live verify → Tasks 7, 8, 10 ✅
+- §12 file list incl. CTA receivers → Task 9 (now also `app/(marketing)/page.tsx` + `HomeLanding20260607.tsx` for the sessionStorage carry) ✅
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code. ✅
+
+**Type consistency:** `mapOfferRow`/`OfferReadRow` (Task 2) consumed unchanged in Task 3; `listPublicOffers`/`getPublicOfferBySlug`/`OfferSegment` names consistent across Tasks 3–10; `PublicOffer`/`PublicOfferDetail` from `lib/types/offer.ts` used everywhere; JSON-LD builder names (`offerProductJsonLd`, `offersItemListJsonLd`) consistent between Task 6 and Tasks 7/8. ✅
+
+**Note for executor:** Tasks 7/8 render Server Components via `await Page()` in jsdom; if `Navbar`/`Footer` import browser-only modules that break under jsdom, mock them at the top of the test (shown in Task 7 Step 6 / Task 8 Step 1).

--- a/docs/superpowers/plans/2026-06-30-admin-assisted-b2b-onboarding.md
+++ b/docs/superpowers/plans/2026-06-30-admin-assisted-b2b-onboarding.md
@@ -1,0 +1,815 @@
+# Admin-Assisted B2B Onboarding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an admin-assisted B2B onboarding path where admins can create a new business customer record or select an existing one, capture emailed business details and documents, send a customer-owned Service Order signoff link, and make the service debit-order billable only after the correct gates pass.
+
+**Architecture:** Extend the existing Unjani/B2B onboarding system instead of building a parallel workflow. Use `customers`, `customer_services`, `onboarding_submissions`, `kyc_documents`, `customer_payment_methods`, `onboarding_tokens`, and the existing document-vetting workbench. Add a manual-intake page/API, purpose-scoped signoff tokens, a customer-facing Service Order acceptance page, and a shared Service Order issuer used after acceptance.
+
+**Tech Stack:** Next.js 15 App Router, React 18, TypeScript, Tailwind/shadcn, Supabase service-role admin routes, Zod, Resend 6.1 attachments, Vitest/Jest, existing CircleTel onboarding/document-vetting helpers.
+
+---
+
+## Verified Starting Points
+
+- Existing admin surfaces:
+  - `/admin/unjani/onboarding` pipeline already manages Unjani clinic onboarding.
+  - `/admin/b2b/vetting` and `/admin/b2b/vetting/[submissionId]` already handle document vetting.
+  - `components/admin/layout/Sidebar.tsx` already has a `B2B Customers` menu group.
+- Existing APIs:
+  - `POST /api/admin/b2b/upload-document` uploads emailed documents but is documents-only and defaults new shells to `segment: 'unjani'`.
+  - `POST /api/admin/b2b/issue-service-order` generates/uploads the PDF, but its email says the PDF is attached while not sending an attachment.
+  - `POST /api/admin/kyc/verify` rolls up onboarding document status and calls `maybeMarkBillingReady`.
+- Existing gates:
+  - `lib/onboarding/billing-ready.ts` currently requires approved docs, active service, and debit-order bank details.
+  - This plan adds Service Order acceptance/final PDF issuance to that gate.
+
+## File Structure
+
+- Create `lib/customers/account-number.ts` for reusable CT account number generation.
+- Create `lib/onboarding/manual-intake.ts` for schema validation and manual-intake persistence.
+- Create `app/api/admin/b2b/manual-intake/route.ts` for admin create/update.
+- Create `app/admin/b2b/manual-intake/page.tsx` for the admin workflow.
+- Create `app/api/admin/b2b/service-order-signoff/send/route.ts` for the signoff email.
+- Create `app/onboarding/service-order/[token]/page.tsx` and `app/api/onboarding/service-order/accept/route.ts` for customer acceptance.
+- Create `lib/onboarding/service-order-issuer.ts` to generate, upload, and email accepted PDFs.
+- Modify `lib/onboarding/onboarding-service.ts`, `lib/onboarding/service-order-terms.ts`, `lib/onboarding/billing-ready.ts`, `components/admin/onboarding/UploadDocumentModal.tsx`, `app/api/admin/b2b/upload-document/route.ts`, `app/api/admin/b2b/issue-service-order/route.ts`, `app/api/admin/b2b/onboarding-pipeline/route.ts`, `app/admin/unjani/onboarding/page.tsx`, `components/admin/layout/Sidebar.tsx`.
+
+## Global Constraints
+
+- Creating a new business customer must create a **pending, non-billable shell**. Never mark `customers.onboarding_status = 'billing_ready'` during manual intake.
+- New customer shell defaults: `customers.account_type = 'business'`, `customers.status = 'pending'`, `customers.account_status = 'pending'`, `customers.onboarding_status = 'in_progress'`.
+- If a service row is created during intake, it must default to `customer_services.status = 'pending'`, `active = false`, and no `activation_date`.
+- Billing-ready requires all four conditions: documents approved, Service Order accepted and final PDF issued, active service, and active debit-order payment method with `account_number` and `branch_code`.
+- Service Order signoff is customer-owned via secure link. Do not add admin attestation as a billing-ready substitute.
+- For Resend 6.1.1, PDF attachments use `attachments: [{ filename, content: Buffer, contentType: 'application/pdf' }]`.
+
+---
+
+### Task 1: Purpose-Scoped Onboarding Tokens
+
+**Files:**
+- Create: `supabase/migrations/20260630090000_onboarding_token_purpose.sql`
+- Modify: `lib/onboarding/onboarding-service.ts`
+- Test: `lib/onboarding/__tests__/onboarding-service-token-purpose.test.ts`
+
+- [ ] **Step 1: Add token-purpose migration**
+
+```sql
+ALTER TABLE onboarding_tokens
+  ADD COLUMN IF NOT EXISTS purpose text NOT NULL DEFAULT 'onboarding'
+    CHECK (purpose IN ('onboarding', 'service_order_signoff'));
+
+ALTER TABLE onboarding_tokens
+  ADD COLUMN IF NOT EXISTS onboarding_submission_id uuid REFERENCES onboarding_submissions(id);
+
+ALTER TABLE onboarding_tokens
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_tokens_purpose_submission
+  ON onboarding_tokens(purpose, onboarding_submission_id)
+  WHERE used_at IS NULL;
+```
+
+- [ ] **Step 2: Extend token issuing/resolution**
+
+Update `issueToken` in `lib/onboarding/onboarding-service.ts` to accept optional purpose metadata while preserving existing callers:
+
+```ts
+export type OnboardingTokenPurpose = 'onboarding' | 'service_order_signoff';
+
+export interface IssueTokenOptions {
+  purpose?: OnboardingTokenPurpose;
+  onboardingSubmissionId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export async function issueToken(
+  customerId: string,
+  sentVia: string,
+  options: IssueTokenOptions = {}
+): Promise<string> {
+  const supabase = svc();
+  const token = generateToken();
+  const { error } = await supabase.from('onboarding_tokens').insert({
+    customer_id: customerId,
+    token_hash: hashToken(token),
+    expires_at: tokenExpiry(),
+    sent_via: sentVia,
+    sent_at: new Date().toISOString(),
+    purpose: options.purpose ?? 'onboarding',
+    onboarding_submission_id: options.onboardingSubmissionId ?? null,
+    metadata: options.metadata ?? {},
+  });
+  if (error) throw new Error(`Failed to issue token: ${error.message}`);
+  return token;
+}
+```
+
+Add a resolver for signoff:
+
+```ts
+export async function resolveTokenForPurpose(
+  token: string,
+  purpose: OnboardingTokenPurpose
+): Promise<{ customerId: string; tokenId: string; onboardingSubmissionId: string | null } | null> {
+  const supabase = svc();
+  const { data, error } = await supabase
+    .from('onboarding_tokens')
+    .select('id, customer_id, expires_at, used_at, purpose, onboarding_submission_id')
+    .eq('token_hash', hashToken(token))
+    .maybeSingle();
+  if (error || !data) return null;
+  if (data.used_at) return null;
+  if (data.purpose !== purpose) return null;
+  if (new Date(data.expires_at).getTime() < Date.now()) return null;
+  return {
+    customerId: data.customer_id,
+    tokenId: data.id,
+    onboardingSubmissionId: data.onboarding_submission_id ?? null,
+  };
+}
+```
+
+- [ ] **Step 3: Test**
+
+Add tests that verify:
+
+```ts
+expect(await resolveTokenForPurpose(serviceOrderToken, 'service_order_signoff')).toMatchObject({
+  customerId: 'customer-1',
+  onboardingSubmissionId: 'submission-1',
+});
+expect(await resolveTokenForPurpose(serviceOrderToken, 'onboarding')).toBeNull();
+expect(await resolveTokenForPurpose(expiredToken, 'service_order_signoff')).toBeNull();
+expect(await resolveTokenForPurpose(usedToken, 'service_order_signoff')).toBeNull();
+```
+
+Run: `npx jest lib/onboarding/__tests__/onboarding-service-token-purpose.test.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260630090000_onboarding_token_purpose.sql lib/onboarding/onboarding-service.ts lib/onboarding/__tests__/onboarding-service-token-purpose.test.ts
+git commit -m "feat(onboarding): scope tokens for service order signoff"
+```
+
+---
+
+### Task 2: Manual Intake Domain Service
+
+**Files:**
+- Create: `lib/customers/account-number.ts`
+- Create: `lib/onboarding/manual-intake.ts`
+- Test: `lib/onboarding/__tests__/manual-intake.test.ts`
+
+- [ ] **Step 1: Extract account number generation**
+
+Create `lib/customers/account-number.ts` from the existing Unjani register-clinic logic:
+
+```ts
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const RESERVED_SUFFIX_FLOOR = 9000;
+
+export async function nextCustomerAccountNumber(supabase: SupabaseClient): Promise<string> {
+  const year = new Date().getFullYear();
+  const prefix = `CT-${year}-`;
+  const { data, error } = await supabase
+    .from('customers')
+    .select('account_number')
+    .like('account_number', `${prefix}%`);
+  if (error) throw new Error(`Failed to read account sequence: ${error.message}`);
+
+  let max = 0;
+  for (const row of data || []) {
+    const value = String(row.account_number || '');
+    const match = value.match(/^CT-\d{4}-(\d{5})$/);
+    if (!match) continue;
+    const n = parseInt(match[1], 10);
+    if (n >= RESERVED_SUFFIX_FLOOR) continue;
+    if (n > max) max = n;
+  }
+  return `${prefix}${String(max + 1).padStart(5, '0')}`;
+}
+```
+
+- [ ] **Step 2: Add manual-intake schema**
+
+Create `lib/onboarding/manual-intake.ts` with:
+
+```ts
+import { z } from 'zod';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { addBusinessDays, now } from '@/lib/dates';
+import { nextCustomerAccountNumber } from '@/lib/customers/account-number';
+import { step2Schema, step5Schema } from './schemas';
+
+export const manualIntakeSegmentSchema = z.enum(['unjani', 'smb', 'edu']);
+
+export const manualIntakeCustomerSchema = z.object({
+  businessName: z.string().min(2),
+  contactFirstName: z.string().min(1),
+  contactLastName: z.string().min(1),
+  email: z.string().email(),
+  phone: z.string().min(9),
+});
+
+export const manualIntakeSiteSchema = z.object({
+  siteName: z.string().min(2),
+  province: z.string().min(2),
+  siteAddress: z.string().min(5),
+  contactName: z.string().min(2),
+  lat: z.string().optional(),
+  lng: z.string().optional(),
+});
+
+export const manualIntakeBankingSchema = z.object({
+  accHolder: z.string().min(2),
+  bank: z.string().min(2),
+  accType: z.string().min(2),
+  accNumber: z.string().min(6),
+  branchCode: z.string().min(5),
+});
+
+export const manualIntakeServiceSchema = z.object({
+  serviceId: z.string().uuid().optional(),
+  packageId: z.string().uuid().optional(),
+  packageName: z.string().min(2).default('Business Connectivity'),
+  serviceType: z.string().min(2).default('business_connectivity'),
+  productCategory: z.string().min(2).default('business'),
+  monthlyPriceExVat: z.number().nonnegative(),
+  setupFee: z.number().nonnegative().default(0),
+  contractMonths: z.number().int().min(0).default(24),
+  billingDay: z.enum(['1', '15', '20', '25']),
+});
+
+export const manualIntakeSchema = z.object({
+  mode: z.enum(['existing_customer', 'new_customer']),
+  customerId: z.string().uuid().optional(),
+  segment: manualIntakeSegmentSchema.default('smb'),
+  customer: manualIntakeCustomerSchema.optional(),
+  site: manualIntakeSiteSchema,
+  business: step2Schema,
+  banking: manualIntakeBankingSchema,
+  service: manualIntakeServiceSchema.optional(),
+  step5: step5Schema.pick({ paymentDate: true }),
+}).superRefine((value, ctx) => {
+  if (value.mode === 'existing_customer' && !value.customerId) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['customerId'], message: 'Existing customer mode requires customerId' });
+  }
+  if (value.mode === 'new_customer' && !value.customer) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['customer'], message: 'New customer mode requires customer details' });
+  }
+});
+
+export type ManualIntakeInput = z.infer<typeof manualIntakeSchema>;
+```
+
+- [ ] **Step 3: Add persistence function**
+
+In the same file, add `saveManualIntake(supabase, input, adminEmail)`. Required behavior:
+
+- If `mode === 'new_customer'`, insert a pending business customer with a new account number.
+- If `service` is present for a new customer, insert a pending inactive `customer_services` row.
+- If `mode === 'existing_customer'`, update contact/business/site fields and optionally update the selected service billing day.
+- Upsert one debit-order `customer_payment_methods` row linked to the submission.
+- Create or update the latest `onboarding_submissions` row with `segment`, `status: 'submitted'`, `document_vetting_status: 'documents_pending'`, `submitted_at`, `vetting_due_date`, and `submission_data`.
+
+The stored `submission_data` shape must be:
+
+```ts
+{
+  manual: true,
+  source: 'admin_manual_intake',
+  uploaded_by: adminEmail,
+  step1: {
+    clinicName: input.site.siteName,
+    province: input.site.province,
+    contact: input.site.contactName,
+    phone: resolvedCustomer.phone,
+    email: resolvedCustomer.email,
+    siteAddress: input.site.siteAddress,
+    lat: input.site.lat,
+    lng: input.site.lng,
+  },
+  step2: input.business,
+  step3: {
+    accHolder: input.banking.accHolder,
+    bank: input.banking.bank,
+    accType: input.banking.accType,
+    accNumber: `****${input.banking.accNumber.slice(-4)}`,
+    branchCode: input.banking.branchCode,
+  },
+  step5: { paymentDate: input.step5.paymentDate },
+  manual_intake: {
+    captured_at: now().toISOString(),
+    captured_by: adminEmail,
+  },
+}
+```
+
+- [ ] **Step 4: Test**
+
+Write tests for:
+
+```ts
+expect(newCustomerInsert).toMatchObject({
+  account_type: 'business',
+  status: 'pending',
+  account_status: 'pending',
+  onboarding_status: 'in_progress',
+});
+expect(newServiceInsert).toMatchObject({ status: 'pending', active: false });
+expect(paymentMethodInsert).toMatchObject({
+  method_type: 'debit_order',
+  mandate_status: 'pending',
+  is_primary: true,
+  is_active: true,
+});
+expect(submissionUpsert.submission_data.manual).toBe(true);
+```
+
+Run: `npx jest lib/onboarding/__tests__/manual-intake.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/customers/account-number.ts lib/onboarding/manual-intake.ts lib/onboarding/__tests__/manual-intake.test.ts
+git commit -m "feat(onboarding): add admin manual intake persistence"
+```
+
+---
+
+### Task 3: Admin Manual Intake API
+
+**Files:**
+- Create: `app/api/admin/b2b/manual-intake/route.ts`
+- Test: `app/api/admin/b2b/__tests__/manual-intake.test.ts`
+
+- [ ] **Step 1: Add route**
+
+Create `POST /api/admin/b2b/manual-intake`:
+
+```ts
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin, requirePermission } from '@/lib/auth/admin-api-auth';
+import { svc } from '@/lib/onboarding/onboarding-service';
+import { manualIntakeSchema, saveManualIntake } from '@/lib/onboarding/manual-intake';
+import { apiLogger } from '@/lib/logging/logger';
+
+export async function POST(request: NextRequest) {
+  const auth = await authenticateAdmin(request);
+  if (!auth.success) return auth.response;
+  const perm = requirePermission(auth.adminUser, ['customers:write', 'kyc:verify']);
+  if (perm) return perm;
+
+  const body = await request.json().catch(() => null);
+  const parsed = manualIntakeSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: 'validation_failed', issues: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await saveManualIntake(svc(), parsed.data, auth.adminUser.email);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    apiLogger.error('[Manual Intake] save failed', { error, admin: auth.adminUser.email });
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Manual intake failed' },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Test**
+
+Test status codes:
+
+```ts
+expect(await postWithoutAdmin()).toHaveStatus(401);
+expect(await postWithoutPermission()).toHaveStatus(403);
+expect(await postInvalidPayload()).toHaveStatus(400);
+expect(await postValidNewCustomer()).toMatchObject({
+  success: true,
+  customerId: expect.any(String),
+  submissionId: expect.any(String),
+});
+```
+
+Run: `npx jest app/api/admin/b2b/__tests__/manual-intake.test.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/admin/b2b/manual-intake/route.ts app/api/admin/b2b/__tests__/manual-intake.test.ts
+git commit -m "feat(admin): add B2B manual intake API"
+```
+
+---
+
+### Task 4: Admin Manual Intake UI And Menu
+
+**Files:**
+- Create: `app/admin/b2b/manual-intake/page.tsx`
+- Modify: `components/admin/layout/Sidebar.tsx`
+
+- [ ] **Step 1: Add menu item**
+
+Under `B2B Customers` in `components/admin/layout/Sidebar.tsx`, add:
+
+```ts
+{ name: 'Manual Intake', href: '/admin/b2b/manual-intake', icon: PiClipboardTextBold },
+```
+
+Import `PiClipboardTextBold` from `react-icons/pi`.
+
+- [ ] **Step 2: Add page**
+
+Create a client page with:
+
+- Mode segmented control: `Create new business` and `Use existing customer`.
+- Segment select: `Unjani`, `SMB`, `Education`.
+- Existing customer search by account number/business name for existing mode.
+- New customer fields: business name, first name, last name, email, phone.
+- Site/contact fields: site name, province, contact name, site address, lat, lng.
+- Business fields matching `step2Schema`: entity name, entity type, reg number, VAT yes/no, VAT number, registered address.
+- Banking fields matching manual banking schema: account holder, bank, account type, account number, branch code.
+- Billing fields: payment date `1/15/20/25`, optional package/service details for new shell.
+- Submit button calls `POST /api/admin/b2b/manual-intake`.
+- Success state links to `/admin/b2b/vetting/[submissionId]` and opens document upload.
+
+- [ ] **Step 3: UI acceptance checks**
+
+Manual browser checks:
+
+- New customer mode refuses submit until business/contact/site/business/banking fields are valid.
+- Existing customer mode refuses submit without `customerId`.
+- Successful submit shows the created `accountNumber` and a link to the vetting submission.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/admin/b2b/manual-intake/page.tsx components/admin/layout/Sidebar.tsx
+git commit -m "feat(admin): add B2B manual intake workspace"
+```
+
+---
+
+### Task 5: Email Provenance For Manual Document Uploads
+
+**Files:**
+- Modify: `components/admin/onboarding/UploadDocumentModal.tsx`
+- Modify: `app/api/admin/b2b/upload-document/route.ts`
+
+- [ ] **Step 1: Extend upload modal**
+
+Add optional props:
+
+```ts
+showEmailProvenance?: boolean;
+defaultReceivedAt?: string;
+```
+
+When `showEmailProvenance` is true, render fields:
+
+- Received from email
+- Received at
+- Email subject
+- Email reference/note
+
+Append these to `FormData`:
+
+```ts
+fd.append('emailFrom', emailFrom.trim());
+fd.append('emailReceivedAt', emailReceivedAt);
+fd.append('emailSubject', emailSubject.trim());
+fd.append('emailReference', emailReference.trim());
+```
+
+- [ ] **Step 2: Extend upload route**
+
+In `app/api/admin/b2b/upload-document/route.ts`, read:
+
+```ts
+const segment = (form.get('segment') as string | null) || 'unjani';
+const emailFrom = (form.get('emailFrom') as string | null)?.trim() || null;
+const emailReceivedAt = (form.get('emailReceivedAt') as string | null)?.trim() || null;
+const emailSubject = (form.get('emailSubject') as string | null)?.trim() || null;
+const emailReference = (form.get('emailReference') as string | null)?.trim() || null;
+```
+
+Use `segment` when creating a shell instead of hardcoded `unjani`. Write metadata:
+
+```ts
+metadata: {
+  source: 'admin_email',
+  uploaded_by: adminEmail,
+  email_from: emailFrom,
+  email_received_at: emailReceivedAt,
+  email_subject: emailSubject,
+  email_reference: emailReference,
+}
+```
+
+- [ ] **Step 3: Wire manual intake page**
+
+On the manual intake page, call `UploadDocumentModal` with `showEmailProvenance` and pass the newly created `submissionId`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/admin/onboarding/UploadDocumentModal.tsx app/api/admin/b2b/upload-document/route.ts app/admin/b2b/manual-intake/page.tsx
+git commit -m "feat(onboarding): record email provenance for admin-uploaded documents"
+```
+
+---
+
+### Task 6: Customer-Owned Service Order Signoff
+
+**Files:**
+- Modify: `lib/onboarding/service-order-terms.ts`
+- Create: `app/api/admin/b2b/service-order-signoff/send/route.ts`
+- Create: `app/onboarding/service-order/[token]/page.tsx`
+- Create: `app/api/onboarding/service-order/accept/route.ts`
+- Create: `lib/onboarding/service-order-issuer.ts`
+- Modify: `app/api/admin/b2b/issue-service-order/route.ts`
+- Test: `lib/onboarding/__tests__/service-order-issuer.test.ts`
+
+- [ ] **Step 1: Make terms segment-aware**
+
+Add:
+
+```ts
+export type ServiceOrderSegment = 'unjani' | 'smb' | 'edu';
+
+export function getServiceOrderTermsContext(segment: ServiceOrderSegment | string) {
+  const isUnjani = segment === 'unjani';
+  return {
+    title: SERVICE_ORDER_TERMS_TITLE,
+    version: SERVICE_ORDER_TERMS_VERSION,
+    terms: SERVICE_ORDER_TERMS,
+    msaReference: isUnjani
+      ? SERVICE_ORDER_MSA_REFERENCE
+      : 'This Service Order is issued under CircleTel standard business service terms and the service-specific terms accepted in this workflow.',
+    msaReferenceUi: isUnjani
+      ? SERVICE_ORDER_MSA_REFERENCE_UI
+      : 'These terms apply to the business service described in this Service Order and are accepted electronically by the authorised customer representative.',
+  };
+}
+```
+
+Update current Unjani self-service acceptance hashing to use `getServiceOrderTermsContext('unjani')`, preserving the current hash inputs for Unjani.
+
+- [ ] **Step 2: Add signoff-send route**
+
+`POST /api/admin/b2b/service-order-signoff/send` must:
+
+- Require `customers:write` and `kyc:verify`.
+- Accept `{ customerId: string; submissionId?: string }`.
+- Load customer, latest submission, service, and `submission_data.step2/step3/step5`.
+- Refuse with 409 if business, banking, or payment date details are missing.
+- Issue token with `purpose: 'service_order_signoff'` and `onboardingSubmissionId`.
+- Email link `${NEXT_PUBLIC_APP_URL}/onboarding/service-order/${token}`.
+- Update `submission_data.service_order_signoff` with `sent_at`, `sent_by`, and `sent_to`.
+
+- [ ] **Step 3: Add customer signoff page**
+
+`app/onboarding/service-order/[token]/page.tsx` must:
+
+- Resolve token with `resolveTokenForPurpose(token, 'service_order_signoff')`.
+- Show read-only customer, site, business, service fee, billing day, masked bank details, and terms.
+- Show an acceptance checkbox: `I accept the CircleTel Service Order terms and confirm I am authorised to sign for this business.`
+- POST to `/api/onboarding/service-order/accept`.
+
+- [ ] **Step 4: Add accept route**
+
+`POST /api/onboarding/service-order/accept` must:
+
+- Accept `{ token: string; accepted: true }`.
+- Resolve service-order token and reject used/expired/wrong-purpose tokens.
+- Write `submission_data.acceptance` with `accepted_at`, `ip`, `user_agent`, `token_id`, `terms_version`, `terms_hash`, `terms_snapshot`, and `msa_reference`.
+- Mark token `used_at`.
+- Call `issueAcceptedServiceOrder(supabase, { customerId, submissionId })`.
+- Call `maybeMarkBillingReady(supabase, customerId)`.
+
+- [ ] **Step 5: Extract final PDF issuer**
+
+Create `lib/onboarding/service-order-issuer.ts` by moving the PDF/upload/email logic from `issue-service-order`.
+
+Use `generateServiceOrderBuffer` for the email attachment:
+
+```ts
+attachments: [
+  {
+    filename: `SO-${customer.account_number}.pdf`,
+    content: pdfBuffer,
+    contentType: 'application/pdf',
+  },
+],
+```
+
+The helper must update:
+
+```ts
+service_order_pdf_path: uploadResult.path,
+service_order_issued_at: new Date().toISOString(),
+submission_data: {
+  ...submissionData,
+  service_order_pdf_sha256: pdfSha256,
+}
+```
+
+- [ ] **Step 6: Guard old admin issue endpoint**
+
+Modify `POST /api/admin/b2b/issue-service-order` so it:
+
+- Loads latest submission.
+- Returns 409 with message `Service Order must be accepted by the customer before final PDF issue.` when `submission_data.acceptance.accepted_at` is missing.
+- Calls `issueAcceptedServiceOrder` when accepted.
+
+- [ ] **Step 7: Test**
+
+Test:
+
+```ts
+expect(signoffTokenForWrongPurpose).toReturnStatus(401);
+expect(acceptanceWrite.submission_data.acceptance.accepted_at).toEqual(expect.any(String));
+expect(emailPayload.attachments[0]).toMatchObject({
+  filename: expect.stringContaining('SO-'),
+  contentType: 'application/pdf',
+});
+expect(adminIssueWithoutAcceptance).toReturnStatus(409);
+```
+
+Run: `npx jest lib/onboarding/__tests__/service-order-issuer.test.ts`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/onboarding/service-order-terms.ts app/api/admin/b2b/service-order-signoff/send/route.ts app/onboarding/service-order/[token]/page.tsx app/api/onboarding/service-order/accept/route.ts lib/onboarding/service-order-issuer.ts app/api/admin/b2b/issue-service-order/route.ts lib/onboarding/__tests__/service-order-issuer.test.ts
+git commit -m "feat(onboarding): add customer service order signoff flow"
+```
+
+---
+
+### Task 7: Billing-Ready Gate Update
+
+**Files:**
+- Modify: `lib/onboarding/billing-ready.ts`
+- Modify: `lib/onboarding/__tests__/billing-ready.test.ts`
+- Modify: `app/api/admin/kyc/verify/route.ts`
+
+- [ ] **Step 1: Require Service Order acceptance and issued PDF**
+
+Update the submission select:
+
+```ts
+.select('id, document_vetting_status, submission_data, service_order_issued_at, service_order_pdf_path')
+```
+
+Add:
+
+```ts
+const acceptance = (submission.submission_data as any)?.acceptance;
+if (!acceptance?.accepted_at) return false;
+if (!submission.service_order_issued_at || !submission.service_order_pdf_path) return false;
+```
+
+- [ ] **Step 2: Keep document approval behavior**
+
+Leave `app/api/admin/kyc/verify/route.ts` calling `maybeMarkBillingReady` after vetting rollup. With the new gate, docs approved before Service Order acceptance will not mark billing-ready; the accept route will call the same gate after final PDF issuance.
+
+- [ ] **Step 3: Test**
+
+Extend tests:
+
+```ts
+expect(await gate({ docs: 'approved', service: 'active', bank: true, acceptance: false })).toBe(false);
+expect(await gate({ docs: 'approved', service: 'active', bank: true, acceptance: true, pdfIssued: false })).toBe(false);
+expect(await gate({ docs: 'approved', service: 'active', bank: true, acceptance: true, pdfIssued: true })).toBe(true);
+```
+
+Run: `npx jest lib/onboarding/__tests__/billing-ready.test.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/onboarding/billing-ready.ts lib/onboarding/__tests__/billing-ready.test.ts app/api/admin/kyc/verify/route.ts
+git commit -m "fix(onboarding): require service order acceptance before billing ready"
+```
+
+---
+
+### Task 8: Pipeline Actions And Status Visibility
+
+**Files:**
+- Modify: `app/api/admin/b2b/onboarding-pipeline/route.ts`
+- Modify: `app/admin/unjani/onboarding/page.tsx`
+- Modify: `app/admin/b2b/vetting/[submissionId]/page.tsx`
+
+- [ ] **Step 1: Return Service Order state in pipeline API**
+
+Add to each pipeline row:
+
+```ts
+service_order_accepted_at: submission?.submission_data?.acceptance?.accepted_at || null,
+service_order_pdf_path: submission?.service_order_pdf_path || null,
+```
+
+Extend `PipelineClinic` in the UI with these fields.
+
+- [ ] **Step 2: Update next action logic**
+
+In `/admin/unjani/onboarding`:
+
+- For `docs_approved` with no `service_order_accepted_at`, next action is `Send Service Order signoff`.
+- For accepted but no PDF path, next action is `Issue accepted Service Order`.
+- For accepted + PDF path + billing-ready, show `Handed over`.
+
+- [ ] **Step 3: Add vetting detail action**
+
+On `/admin/b2b/vetting/[submissionId]`, add an inspector action after all required docs are approved:
+
+- `Send Service Order signoff`
+- calls `POST /api/admin/b2b/service-order-signoff/send`
+- disabled until `document_vetting_status === 'approved'`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/api/admin/b2b/onboarding-pipeline/route.ts app/admin/unjani/onboarding/page.tsx app/admin/b2b/vetting/[submissionId]/page.tsx
+git commit -m "feat(admin): surface service order signoff in B2B pipeline"
+```
+
+---
+
+### Task 9: Verification, Docs, And Rollout
+
+**Files:**
+- Modify: `docs/onboarding/UNJANI_ONBOARDING_SALES_ADMIN_GUIDE.md`
+- Optionally create: `docs/features/2026-06-30_admin-assisted-b2b-onboarding/README.md`
+
+- [ ] **Step 1: Run targeted tests**
+
+```bash
+npx jest lib/onboarding/__tests__/manual-intake.test.ts
+npx jest lib/onboarding/__tests__/billing-ready.test.ts
+npx jest lib/onboarding/__tests__/service-order-issuer.test.ts
+npx jest app/api/admin/b2b/__tests__/manual-intake.test.ts
+```
+
+- [ ] **Step 2: Run type check**
+
+```bash
+npm run type-check:memory
+```
+
+Expected: no new TypeScript errors in touched files. If the repo still has unrelated pre-existing errors, document the first unrelated file and run a filtered `tsc`/test pass for the touched files.
+
+- [ ] **Step 3: Browser verification**
+
+Run the dev server:
+
+```bash
+npm run dev:memory
+```
+
+Manually verify:
+
+- `/admin/b2b/manual-intake` creates a new pending business customer.
+- The created customer is not billable before gates pass.
+- Admin uploads an emailed document with provenance.
+- Vetting approves documents.
+- Admin sends Service Order signoff.
+- Customer accepts via `/onboarding/service-order/[token]`.
+- Final PDF is stored and emailed with an attachment.
+- Customer becomes `billing_ready` only after service is active and bank details exist.
+
+- [ ] **Step 4: Update docs**
+
+Document the admin process:
+
+1. Create/select customer.
+2. Capture business/site/banking details.
+3. Upload emailed documents.
+4. Vet documents.
+5. Send Service Order signoff.
+6. Confirm billing-ready only after service activation and acceptance.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add docs/onboarding/UNJANI_ONBOARDING_SALES_ADMIN_GUIDE.md docs/features/2026-06-30_admin-assisted-b2b-onboarding/README.md
+git commit -m "docs(onboarding): document admin-assisted B2B intake"
+```
+
+## Self-Review
+
+- Spec coverage: new business customer creation, existing customer support, emailed document upload, manual business/banking capture, customer-owned Service Order signoff, final PDF issue, debit-order billing-ready gate, and admin menu placement are all mapped to tasks.
+- Placeholder scan: no task relies on unspecified tables or invented routes; all new paths are named.
+- Type consistency: `segment`, `submission_data.step1/step2/step3/step5`, `onboarding_submission_id`, `service_order_pdf_path`, `service_order_issued_at`, and token `purpose` are used consistently across tasks.

--- a/docs/superpowers/specs/2026-06-28-offer-storefront-read-design.md
+++ b/docs/superpowers/specs/2026-06-28-offer-storefront-read-design.md
@@ -1,0 +1,234 @@
+# Plan 2 — Offer Storefront Read (`/offers`) — Design
+
+**Date:** 2026-06-28
+**Status:** Approved (design) — pending implementation plan
+**Depends on:** Offer Spine Phase 0 (PR #578 + #585, merged + live-verified)
+**Blueprint:** `docs/superpowers/specs/2026-06-27-commerce-product-platform-blueprint-design.md` (Domain 4 — Storefront & Commerce; Phase 1 "ship this week" play)
+
+---
+
+## 1. Goal
+
+Ship the public, browseable, data-driven catalogue that the Offer Spine makes possible — a
+**snapshot-fed pricing surface with structured data (JSON-LD)**. The blueprint names this the
+"#1 ship-this-week play": Vox is the only SA competitor exposing pricing publicly (via JSON-LD),
+and CircleTel has priced products with no public way to browse them.
+
+This plan is **read-only**. It adds no write paths, no cart, and no checkout. It reads the
+pre-computed `offer_pricing_snapshot` rows produced by Phase 0 and renders them.
+
+### Success criteria
+- `/offers` renders every active offer that has a pricing snapshot, split into consumer/business tabs.
+- `/offers/[slug]` renders a per-offer detail page with `Product`/`Offer` JSON-LD.
+- The public API and pages **never expose cost, margin, or source provenance**.
+- Pages serve fast (ISR, snapshot-backed) and never block on staleness.
+- Tests prove the no-cost-leakage guarantee.
+
+---
+
+## 2. Existing surfaces (why a new route)
+
+| Surface | What it is today | Why not reuse |
+|---|---|---|
+| `app/pricing` | Fully **hardcoded** static marketing page ("Basic IT — From R2,500"); framed as IT services | Not data-driven; content mismatch (IT services, not connectivity) |
+| `app/packages` | 432-line **coverage-gated** Supabase read; requires a `planId`/lead, redirects otherwise | Post-coverage funnel, not a browseable catalogue |
+| `app/products` | CMS-style product **marketing** pages | Editorial content, not a priced catalogue |
+
+There is **no public, browseable, data-driven catalogue** today. `/offers` fills that gap with
+zero blast radius on the above. (A future fold-in of `/offers` content into `/pricing` is possible
+once proven, but is out of scope here.)
+
+---
+
+## 3. Architecture & data flow
+
+```
+offers + offer_pricing_snapshot ──► public read layer ──► GET /api/offers, /api/offers/[slug]
+   (service-role, RLS)              (sanitizes fields)         │
+                                                               ▼
+                                          /offers (list, consumer/business tabs)
+                                          /offers/[slug] (detail + JSON-LD)
+                                                               │ CTA
+                                                               ▼
+                                          existing coverage funnel / contact
+```
+
+An offer appears publicly **only if** it has a snapshot row (i.e. a resolved price exists). The
+public surface reads snapshots — never resolves pricing per request.
+
+---
+
+## 4. Public read layer — `lib/offers/public-read.ts` (security-critical)
+
+A single, dedicated read module so internal cost data can never leak. The API routes use **only**
+this module; they never query `offers`/`offer_pricing_snapshot` directly.
+
+### Field policy
+
+| Field | Source | Public? |
+|---|---|---|
+| `slug` | offers | ✅ exposed |
+| `title` | offers | ✅ exposed |
+| `media` | offers | ✅ exposed (jsonb; see note below) |
+| `customer_type` | offers | ✅ exposed (drives tabs) |
+| `price` | snapshot `resolved_price` | ✅ exposed |
+
+> **Schema note — no `description` column.** The Phase 0 `offers` table has `title` and a `media jsonb`
+> blob, but **no `description` column**, and the Phase 0 publisher does not yet populate `media`
+> (it defaults to `{}`). So "blurb"/"image" are read **from `media`** when present
+> (`media.description`, `media.image`) and **gracefully omitted** when absent. The page degrades to
+> **title + price** until a future publisher enrichment fills `media`. Plan 2 adds **no column and no
+> migration** for this — enrichment is out of scope.
+| `cost_buildup`, `total_cost`, `margin_pct`, `guardrail_status` | snapshot | ❌ **NEVER** |
+| `source_uid` | offers | ❌ never (provenance) |
+| component `unit_cost`, `unit_price`, `source_id` | offer_components | ❌ never |
+
+### Behaviour
+- Filter: `status = 'active' AND lifecycle_state = 'active'`, and a snapshot row must exist
+  (inner join on `offer_pricing_snapshot`).
+- Segment filter: `consumer` → `customer_type IN ('consumer','both')`; `business` →
+  `customer_type IN ('business','both')`; `all` → no filter.
+- Reads via the **service-role server client** (`@/lib/supabase/server`). The Phase 0 tables have
+  **no anon RLS policy** by design, so this module only ever runs server-side. It must never be
+  imported into a client component.
+
+### Public types
+A `PublicOffer` type (list shape) and `PublicOfferDetail` (detail shape) defined in
+`lib/types/offer.ts` (or a sibling `public-offer.ts`), containing only the exposed fields above.
+Mapping from DB row → public type is the sanitization boundary.
+
+---
+
+## 5. API endpoints
+
+Both are Next.js 15 App Router routes with async params where applicable.
+
+- `GET /api/offers?segment=consumer|business|all`
+  → `{ offers: PublicOffer[] }`. Default `segment=all`. Invalid segment → 400.
+- `GET /api/offers/[slug]`
+  → `{ offer: PublicOfferDetail }` or 404 if missing/inactive/no-snapshot.
+  ```ts
+  export async function GET(
+    request: NextRequest,
+    context: { params: Promise<{ slug: string }> }
+  ) {
+    const { slug } = await context.params
+    // ...read via public-read layer
+  }
+  ```
+
+Both routes are public (no auth) and read-only.
+
+---
+
+## 6. Pages
+
+### `/offers` (list)
+- Server component. Reads via `public-read` (not the API — direct module call server-side).
+- Consumer/business tabs driven by `?segment=`. When the URL has no `segment`, the **page** selects
+  the `consumer` tab (B2C front door) and reads with `segment=consumer` — this UI default is distinct
+  from the **API's** neutral `all` default (§5). `both` offers appear in both tabs.
+- Responsive card grid: title, price (`R{price}`), short blurb (from `media.description` when
+  present, else omitted), CTA.
+- Uses existing `Navbar` + `Footer` and CircleTel design tokens (`circleTel-navy`, `circleTel-orange`).
+- `ItemList` JSON-LD for the visible offers.
+
+### `/offers/[slug]` (detail)
+- Server component. `generateStaticParams` from active+snapshotted offers.
+- Renders title, price, CTA, plus blurb/image from `media` when present.
+- `Product` + `Offer` JSON-LD (see §7).
+- 404 via `notFound()` when the slug is missing/inactive.
+
+### CTA behaviour (interim, pre–Plan 3)
+- Primary CTA routes into the **existing coverage funnel** ("Check availability" / "Get started").
+- Hardware / non-coverage offers route to contact/quote.
+- No "Add to cart" yet — that CTA swap is Plan 3. No disabled/placeholder buttons.
+
+---
+
+## 7. JSON-LD (structured data — the SEO play)
+
+- **List page** (`/offers`): `ItemList` whose items reference each offer's detail URL.
+- **Detail page** (`/offers/[slug]`): schema.org `Product` with an `offers` `Offer`:
+  ```json
+  {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    "name": "<title>",
+    "image": "<media.image, omitted if absent>",
+    "description": "<media.description, omitted if absent>",
+    "offers": {
+      "@type": "Offer",
+      "price": "<resolved_price>",
+      "priceCurrency": "ZAR",
+      "availability": "https://schema.org/InStock",
+      "url": "https://www.circletel.co.za/offers/<slug>"
+    }
+  }
+  ```
+- Emitted as a `<script type="application/ld+json">` block. No cost/margin fields ever appear.
+
+---
+
+## 8. Render & caching
+
+- ISR: `export const revalidate = 300` (5 minutes) on both pages.
+- Pages serve static-fast from the latest snapshot; revalidation picks up republished prices.
+- **Serves last-good always** — the public surface never blocks on snapshot staleness. Staleness is
+  an **admin-only** signal (per the blueprint); the public page shows the last computed price
+  regardless.
+
+---
+
+## 9. Bundled fix — staleness guard (from the deferred ledger)
+
+Phase 0 left a known gap: `recompute-offer-pricing` `loadDraft` sets `sourceUpdatedAt` from the
+offer's own `updated_at` (always ≥ `computed_at`), so the `isSnapshotStale` guard never fires.
+
+Fix in this plan: compare against the **source product's** `updated_at` (from the unified
+aggregator / source table) rather than the offer's own. This makes the admin "stale — recompute"
+signal correct. Scoped and small; included here because this plan owns the snapshot read path.
+
+> If, during implementation, sourcing the source product's timestamp proves to require new
+> aggregator plumbing beyond a few lines, this fix is split into its own follow-up rather than
+> bloating Plan 2. The public read surface does not depend on it.
+
+---
+
+## 10. Testing (TDD)
+
+- `public-read` unit tests:
+  - **Asserts cost/margin/provenance fields are absent** from the returned objects (the security guarantee).
+  - Segment filtering (`consumer`/`business`/`all`, `both` membership).
+  - Active-only + snapshot-required filtering.
+- API route tests: response shape, `404` for unknown slug, `400` for invalid segment.
+- Live verify script (`scripts/offers/verify-storefront.ts`): hit `GET /api/offers` and
+  `GET /api/offers/[slug]` against the real published offer; assert price present and **no cost
+  leakage** in the JSON.
+
+---
+
+## 11. Out of scope (→ Plan 3)
+
+- Cart, `cart_items`, `order_line_items`, status rollup.
+- Checkout / NetCash cart total.
+- `consumer_orders` channel + attribution.
+- "Add to cart" CTA swap.
+- Auth-after-cart flow (see `docs/superpowers/specs/2026-06-28-phase2-auth-after-cart-design.md`).
+
+---
+
+## 12. New / changed files (anticipated)
+
+| File | Change |
+|---|---|
+| `lib/offers/public-read.ts` | NEW — sanitized read layer |
+| `lib/types/offer.ts` (or `public-offer.ts`) | NEW types `PublicOffer`, `PublicOfferDetail` |
+| `app/api/offers/route.ts` | NEW — list endpoint |
+| `app/api/offers/[slug]/route.ts` | NEW — detail endpoint |
+| `app/offers/page.tsx` | NEW — list page + tabs + ItemList JSON-LD |
+| `app/offers/[slug]/page.tsx` | NEW — detail page + Product/Offer JSON-LD |
+| `lib/inngest/functions/recompute-offer-pricing.ts` | EDIT — staleness source timestamp fix (§9) |
+| `__tests__/lib/offers/public-read.test.ts` | NEW — sanitization + filtering tests |
+| `__tests__/app/api/offers/*` | NEW — route tests |
+| `scripts/offers/verify-storefront.ts` | NEW — live verification |

--- a/docs/superpowers/specs/2026-06-28-offer-storefront-read-design.md
+++ b/docs/superpowers/specs/2026-06-28-offer-storefront-read-design.md
@@ -4,6 +4,7 @@
 **Status:** Approved (design) — pending implementation plan
 **Depends on:** Offer Spine Phase 0 (PR #578 + #585, merged + live-verified)
 **Blueprint:** `docs/superpowers/specs/2026-06-27-commerce-product-platform-blueprint-design.md` (Domain 4 — Storefront & Commerce; Phase 1 "ship this week" play)
+**Review:** incorporates document-review P0/P1/P2 (2026-06-28) — VAT price contract, media whitelist, ISR/segment resolution, server-only, leakage tests, concrete CTA URLs; staleness fix de-scoped (see §9).
 
 ---
 
@@ -18,11 +19,12 @@ This plan is **read-only**. It adds no write paths, no cart, and no checkout. It
 pre-computed `offer_pricing_snapshot` rows produced by Phase 0 and renders them.
 
 ### Success criteria
-- `/offers` renders every active offer that has a pricing snapshot, split into consumer/business tabs.
+- `/offers` renders every active offer that has a pricing snapshot, with consumer/business tabs.
 - `/offers/[slug]` renders a per-offer detail page with `Product`/`Offer` JSON-LD.
+- **All public prices are VAT-inclusive and labelled** (§4.1) — no ex-VAT price is ever displayed.
 - The public API and pages **never expose cost, margin, or source provenance**.
-- Pages serve fast (ISR, snapshot-backed) and never block on staleness.
-- Tests prove the no-cost-leakage guarantee.
+- Pages serve fast (static + ISR, snapshot-backed) and never block on staleness.
+- Tests prove both the **no-cost-leakage** and **VAT-inclusive** guarantees, including in rendered HTML/JSON-LD.
 
 ---
 
@@ -44,9 +46,9 @@ once proven, but is out of scope here.)
 
 ```
 offers + offer_pricing_snapshot ──► public read layer ──► GET /api/offers, /api/offers/[slug]
-   (service-role, RLS)              (sanitizes fields)         │
+   (service-role, RLS)              (sanitize + add VAT)       │
                                                                ▼
-                                          /offers (list, consumer/business tabs)
+                                          /offers (static list, client tabs)
                                           /offers/[slug] (detail + JSON-LD)
                                                                │ CTA
                                                                ▼
@@ -60,53 +62,91 @@ public surface reads snapshots — never resolves pricing per request.
 
 ## 4. Public read layer — `lib/offers/public-read.ts` (security-critical)
 
-A single, dedicated read module so internal cost data can never leak. The API routes use **only**
-this module; they never query `offers`/`offer_pricing_snapshot` directly.
+A single, dedicated read module so internal cost data can never leak. The API routes and the pages
+use **only** this module; they never query `offers`/`offer_pricing_snapshot` directly.
 
-### Field policy
+**First line of the file:** `import 'server-only'` — mechanically prevents this module (and the
+service-role client + cost data) from ever being bundled into a client component. Build fails if a
+client component imports it.
+
+### 4.1 Price contract (VAT) — P0
+
+`offer_pricing_snapshot.resolved_price` is stored **EX-VAT**. This is the established
+`service_packages` convention (`app/packages/page.tsx`: *"service_packages stores prices ex-VAT —
+multiply by 1.15 for display"*), and the Phase 0 resolver sets `resolvedPrice = basePrice` directly
+from the source, carrying that ex-VAT basis through unchanged.
+
+**The public surface must never display an ex-VAT price.** The read layer computes and exposes:
+
+| Public field | Definition |
+|---|---|
+| `priceInclVat` | `round(resolved_price * (1 + VAT_RATE) * 100) / 100` — **the only price shown in UI and JSON-LD** |
+| `priceExclVat` | `resolved_price` (provided for completeness; UI shows incl-VAT) |
+| `vatRate` | `0.15` |
+| `vatLabel` | `"incl. VAT"` (rendered next to every price) |
+
+`VAT_RATE` comes from a new shared constant `lib/billing/vat.ts` (`export const VAT_RATE = 0.15`
++ `addVat(excl: number): number`). There is currently **no** shared VAT constant — `0.15` is
+duplicated across `lib/invoices/*`, `lib/contracts/*`, `lib/integrations/zoho/*`. This plan adds the
+single shared helper and uses it; it does **not** refactor those existing call sites (out of scope).
+
+#### Mixed-VAT precondition guard (P0)
+The spine has **no per-source VAT-basis flag**. Only `service_packages` (uniformly ex-VAT) are
+published as offers today, so grossing every `resolved_price` up by 15% is correct **now**. But
+MTN/hardware/supplier sources may normalize to **incl-VAT**, which would be **double-taxed** if
+published and grossed again.
+
+Therefore Plan 2 enforces an explicit invariant: **only ex-VAT-basis sources may be exposed
+publicly.** The read layer filters to offers whose primary component `source_type = 'service_package'`
+(the only proven ex-VAT source) and **logs + excludes** any active+snapshotted offer from another
+source type, rather than guessing its VAT basis. A test asserts a non-`service_package` offer is
+excluded. When future sources are published, a per-source VAT-basis flag must be added to the spine
+**before** they appear here — captured as an explicit out-of-scope item (§11).
+
+### 4.2 Field policy
 
 | Field | Source | Public? |
 |---|---|---|
 | `slug` | offers | ✅ exposed |
 | `title` | offers | ✅ exposed |
-| `media` | offers | ✅ exposed (jsonb; see note below) |
+| `description` | `media.description` (string) only | ✅ exposed when present, else omitted |
+| `image` | `media.image` (string) only | ✅ exposed when present, else omitted |
 | `customer_type` | offers | ✅ exposed (drives tabs) |
-| `price` | snapshot `resolved_price` | ✅ exposed |
-
-> **Schema note — no `description` column.** The Phase 0 `offers` table has `title` and a `media jsonb`
-> blob, but **no `description` column**, and the Phase 0 publisher does not yet populate `media`
-> (it defaults to `{}`). So "blurb"/"image" are read **from `media`** when present
-> (`media.description`, `media.image`) and **gracefully omitted** when absent. The page degrades to
-> **title + price** until a future publisher enrichment fills `media`. Plan 2 adds **no column and no
-> migration** for this — enrichment is out of scope.
+| `priceInclVat`, `priceExclVat`, `vatRate`, `vatLabel` | derived (§4.1) | ✅ exposed |
+| **raw `media` blob** | offers | ❌ **never exposed whole** — only the two whitelisted keys above are read |
+| `resolved_price` (raw, unlabelled) | snapshot | ❌ never exposed raw (only via `priceInclVat`/`priceExclVat`) |
 | `cost_buildup`, `total_cost`, `margin_pct`, `guardrail_status` | snapshot | ❌ **NEVER** |
-| `source_uid` | offers | ❌ never (provenance) |
-| component `unit_cost`, `unit_price`, `source_id` | offer_components | ❌ never |
+| `source_uid`, `source_type`, `source_id` | offers / components | ❌ never (provenance) |
+| component `unit_cost`, `unit_price` | offer_components | ❌ never |
 
-### Behaviour
-- Filter: `status = 'active' AND lifecycle_state = 'active'`, and a snapshot row must exist
-  (inner join on `offer_pricing_snapshot`).
-- Segment filter: `consumer` → `customer_type IN ('consumer','both')`; `business` →
-  `customer_type IN ('business','both')`; `all` → no filter.
+> The `media` blob is **whitelisted, not passed through**: the mapper reads only
+> `media.description` and `media.image` (and only if they are strings). Any other key — present or
+> future — is dropped. A test asserts unknown `media` keys never reach the output.
+
+### 4.3 Behaviour
+- Filter: `status = 'active' AND lifecycle_state = 'active'`, a snapshot row must exist (inner join
+  on `offer_pricing_snapshot`), and the VAT-basis guard (§4.1) excludes non-`service_package` sources.
+- Segment filter (used by the API; the page filters client-side, §6): `consumer` →
+  `customer_type IN ('consumer','both')`; `business` → `customer_type IN ('business','both')`;
+  `all` → no filter.
 - Reads via the **service-role server client** (`@/lib/supabase/server`). The Phase 0 tables have
-  **no anon RLS policy** by design, so this module only ever runs server-side. It must never be
-  imported into a client component.
+  **no anon RLS policy** by design; `server-only` enforces server-side execution.
 
-### Public types
-A `PublicOffer` type (list shape) and `PublicOfferDetail` (detail shape) defined in
-`lib/types/offer.ts` (or a sibling `public-offer.ts`), containing only the exposed fields above.
-Mapping from DB row → public type is the sanitization boundary.
+### 4.4 Public types
+`PublicOffer` (list shape) and `PublicOfferDetail` (detail shape) in `lib/types/offer.ts`,
+containing only the exposed fields above. The DB-row → public-type mapper is the single
+sanitization + VAT boundary.
 
 ---
 
 ## 5. API endpoints
 
-Both are Next.js 15 App Router routes with async params where applicable.
+App Router route handlers (not bound by the page-ISR concern in §8). Async params where applicable.
 
 - `GET /api/offers?segment=consumer|business|all`
   → `{ offers: PublicOffer[] }`. Default `segment=all`. Invalid segment → 400.
 - `GET /api/offers/[slug]`
-  → `{ offer: PublicOfferDetail }` or 404 if missing/inactive/no-snapshot.
+  → `{ offer: PublicOfferDetail }` or 404 if missing/inactive/no-snapshot/non-ex-VAT-source.
   ```ts
   export async function GET(
     request: NextRequest,
@@ -123,33 +163,41 @@ Both routes are public (no auth) and read-only.
 
 ## 6. Pages
 
-### `/offers` (list)
-- Server component. Reads via `public-read` (not the API — direct module call server-side).
-- Consumer/business tabs driven by `?segment=`. When the URL has no `segment`, the **page** selects
-  the `consumer` tab (B2C front door) and reads with `segment=consumer` — this UI default is distinct
-  from the **API's** neutral `all` default (§5). `both` offers appear in both tabs.
-- Responsive card grid: title, price (`R{price}`), short blurb (from `media.description` when
-  present, else omitted), CTA.
+### `/offers` (list) — static + client-side tabs (P1)
+- **Static** server component (no `searchParams`, preserving ISR — §8). It reads **all** active,
+  snapshotted, ex-VAT offers via `public-read` server-side at build/revalidate.
+- It passes that single dataset to a small **client** tab component that filters by `customer_type`
+  in the browser (consumer default tab; `both` offers appear in both). No server round-trip per tab,
+  so the page stays static — this is what resolves the searchParams-vs-ISR conflict.
+- Responsive card grid: title, `R{priceInclVat}` + `vatLabel`, optional blurb (`description`), CTA.
 - Uses existing `Navbar` + `Footer` and CircleTel design tokens (`circleTel-navy`, `circleTel-orange`).
-- `ItemList` JSON-LD for the visible offers.
+- `ItemList` JSON-LD covering all offers (built server-side, VAT-inclusive prices).
 
 ### `/offers/[slug]` (detail)
-- Server component. `generateStaticParams` from active+snapshotted offers.
-- Renders title, price, CTA, plus blurb/image from `media` when present.
-- `Product` + `Offer` JSON-LD (see §7).
-- 404 via `notFound()` when the slug is missing/inactive.
+- Server component. `generateStaticParams` from active+snapshotted ex-VAT offers.
+- Renders title, `R{priceInclVat}` + `vatLabel`, CTA, plus blurb/image from whitelisted `media` when present.
+- `Product` + `Offer` JSON-LD (§7).
+- 404 via `notFound()` when the slug is missing/inactive/excluded.
 
-### CTA behaviour (interim, pre–Plan 3)
-- Primary CTA routes into the **existing coverage funnel** ("Check availability" / "Get started").
-- Hardware / non-coverage offers route to contact/quote.
+### CTA behaviour (interim, pre–Plan 3) — concrete URLs (P2)
+Offer intent/attribution is carried on the query string so it survives the hop:
+- **Connectivity offers** (primary component `service_package`): CTA "Check availability" →
+  **`/coverage-check?offer=<slug>`**. (`app/coverage-check` is the existing standalone entry; the
+  `offer` param is read for attribution and to pre-select intent.)
+- **Hardware / non-coverage offers**: CTA "Request a quote" → **`/contact?subject=<title>&offer=<slug>`**.
 - No "Add to cart" yet — that CTA swap is Plan 3. No disabled/placeholder buttons.
+
+> Note: in Plan 2 only `service_package` offers are exposed (§4.1 guard), so the connectivity CTA is
+> the live path; the hardware branch is specified now so the component is complete when hardware
+> offers become eligible.
 
 ---
 
 ## 7. JSON-LD (structured data — the SEO play)
 
 - **List page** (`/offers`): `ItemList` whose items reference each offer's detail URL.
-- **Detail page** (`/offers/[slug]`): schema.org `Product` with an `offers` `Offer`:
+- **Detail page** (`/offers/[slug]`): schema.org `Product` with an `offers` `Offer`. **Price is
+  VAT-inclusive** (`priceInclVat`):
   ```json
   {
     "@context": "https://schema.org",
@@ -159,62 +207,78 @@ Both routes are public (no auth) and read-only.
     "description": "<media.description, omitted if absent>",
     "offers": {
       "@type": "Offer",
-      "price": "<resolved_price>",
+      "price": "<priceInclVat>",
       "priceCurrency": "ZAR",
       "availability": "https://schema.org/InStock",
       "url": "https://www.circletel.co.za/offers/<slug>"
     }
   }
   ```
-- Emitted as a `<script type="application/ld+json">` block. No cost/margin fields ever appear.
+- Emitted as a `<script type="application/ld+json">` block. No cost/margin/provenance fields ever
+  appear, and no ex-VAT price ever appears.
 
 ---
 
 ## 8. Render & caching
 
-- ISR: `export const revalidate = 300` (5 minutes) on both pages.
+- Both pages are **statically rendered with ISR**: `export const revalidate = 300` (5 minutes).
+- The list page takes **no `searchParams`** (tabs are client-side, §6), so it is not forced into
+  dynamic rendering — the ISR/static promise holds. (Per Next.js docs, reading `searchParams` opts a
+  page into dynamic rendering; we avoid it deliberately.)
 - Pages serve static-fast from the latest snapshot; revalidation picks up republished prices.
 - **Serves last-good always** — the public surface never blocks on snapshot staleness. Staleness is
-  an **admin-only** signal (per the blueprint); the public page shows the last computed price
-  regardless.
+  an admin concern, not surfaced here (§9).
 
 ---
 
-## 9. Bundled fix — staleness guard (from the deferred ledger)
+## 9. Staleness guard — explicitly NOT in Plan 2 (de-scoped per review)
 
-Phase 0 left a known gap: `recompute-offer-pricing` `loadDraft` sets `sourceUpdatedAt` from the
-offer's own `updated_at` (always ≥ `computed_at`), so the `isSnapshotStale` guard never fires.
+Phase 0 left `recompute-offer-pricing.loadDraft` setting `sourceUpdatedAt` from the offer's own
+`updated_at`, so `isSnapshotStale` never fires. The review correctly notes that **`isSnapshotStale`
+is currently dead code with no calling path** — fixing `loadDraft` alone produces no working signal,
+because nothing consumes it.
 
-Fix in this plan: compare against the **source product's** `updated_at` (from the unified
-aggregator / source table) rather than the offer's own. This makes the admin "stale — recompute"
-signal correct. Scoped and small; included here because this plan owns the snapshot read path.
-
-> If, during implementation, sourcing the source product's timestamp proves to require new
-> aggregator plumbing beyond a few lines, this fix is split into its own follow-up rather than
-> bloating Plan 2. The public read surface does not depend on it.
+A correct admin "stale — recompute" signal requires (a) sourcing the source product's real
+`updated_at`, **and** (b) an admin read/display path that calls `isSnapshotStale` and shows it.
+That is its own small feature, not a line-fix, and it has **no bearing on the public read surface**
+(which serves last-good regardless). It is therefore **removed from Plan 2** and remains a separate
+deferred item with this corrected scope.
 
 ---
 
 ## 10. Testing (TDD)
 
+- `lib/billing/vat.ts`: `addVat` rounds correctly (e.g. `1899 → 2183.85`).
 - `public-read` unit tests:
-  - **Asserts cost/margin/provenance fields are absent** from the returned objects (the security guarantee).
-  - Segment filtering (`consumer`/`business`/`all`, `both` membership).
-  - Active-only + snapshot-required filtering.
-- API route tests: response shape, `404` for unknown slug, `400` for invalid segment.
+  - **VAT:** output `priceInclVat` equals `resolved_price * 1.15` rounded; `priceExclVat` equals raw;
+    no raw/unlabelled price leaks.
+  - **No leakage:** cost/margin/provenance fields are absent from returned objects.
+  - **Media whitelist:** unknown `media` keys are dropped; only `description`/`image` strings pass.
+  - **VAT-basis guard:** a non-`service_package` offer is excluded; a `service_package` offer passes.
+  - **Filtering:** segment membership (`consumer`/`business`/`all`, `both`), active-only, snapshot-required.
+- API route tests: response shape, `404` (unknown/excluded slug), `400` (invalid segment).
+- **Rendered-output leakage test (P2):** render `/offers` and a detail page (or fetch their HTML) and
+  assert the HTML **and** the JSON-LD block contain none of `total_cost`, `margin_pct`, `cost_buildup`,
+  `source_uid`, and contain the VAT label — guarding the template layer, not just the data layer.
 - Live verify script (`scripts/offers/verify-storefront.ts`): hit `GET /api/offers` and
-  `GET /api/offers/[slug]` against the real published offer; assert price present and **no cost
-  leakage** in the JSON.
+  `GET /api/offers/[slug]` against the real published offer; assert `priceInclVat` present, equals
+  ex-VAT×1.15, and **no cost leakage**.
 
 ---
 
-## 11. Out of scope (→ Plan 3)
+## 11. Out of scope
 
-- Cart, `cart_items`, `order_line_items`, status rollup.
-- Checkout / NetCash cart total.
-- `consumer_orders` channel + attribution.
-- "Add to cart" CTA swap.
-- Auth-after-cart flow (see `docs/superpowers/specs/2026-06-28-phase2-auth-after-cart-design.md`).
+→ **Plan 3:** cart, `cart_items`, `order_line_items`, status rollup, checkout / NetCash cart total,
+`consumer_orders` channel + attribution, "Add to cart" CTA swap, auth-after-cart
+(`docs/superpowers/specs/2026-06-28-phase2-auth-after-cart-design.md`).
+
+→ **Deferred, prerequisite for exposing non-service-package offers:** a **per-source VAT-basis flag**
+on the spine (so MTN/hardware/supplier offers can be priced correctly and pass the §4.1 guard).
+
+→ **Deferred, separate feature:** the admin snapshot-staleness signal (§9).
+
+→ **Not in this plan:** `media` enrichment by the publisher (offers ship as title + price until then);
+refactoring existing duplicated VAT constants.
 
 ---
 
@@ -222,13 +286,18 @@ signal correct. Scoped and small; included here because this plan owns the snaps
 
 | File | Change |
 |---|---|
-| `lib/offers/public-read.ts` | NEW — sanitized read layer |
-| `lib/types/offer.ts` (or `public-offer.ts`) | NEW types `PublicOffer`, `PublicOfferDetail` |
+| `lib/billing/vat.ts` | NEW — shared `VAT_RATE` + `addVat` |
+| `lib/offers/public-read.ts` | NEW — `server-only` sanitized + VAT read layer, VAT-basis guard |
+| `lib/types/offer.ts` | EDIT — add `PublicOffer`, `PublicOfferDetail` |
 | `app/api/offers/route.ts` | NEW — list endpoint |
 | `app/api/offers/[slug]/route.ts` | NEW — detail endpoint |
-| `app/offers/page.tsx` | NEW — list page + tabs + ItemList JSON-LD |
+| `app/offers/page.tsx` | NEW — static list page + ItemList JSON-LD |
+| `components/offers/OfferTabs.tsx` | NEW — client tab/filter component |
 | `app/offers/[slug]/page.tsx` | NEW — detail page + Product/Offer JSON-LD |
-| `lib/inngest/functions/recompute-offer-pricing.ts` | EDIT — staleness source timestamp fix (§9) |
-| `__tests__/lib/offers/public-read.test.ts` | NEW — sanitization + filtering tests |
+| `__tests__/lib/billing/vat.test.ts` | NEW |
+| `__tests__/lib/offers/public-read.test.ts` | NEW — VAT, sanitization, whitelist, guard, filtering |
 | `__tests__/app/api/offers/*` | NEW — route tests |
+| `__tests__/app/offers/*` | NEW — rendered HTML / JSON-LD leakage |
 | `scripts/offers/verify-storefront.ts` | NEW — live verification |
+
+*(No edit to `recompute-offer-pricing.ts` — staleness fix de-scoped, §9.)*

--- a/docs/superpowers/specs/2026-06-28-offer-storefront-read-design.md
+++ b/docs/superpowers/specs/2026-06-28-offer-storefront-read-design.md
@@ -81,7 +81,6 @@ from the source, carrying that ex-VAT basis through unchanged.
 | Public field | Definition |
 |---|---|
 | `priceInclVat` | `round(resolved_price * (1 + VAT_RATE) * 100) / 100` — **the only price shown in UI and JSON-LD** |
-| `priceExclVat` | `resolved_price` (provided for completeness; UI shows incl-VAT) |
 | `vatRate` | `0.15` |
 | `vatLabel` | `"incl. VAT"` (rendered next to every price) |
 
@@ -91,17 +90,23 @@ duplicated across `lib/invoices/*`, `lib/contracts/*`, `lib/integrations/zoho/*`
 single shared helper and uses it; it does **not** refactor those existing call sites (out of scope).
 
 #### Mixed-VAT precondition guard (P0)
-The spine has **no per-source VAT-basis flag**. Only `service_packages` (uniformly ex-VAT) are
-published as offers today, so grossing every `resolved_price` up by 15% is correct **now**. But
-MTN/hardware/supplier sources may normalize to **incl-VAT**, which would be **double-taxed** if
-published and grossed again.
+The spine has **no per-source VAT-basis flag**. For this public surface, only `service_packages`
+(uniformly ex-VAT) are eligible, so grossing every exposed `resolved_price` up by 15% is correct.
+But Phase 0 can publish other sources into offers, and MTN/hardware/supplier sources may normalize
+to **incl-VAT**, which would be **double-taxed** if exposed and grossed again.
 
-Therefore Plan 2 enforces an explicit invariant: **only ex-VAT-basis sources may be exposed
-publicly.** The read layer filters to offers whose primary component `source_type = 'service_package'`
-(the only proven ex-VAT source) and **logs + excludes** any active+snapshotted offer from another
-source type, rather than guessing its VAT basis. A test asserts a non-`service_package` offer is
-excluded. When future sources are published, a per-source VAT-basis flag must be added to the spine
-**before** they appear here — captured as an explicit out-of-scope item (§11).
+Therefore Plan 2 enforces an explicit invariant: **only offers sourced from the `service_packages`
+table may be exposed publicly.** The read layer filters to offers whose internal
+`offers.source_uid` starts with `service_packages:` **and** whose primary component
+`source_type = 'service_package'`. The `source_type` check alone is not enough, because Phase 0 maps
+both `admin_products` and `service_packages` to `source_type = 'service_package'`; the `source_uid`
+prefix is the source-table proof.
+
+The read layer **logs + excludes** any active+snapshotted offer from another source, rather than
+guessing its VAT basis. Tests assert that `admin_products:*`, `mtn_dealer_products:*`, and hardware
+offers are excluded, while `service_packages:*` offers pass. When future sources are published, a
+per-source VAT-basis flag must be added to the spine **before** they appear here — captured as an
+explicit out-of-scope item (§11).
 
 ### 4.2 Field policy
 
@@ -112,9 +117,9 @@ excluded. When future sources are published, a per-source VAT-basis flag must be
 | `description` | `media.description` (string) only | ✅ exposed when present, else omitted |
 | `image` | `media.image` (string) only | ✅ exposed when present, else omitted |
 | `customer_type` | offers | ✅ exposed (drives tabs) |
-| `priceInclVat`, `priceExclVat`, `vatRate`, `vatLabel` | derived (§4.1) | ✅ exposed |
+| `priceInclVat`, `vatRate`, `vatLabel` | derived (§4.1) | ✅ exposed |
 | **raw `media` blob** | offers | ❌ **never exposed whole** — only the two whitelisted keys above are read |
-| `resolved_price` (raw, unlabelled) | snapshot | ❌ never exposed raw (only via `priceInclVat`/`priceExclVat`) |
+| `resolved_price` / `priceExclVat` | snapshot / derived | ❌ never exposed publicly; used server-side only to compute `priceInclVat` |
 | `cost_buildup`, `total_cost`, `margin_pct`, `guardrail_status` | snapshot | ❌ **NEVER** |
 | `source_uid`, `source_type`, `source_id` | offers / components | ❌ never (provenance) |
 | component `unit_cost`, `unit_price` | offer_components | ❌ never |
@@ -125,7 +130,8 @@ excluded. When future sources are published, a per-source VAT-basis flag must be
 
 ### 4.3 Behaviour
 - Filter: `status = 'active' AND lifecycle_state = 'active'`, a snapshot row must exist (inner join
-  on `offer_pricing_snapshot`), and the VAT-basis guard (§4.1) excludes non-`service_package` sources.
+  on `offer_pricing_snapshot`), and the VAT-basis guard (§4.1) excludes non-`service_packages:*`
+  source UIDs.
 - Segment filter (used by the API; the page filters client-side, §6): `consumer` →
   `customer_type IN ('consumer','both')`; `business` → `customer_type IN ('business','both')`;
   `all` → no filter.
@@ -183,8 +189,11 @@ Both routes are public (no auth) and read-only.
 Offer intent/attribution is carried on the query string so it survives the hop:
 - **Connectivity offers** (primary component `service_package`): CTA "Check availability" →
   **`/coverage-check?offer=<slug>`**. (`app/coverage-check` is the existing standalone entry; the
-  `offer` param is read for attribution and to pre-select intent.)
+  `offer` param is read for attribution and to pre-select intent; Plan 2 updates this redirect
+  route because it currently only understands `plan`.)
 - **Hardware / non-coverage offers**: CTA "Request a quote" → **`/contact?subject=<title>&offer=<slug>`**.
+  Plan 2 updates the contact page to read `subject`/`offer` into the form message; it currently only
+  pre-fills coverage-related params.
 - No "Add to cart" yet — that CTA swap is Plan 3. No disabled/placeholder buttons.
 
 > Note: in Plan 2 only `service_package` offers are exposed (§4.1 guard), so the connectivity CTA is
@@ -250,11 +259,12 @@ deferred item with this corrected scope.
 
 - `lib/billing/vat.ts`: `addVat` rounds correctly (e.g. `1899 → 2183.85`).
 - `public-read` unit tests:
-  - **VAT:** output `priceInclVat` equals `resolved_price * 1.15` rounded; `priceExclVat` equals raw;
-    no raw/unlabelled price leaks.
+  - **VAT:** output `priceInclVat` equals `resolved_price * 1.15` rounded; public objects contain no
+    `priceExclVat`, `resolved_price`, raw/unlabelled price, or ex-VAT price.
   - **No leakage:** cost/margin/provenance fields are absent from returned objects.
   - **Media whitelist:** unknown `media` keys are dropped; only `description`/`image` strings pass.
-  - **VAT-basis guard:** a non-`service_package` offer is excluded; a `service_package` offer passes.
+  - **VAT-basis guard:** `service_packages:*` offers pass; `admin_products:*`, MTN, and hardware
+    offers are excluded even if their component `source_type` would otherwise look eligible.
   - **Filtering:** segment membership (`consumer`/`business`/`all`, `both`), active-only, snapshot-required.
 - API route tests: response shape, `404` (unknown/excluded slug), `400` (invalid segment).
 - **Rendered-output leakage test (P2):** render `/offers` and a detail page (or fetch their HTML) and
@@ -294,6 +304,8 @@ refactoring existing duplicated VAT constants.
 | `app/offers/page.tsx` | NEW — static list page + ItemList JSON-LD |
 | `components/offers/OfferTabs.tsx` | NEW — client tab/filter component |
 | `app/offers/[slug]/page.tsx` | NEW — detail page + Product/Offer JSON-LD |
+| `app/coverage-check/page.tsx` | EDIT — preserve `offer=<slug>` attribution/preselect intent instead of redirecting home |
+| `app/contact/page.tsx` | EDIT — read `subject`/`offer` params into the form message |
 | `__tests__/lib/billing/vat.test.ts` | NEW |
 | `__tests__/lib/offers/public-read.test.ts` | NEW — VAT, sanitization, whitelist, guard, filtering |
 | `__tests__/app/api/offers/*` | NEW — route tests |

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,7 @@ const customJestConfig = {
 
   // Module name mapper for path aliases
   moduleNameMapper: {
+    '^server-only$': '<rootDir>/__mocks__/empty-module.js',
     '^@/(.*)$': '<rootDir>/$1',
     '^@/lib/(.*)$': '<rootDir>/lib/$1',
     '^@/components/(.*)$': '<rootDir>/components/$1',

--- a/lib/billing/vat.ts
+++ b/lib/billing/vat.ts
@@ -1,0 +1,6 @@
+export const VAT_RATE = 0.15;
+
+/** Gross an ex-VAT ZAR amount up to VAT-inclusive, rounded to 2 decimals. */
+export function addVat(excl: number): number {
+  return Math.round(excl * (1 + VAT_RATE) * 100) / 100;
+}

--- a/lib/offers/offer-jsonld.ts
+++ b/lib/offers/offer-jsonld.ts
@@ -1,0 +1,33 @@
+import type { PublicOffer, PublicOfferDetail } from '@/lib/types/offer';
+
+export const OFFERS_BASE_URL = 'https://www.circletel.co.za';
+
+export function offerProductJsonLd(o: PublicOfferDetail): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: o.title,
+    ...(o.image ? { image: o.image } : {}),
+    ...(o.description ? { description: o.description } : {}),
+    offers: {
+      '@type': 'Offer',
+      price: o.priceInclVat,
+      priceCurrency: 'ZAR',
+      availability: 'https://schema.org/InStock',
+      url: `${OFFERS_BASE_URL}/offers/${o.slug}`,
+    },
+  };
+}
+
+export function offersItemListJsonLd(offers: PublicOffer[]): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement: offers.map((o, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: o.title,
+      url: `${OFFERS_BASE_URL}/offers/${o.slug}`,
+    })),
+  };
+}

--- a/lib/offers/public-read.ts
+++ b/lib/offers/public-read.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { addVat, VAT_RATE } from '@/lib/billing/vat';
 import type { PublicOffer, OfferCustomerType } from '@/lib/types/offer';
 import { apiLogger } from '@/lib/logging/logger';
+import { createClient } from '@/lib/supabase/server';
 
 export type { PublicOffer, PublicOfferDetail } from '@/lib/types/offer';
 
@@ -62,4 +63,55 @@ export function mapOfferRow(row: OfferReadRow): PublicOffer | null {
     ...(description ? { description } : {}),
     ...(image ? { image } : {}),
   };
+}
+
+// --- DB functions below ---
+
+export type OfferSegment = 'consumer' | 'business' | 'all';
+
+/** PostgREST select: offer + its snapshot (inner) + components, public-safe columns only. */
+export const OFFER_SELECT =
+  'slug,title,customer_type,source_uid,media,' +
+  'offer_pricing_snapshot!inner(resolved_price),' +
+  'offer_components(role,source_type)';
+
+function matchesSegment(customerType: string, segment: OfferSegment): boolean {
+  if (segment === 'all') return true;
+  if (segment === 'consumer') return customerType === 'consumer' || customerType === 'both';
+  return customerType === 'business' || customerType === 'both';
+}
+
+export async function listPublicOffers(segment: OfferSegment = 'all'): Promise<PublicOffer[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('offers')
+    .select(OFFER_SELECT)
+    .eq('status', 'active')
+    .eq('lifecycle_state', 'active');
+
+  if (error || !data) {
+    if (error) apiLogger.error('[offers/public-read] list failed', { error: error.message });
+    return [];
+  }
+
+  return (data as unknown as OfferReadRow[])
+    .filter((r) => matchesSegment(r.customer_type, segment))
+    .map(mapOfferRow)
+    .filter((o): o is PublicOffer => o !== null);
+}
+
+export async function getPublicOfferBySlug(slug: string): Promise<PublicOfferDetail | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('offers')
+    .select(OFFER_SELECT)
+    .eq('status', 'active')
+    .eq('lifecycle_state', 'active')
+    .eq('slug', slug);
+
+  if (error || !data || data.length === 0) {
+    if (error) apiLogger.error('[offers/public-read] detail failed', { error: error.message, slug });
+    return null;
+  }
+  return mapOfferRow((data as unknown as OfferReadRow[])[0]);
 }

--- a/lib/offers/public-read.ts
+++ b/lib/offers/public-read.ts
@@ -1,0 +1,65 @@
+import 'server-only';
+import { addVat, VAT_RATE } from '@/lib/billing/vat';
+import type { PublicOffer, OfferCustomerType } from '@/lib/types/offer';
+import { apiLogger } from '@/lib/logging/logger';
+
+export type { PublicOffer, PublicOfferDetail } from '@/lib/types/offer';
+
+/** Raw row shape returned by the storefront query (see listPublicOffers). */
+export interface OfferReadRow {
+  slug: string;
+  title: string;
+  customer_type: OfferCustomerType;
+  source_uid: string | null;
+  media: Record<string, unknown> | null;
+  offer_pricing_snapshot:
+    | { resolved_price: number }
+    | { resolved_price: number }[]
+    | null;
+  offer_components: { role: string; source_type: string }[] | null;
+}
+
+const VAT_LABEL = 'incl. VAT';
+
+function firstSnapshot(s: OfferReadRow['offer_pricing_snapshot']): { resolved_price: number } | null {
+  if (!s) return null;
+  return Array.isArray(s) ? (s[0] ?? null) : s;
+}
+
+function whitelistedString(media: Record<string, unknown> | null, key: string): string | undefined {
+  const v = media?.[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Pure sanitization + VAT + VAT-basis guard. Returns null when the offer is not
+ * a service_packages-sourced row (the only ex-VAT basis we may expose) or has no price.
+ */
+export function mapOfferRow(row: OfferReadRow): PublicOffer | null {
+  // VAT-basis guard: source_uid prefix is the source-table proof; component type alone
+  // is insufficient (admin_products also maps to source_type 'service_package').
+  const fromServicePackages = (row.source_uid ?? '').startsWith('service_packages:');
+  const primary = (row.offer_components ?? []).find((c) => c.role === 'primary');
+  const primaryIsServicePackage = primary?.source_type === 'service_package';
+  if (!fromServicePackages || !primaryIsServicePackage) {
+    apiLogger.warn('[offers/public-read] excluded non-service_package offer', { slug: row.slug, sourceUid: row.source_uid });
+    return null;
+  }
+
+  const snap = firstSnapshot(row.offer_pricing_snapshot);
+  if (!snap || typeof snap.resolved_price !== 'number') return null;
+
+  const description = whitelistedString(row.media, 'description');
+  const image = whitelistedString(row.media, 'image');
+
+  return {
+    slug: row.slug,
+    title: row.title,
+    customerType: row.customer_type,
+    priceInclVat: addVat(snap.resolved_price),
+    vatRate: VAT_RATE,
+    vatLabel: VAT_LABEL,
+    ...(description ? { description } : {}),
+    ...(image ? { image } : {}),
+  };
+}

--- a/lib/offers/public-read.ts
+++ b/lib/offers/public-read.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { addVat, VAT_RATE } from '@/lib/billing/vat';
-import type { PublicOffer, OfferCustomerType } from '@/lib/types/offer';
+import type { PublicOffer, PublicOfferDetail, OfferCustomerType } from '@/lib/types/offer';
 import { apiLogger } from '@/lib/logging/logger';
 import { createClient } from '@/lib/supabase/server';
 

--- a/lib/types/offer.ts
+++ b/lib/types/offer.ts
@@ -63,3 +63,18 @@ export interface OfferPricingSnapshot extends OfferPricingSnapshotInput {
   offerId: string;
   computedAt: string;     // ISO
 }
+
+/** Public, sanitized offer for the storefront (no cost/margin/provenance). */
+export interface PublicOffer {
+  slug: string;
+  title: string;
+  customerType: OfferCustomerType;
+  priceInclVat: number;   // ZAR incl. 15% VAT — the only price ever shown
+  vatRate: number;        // 0.15
+  vatLabel: string;       // "incl. VAT"
+  description?: string;   // from media.description (string) only
+  image?: string;         // from media.image (string) only
+}
+
+/** Detail-page shape — identical to PublicOffer in Plan 2. */
+export type PublicOfferDetail = PublicOffer;

--- a/memory-os/long-term/agent-context.md
+++ b/memory-os/long-term/agent-context.md
@@ -58,6 +58,13 @@ Format:
 - **Notes:** 50/100 Mbps use CSP `feasibilityOld`; 200 Mbps uses `feasibilityCheck`. CSP `orderable` is the final orderability authority when TCS has an online/covered BN; active BN with zero active RN evidence lowers confidence and should show a site-survey/install caution, but does not by itself block CSP-orderable coverage.
 - **Admin UI:** `/admin/coverage/checker` now includes a SkyFibre Orderability card under Tarana results and auto-runs the combined gate at 100 Mbps after each Tarana address check. The page shows a "Final Sales Decision" banner that treats the combined TCS + CSP result as the sales authority, renames the old coverage verdict to an RF signal estimate, blocks package recommendations unless the gate is `orderable`, and treats RF-vs-TCS BN mismatches as manual review. Admins can still switch to 50/100/200 Mbps and re-run manually. `/admin/sales/feasibility` single-site review also shows the same card for selected SkyFibre/Tarana packages. Both call the combined endpoint with `segment: "business"` for MTN CSP validation.
 - **RPC quirk:** The deployed `find_nearest_tarana_base_station` RPC may omit `device_status`. `lib/coverage/mtn/base-station-service.ts` hydrates missing BN status from `tarana_base_stations` before deciding whether the BN is online; otherwise online BNs can be misread as offline and CSP will be skipped.
+
+### 2026-06-28: Offer Spine storefront review caveats
+- **Context:** Review of `docs/superpowers/specs/2026-06-28-offer-storefront-read-design.md` for the planned public `/offers` catalogue.
+- **Pattern:** Treat public offer pricing as a separate sanitized contract from internal snapshots. `service_packages` prices are commonly stored/displayed as ex-VAT in the DB while MTN and hardware normalized products can already be incl-VAT, so `/offers` must define/normalize VAT basis before exposing JSON-LD or UI prices.
+- **Guard caveat:** `offer_components.source_type = 'service_package'` is not enough to prove the underlying source table because Phase 0 maps both `admin_products` and `service_packages` to that component type. Use internal `offers.source_uid` prefixes (for example `service_packages:*`) when the source table matters.
+- **Staleness quirk:** `lib/offers/staleness.ts` currently appears only in tests; `recompute-offer-pricing.loadDraft` sets `sourceUpdatedAt` from `offers.updated_at`, but changing that alone will not create an admin stale signal unless a read/admin path actually calls `isSnapshotStale`.
+- **Discovered by:** Codex
 ### YYYY-MM-DD: Pattern
 - **Context:** When this applies
 - **Pattern:** The approach that works

--- a/memory-os/long-term/agent-context.md
+++ b/memory-os/long-term/agent-context.md
@@ -65,6 +65,11 @@ Format:
 - **Guard caveat:** `offer_components.source_type = 'service_package'` is not enough to prove the underlying source table because Phase 0 maps both `admin_products` and `service_packages` to that component type. Use internal `offers.source_uid` prefixes (for example `service_packages:*`) when the source table matters.
 - **Staleness quirk:** `lib/offers/staleness.ts` currently appears only in tests; `recompute-offer-pricing.loadDraft` sets `sourceUpdatedAt` from `offers.updated_at`, but changing that alone will not create an admin stale signal unless a read/admin path actually calls `isSnapshotStale`.
 - **Discovered by:** Codex
+
+### 2026-06-28: Consumer Checkout Fee Split
+- **Context:** Consumer/Vox-style checkout no longer uses the old "R1 validation charge credited back" copy.
+- **Pattern:** New checkout orders use `ORDER_PROCESSING_FEE_AMOUNT` (R149.00) from `lib/payments/payment-amounts.ts`; order creation stamps this amount server-side, Netcash initiation derives it from the order row and describes it as "CircleTel - Order processing fee", and the webhook marks that R149 payment as `confirmed` without activating service. The R1 constants/helpers remain intentionally for legacy rows and dashboard/payment-method validation flows only.
+- **Discovered by:** Codex
 ### YYYY-MM-DD: Pattern
 - **Context:** When this applies
 - **Pattern:** The approach that works

--- a/memory-os/long-term/agent-context.md
+++ b/memory-os/long-term/agent-context.md
@@ -70,6 +70,37 @@ Format:
 - **Context:** Consumer/Vox-style checkout no longer uses the old "R1 validation charge credited back" copy.
 - **Pattern:** New checkout orders use `ORDER_PROCESSING_FEE_AMOUNT` (R149.00) from `lib/payments/payment-amounts.ts`; order creation stamps this amount server-side, Netcash initiation derives it from the order row and describes it as "CircleTel - Order processing fee", and the webhook marks that R149 payment as `confirmed` without activating service. The R1 constants/helpers remain intentionally for legacy rows and dashboard/payment-method validation flows only.
 - **Discovered by:** Codex
+
+### 2026-06-30: Admin-Assisted B2B Manual Intake Direction
+- **Context:** Planning for admin-assisted B2B onboarding/manual intake from documents received by email, covering Unjani and future business customers.
+- **Pattern:** Manual intake must support both selecting an existing B2B/Unjani customer and creating a new pending business customer shell. New shells must stay non-billable until documents are approved, debit-order banking details are captured, the customer accepts the Service Order through a secure signoff link, a final Service Order PDF is issued, and the service is active/billable.
+- **Plan:** Executable implementation plan saved at `docs/superpowers/plans/2026-06-30-admin-assisted-b2b-onboarding.md`.
+- **Discovered by:** Codex
+
+### 2026-06-30: Staging Runner Disk Pressure Cleanup
+- **Context:** Staging deploy run `28447363810` failed before checkout because `/dev/sda1` had only ~3.4GB free after cleanup, below the workflow's 4GB guard.
+- **Pattern:** First safe reclaim batch is runner workspace/cache plus merged worktrees: remove `/home/actions-runner/_work/circletel/circletel`, `/home/actions-runner/.next-cache`, `/home/actions-runner/node_modules.tar`, `/home/actions-runner/.nm-cache-key`, and merged worktree `/home/circletel/.worktrees/admin-assisted-b2b-onboarding`. This reclaimed ~14GB and left `/` at 18GB free.
+- **Discovered by:** Codex
+
+### 2026-06-30: Product Docs Residential Pricing Drift
+- **Context:** Read-through of `products/` found conflicting SkyFibre Home residential references.
+- **Pattern:** Treat `products/connectivity/residential/SkyFibre_Residential_Product_Document_v3_0.md`, the standalone March 31 DOCX files, and `skyfibre_home_residential_products_v2_0.json` as the corrected residential sources for Plus/Max: 50/12.5 Mbps at R899 incl. VAT and 100/25 Mbps at R999 incl. VAT, both 4:1 asymmetric. Older catalogue/spec files still show outdated higher/ex-VAT-style pricing, and the Ultra DOCX exists at R1,299 incl. VAT but is absent from the JSON.
+- **Discovered by:** Codex
+
+### 2026-06-30: Offer-Driven No-Code Product Publishing Direction
+- **Context:** User wants to stop coding a bespoke Next.js frontend page for every new product, hardware sale, bundle, or solution.
+- **Pattern:** Treat `Offer` as the customer-buyable commercial source, then attach marketing/content/channel publishing metadata to Offers. Public website pages, campaign landing pages, Google Shopping, Facebook/Meta catalog, WhatsApp sales flows, and partner/admin quote flows should consume published Offers instead of each querying product source tables directly. Source product tables remain systems of record; CMS/page-builder blocks should reference Offer IDs so sales and marketing can publish pages/promotions without manually duplicating price, VAT, availability, or fulfilment rules.
+- **Discovered by:** Codex
+
+### 2026-06-30: Astro CMS Fit Decision
+- **Context:** User asked whether Astro should be hosted in this repo to make CMS/product pages easier.
+- **Pattern:** Astro is viable only as a separate marketing/static-content zone with unique path ownership, but the recommended first move for CircleTel is Next-native dynamic CMS pages because the repo already has `pb_pages`, CMS block renderers, admin CMS builder APIs, Offer public read code, auth, Supabase, checkout, and channel/order flows in Next. Do not put Astro inside the existing Next `app/` tree. If Astro is adopted later, isolate it as a monorepo app or separate container under a route prefix such as `/blog/*`, `/resources/*`, or `/campaign-static/*`, and keep buyable products/pricing/stock/checkout driven by Next Offers.
+- **Discovered by:** Codex
+
+### 2026-06-30: Product CMS Should Be Template-Driven First
+- **Context:** User clarified that the existing CircleTel CMS/page builder is not polished or fully functional today, and showed Teljoy-style storefront, product detail, category, modal, and campaign examples as the target.
+- **Pattern:** Treat the current CMS as an unfinished prototype, not the launch dependency. The recommended product-publishing path is a template-driven Product Publishing Studio: Offer data supplies commercial truth, curated templates render storefront/category/product/campaign pages, AI generates draft copy/assets from approved Offer context, and marketing approves/schedules publication. Avoid a broad freeform drag-and-drop rebuild as Phase 1; Teljoy-like commerce pages are mostly structured templates plus promotional creative, not arbitrary page composition.
+- **Discovered by:** Codex
 ### YYYY-MM-DD: Pattern
 - **Context:** When this applies
 - **Pattern:** The approach that works

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
         "react-signature-canvas": "^1.1.0-alpha.2",
         "recharts": "^2.15.4",
         "resend": "^6.1.1",
+        "server-only": "^0.0.1",
         "sharp": "^0.34.4",
         "sonner": "^1.7.4",
         "tailwind-merge": "^2.6.0",
@@ -23092,6 +23093,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "react-signature-canvas": "^1.1.0-alpha.2",
     "recharts": "^2.15.4",
     "resend": "^6.1.1",
+    "server-only": "^0.0.1",
     "sharp": "^0.34.4",
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.0",

--- a/scripts/offers/verify-storefront.ts
+++ b/scripts/offers/verify-storefront.ts
@@ -1,0 +1,42 @@
+// scripts/offers/verify-storefront.ts
+// Run against a RUNNING server. Override with OFFERS_VERIFY_BASE_URL (e.g. https://www.circletel.co.za).
+const BASE = process.env.OFFERS_VERIFY_BASE_URL ?? 'http://localhost:3000';
+const FORBIDDEN = ['resolved_price', 'priceExclVat', 'total_cost', 'margin_pct', 'cost_buildup', 'source_uid', 'source_type'];
+
+function assertNoLeak(label: string, payload: string) {
+  for (const k of FORBIDDEN) {
+    if (payload.includes(k)) throw new Error(`LEAK: forbidden key "${k}" present in ${label}`);
+  }
+}
+
+async function getJson(path: string): Promise<{ status: number; text: string; json: any }> {
+  const res = await fetch(`${BASE}${path}`);
+  const text = await res.text();
+  return { status: res.status, text, json: text ? JSON.parse(text) : null };
+}
+
+async function main() {
+  const list = await getJson('/api/offers?segment=all');
+  if (list.status !== 200) throw new Error(`GET /api/offers -> ${list.status}`);
+  const offers = list.json.offers as Array<{ slug: string; priceInclVat: number; vatLabel: string }>;
+  console.log(`GET /api/offers -> 200, ${offers.length} offer(s)`);
+  if (offers.length === 0) throw new Error('No public offers — publish at least one active service_packages offer first');
+  assertNoLeak('list response', list.text);
+
+  const first = offers[0];
+  if (typeof first.priceInclVat !== 'number' || first.vatLabel !== 'incl. VAT') {
+    throw new Error('VAT contract violated on list output');
+  }
+
+  const detail = await getJson(`/api/offers/${encodeURIComponent(first.slug)}`);
+  if (detail.status !== 200) throw new Error(`GET /api/offers/${first.slug} -> ${detail.status}`);
+  assertNoLeak('detail response', detail.text);
+  console.log('Detail:', JSON.stringify(detail.json.offer, null, 2));
+
+  // Negative check: an unknown slug must 404, not leak.
+  const missing = await getJson('/api/offers/__definitely_not_a_real_slug__');
+  if (missing.status !== 404) throw new Error(`expected 404 for unknown slug, got ${missing.status}`);
+
+  console.log('VERIFY OK — VAT-inclusive, no leakage, 404 on unknown');
+}
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

Plan 2 of the Offer Spine: a **public, read-only storefront** over published Offers. Customer-facing pages and APIs consume `offers` (service-role read, sanitized) instead of querying product source tables directly.

### What's included
- **Public read layer** — `listPublicOffers` + `getPublicOfferBySlug` (`lib/offers/public-read.ts`), `server-only`, with a sanitization mapper that strips internal fields. DTO types in `lib/types/offer.ts`.
- **APIs** — `GET /api/offers` (list, consumer/business segment) and `GET /api/offers/[slug]` (detail).
- **Pages** — `/offers` list (consumer/business tabs) and `/offers/[slug]` detail with coverage CTA.
- **SEO** — Product + ItemList JSON-LD builders, VAT-inclusive (`lib/offers/offer-jsonld.ts`).
- **VAT** — shared `VAT_RATE` + `addVat` helper (`lib/billing/vat.ts`).
- **Attribution** — coverage-check redirect, `sessionStorage` carry, contact prefill.

### Tests
- List/detail rendered with real `OfferTabs`/`OfferCard` + JSON-LD; leak guards assert internal fields never reach the client or structured data.
- Live storefront verification via HTTP routes (VAT correctness + no-leakage) — `scripts/offers/verify-storefront.ts`.

### Notes for reviewers
- `offers` tables are RLS service-role only by design; all reads go through the sanitizing server layer.
- Pricing contract is **VAT-inclusive**; `priceExclVat` intentionally dropped.
- This branch's diff vs `main` also carries some unrelated already-in-flight changes (NetCash webhook processor, payment-amounts, a Rectron price-list asset, vox-pages reference images) inherited from its base — they are not part of the offers feature and can be ignored for offers review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
