### PR TITLE
Manual B2B Onboarding wizard + v1.0 validation polish

### DIFF
--- a/app/admin/b2b/manual-intake/page.tsx
+++ b/app/admin/b2b/manual-intake/page.tsx
@@ -1,0 +1,2112 @@
+"use client";
+
+import Link from "next/link";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  PiArrowRightBold,
+  PiBankBold,
+  PiBuildingsBold,
+  PiCheckCircleBold,
+  PiClipboardTextBold,
+  PiFileTextBold,
+  PiFloppyDiskBold,
+  PiMagnifyingGlassBold,
+  PiUserCircleBold,
+  PiUploadSimpleBold,
+  PiWarningCircleBold,
+  PiXBold,
+} from "react-icons/pi";
+import { UploadDocumentModal } from "@/components/admin/onboarding/UploadDocumentModal";
+import { SectionCard } from "@/components/backend";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+type BillingDay = "1" | "15" | "20" | "25";
+type IntakeStepId =
+  | "customer"
+  | "contact"
+  | "service"
+  | "documents"
+  | "debit"
+  | "review";
+
+interface FormState {
+  customerId: string;
+  submissionId: string;
+  serviceId: string;
+  paymentMethodId: string;
+  segment: string;
+  businessName: string;
+  entityType: string;
+  registrationNumber: string;
+  vatRegistered: boolean;
+  vatNumber: string;
+  registeredAddress: string;
+  contactName: string;
+  email: string;
+  phone: string;
+  clinicName: string;
+  province: string;
+  siteAddress: string;
+  packageName: string;
+  serviceType: string;
+  monthlyPrice: string;
+  activationDate: string;
+  billingDay: BillingDay;
+  includeDebitOrder: boolean;
+  accountHolderName: string;
+  bankName: string;
+  accountType: string;
+  accountNumber: string;
+  branchCode: string;
+}
+
+interface IntakeResult {
+  customerId: string;
+  accountNumber: string | null;
+  submissionId: string;
+  createdCustomer: boolean;
+  createdSubmission: boolean;
+  serviceId?: string;
+  paymentMethodId?: string;
+}
+
+interface CustomerSearchResult {
+  id: string;
+  accountNumber: string | null;
+  businessName: string;
+  email: string | null;
+  phone: string | null;
+  registrationNumber: string | null;
+  onboardingStatus: string | null;
+}
+
+interface SelectedCustomer extends CustomerSearchResult {
+  latestSubmissionId?: string | null;
+  activeServiceId?: string | null;
+  paymentMethodId?: string | null;
+  paymentLastFour?: string | null;
+}
+
+interface ManualIntakePrefill {
+  customer: SelectedCustomer;
+  form: Partial<FormState>;
+}
+
+const initialState: FormState = {
+  customerId: "",
+  submissionId: "",
+  serviceId: "",
+  paymentMethodId: "",
+  segment: "unjani",
+  businessName: "",
+  entityType: "Private Company",
+  registrationNumber: "",
+  vatRegistered: false,
+  vatNumber: "",
+  registeredAddress: "",
+  contactName: "",
+  email: "",
+  phone: "",
+  clinicName: "",
+  province: "",
+  siteAddress: "",
+  packageName: "CircleTel ClinicConnect",
+  serviceType: "managed_connectivity",
+  monthlyPrice: "450",
+  activationDate: "",
+  billingDay: "25",
+  includeDebitOrder: true,
+  accountHolderName: "",
+  bankName: "",
+  accountType: "Cheque",
+  accountNumber: "",
+  branchCode: "",
+};
+
+const intakeSteps: {
+  id: IntakeStepId;
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+}[] = [
+  {
+    id: "customer",
+    label: "Customer & Business",
+    description: "Customer record and legal details",
+    icon: PiClipboardTextBold,
+  },
+  {
+    id: "contact",
+    label: "Contact & Site",
+    description: "Primary contact and service location",
+    icon: PiBuildingsBold,
+  },
+  {
+    id: "service",
+    label: "Billable Service",
+    description: "Commercial package and billing schedule",
+    icon: PiCheckCircleBold,
+  },
+  {
+    id: "documents",
+    label: "Documents",
+    description: "Onboarding pack uploads for vetting",
+    icon: PiFileTextBold,
+  },
+  {
+    id: "debit",
+    label: "Debit Order",
+    description: "Banking details and mandate readiness",
+    icon: PiBankBold,
+  },
+  {
+    id: "review",
+    label: "Review & Submit",
+    description: "Final validation before vetting",
+    icon: PiCheckCircleBold,
+  },
+];
+
+function stepFieldKeys(stepId: IntakeStepId, includeDebitOrder: boolean): string[] {
+  switch (stepId) {
+    case "customer":
+      return ["businessName", "registrationNumber", "vatNumber", "registeredAddress"];
+    case "contact":
+      return ["contactName", "email", "phone", "siteAddress"];
+    case "service":
+      return ["packageName", "serviceType", "monthlyPrice"];
+    case "debit":
+      return includeDebitOrder
+        ? ["accountHolderName", "bankName", "accountNumber", "branchCode", "mandate"]
+        : [];
+    case "documents":
+    case "review":
+    default:
+      return [];
+  }
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-ZA", {
+    style: "currency",
+    currency: "ZAR",
+  }).format(value);
+}
+
+function trimOrUndefined(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+const emailOk = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
+const phoneOk = (v: string) => {
+  const d = v.replace(/\D/g, "");
+  return d.length === 10 || (d.length === 11 && d.startsWith("27"));
+};
+const vatOk = (v: string) => /^\d{10}$/.test(v.trim());
+const acctOk = (v: string) => /^\d{6,13}$/.test(v.replace(/\s/g, ""));
+const branchOk = (v: string) => /^\d{6}$/.test(v.trim());
+
+// Returns "" when valid, otherwise a human message. Pure — depends only on args.
+function fieldError(
+  key: string,
+  form: FormState,
+  mandateAuthorised: boolean,
+): string {
+  switch (key) {
+    case "businessName":
+      return form.businessName.trim() ? "" : "Enter the registered business name.";
+    case "registrationNumber":
+      return form.registrationNumber.trim()
+        ? ""
+        : "Enter the registration or owner ID.";
+    case "vatNumber":
+      if (!form.vatRegistered) return "";
+      if (!form.vatNumber.trim()) return "Enter the 10-digit VAT number.";
+      return vatOk(form.vatNumber) ? "" : "VAT number must be 10 digits.";
+    case "registeredAddress":
+      return form.registeredAddress.trim() ? "" : "Enter the registered address.";
+    case "contactName":
+      return form.contactName.trim() ? "" : "Enter the contact person's name.";
+    case "email":
+      if (!form.email.trim()) return "Enter an email address.";
+      return emailOk(form.email) ? "" : "Enter a valid email address.";
+    case "phone":
+      if (!form.phone.trim()) return "Enter a contact number.";
+      return phoneOk(form.phone) ? "" : "Enter a valid 10-digit number.";
+    case "siteAddress":
+      return form.siteAddress.trim() ? "" : "Enter the service address.";
+    case "packageName":
+      return form.packageName.trim() ? "" : "Enter the package name.";
+    case "serviceType":
+      return form.serviceType.trim() ? "" : "Enter the service type.";
+    case "monthlyPrice":
+      return Number(form.monthlyPrice) > 0
+        ? ""
+        : "Enter a monthly price greater than zero.";
+    case "accountHolderName":
+      return form.accountHolderName.trim() ? "" : "Enter the account holder name.";
+    case "bankName":
+      return form.bankName.trim() ? "" : "Enter the bank name.";
+    case "accountNumber":
+      if (!form.accountNumber.trim()) return "Enter the account number.";
+      return acctOk(form.accountNumber) ? "" : "Account number must be 6-13 digits.";
+    case "branchCode":
+      if (!form.branchCode.trim()) return "Enter the branch code.";
+      return branchOk(form.branchCode) ? "" : "Branch code must be 6 digits.";
+    case "mandate":
+      return mandateAuthorised ? "" : "Authorise the debit order mandate to continue.";
+    default:
+      return "";
+  }
+}
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${localStorage.getItem("admin_token") || ""}`,
+  };
+}
+
+function hasTypedFormValues(form: FormState) {
+  return (Object.keys(initialState) as (keyof FormState)[]).some((key) => {
+    const current = form[key];
+    const initial = initialState[key];
+    if (typeof current === "string") {
+      return current.trim().length > 0 && current !== initial;
+    }
+    return current !== initial;
+  });
+}
+
+function Field({
+  id,
+  label,
+  children,
+  className,
+  error,
+}: {
+  id: string;
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+  error?: string;
+}) {
+  return (
+    <div className={`space-y-2 ${className ?? ""}`}>
+      <Label
+        htmlFor={id}
+        className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+      >
+        {label}
+      </Label>
+      {children}
+      {error ? (
+        <p
+          id={`${id}-error`}
+          className="flex items-center gap-1.5 text-xs font-medium text-red-600"
+          role="alert"
+        >
+          <PiWarningCircleBold className="h-3.5 w-3.5 shrink-0" />
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function StepStatusPill({
+  ready,
+  active,
+}: {
+  ready: boolean;
+  active: boolean;
+}) {
+  if (ready) {
+    return (
+      <span className="text-xs font-semibold text-emerald-700">Completed</span>
+    );
+  }
+
+  return (
+    <span
+      className={
+        active
+          ? "text-xs font-semibold text-circleTel-orange"
+          : "text-xs text-gray-500"
+      }
+    >
+      {active ? "In progress" : "Not started"}
+    </span>
+  );
+}
+
+function StatusPill({
+  ready,
+  warning,
+  label,
+}: {
+  ready?: boolean;
+  warning?: boolean;
+  label?: string;
+}) {
+  if (ready) {
+    return (
+      <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700">
+        {label ?? "Ready"}
+      </span>
+    );
+  }
+
+  if (warning) {
+    return (
+      <span className="rounded-full bg-orange-50 px-2.5 py-1 text-[11px] font-semibold text-circleTel-orange-dark">
+        {label ?? "In progress"}
+      </span>
+    );
+  }
+
+  return (
+    <span className="rounded-full bg-gray-100 px-2.5 py-1 text-[11px] font-semibold text-gray-600">
+      {label ?? "Pending"}
+    </span>
+  );
+}
+
+function ReviewRow({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+        {label}
+      </p>
+      <p className="mt-1 whitespace-pre-line text-sm font-medium text-gray-900">
+        {value?.trim() || "Not captured"}
+      </p>
+    </div>
+  );
+}
+
+function ReviewTag({ ready }: { ready: boolean }) {
+  return ready ? (
+    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700">
+      <PiCheckCircleBold className="h-3.5 w-3.5" />
+      Complete
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 rounded-full bg-orange-50 px-2.5 py-1 text-[11px] font-semibold text-circleTel-orange-dark">
+      <PiWarningCircleBold className="h-3.5 w-3.5" />
+      Incomplete
+    </span>
+  );
+}
+
+export default function ManualB2BIntakePage() {
+  const [form, setForm] = useState<FormState>(initialState);
+  const [saving, setSaving] = useState(false);
+  const [result, setResult] = useState<IntakeResult | null>(null);
+  const [customerSearch, setCustomerSearch] = useState("");
+  const [customerResults, setCustomerResults] = useState<
+    CustomerSearchResult[]
+  >([]);
+  const [customerSearching, setCustomerSearching] = useState(false);
+  const [selectedCustomer, setSelectedCustomer] =
+    useState<SelectedCustomer | null>(null);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [uploadedCount, setUploadedCount] = useState(0);
+  const [activeStep, setActiveStep] = useState<IntakeStepId>("customer");
+  const [visited, setVisited] = useState<Record<string, boolean>>({});
+  const [attempted, setAttempted] = useState<Partial<Record<IntakeStepId, boolean>>>({});
+  const [mandateAuthorised, setMandateAuthorised] = useState(false);
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const summaryRef = useRef<HTMLDivElement>(null);
+
+  const serviceMonthlyPrice = useMemo(() => {
+    const parsed = Number(form.monthlyPrice);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }, [form.monthlyPrice]);
+  const activeStepIndex = intakeSteps.findIndex(
+    (step) => step.id === activeStep,
+  );
+  const activeStepMeta = intakeSteps[activeStepIndex] ?? intakeSteps[0];
+
+  const canUploadDocuments = form.customerId.trim().length > 0;
+  const documentCustomerName =
+    form.businessName ||
+    form.clinicName ||
+    selectedCustomer?.businessName ||
+    "Business customer";
+  const contactLabel =
+    [form.email, form.phone].filter(Boolean).join(" - ") || "Contact pending";
+  const accountLabel =
+    selectedCustomer?.accountNumber ||
+    result?.accountNumber ||
+    (form.customerId ? "Customer linked" : "New customer");
+  const stepErrors = (stepId: IntakeStepId): { key: string; msg: string }[] => {
+    if (stepId === "documents") {
+      return uploadedCount > 0
+        ? []
+        : [{ key: "documents", msg: "Upload at least one document for this onboarding pack." }];
+    }
+    return stepFieldKeys(stepId, form.includeDebitOrder)
+      .map((key) => ({ key, msg: fieldError(key, form, mandateAuthorised) }))
+      .filter((entry) => entry.msg.length > 0);
+  };
+
+  const customerReady = stepErrors("customer").length === 0;
+  const contactReady = stepErrors("contact").length === 0;
+  const serviceReady = stepErrors("service").length === 0;
+  const documentsReady = uploadedCount > 0;
+  const debitReady = stepErrors("debit").length === 0;
+  const stepReadiness: Record<IntakeStepId, boolean> = {
+    customer: customerReady,
+    contact: contactReady,
+    service: serviceReady,
+    documents: documentsReady,
+    debit: debitReady,
+    review:
+      customerReady && contactReady && serviceReady && documentsReady && debitReady,
+  };
+  const allRequiredReady = stepReadiness.review;
+  const readySteps = [customerReady, contactReady, serviceReady, documentsReady, debitReady];
+  const completion = Math.round(
+    (readySteps.filter(Boolean).length / readySteps.length) * 100,
+  );
+  const missingItems = [
+    !customerReady ? "Customer record" : null,
+    !contactReady ? "Contact & site details" : null,
+    !serviceReady ? "Billable service" : null,
+    !documentsReady ? "Documents" : null,
+    !debitReady ? "Debit order" : null,
+  ].filter((item): item is string => item !== null);
+  const visibleStepErrors = attempted[activeStep] ? stepErrors(activeStep) : [];
+  const linkedRecords = [
+    {
+      label: "Customer",
+      value: form.customerId ? accountLabel : "Will be created on save",
+      ready: Boolean(form.customerId),
+    },
+    {
+      label: "Submission",
+      value: form.submissionId ? "Linked" : "Will be created or matched",
+      ready: Boolean(form.submissionId),
+    },
+    {
+      label: "Active service",
+      value: form.serviceId ? "Linked" : "Will be created or updated",
+      ready: Boolean(form.serviceId),
+    },
+    {
+      label: "Debit order",
+      value: form.paymentMethodId
+        ? `Linked${selectedCustomer?.paymentLastFour ? ` ending ${selectedCustomer.paymentLastFour}` : ""}`
+        : form.includeDebitOrder
+          ? "Capture required"
+          : "Not captured",
+      ready: Boolean(form.paymentMethodId) || !form.includeDebitOrder,
+    },
+  ];
+  const checklist = [
+    { label: "Customer record is complete", ready: customerReady },
+    { label: "Contact and site details are complete", ready: contactReady },
+    { label: "Billable service is defined", ready: serviceReady },
+    { label: "Required documents are uploaded", ready: documentsReady },
+    { label: "Debit order details are provided", ready: debitReady },
+  ];
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((current) => ({ ...current, [key]: value }));
+  }
+
+  function blur(key: string) {
+    setVisited((current) => ({ ...current, [key]: true }));
+  }
+
+  function errFor(key: string) {
+    return visited[key] || attempted[activeStep]
+      ? fieldError(key, form, mandateAuthorised)
+      : "";
+  }
+
+  function errClass(key: string) {
+    return errFor(key)
+      ? "border-red-400 focus-visible:ring-red-400/40"
+      : "";
+  }
+
+  useEffect(() => {
+    if (attempted[activeStep] && stepErrors(activeStep).length > 0) {
+      summaryRef.current?.focus();
+    }
+    // Focus only on the Next/submit attempt transition, not on every field edit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attempted, activeStep]);
+
+  function goToStep(index: number) {
+    const next = intakeSteps[index];
+    if (next) setActiveStep(next.id);
+  }
+
+  function goToNextStep() {
+    const errs = stepErrors(activeStep);
+    if (errs.length > 0) {
+      setAttempted((current) => ({ ...current, [activeStep]: true }));
+      return;
+    }
+    goToStep(Math.min(activeStepIndex + 1, intakeSteps.length - 1));
+  }
+
+  function goToPreviousStep() {
+    goToStep(Math.max(activeStepIndex - 1, 0));
+  }
+
+  async function handleCustomerSearch() {
+    const query = customerSearch.trim();
+    if (query.length < 2) {
+      toast.error("Enter at least 2 characters to search");
+      return;
+    }
+
+    setCustomerSearching(true);
+    try {
+      const response = await fetch(
+        `/api/admin/b2b/manual-intake?q=${encodeURIComponent(query)}`,
+        { headers: authHeaders() },
+      );
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || "Customer search failed");
+      }
+      setCustomerResults(data.results || []);
+      if ((data.results || []).length === 0) {
+        toast.info("No existing business customers found");
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Customer search failed",
+      );
+    } finally {
+      setCustomerSearching(false);
+    }
+  }
+
+  async function loadCustomerPrefill(customerId: string) {
+    if (
+      hasTypedFormValues(form) &&
+      !window.confirm(
+        "Replace the current form fields with this customer record?",
+      )
+    ) {
+      return;
+    }
+
+    setCustomerSearching(true);
+    try {
+      const response = await fetch(
+        `/api/admin/b2b/manual-intake?customerId=${encodeURIComponent(customerId)}`,
+        { headers: authHeaders() },
+      );
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || "Customer details could not be loaded");
+      }
+
+      const prefill = data.prefill as ManualIntakePrefill;
+      setForm((current) => ({ ...current, ...prefill.form }));
+      setSelectedCustomer(prefill.customer);
+      setResult(null);
+      setCustomerResults([]);
+      setCustomerSearch(prefill.customer.businessName);
+      setMandateAuthorised(false);
+      setVisited({});
+      setAttempted({});
+      toast.success("Customer details loaded into manual onboarding");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Customer details could not be loaded",
+      );
+    } finally {
+      setCustomerSearching(false);
+    }
+  }
+
+  function clearSelectedCustomer() {
+    setForm(initialState);
+    setSelectedCustomer(null);
+    setCustomerResults([]);
+    setCustomerSearch("");
+    setResult(null);
+    setUploadedCount(0);
+    setVisited({});
+    setAttempted({});
+    setMandateAuthorised(false);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const submitter =
+      "submitter" in event.nativeEvent
+        ? (event.nativeEvent as SubmitEvent).submitter
+        : null;
+    const submitIntent =
+      submitter instanceof HTMLButtonElement
+        ? submitter.dataset.intent
+        : "save";
+
+    if (!customerReady || !contactReady) {
+      const target: IntakeStepId = !customerReady ? "customer" : "contact";
+      setActiveStep(target);
+      setAttempted((current) => ({ ...current, [target]: true }));
+      toast.error(
+        "Complete customer, contact, and site details before saving onboarding.",
+      );
+      return;
+    }
+
+    if (submitIntent === "vetting" && !allRequiredReady) {
+      const firstMissingStep = intakeSteps
+        .slice(0, 5)
+        .find((step) => !stepReadiness[step.id]);
+      if (firstMissingStep) {
+        setActiveStep(firstMissingStep.id);
+        setAttempted((current) => ({ ...current, [firstMissingStep.id]: true }));
+      }
+      toast.error(
+        "Complete all required onboarding items before submitting for vetting.",
+      );
+      return;
+    }
+
+    setSaving(true);
+    setResult(null);
+
+    const payload = {
+      customerId: trimOrUndefined(form.customerId),
+      submissionId: trimOrUndefined(form.submissionId),
+      segment: form.segment,
+      business: {
+        businessName: form.businessName.trim(),
+        entityType: form.entityType,
+        registrationNumber: form.registrationNumber.trim(),
+        vatRegistered: form.vatRegistered,
+        vatNumber: form.vatRegistered
+          ? trimOrUndefined(form.vatNumber)
+          : undefined,
+        registeredAddress: form.registeredAddress.trim(),
+      },
+      contact: {
+        contactName: form.contactName.trim(),
+        email: form.email.trim(),
+        phone: form.phone.trim(),
+      },
+      site: {
+        clinicName: trimOrUndefined(form.clinicName),
+        province: trimOrUndefined(form.province),
+        siteAddress: trimOrUndefined(form.siteAddress),
+      },
+      service: {
+        serviceId: trimOrUndefined(form.serviceId),
+        packageName: form.packageName.trim(),
+        serviceType: form.serviceType.trim(),
+        monthlyPrice: serviceMonthlyPrice || 450,
+        activationDate: trimOrUndefined(form.activationDate),
+        billingDay: form.billingDay,
+      },
+      debitOrder: form.includeDebitOrder
+        ? {
+            paymentMethodId: trimOrUndefined(form.paymentMethodId),
+            accountHolderName: form.accountHolderName.trim(),
+            bankName: form.bankName.trim(),
+            accountType: form.accountType,
+            accountNumber: form.accountNumber.trim(),
+            branchCode: form.branchCode.trim(),
+          }
+        : undefined,
+    };
+
+    try {
+      const response = await fetch("/api/admin/b2b/manual-intake", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("admin_token") || ""}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || "Manual onboarding failed");
+      }
+      const intake = data.intake as IntakeResult;
+      setResult(intake);
+      setForm((current) => ({
+        ...current,
+        customerId: intake.customerId,
+        submissionId: intake.submissionId,
+        serviceId: intake.serviceId ?? current.serviceId,
+        paymentMethodId: intake.paymentMethodId ?? current.paymentMethodId,
+      }));
+      setSelectedCustomer((current) => ({
+        id: intake.customerId,
+        accountNumber: intake.accountNumber,
+        businessName: form.businessName,
+        email: form.email,
+        phone: form.phone,
+        registrationNumber: form.registrationNumber,
+        onboardingStatus: current?.onboardingStatus ?? "submitted",
+        latestSubmissionId: intake.submissionId,
+        activeServiceId: intake.serviceId ?? current?.activeServiceId ?? null,
+        paymentMethodId:
+          intake.paymentMethodId ?? current?.paymentMethodId ?? null,
+        paymentLastFour: current?.paymentLastFour ?? null,
+      }));
+      toast.success(
+        intake.createdCustomer
+          ? `Business customer created: ${intake.accountNumber || intake.customerId}`
+          : "Business customer updated",
+      );
+      if (allRequiredReady) setActiveStep("review");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Manual onboarding failed",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const ActiveIcon = activeStepMeta.icon;
+
+  return (
+    <main className="mx-auto max-w-[1500px] px-4 py-8">
+      <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight text-gray-950">
+            Manual B2B Onboarding
+          </h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Admin-assisted capture for emailed client onboarding packs
+          </p>
+          <span className="mt-3 inline-flex items-center gap-2 rounded-full border border-orange-100 bg-orange-50 px-3 py-1 text-xs font-semibold text-circleTel-orange-dark">
+            Step {activeStepIndex + 1} of {intakeSteps.length}
+            <span className="text-gray-400">·</span>
+            {activeStepMeta.label}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <Button
+            type="submit"
+            form="manual-b2b-intake-form"
+            data-intent="save"
+            variant="outline"
+            disabled={saving}
+          >
+            <PiFloppyDiskBold className="h-4 w-4" />
+            {saving ? "Saving..." : "Save Onboarding"}
+          </Button>
+          <Button
+            type="submit"
+            form="manual-b2b-intake-form"
+            data-intent="vetting"
+            disabled={saving || !allRequiredReady}
+            className="bg-circleTel-orange text-white hover:bg-circleTel-orange-dark"
+          >
+            {saving ? "Saving..." : "Submit for Vetting"}
+            <PiArrowRightBold className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[220px_minmax(0,760px)_320px]">
+        <aside className="space-y-4">
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div className="border-b border-gray-100 px-5 py-4">
+              <h2 className="text-base font-semibold text-gray-950">
+                Onboarding Progress
+              </h2>
+              <p className="mt-1 text-sm text-gray-500">
+                Step {activeStepIndex + 1} of {intakeSteps.length}
+              </p>
+            </div>
+            <div className="space-y-1 px-4 py-4">
+              {intakeSteps.map((step, index) => {
+                const active = step.id === activeStep;
+                const ready = stepReadiness[step.id];
+                return (
+                  <button
+                    key={step.id}
+                    type="button"
+                    onClick={() => setActiveStep(step.id)}
+                    className="grid w-full grid-cols-[32px_minmax(0,1fr)] gap-3 rounded-md px-2 py-3 text-left transition hover:bg-gray-50"
+                  >
+                    <span
+                      className={
+                        ready
+                          ? "flex h-7 w-7 items-center justify-center rounded-full bg-emerald-500 text-xs font-semibold text-white"
+                          : active
+                            ? "flex h-7 w-7 items-center justify-center rounded-full bg-circleTel-orange text-xs font-semibold text-white"
+                            : "flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 text-xs font-semibold text-gray-600"
+                      }
+                    >
+                      {ready ? (
+                        <PiCheckCircleBold className="h-4 w-4" />
+                      ) : (
+                        index + 1
+                      )}
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block text-sm font-semibold text-gray-950">
+                        {step.label}
+                      </span>
+                      <StepStatusPill ready={ready} active={active} />
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-orange-100 bg-orange-50/60 p-4 text-sm">
+            <PiWarningCircleBold className="h-5 w-5 text-circleTel-orange" />
+            <p className="mt-3 font-semibold text-gray-950">Need help?</p>
+            <p className="mt-1 text-gray-600">
+              Use the onboarding guide when emailed packs are incomplete.
+            </p>
+            <Button asChild variant="outline" size="sm" className="mt-4 w-full">
+              <Link href="/admin/unjani/onboarding">
+                View pipeline
+                <PiArrowRightBold className="h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+        </aside>
+
+        <form
+          id="manual-b2b-intake-form"
+          className="space-y-6"
+          onSubmit={handleSubmit}
+        >
+          <SectionCard
+            title={activeStepMeta.label}
+            icon={ActiveIcon}
+            action={
+              activeStep === "customer" && selectedCustomer ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={clearSelectedCustomer}
+                >
+                  <PiXBold className="h-4 w-4" />
+                  Clear
+                </Button>
+              ) : null
+            }
+          >
+            <p className="-mt-2 mb-6 text-sm text-gray-500">
+              {activeStepMeta.description}
+            </p>
+
+            {visibleStepErrors.length > 0 ? (
+              <div
+                ref={summaryRef}
+                tabIndex={-1}
+                role="alert"
+                className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 outline-none"
+              >
+                <p className="flex items-center gap-2 text-sm font-semibold text-red-700">
+                  <PiWarningCircleBold className="h-4 w-4" />
+                  Please fix {visibleStepErrors.length}{" "}
+                  {visibleStepErrors.length === 1 ? "item" : "items"} on this step:
+                </p>
+                <ul className="mt-2 list-disc pl-6 text-sm text-red-700">
+                  {visibleStepErrors.map((entry) => (
+                    <li key={entry.key}>{entry.msg}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
+            {activeStep === "customer" && (
+              <div className="space-y-6">
+                <div className="space-y-3 border-b border-gray-100 pb-6">
+                  <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
+                    <Field id="customerSearch" label="Find existing customer">
+                      <Input
+                        id="customerSearch"
+                        value={customerSearch}
+                        onChange={(event) =>
+                          setCustomerSearch(event.target.value)
+                        }
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            void handleCustomerSearch();
+                          }
+                        }}
+                        placeholder="Search name, account number, email, phone, or registration"
+                      />
+                    </Field>
+                    <div className="flex items-end">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => void handleCustomerSearch()}
+                        disabled={customerSearching}
+                      >
+                        <PiMagnifyingGlassBold className="h-4 w-4" />
+                        {customerSearching ? "Searching..." : "Search"}
+                      </Button>
+                    </div>
+                  </div>
+
+                  {customerResults.length > 0 && (
+                    <div className="overflow-hidden rounded-md border border-gray-200 bg-white">
+                      {customerResults.map((customer) => (
+                        <button
+                          key={customer.id}
+                          type="button"
+                          onClick={() => void loadCustomerPrefill(customer.id)}
+                          className="flex w-full items-center justify-between gap-3 border-b border-gray-100 px-3 py-2.5 text-left last:border-b-0 hover:bg-gray-50"
+                        >
+                          <span className="min-w-0">
+                            <span className="block truncate font-semibold text-gray-900">
+                              {customer.businessName}
+                            </span>
+                            <span className="block truncate text-sm text-gray-600">
+                              {customer.accountNumber || "No account number"}
+                              {customer.email ? ` - ${customer.email}` : ""}
+                              {customer.phone ? ` - ${customer.phone}` : ""}
+                            </span>
+                          </span>
+                          {customer.onboardingStatus && (
+                            <span className="shrink-0 rounded-full bg-gray-100 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-600">
+                              {customer.onboardingStatus.replace(/_/g, " ")}
+                            </span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+
+                  {selectedCustomer && (
+                    <div className="flex items-start gap-3 rounded-md border border-gray-200 border-l-4 border-l-circleTel-orange bg-gray-50 px-3 py-3 text-sm">
+                      <PiUserCircleBold className="mt-0.5 h-5 w-5 shrink-0 text-circleTel-orange" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="truncate font-semibold text-gray-900">
+                            {selectedCustomer.businessName}
+                          </p>
+                          <span className="rounded-full bg-circleTel-orange-light px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-circleTel-orange-dark">
+                            Linked
+                          </span>
+                        </div>
+                        <p className="mt-0.5 truncate text-gray-600">
+                          {selectedCustomer.accountNumber ||
+                            "No account number"}
+                          {selectedCustomer.email
+                            ? ` - ${selectedCustomer.email}`
+                            : ""}
+                          {selectedCustomer.phone
+                            ? ` - ${selectedCustomer.phone}`
+                            : ""}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {!selectedCustomer && !form.customerId && (
+                    <div className="flex items-start gap-3 rounded-md border border-dashed border-gray-200 px-3 py-3 text-sm">
+                      <PiUserCircleBold className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+                      <div>
+                        <p className="font-semibold text-gray-900">
+                          New business customer
+                        </p>
+                        <p className="mt-0.5 text-gray-500">
+                          Leave unlinked to create a new customer when this
+                          onboarding is saved.
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <div className="space-y-4">
+                  <p className="text-sm font-semibold text-gray-950">
+                    Business details
+                  </p>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <Field id="segment" label="Segment">
+                      <Select
+                        value={form.segment}
+                        onValueChange={(value) => update("segment", value)}
+                      >
+                        <SelectTrigger id="segment">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="unjani">Unjani</SelectItem>
+                          <SelectItem value="smb">SMB</SelectItem>
+                          <SelectItem value="edu">Education</SelectItem>
+                          <SelectItem value="enterprise">Enterprise</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                    <Field id="businessName" label="Registered business name" error={errFor("businessName")}>
+                      <Input
+                        id="businessName"
+                        value={form.businessName}
+                        onChange={(event) =>
+                          update("businessName", event.target.value)
+                        }
+                        onBlur={() => blur("businessName")}
+                        aria-invalid={Boolean(errFor("businessName"))}
+                        aria-describedby={errFor("businessName") ? "businessName-error" : undefined}
+                        className={errClass("businessName")}
+                        required
+                      />
+                    </Field>
+                    <Field id="entityType" label="Entity type">
+                      <Select
+                        value={form.entityType}
+                        onValueChange={(value) => update("entityType", value)}
+                      >
+                        <SelectTrigger id="entityType">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="Private Company">
+                            Private Company
+                          </SelectItem>
+                          <SelectItem value="Sole Proprietor">
+                            Sole Proprietor
+                          </SelectItem>
+                          <SelectItem value="Non-Profit Company">
+                            Non-Profit Company
+                          </SelectItem>
+                          <SelectItem value="Partnership">
+                            Partnership
+                          </SelectItem>
+                          <SelectItem value="Trust">Trust</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                    <Field
+                      id="registrationNumber"
+                      label="Registration or owner ID"
+                      error={errFor("registrationNumber")}
+                    >
+                      <Input
+                        id="registrationNumber"
+                        value={form.registrationNumber}
+                        onChange={(event) =>
+                          update("registrationNumber", event.target.value)
+                        }
+                        onBlur={() => blur("registrationNumber")}
+                        aria-invalid={Boolean(errFor("registrationNumber"))}
+                        aria-describedby={errFor("registrationNumber") ? "registrationNumber-error" : undefined}
+                        className={errClass("registrationNumber")}
+                        required
+                      />
+                    </Field>
+                    <Field id="vatNumber" label="VAT number" error={errFor("vatNumber")}>
+                      <div className="flex gap-3">
+                        <div className="flex h-10 items-center gap-2 rounded-md border border-gray-200 px-3">
+                          <Checkbox
+                            id="vatRegistered"
+                            checked={form.vatRegistered}
+                            onCheckedChange={(checked) => {
+                              update("vatRegistered", checked === true);
+                              blur("vatNumber");
+                            }}
+                          />
+                          <Label htmlFor="vatRegistered" className="text-sm text-gray-700">VAT</Label>
+                        </div>
+                        <Input
+                          id="vatNumber"
+                          value={form.vatNumber}
+                          onChange={(event) =>
+                            update("vatNumber", event.target.value)
+                          }
+                          onBlur={() => blur("vatNumber")}
+                          aria-invalid={Boolean(errFor("vatNumber"))}
+                          aria-describedby={errFor("vatNumber") ? "vatNumber-error" : undefined}
+                          className={errClass("vatNumber")}
+                          disabled={!form.vatRegistered}
+                        />
+                      </div>
+                    </Field>
+                    <Field
+                      id="registeredAddress"
+                      label="Registered address"
+                      className="md:col-span-2"
+                      error={errFor("registeredAddress")}
+                    >
+                      <Textarea
+                        id="registeredAddress"
+                        value={form.registeredAddress}
+                        onChange={(event) =>
+                          update("registeredAddress", event.target.value)
+                        }
+                        onBlur={() => blur("registeredAddress")}
+                        aria-invalid={Boolean(errFor("registeredAddress"))}
+                        aria-describedby={errFor("registeredAddress") ? "registeredAddress-error" : undefined}
+                        className={`min-h-28 ${errClass("registeredAddress")}`}
+                        required
+                      />
+                    </Field>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {activeStep === "contact" && (
+              <div className="space-y-6">
+                {(selectedCustomer || form.businessName) && (
+                  <div className="flex items-start gap-3 rounded-md border border-gray-200 border-l-4 border-l-circleTel-orange bg-gray-50 px-4 py-4 text-sm">
+                    <PiUserCircleBold className="mt-0.5 h-5 w-5 shrink-0 text-circleTel-orange" />
+                    <div className="min-w-0">
+                      <p className="font-semibold text-gray-950">
+                        {documentCustomerName}
+                        <span className="ml-2 rounded-full bg-circleTel-orange-light px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-circleTel-orange-dark">
+                          Linked
+                        </span>
+                      </p>
+                      <p className="mt-1 text-gray-600">
+                        {accountLabel} - {contactLabel}
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <Field id="contactName" label="Authorized contact" error={errFor("contactName")}>
+                    <Input
+                      id="contactName"
+                      value={form.contactName}
+                      onChange={(event) =>
+                        update("contactName", event.target.value)
+                      }
+                      onBlur={() => blur("contactName")}
+                      aria-invalid={Boolean(errFor("contactName"))}
+                      aria-describedby={errFor("contactName") ? "contactName-error" : undefined}
+                      className={errClass("contactName")}
+                      required
+                    />
+                  </Field>
+                  <Field id="email" label="Email" error={errFor("email")}>
+                    <Input
+                      id="email"
+                      type="email"
+                      value={form.email}
+                      onChange={(event) => update("email", event.target.value)}
+                      onBlur={() => blur("email")}
+                      aria-invalid={Boolean(errFor("email"))}
+                      aria-describedby={errFor("email") ? "email-error" : undefined}
+                      className={errClass("email")}
+                      required
+                    />
+                  </Field>
+                  <Field id="phone" label="Phone" error={errFor("phone")}>
+                    <Input
+                      id="phone"
+                      value={form.phone}
+                      onChange={(event) => update("phone", event.target.value)}
+                      onBlur={() => blur("phone")}
+                      aria-invalid={Boolean(errFor("phone"))}
+                      aria-describedby={errFor("phone") ? "phone-error" : undefined}
+                      className={errClass("phone")}
+                      required
+                    />
+                  </Field>
+                  <Field id="clinicName" label="Trading or clinic name">
+                    <Input
+                      id="clinicName"
+                      value={form.clinicName}
+                      onChange={(event) =>
+                        update("clinicName", event.target.value)
+                      }
+                    />
+                  </Field>
+                  <Field id="province" label="Province">
+                    <Input
+                      id="province"
+                      value={form.province}
+                      onChange={(event) =>
+                        update("province", event.target.value)
+                      }
+                    />
+                  </Field>
+                  <Field
+                    id="siteAddress"
+                    label="Service address"
+                    className="md:col-span-2"
+                    error={errFor("siteAddress")}
+                  >
+                    <Textarea
+                      id="siteAddress"
+                      value={form.siteAddress}
+                      onChange={(event) =>
+                        update("siteAddress", event.target.value)
+                      }
+                      onBlur={() => blur("siteAddress")}
+                      aria-invalid={Boolean(errFor("siteAddress"))}
+                      aria-describedby={errFor("siteAddress") ? "siteAddress-error" : undefined}
+                      className={`min-h-28 ${errClass("siteAddress")}`}
+                    />
+                  </Field>
+                </div>
+              </div>
+            )}
+
+            {activeStep === "service" && (
+              <div className="space-y-6">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <Field id="packageName" label="Package" error={errFor("packageName")}>
+                    <Input
+                      id="packageName"
+                      value={form.packageName}
+                      onChange={(event) =>
+                        update("packageName", event.target.value)
+                      }
+                      onBlur={() => blur("packageName")}
+                      aria-invalid={Boolean(errFor("packageName"))}
+                      aria-describedby={errFor("packageName") ? "packageName-error" : undefined}
+                      className={errClass("packageName")}
+                      required
+                    />
+                  </Field>
+                  <Field id="serviceType" label="Service type" error={errFor("serviceType")}>
+                    <Input
+                      id="serviceType"
+                      value={form.serviceType}
+                      onChange={(event) =>
+                        update("serviceType", event.target.value)
+                      }
+                      onBlur={() => blur("serviceType")}
+                      aria-invalid={Boolean(errFor("serviceType"))}
+                      aria-describedby={errFor("serviceType") ? "serviceType-error" : undefined}
+                      className={errClass("serviceType")}
+                      required
+                    />
+                  </Field>
+                  <Field id="monthlyPrice" label="Monthly ex VAT" error={errFor("monthlyPrice")}>
+                    <Input
+                      id="monthlyPrice"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={form.monthlyPrice}
+                      onChange={(event) =>
+                        update("monthlyPrice", event.target.value)
+                      }
+                      onBlur={() => blur("monthlyPrice")}
+                      aria-invalid={Boolean(errFor("monthlyPrice"))}
+                      aria-describedby={errFor("monthlyPrice") ? "monthlyPrice-error" : undefined}
+                      className={errClass("monthlyPrice")}
+                      required
+                    />
+                  </Field>
+                  <Field id="billingDay" label="Billing day">
+                    <Select
+                      value={form.billingDay}
+                      onValueChange={(value) =>
+                        update("billingDay", value as BillingDay)
+                      }
+                    >
+                      <SelectTrigger id="billingDay">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="1">1st</SelectItem>
+                        <SelectItem value="15">15th</SelectItem>
+                        <SelectItem value="20">20th</SelectItem>
+                        <SelectItem value="25">25th</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                  <Field id="activationDate" label="Activation date">
+                    <Input
+                      id="activationDate"
+                      type="date"
+                      value={form.activationDate}
+                      onChange={(event) =>
+                        update("activationDate", event.target.value)
+                      }
+                    />
+                  </Field>
+                </div>
+
+                <div className="ml-auto rounded-lg border border-orange-100 bg-orange-50 p-4 text-sm md:w-80">
+                  <p className="font-semibold text-circleTel-orange-dark">
+                    Monthly Pricing Summary
+                  </p>
+                  <div className="mt-3 space-y-2">
+                    <div className="flex justify-between gap-3">
+                      <span className="text-gray-600">Base package</span>
+                      <span className="font-semibold text-gray-950">
+                        {formatCurrency(serviceMonthlyPrice || 450)}
+                      </span>
+                    </div>
+                    <div className="border-t border-orange-200 pt-2">
+                      <div className="flex justify-between gap-3 text-base">
+                        <span className="font-semibold text-circleTel-orange-dark">
+                          Total ex VAT
+                        </span>
+                        <span className="font-semibold text-circleTel-orange-dark">
+                          {formatCurrency(serviceMonthlyPrice || 450)}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {activeStep === "documents" && (
+              <div className="space-y-6">
+                <button
+                  type="button"
+                  className="flex cursor-pointer flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-9 text-center transition hover:border-circleTel-orange hover:bg-orange-50"
+                  onClick={() => {
+                    if (canUploadDocuments) setUploadOpen(true);
+                  }}
+                  disabled={!canUploadDocuments}
+                >
+                  <PiUploadSimpleBold className="h-9 w-9 text-circleTel-orange" />
+                  <span className="mt-3 font-semibold text-gray-950">
+                    Open the document uploader
+                  </span>
+                  <span className="mt-1 text-sm text-gray-500">
+                    Drag and drop PDF, JPG, or PNG files, then classify each
+                    document inside this client onboarding pack.
+                  </span>
+                </button>
+
+                <div className="rounded-lg border border-gray-200">
+                  <div className="grid grid-cols-[1fr_auto] gap-3 border-b border-gray-100 px-4 py-3">
+                    <div>
+                      <p className="font-semibold text-gray-950">
+                        Upload target
+                      </p>
+                      <p className="text-sm text-gray-500">
+                        {canUploadDocuments
+                          ? documentCustomerName
+                          : "Save this onboarding first to create an upload target."}
+                      </p>
+                    </div>
+                    <StatusPill
+                      ready={documentsReady}
+                      warning={canUploadDocuments && !documentsReady}
+                      label={
+                        documentsReady
+                          ? `${uploadedCount} uploaded`
+                          : canUploadDocuments
+                            ? "Ready to upload"
+                            : "Pending"
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-3 p-4 md:grid-cols-3">
+                    {[
+                      "Company registration",
+                      "VAT certificate",
+                      "Owner / Director ID",
+                      "Proof of address",
+                      "Bank confirmation",
+                      "Other supporting docs",
+                    ].map((item) => (
+                      <div
+                        key={item}
+                        className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2 text-sm text-gray-700"
+                      >
+                        {item}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <Button
+                  type="button"
+                  className="w-full bg-circleTel-orange text-white hover:bg-circleTel-orange-dark"
+                  disabled={!canUploadDocuments}
+                  onClick={() => setUploadOpen(true)}
+                >
+                  <PiUploadSimpleBold className="h-4 w-4" />
+                  Upload documents
+                </Button>
+              </div>
+            )}
+
+            {activeStep === "debit" && (
+              <div className="space-y-5">
+                <div className="flex items-center justify-between rounded-md border border-gray-200 bg-gray-50 px-4 py-3">
+                  <div>
+                    <p className="font-semibold text-gray-950">
+                      Capture debit order
+                    </p>
+                    <p className="text-sm text-gray-500">
+                      Required before the service can become billable.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      id="includeDebitOrder"
+                      checked={form.includeDebitOrder}
+                      onCheckedChange={(checked) =>
+                        update("includeDebitOrder", checked === true)
+                      }
+                    />
+                    <Label htmlFor="includeDebitOrder" className="text-sm">
+                      Capture
+                    </Label>
+                  </div>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <Field id="accountHolderName" label="Account holder" error={errFor("accountHolderName")}>
+                    <Input
+                      id="accountHolderName"
+                      value={form.accountHolderName}
+                      onChange={(event) =>
+                        update("accountHolderName", event.target.value)
+                      }
+                      onBlur={() => blur("accountHolderName")}
+                      aria-invalid={Boolean(errFor("accountHolderName"))}
+                      aria-describedby={errFor("accountHolderName") ? "accountHolderName-error" : undefined}
+                      className={errClass("accountHolderName")}
+                      required={form.includeDebitOrder}
+                      disabled={!form.includeDebitOrder}
+                    />
+                  </Field>
+                  <Field id="bankName" label="Bank" error={errFor("bankName")}>
+                    <Input
+                      id="bankName"
+                      value={form.bankName}
+                      onChange={(event) =>
+                        update("bankName", event.target.value)
+                      }
+                      onBlur={() => blur("bankName")}
+                      aria-invalid={Boolean(errFor("bankName"))}
+                      aria-describedby={errFor("bankName") ? "bankName-error" : undefined}
+                      className={errClass("bankName")}
+                      required={form.includeDebitOrder}
+                      disabled={!form.includeDebitOrder}
+                    />
+                  </Field>
+                  <Field id="accountType" label="Account type">
+                    <Select
+                      value={form.accountType}
+                      onValueChange={(value) => update("accountType", value)}
+                      disabled={!form.includeDebitOrder}
+                    >
+                      <SelectTrigger id="accountType">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Cheque">Cheque</SelectItem>
+                        <SelectItem value="Savings">Savings</SelectItem>
+                        <SelectItem value="Transmission">
+                          Transmission
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                  <Field id="accountNumber" label="Account number" error={errFor("accountNumber")}>
+                    <Input
+                      id="accountNumber"
+                      value={form.accountNumber}
+                      onChange={(event) =>
+                        update("accountNumber", event.target.value)
+                      }
+                      onBlur={() => blur("accountNumber")}
+                      aria-invalid={Boolean(errFor("accountNumber"))}
+                      aria-describedby={errFor("accountNumber") ? "accountNumber-error" : undefined}
+                      className={errClass("accountNumber")}
+                      required={form.includeDebitOrder}
+                      disabled={!form.includeDebitOrder}
+                    />
+                  </Field>
+                  <Field id="branchCode" label="Branch code" error={errFor("branchCode")}>
+                    <Input
+                      id="branchCode"
+                      value={form.branchCode}
+                      onChange={(event) =>
+                        update("branchCode", event.target.value)
+                      }
+                      onBlur={() => blur("branchCode")}
+                      aria-invalid={Boolean(errFor("branchCode"))}
+                      aria-describedby={errFor("branchCode") ? "branchCode-error" : undefined}
+                      className={errClass("branchCode")}
+                      required={form.includeDebitOrder}
+                      disabled={!form.includeDebitOrder}
+                    />
+                  </Field>
+                </div>
+
+                <div
+                  className={`rounded-md border p-4 ${
+                    errFor("mandate") ? "border-red-300 bg-red-50" : "border-gray-200"
+                  }`}
+                >
+                  <label className="flex items-start gap-2 text-sm text-gray-700">
+                    <Checkbox
+                      checked={mandateAuthorised}
+                      disabled={!form.includeDebitOrder}
+                      onCheckedChange={(checked) => {
+                        setMandateAuthorised(checked === true);
+                        blur("mandate");
+                      }}
+                    />
+                    <span>
+                      I/we authorise CircleTel to debit the customer account
+                      according to the selected billable service.
+                    </span>
+                  </label>
+                  {errFor("mandate") ? (
+                    <p className="mt-2 flex items-center gap-1.5 text-xs font-medium text-red-600" role="alert">
+                      <PiWarningCircleBold className="h-3.5 w-3.5 shrink-0" />
+                      {errFor("mandate")}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+            )}
+
+            {activeStep === "review" && (
+              <div className="space-y-5">
+                {allRequiredReady ? (
+                  <div className="flex items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+                    <PiCheckCircleBold className="mt-0.5 h-5 w-5 text-emerald-600" />
+                    <div>
+                      <p className="font-semibold text-emerald-900">
+                        Ready for vetting
+                      </p>
+                      <p className="text-sm text-emerald-800">
+                        All required information has been captured. Please
+                        review and submit.
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex items-start gap-3 rounded-lg border border-orange-200 bg-orange-50 px-4 py-3">
+                    <PiWarningCircleBold className="mt-0.5 h-5 w-5 text-circleTel-orange" />
+                    <div>
+                      <p className="font-semibold text-circleTel-orange-dark">
+                        Missing required items
+                      </p>
+                      <p className="text-sm text-gray-700">
+                        Complete the highlighted steps before submitting for
+                        vetting.
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                <div className="grid gap-4">
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <div className="mb-4 flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <h3 className="text-lg font-semibold text-gray-950">Customer Record</h3>
+                        <ReviewTag ready={stepReadiness.customer} />
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setActiveStep("customer")}
+                      >
+                        Edit
+                      </Button>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <ReviewRow
+                        label="Customer"
+                        value={documentCustomerName}
+                      />
+                      <ReviewRow
+                        label="Registered business name"
+                        value={form.businessName}
+                      />
+                      <ReviewRow label="Entity type" value={form.entityType} />
+                      <ReviewRow
+                        label="Registration or owner ID"
+                        value={form.registrationNumber}
+                      />
+                      <ReviewRow
+                        label="VAT number"
+                        value={
+                          form.vatRegistered
+                            ? form.vatNumber || "VAT registered"
+                            : "Not VAT registered"
+                        }
+                      />
+                      <ReviewRow
+                        label="Registered address"
+                        value={form.registeredAddress}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <div className="mb-4 flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <h3 className="text-lg font-semibold text-gray-950">Contact &amp; Site</h3>
+                        <ReviewTag ready={stepReadiness.contact} />
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setActiveStep("contact")}
+                      >
+                        Edit
+                      </Button>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <ReviewRow
+                        label="Authorized contact"
+                        value={form.contactName}
+                      />
+                      <ReviewRow label="Email" value={form.email} />
+                      <ReviewRow label="Phone" value={form.phone} />
+                      <ReviewRow
+                        label="Trading or clinic name"
+                        value={form.clinicName}
+                      />
+                      <ReviewRow label="Province" value={form.province} />
+                      <ReviewRow
+                        label="Service address"
+                        value={form.siteAddress}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <div className="mb-4 flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <h3 className="text-lg font-semibold text-gray-950">Billable Service</h3>
+                        <ReviewTag ready={stepReadiness.service} />
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setActiveStep("service")}
+                      >
+                        Edit
+                      </Button>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <ReviewRow label="Package" value={form.packageName} />
+                      <ReviewRow
+                        label="Service type"
+                        value={form.serviceType}
+                      />
+                      <ReviewRow
+                        label="Monthly ex VAT"
+                        value={String(serviceMonthlyPrice || 450)}
+                      />
+                      <ReviewRow label="Billing day" value={form.billingDay} />
+                      <ReviewRow
+                        label="Activation date"
+                        value={form.activationDate}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <div className="mb-4 flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <h3 className="text-lg font-semibold text-gray-950">Documents</h3>
+                        <ReviewTag ready={stepReadiness.documents} />
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setActiveStep("documents")}
+                      >
+                        Edit
+                      </Button>
+                    </div>
+                    <ReviewRow
+                      label="Uploaded documents"
+                      value={
+                        uploadedCount > 0
+                          ? `${uploadedCount} uploaded in this session`
+                          : "No documents uploaded in this session"
+                      }
+                    />
+                  </div>
+
+                  <div className="rounded-lg border border-gray-200 p-4">
+                    <div className="mb-4 flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <h3 className="text-lg font-semibold text-gray-950">Debit Order</h3>
+                        <ReviewTag ready={stepReadiness.debit} />
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setActiveStep("debit")}
+                      >
+                        Edit
+                      </Button>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <ReviewRow
+                        label="Account holder"
+                        value={form.accountHolderName}
+                      />
+                      <ReviewRow label="Bank" value={form.bankName} />
+                      <ReviewRow
+                        label="Account type"
+                        value={form.accountType}
+                      />
+                      <ReviewRow
+                        label="Account number"
+                        value={form.accountNumber}
+                      />
+                      <ReviewRow label="Branch code" value={form.branchCode} />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="rounded-lg border border-gray-200 p-4">
+                      <h3 className="mb-3 text-base font-semibold text-gray-950">
+                        Final validation checklist
+                      </h3>
+                      <div className="space-y-3">
+                        {checklist.map((item) => (
+                          <div
+                            key={item.label}
+                            className="flex items-center gap-2 text-sm"
+                          >
+                            <PiCheckCircleBold
+                              className={
+                                item.ready
+                                  ? "h-4 w-4 text-emerald-600"
+                                  : "h-4 w-4 text-gray-300"
+                              }
+                            />
+                            <span className="text-gray-700">{item.label}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="rounded-lg border border-gray-200 p-4">
+                      <h3 className="mb-3 text-base font-semibold text-gray-950">
+                        Activity timeline
+                      </h3>
+                      <div className="space-y-3 text-sm text-gray-600">
+                        <p>Customer record loaded by admin</p>
+                        <p>Onboarding details captured</p>
+                        <p>Documents uploaded through manual onboarding</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="mt-8 flex items-center justify-between border-t border-gray-100 pt-5">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={activeStepIndex === 0}
+                onClick={goToPreviousStep}
+              >
+                Back
+              </Button>
+              {activeStepIndex < intakeSteps.length - 1 ? (
+                <Button
+                  type="button"
+                  className="bg-circleTel-orange text-white hover:bg-circleTel-orange-dark"
+                  onClick={goToNextStep}
+                >
+                  Next
+                  <PiArrowRightBold className="h-4 w-4" />
+                </Button>
+              ) : (
+                <Button
+                  type="submit"
+                  data-intent="vetting"
+                  disabled={saving || !allRequiredReady}
+                  className="bg-circleTel-orange text-white hover:bg-circleTel-orange-dark"
+                >
+                  {saving ? "Saving..." : "Submit for Vetting"}
+                  <PiArrowRightBold className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          </SectionCard>
+        </form>
+
+        <aside className="space-y-4">
+          <SectionCard
+            title="Capture Status"
+            icon={PiClipboardTextBold}
+            compact
+          >
+            <div className="space-y-5">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-sm font-semibold text-gray-950">
+                  Overall status
+                </p>
+                <StatusPill
+                  ready={allRequiredReady}
+                  warning={!allRequiredReady}
+                  label={allRequiredReady ? "Ready" : "In progress"}
+                />
+              </div>
+
+              {result && (
+                <div className="rounded-md border border-emerald-100 bg-emerald-50 px-3 py-2 text-sm">
+                  <p className="font-semibold text-emerald-800">
+                    {result.createdCustomer
+                      ? "New customer created"
+                      : "Customer updated"}
+                  </p>
+                  <p className="mt-1 text-emerald-700">
+                    {result.accountNumber || documentCustomerName}
+                  </p>
+                </div>
+              )}
+
+              <div className="border-t border-gray-100 pt-4">
+                <div className="mb-3 flex items-center justify-between">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Required items
+                  </p>
+                  <span className="text-xs font-semibold text-gray-700">
+                    {completion}%
+                  </span>
+                </div>
+                <div className="mb-3 h-2 w-full overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    className="h-full rounded-full bg-circleTel-orange transition-all"
+                    style={{ width: `${completion}%` }}
+                    role="progressbar"
+                    aria-valuenow={completion}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label="Required items complete"
+                  />
+                </div>
+                <div className="space-y-3">
+                  {intakeSteps.slice(0, 5).map((step) => {
+                    const active = activeStep === step.id;
+                    const ready = stepReadiness[step.id];
+                    return (
+                      <button
+                        key={step.id}
+                        type="button"
+                        onClick={() => setActiveStep(step.id)}
+                        className="flex w-full items-center justify-between gap-3 text-left text-sm"
+                      >
+                        <span className="font-medium text-gray-800">
+                          {step.label}
+                        </span>
+                        <StatusPill ready={ready} warning={active && !ready} />
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="border-t border-gray-100 pt-4">
+                <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Linked records
+                </p>
+                <div className="space-y-3">
+                  {linkedRecords.map((record) => (
+                    <div
+                      key={record.label}
+                      className="flex items-start justify-between gap-3 text-sm"
+                    >
+                      <div className="min-w-0">
+                        <p className="font-medium text-gray-900">
+                          {record.label}
+                        </p>
+                        <p className="truncate text-xs text-gray-500">
+                          {record.value}
+                        </p>
+                      </div>
+                      <StatusPill ready={record.ready} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {missingItems.length > 0 ? (
+                <div className="rounded-lg border border-orange-100 bg-orange-50 p-4 text-sm">
+                  <div className="flex items-center gap-2 font-semibold text-circleTel-orange-dark">
+                    <PiWarningCircleBold className="h-4 w-4" />
+                    Missing required details
+                  </div>
+                  <ul className="mt-3 space-y-1 text-gray-700">
+                    {missingItems.map((item) => (
+                      <li key={item}>- {item}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-4 text-sm">
+                  <div className="flex items-center gap-2 font-semibold text-emerald-800">
+                    <PiCheckCircleBold className="h-4 w-4" />
+                    All set
+                  </div>
+                  <p className="mt-2 text-emerald-700">
+                    The onboarding pack is ready to submit for vetting.
+                  </p>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Button
+                  type="submit"
+                  form="manual-b2b-intake-form"
+                  data-intent="vetting"
+                  disabled={saving || !allRequiredReady}
+                  className="w-full bg-circleTel-orange text-white hover:bg-circleTel-orange-dark"
+                >
+                  <PiArrowRightBold className="h-4 w-4" />
+                  {saving ? "Saving..." : "Submit for Vetting"}
+                </Button>
+                <Button
+                  type="submit"
+                  form="manual-b2b-intake-form"
+                  data-intent="save"
+                  variant="outline"
+                  disabled={saving}
+                  className="w-full"
+                >
+                  <PiFloppyDiskBold className="h-4 w-4" />
+                  {saving ? "Saving..." : "Save Onboarding"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => setConfirmDiscard(true)}
+                >
+                  Discard Onboarding
+                </Button>
+              </div>
+
+              {result && (
+                <div className="grid gap-2">
+                  <Button
+                    asChild
+                    variant="outline"
+                    size="sm"
+                    className="justify-between"
+                  >
+                    <Link href={`/admin/customers/${result.customerId}`}>
+                      Customer Record
+                      <PiArrowRightBold className="h-4 w-4" />
+                    </Link>
+                  </Button>
+                  <Button
+                    asChild
+                    variant="outline"
+                    size="sm"
+                    className="justify-between"
+                  >
+                    <Link href={`/admin/b2b/vetting/${result.submissionId}`}>
+                      Vetting Workbench
+                      <PiArrowRightBold className="h-4 w-4" />
+                    </Link>
+                  </Button>
+                </div>
+              )}
+            </div>
+          </SectionCard>
+
+          <SectionCard title="Guidance" icon={PiFileTextBold} compact>
+            <div className="space-y-3 text-sm">
+              <p className="text-gray-600">
+                Follow each step to complete the onboarding pack before vetting.
+              </p>
+              <Button asChild variant="ghost" size="sm" className="px-0">
+                <Link href="/admin/unjani/onboarding">
+                  View onboarding guide
+                  <PiArrowRightBold className="h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          </SectionCard>
+        </aside>
+      </div>
+
+      {canUploadDocuments && (
+        <UploadDocumentModal
+          open={uploadOpen}
+          onOpenChange={setUploadOpen}
+          customerId={form.customerId}
+          clinicName={documentCustomerName}
+          submissionId={trimOrUndefined(form.submissionId)}
+          defaultSegment={form.segment}
+          authHeaders={authHeaders}
+          onUploaded={(count) => {
+            if (count > 0) setUploadedCount((current) => current + count);
+          }}
+        />
+      )}
+
+      <Dialog open={confirmDiscard} onOpenChange={setConfirmDiscard}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Discard this onboarding?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-gray-600">
+            All captured details will be cleared. This cannot be undone.
+          </p>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setConfirmDiscard(false)}
+            >
+              Keep editing
+            </Button>
+            <Button
+              type="button"
+              className="bg-red-600 text-white hover:bg-red-700"
+              onClick={() => {
+                clearSelectedCustomer();
+                setConfirmDiscard(false);
+                toast.success("Onboarding discarded.");
+              }}
+            >
+              Discard
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </main>
+  );
+}

--- a/app/api/admin/b2b/manual-intake/__tests__/route.test.ts
+++ b/app/api/admin/b2b/manual-intake/__tests__/route.test.ts
@@ -1,0 +1,355 @@
+import { NextRequest } from "next/server";
+
+import { GET, POST } from "../route";
+import {
+  authenticateAdmin,
+  requirePermission,
+} from "@/lib/auth/admin-api-auth";
+import { svc } from "@/lib/onboarding/onboarding-service";
+import { saveManualB2BIntake } from "@/lib/onboarding/manual-intake";
+
+jest.mock("@/lib/auth/admin-api-auth", () => ({
+  authenticateAdmin: jest.fn(),
+  requirePermission: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/onboarding-service", () => ({
+  svc: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/manual-intake", () => {
+  const actual = jest.requireActual("@/lib/onboarding/manual-intake");
+  return {
+    ...actual,
+    saveManualB2BIntake: jest.fn(),
+  };
+});
+
+jest.mock("@/lib/logging/logger", () => ({
+  apiLogger: {
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+const mockAuthenticateAdmin = authenticateAdmin as jest.MockedFunction<
+  typeof authenticateAdmin
+>;
+const mockRequirePermission = requirePermission as jest.MockedFunction<
+  typeof requirePermission
+>;
+const mockSvc = svc as jest.MockedFunction<typeof svc>;
+const mockSaveManualB2BIntake = saveManualB2BIntake as jest.MockedFunction<
+  typeof saveManualB2BIntake
+>;
+
+function request(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/admin/b2b/manual-intake", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+function getRequest(path: string) {
+  return new Request(`http://localhost${path}`) as NextRequest;
+}
+
+const validBody = {
+  segment: "unjani",
+  business: {
+    businessName: "Unjani Alexandra Clinic",
+    entityType: "Private Company",
+    registrationNumber: "2026/123456/07",
+    vatRegistered: false,
+    registeredAddress: "10 Clinic Road, Alexandra",
+  },
+  contact: {
+    contactName: "Thandi Maseko",
+    email: "thandi@example.co.za",
+    phone: "0821234567",
+  },
+  site: {
+    clinicName: "Unjani Alexandra",
+    province: "Gauteng",
+    siteAddress: "10 Clinic Road, Alexandra",
+  },
+};
+
+function createManualIntakeSupabaseMock() {
+  const from = jest.fn((table: string) => {
+    const builder: any = {
+      select: jest.fn(() => builder),
+      eq: jest.fn(() => builder),
+      or: jest.fn(() => builder),
+      order: jest.fn((column: string) => {
+        if (table === "onboarding_submissions" && column === "created_at") {
+          throw new Error("onboarding_submissions.created_at does not exist");
+        }
+        return builder;
+      }),
+      limit: jest.fn(() => builder),
+      maybeSingle: jest.fn(() => {
+        if (table === "onboarding_submissions") {
+          return Promise.resolve({
+            data: {
+              id: "submission-1",
+              segment: "unjani",
+              submission_data: {
+                step1: {
+                  clinicName: "Unjani Delmas",
+                  province: "Mpumalanga",
+                  contact: "Lesedi Mmoneng",
+                  phone: "0792277729",
+                  email: "delmas@unjani.org",
+                  siteAddress: "Corner R42 and Nelson Mandela drive, Delmas",
+                },
+                step2: {
+                  entityName: "Unjani Clinic - Delmas",
+                  entityType: "Private Company",
+                  regNumber: "2026/00033/07",
+                  vat: "No",
+                  regAddress: "Corner R42 and Nelson Mandela drive, Delmas",
+                },
+                step5: { paymentDate: "25" },
+              },
+            },
+            error: null,
+          });
+        }
+        if (table === "customer_services") {
+          return Promise.resolve({
+            data: {
+              id: "service-1",
+              package_name: "CircleTel ClinicConnect",
+              service_type: "managed_connectivity",
+              monthly_price: 650,
+              activation_date: "2026-06-01",
+              billing_day: 25,
+              provider_name: "MTN",
+            },
+            error: null,
+          });
+        }
+        if (table === "customer_payment_methods") {
+          return Promise.resolve({
+            data: {
+              id: "payment-1",
+              last_four: "1234",
+              mandate_status: "pending",
+              encrypted_details: {
+                bank_name: "FNB",
+                account_holder_name: "Unjani Clinic Delmas",
+                account_type: "Cheque",
+                branch_code: "250655",
+              },
+            },
+            error: null,
+          });
+        }
+        return Promise.resolve({ data: null, error: null });
+      }),
+      single: jest.fn(() => {
+        if (table === "customers") {
+          return Promise.resolve({
+            data: {
+              id: "customer-1",
+              account_number: "CT-2026-00033",
+              business_name: "Unjani Clinic - Delmas",
+              business_registration: "2026/00033/07",
+              tax_number: null,
+              first_name: "Lesedi",
+              last_name: "Mmoneng",
+              email: "delmas@unjani.org",
+              phone: "0792277729",
+              account_type: "business",
+              account_status: "active",
+              onboarding_status: "submitted",
+              clinic_details: {
+                clinic_name: "Unjani Delmas",
+                province: "Mpumalanga",
+                site_address: "Corner R42 and Nelson Mandela drive, Delmas",
+              },
+            },
+            error: null,
+          });
+        }
+        return Promise.resolve({ data: null, error: null });
+      }),
+      then: (resolve: any) => {
+        if (table === "customers") {
+          return Promise.resolve({
+            data: [
+              {
+                id: "customer-1",
+                account_number: "CT-2026-00033",
+                business_name: "Unjani Clinic - Delmas",
+                email: "delmas@unjani.org",
+                phone: "0792277729",
+                business_registration: "2026/00033/07",
+                onboarding_status: "submitted",
+              },
+            ],
+            error: null,
+          }).then(resolve);
+        }
+        return Promise.resolve({ data: [], error: null }).then(resolve);
+      },
+    };
+    return builder;
+  });
+
+  return { from } as any;
+}
+
+describe("POST /api/admin/b2b/manual-intake", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticateAdmin.mockResolvedValue({
+      success: true,
+      user: { id: "user-1", email: "admin@circletel.co.za" } as any,
+      adminUser: {
+        id: "admin-1",
+        email: "admin@circletel.co.za",
+        role: "admin",
+      } as any,
+    });
+    mockRequirePermission.mockReturnValue(null);
+    mockSvc.mockReturnValue({ from: jest.fn() } as any);
+    mockSaveManualB2BIntake.mockResolvedValue({
+      customerId: "customer-1",
+      accountNumber: "CT-2026-00042",
+      submissionId: "submission-1",
+      createdCustomer: true,
+      createdSubmission: true,
+    });
+  });
+
+  it("requires customer write or KYC verification permission", async () => {
+    await POST(request(validBody));
+
+    expect(mockRequirePermission).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "admin@circletel.co.za" }),
+      ["customers:write", "kyc:verify"],
+    );
+  });
+
+  it("delegates valid manual intake payloads to the domain service", async () => {
+    const response = await POST(request(validBody));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      intake: {
+        customerId: "customer-1",
+        accountNumber: "CT-2026-00042",
+        submissionId: "submission-1",
+        createdCustomer: true,
+        createdSubmission: true,
+      },
+    });
+    expect(mockSaveManualB2BIntake).toHaveBeenCalledWith(
+      expect.any(Object),
+      validBody,
+      { adminId: "admin-1", adminEmail: "admin@circletel.co.za" },
+    );
+  });
+
+  it("rejects malformed payloads before touching Supabase", async () => {
+    const response = await POST(request({ business: { businessName: "A" } }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("validation_failed");
+    expect(mockSvc).not.toHaveBeenCalled();
+    expect(mockSaveManualB2BIntake).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/admin/b2b/manual-intake", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticateAdmin.mockResolvedValue({
+      success: true,
+      user: { id: "user-1", email: "admin@circletel.co.za" } as any,
+      adminUser: {
+        id: "admin-1",
+        email: "admin@circletel.co.za",
+        role: "admin",
+      } as any,
+    });
+    mockRequirePermission.mockReturnValue(null);
+    mockSvc.mockReturnValue(createManualIntakeSupabaseMock());
+  });
+
+  it("searches existing B2B customers for manual intake selection", async () => {
+    const response = await GET(
+      getRequest("/api/admin/b2b/manual-intake?q=delmas"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.results).toEqual([
+      expect.objectContaining({
+        id: "customer-1",
+        accountNumber: "CT-2026-00033",
+        businessName: "Unjani Clinic - Delmas",
+        email: "delmas@unjani.org",
+      }),
+    ]);
+  });
+
+  it("returns existing customer details mapped to manual-intake form fields", async () => {
+    const response = await GET(
+      getRequest("/api/admin/b2b/manual-intake?customerId=customer-1"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.prefill).toEqual(
+      expect.objectContaining({
+        customer: expect.objectContaining({
+          id: "customer-1",
+          accountNumber: "CT-2026-00033",
+          businessName: "Unjani Clinic - Delmas",
+          latestSubmissionId: "submission-1",
+          activeServiceId: "service-1",
+          paymentMethodId: "payment-1",
+          paymentLastFour: "1234",
+        }),
+        form: expect.objectContaining({
+          customerId: "customer-1",
+          submissionId: "submission-1",
+          serviceId: "service-1",
+          paymentMethodId: "payment-1",
+          segment: "unjani",
+          businessName: "Unjani Clinic - Delmas",
+          entityType: "Private Company",
+          registrationNumber: "2026/00033/07",
+          vatRegistered: false,
+          registeredAddress: "Corner R42 and Nelson Mandela drive, Delmas",
+          contactName: "Lesedi Mmoneng",
+          email: "delmas@unjani.org",
+          phone: "0792277729",
+          clinicName: "Unjani Delmas",
+          province: "Mpumalanga",
+          siteAddress: "Corner R42 and Nelson Mandela drive, Delmas",
+          packageName: "CircleTel ClinicConnect",
+          serviceType: "managed_connectivity",
+          monthlyPrice: "650",
+          activationDate: "2026-06-01",
+          billingDay: "25",
+          includeDebitOrder: false,
+          bankName: "FNB",
+          accountHolderName: "Unjani Clinic Delmas",
+          accountType: "Cheque",
+          branchCode: "250655",
+        }),
+      }),
+    );
+  });
+});

--- a/app/api/admin/b2b/manual-intake/route.ts
+++ b/app/api/admin/b2b/manual-intake/route.ts
@@ -1,0 +1,342 @@
+/**
+ * /api/admin/b2b/manual-intake
+ *
+ * Admin-assisted B2B onboarding capture for business details received by email.
+ * Supports creating a new business customer record or updating an existing one.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  authenticateAdmin,
+  requirePermission,
+} from "@/lib/auth/admin-api-auth";
+import { svc } from "@/lib/onboarding/onboarding-service";
+import {
+  manualB2BIntakeSchema,
+  saveManualB2BIntake,
+} from "@/lib/onboarding/manual-intake";
+import { apiLogger } from "@/lib/logging/logger";
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {};
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function nullableString(value: unknown): string | null {
+  const text = stringValue(value).trim();
+  return text.length > 0 ? text : null;
+}
+
+function boolFromVat(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    return ["yes", "true", "registered"].includes(value.toLowerCase());
+  }
+  return fallback;
+}
+
+function normalizeBillingDay(value: unknown): "1" | "15" | "20" | "25" {
+  const text = String(value ?? "").trim();
+  if (text === "15" || text === "20" || text === "25") return text;
+  return "1";
+}
+
+function fullName(firstName: unknown, lastName: unknown): string {
+  return [stringValue(firstName), stringValue(lastName)]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+}
+
+function mapSearchCustomer(row: JsonRecord) {
+  return {
+    id: stringValue(row.id),
+    accountNumber: nullableString(row.account_number),
+    businessName: stringValue(row.business_name) || "Unnamed business",
+    email: nullableString(row.email),
+    phone: nullableString(row.phone),
+    registrationNumber: nullableString(row.business_registration),
+    onboardingStatus: nullableString(row.onboarding_status),
+  };
+}
+
+function mapCustomerPrefill({
+  customer,
+  submission,
+  service,
+  paymentMethod,
+}: {
+  customer: JsonRecord;
+  submission: JsonRecord | null;
+  service: JsonRecord | null;
+  paymentMethod: JsonRecord | null;
+}) {
+  const submissionData = asRecord(submission?.submission_data);
+  const step1 = asRecord(submissionData.step1);
+  const step2 = asRecord(submissionData.step2);
+  const step5 = asRecord(submissionData.step5);
+  const clinicDetails = asRecord(customer.clinic_details);
+  const paymentDetails = asRecord(paymentMethod?.encrypted_details);
+
+  const businessName =
+    stringValue(step2.entityName) ||
+    stringValue(submissionData.business_name) ||
+    stringValue(customer.business_name);
+  const registeredAddress =
+    stringValue(step2.regAddress) ||
+    stringValue(clinicDetails.site_address) ||
+    stringValue(step1.siteAddress);
+  const contactName =
+    stringValue(step1.contact) ||
+    fullName(customer.first_name, customer.last_name) ||
+    businessName;
+  const clinicName =
+    stringValue(step1.clinicName) ||
+    stringValue(clinicDetails.clinic_name) ||
+    businessName;
+  const province =
+    stringValue(step1.province) || stringValue(clinicDetails.province);
+  const siteAddress =
+    stringValue(step1.siteAddress) ||
+    stringValue(clinicDetails.site_address) ||
+    registeredAddress;
+  const taxNumber = stringValue(customer.tax_number);
+  const latestSubmissionId = nullableString(submission?.id);
+  const activeServiceId = nullableString(service?.id);
+  const paymentMethodId = nullableString(paymentMethod?.id);
+
+  return {
+    customer: {
+      id: stringValue(customer.id),
+      accountNumber: nullableString(customer.account_number),
+      businessName,
+      email: nullableString(customer.email),
+      phone: nullableString(customer.phone),
+      latestSubmissionId,
+      activeServiceId,
+      paymentMethodId,
+      paymentLastFour: nullableString(paymentMethod?.last_four),
+    },
+    form: {
+      customerId: stringValue(customer.id),
+      submissionId: latestSubmissionId ?? "",
+      serviceId: activeServiceId ?? "",
+      paymentMethodId: paymentMethodId ?? "",
+      segment: stringValue(submission?.segment) || "unjani",
+      businessName,
+      entityType: stringValue(step2.entityType) || "Private Company",
+      registrationNumber:
+        stringValue(step2.regNumber) ||
+        stringValue(customer.business_registration),
+      vatRegistered: boolFromVat(step2.vat, Boolean(taxNumber)),
+      vatNumber: stringValue(step2.vatNumber) || taxNumber,
+      registeredAddress,
+      contactName,
+      email: stringValue(step1.email) || stringValue(customer.email),
+      phone: stringValue(step1.phone) || stringValue(customer.phone),
+      clinicName,
+      province,
+      siteAddress,
+      packageName:
+        stringValue(service?.package_name) || "CircleTel ClinicConnect",
+      serviceType: stringValue(service?.service_type) || "managed_connectivity",
+      monthlyPrice: String(service?.monthly_price ?? 450),
+      activationDate: stringValue(service?.activation_date),
+      billingDay: normalizeBillingDay(
+        service?.billing_day ?? step5.paymentDate,
+      ),
+      includeDebitOrder: !paymentMethodId,
+      accountHolderName: stringValue(paymentDetails.account_holder_name),
+      bankName: stringValue(paymentDetails.bank_name),
+      accountType: stringValue(paymentDetails.account_type) || "Cheque",
+      accountNumber: "",
+      branchCode: stringValue(paymentDetails.branch_code),
+    },
+  };
+}
+
+async function authenticateManualIntake(request: NextRequest) {
+  const auth = await authenticateAdmin(request);
+  if (!auth.success) return { auth, response: auth.response };
+
+  const perm = requirePermission(auth.adminUser, [
+    "customers:write",
+    "kyc:verify",
+  ]);
+  if (perm) return { auth, response: perm };
+
+  return { auth, response: null };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { auth, response } = await authenticateManualIntake(request);
+    if (response) return response;
+
+    const supabase = svc();
+    const { searchParams } = new URL(request.url);
+    const customerId = searchParams.get("customerId")?.trim();
+    const query = searchParams.get("q")?.trim();
+
+    if (customerId) {
+      const { data: customer, error: customerError } = await supabase
+        .from("customers")
+        .select(
+          "id, account_number, business_name, business_registration, tax_number, first_name, last_name, email, phone, account_type, account_status, onboarding_status, clinic_details",
+        )
+        .eq("id", customerId)
+        .single();
+
+      if (customerError || !customer) {
+        return NextResponse.json(
+          { success: false, error: "customer_not_found" },
+          { status: 404 },
+        );
+      }
+
+      const { data: submission, error: submissionError } = await supabase
+        .from("onboarding_submissions")
+        .select("id, segment, submission_data")
+        .eq("customer_id", customerId)
+        .order("submitted_at", { ascending: false, nullsFirst: false })
+        .limit(1)
+        .maybeSingle();
+      if (submissionError) throw submissionError;
+
+      const { data: service, error: serviceError } = await supabase
+        .from("customer_services")
+        .select(
+          "id, package_name, service_type, monthly_price, activation_date, billing_day, provider_name",
+        )
+        .eq("customer_id", customerId)
+        .eq("status", "active")
+        .order("activation_date", { ascending: false, nullsFirst: false })
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (serviceError) throw serviceError;
+
+      const { data: paymentMethod, error: paymentError } = await supabase
+        .from("customer_payment_methods")
+        .select("id, last_four, mandate_status, encrypted_details")
+        .eq("customer_id", customerId)
+        .eq("method_type", "debit_order")
+        .eq("is_active", true)
+        .order("is_primary", { ascending: false })
+        .order("updated_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (paymentError) throw paymentError;
+
+      return NextResponse.json({
+        success: true,
+        prefill: mapCustomerPrefill({
+          customer: asRecord(customer),
+          submission: submission ? asRecord(submission) : null,
+          service: service ? asRecord(service) : null,
+          paymentMethod: paymentMethod ? asRecord(paymentMethod) : null,
+        }),
+      });
+    }
+
+    if (!query || query.length < 2) {
+      return NextResponse.json(
+        { success: false, error: "search_query_too_short" },
+        { status: 400 },
+      );
+    }
+
+    const search = query.replace(/[%,]/g, " ").trim();
+    const { data, error } = await supabase
+      .from("customers")
+      .select(
+        "id, account_number, business_name, email, phone, business_registration, onboarding_status",
+      )
+      .eq("account_type", "business")
+      .or(
+        [
+          `business_name.ilike.%${search}%`,
+          `account_number.ilike.%${search}%`,
+          `email.ilike.%${search}%`,
+          `phone.ilike.%${search}%`,
+          `business_registration.ilike.%${search}%`,
+        ].join(","),
+      )
+      .order("updated_at", { ascending: false })
+      .limit(12);
+
+    if (error) throw error;
+
+    apiLogger.info("[Manual B2B Intake] customer search", {
+      q: query,
+      resultCount: Array.isArray(data) ? data.length : 0,
+      by: auth.adminUser.email,
+    });
+
+    return NextResponse.json({
+      success: true,
+      results: (Array.isArray(data) ? data : []).map((row) =>
+        mapSearchCustomer(asRecord(row)),
+      ),
+    });
+  } catch (error) {
+    apiLogger.error("[Manual B2B Intake] lookup failed", { error });
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Internal server error",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { auth, response } = await authenticateManualIntake(request);
+    if (response) return response;
+
+    const body = await request.json();
+    const parsed = manualB2BIntakeSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "validation_failed",
+          issues: parsed.error.flatten(),
+        },
+        { status: 400 },
+      );
+    }
+
+    const result = await saveManualB2BIntake(svc(), body, {
+      adminId: auth.adminUser.id ?? auth.user.id,
+      adminEmail: auth.adminUser.email,
+    });
+
+    apiLogger.info("[Manual B2B Intake] captured", {
+      customerId: result.customerId,
+      submissionId: result.submissionId,
+      createdCustomer: result.createdCustomer,
+      by: auth.adminUser.email,
+    });
+
+    return NextResponse.json({ success: true, intake: result });
+  } catch (error) {
+    apiLogger.error("[Manual B2B Intake] failed", { error });
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Internal server error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { PiArrowsClockwiseBold, PiBellBold, PiBriefcaseBold, PiBuildingsBold, PiCalendarBold, PiCaretDownBold, PiCaretLeftBold, PiCaretRightBold, PiChartBarBold, PiCheckCircleBold, PiClockBold, PiCreditCardBold, PiFileTextBold, PiGearBold, PiGlobeBold, PiGraphBold, PiHandshakeBold, PiImageBold, PiLightningBold, PiLinkBold, PiListBold, PiMapPinBold, PiMapTrifoldBold, PiMegaphoneBold, PiPackageBold, PiPercentBold, PiPlusBold, PiPulseBold, PiRadioBold, PiReceiptBold, PiRocketBold, PiShieldCheckBold, PiShoppingCartBold, PiSidebarSimpleBold, PiSparkleBold, PiSquaresFourBold, PiTargetBold, PiTestTubeBold, PiTrendUpBold, PiTruckBold, PiUserCheckBold, PiUserPlusBold, PiUsersBold, PiWarningCircleBold, PiWifiHighBold, PiWrenchBold } from 'react-icons/pi';
+import { PiArrowsClockwiseBold, PiBellBold, PiBriefcaseBold, PiBuildingsBold, PiCalendarBold, PiCaretDownBold, PiCaretLeftBold, PiCaretRightBold, PiChartBarBold, PiCheckCircleBold, PiClipboardTextBold, PiClockBold, PiCreditCardBold, PiFileTextBold, PiGearBold, PiGlobeBold, PiGraphBold, PiHandshakeBold, PiImageBold, PiLightningBold, PiLinkBold, PiListBold, PiMapPinBold, PiMapTrifoldBold, PiMegaphoneBold, PiPackageBold, PiPercentBold, PiPlusBold, PiPulseBold, PiRadioBold, PiReceiptBold, PiRocketBold, PiShieldCheckBold, PiShoppingCartBold, PiSidebarSimpleBold, PiSparkleBold, PiSquaresFourBold, PiTargetBold, PiTestTubeBold, PiTrendUpBold, PiTruckBold, PiUserCheckBold, PiUserPlusBold, PiUsersBold, PiWarningCircleBold, PiWifiHighBold, PiWrenchBold } from 'react-icons/pi';
 
 import Link from 'next/link';
 import Image from 'next/image';
@@ -142,6 +142,7 @@ const navigationSections: NavSection[] = [
         description: 'Business customer journey',
         children: [
           { name: 'Clinic Onboarding', href: '/admin/unjani/onboarding', icon: PiUserPlusBold },
+          { name: 'Manual Onboarding', href: '/admin/b2b/manual-intake', icon: PiClipboardTextBold },
           { name: 'Document Vetting', href: '/admin/b2b/vetting', icon: PiUserCheckBold },
           { name: 'All B2B Customers', href: '/admin/b2b-customers', icon: PiBuildingsBold },
           { name: 'Site Details', href: '/admin/b2b-customers/site-details', icon: PiMapPinBold },

--- a/components/admin/onboarding/UploadDocumentModal.tsx
+++ b/components/admin/onboarding/UploadDocumentModal.tsx
@@ -1,21 +1,37 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { toast } from 'sonner';
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+} from "react";
+import { toast } from "sonner";
+import {
+  PiCheckCircleBold,
+  PiFileBold,
+  PiUploadSimpleBold,
+  PiWarningCircleBold,
+  PiXBold,
+} from "react-icons/pi";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogFooter,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   DOC_TYPE_OPTIONS,
-  ALLOWED_FILE_TYPES,
-  MAX_DOC_BYTES,
+  buildDocumentUploadQueue,
   type DocType,
-} from '@/lib/onboarding/document-upload';
+  type QueuedDocumentUpload,
+} from "@/lib/onboarding/document-upload";
+import { cn } from "@/lib/utils";
 
 interface UploadDocumentModalProps {
   open: boolean;
@@ -23,9 +39,15 @@ interface UploadDocumentModalProps {
   customerId: string;
   clinicName: string;
   submissionId?: string;
+  defaultSegment?: string;
   authHeaders: () => Record<string, string>;
   onUploaded: (count: number) => void;
 }
+
+type UploadQueueItem = QueuedDocumentUpload & {
+  docType: DocType;
+  uploadError?: string;
+};
 
 export function UploadDocumentModal({
   open,
@@ -33,58 +55,159 @@ export function UploadDocumentModal({
   customerId,
   clinicName,
   submissionId,
+  defaultSegment = "unjani",
   authHeaders,
   onUploaded,
 }: UploadDocumentModalProps) {
-  const [docType, setDocType] = useState<DocType>('company_registration');
-  const [file, setFile] = useState<File | null>(null);
+  const [segment, setSegment] = useState(defaultSegment);
+  const [emailFrom, setEmailFrom] = useState("");
+  const [emailSubject, setEmailSubject] = useState("");
+  const [emailReceivedAt, setEmailReceivedAt] = useState("");
+  const [queuedFiles, setQueuedFiles] = useState<UploadQueueItem[]>([]);
+  const [dragging, setDragging] = useState(false);
   const [uploading, setUploading] = useState(false);
-  const [uploaded, setUploaded] = useState<{ type: string; name: string }[]>([]);
+  const [currentUpload, setCurrentUpload] = useState<string | null>(null);
+  const [uploaded, setUploaded] = useState<{ type: string; name: string }[]>(
+    [],
+  );
+
+  useEffect(() => {
+    if (open) setSegment(defaultSegment);
+  }, [defaultSegment, open]);
+
+  const validFileCount = useMemo(
+    () => queuedFiles.filter((item) => item.valid).length,
+    [queuedFiles],
+  );
 
   const reset = () => {
-    setDocType('company_registration');
-    setFile(null);
+    setSegment(defaultSegment);
+    setEmailFrom("");
+    setEmailSubject("");
+    setEmailReceivedAt("");
+    setQueuedFiles([]);
+    setDragging(false);
+    setUploading(false);
+    setCurrentUpload(null);
     setUploaded([]);
   };
 
+  const addFiles = (files: File[]) => {
+    if (files.length === 0) return;
+    const batchStamp = Date.now();
+    const next = buildDocumentUploadQueue(files).map((item, index) => ({
+      ...item,
+      id: `${item.id}-${batchStamp}-${index}`,
+      docType: "company_registration" as DocType,
+    }));
+    setQueuedFiles((current) => [...current, ...next]);
+
+    const invalidCount = next.filter((item) => !item.valid).length;
+    if (invalidCount > 0) {
+      toast.warning(
+        `${invalidCount} file${invalidCount === 1 ? "" : "s"} need attention`,
+      );
+    }
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    addFiles(Array.from(event.target.files ?? []));
+    event.target.value = "";
+  };
+
+  const handleDrop = (event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+    setDragging(false);
+    addFiles(Array.from(event.dataTransfer.files));
+  };
+
+  const removeQueuedFile = (id: string) => {
+    setQueuedFiles((current) => current.filter((item) => item.id !== id));
+  };
+
+  const updateQueuedFileDocType = (id: string, docType: DocType) => {
+    setQueuedFiles((current) =>
+      current.map((item) => (item.id === id ? { ...item, docType } : item)),
+    );
+  };
+
+  const uploadOne = async (item: UploadQueueItem) => {
+    const fd = new FormData();
+    fd.append("customerId", customerId);
+    fd.append("documentType", item.docType);
+    fd.append("segment", segment);
+    if (emailFrom.trim()) fd.append("emailFrom", emailFrom.trim());
+    if (emailSubject.trim()) fd.append("emailSubject", emailSubject.trim());
+    if (emailReceivedAt.trim())
+      fd.append("emailReceivedAt", emailReceivedAt.trim());
+    if (submissionId) fd.append("submissionId", submissionId);
+    fd.append("file", item.file);
+
+    const res = await fetch("/api/admin/b2b/upload-document", {
+      method: "POST",
+      headers: { ...authHeaders() },
+      body: fd,
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data.success) {
+      throw new Error(data.error || "Upload failed");
+    }
+  };
+
   const handleUpload = async () => {
-    if (!file) {
-      toast.error('Choose a file first');
+    const ready = queuedFiles.filter((item) => item.valid);
+    if (ready.length === 0) {
+      toast.error("Add a JPG, PNG, or PDF before uploading");
       return;
     }
-    if (!ALLOWED_FILE_TYPES.includes(file.type)) {
-      toast.error('File must be a JPG, PNG, or PDF');
-      return;
-    }
-    if (file.size > MAX_DOC_BYTES) {
-      toast.error('File must be 5MB or smaller');
-      return;
-    }
+
+    const successfulIds = new Set<string>();
+    const failures = new Map<string, string>();
+
     setUploading(true);
     try {
-      const fd = new FormData();
-      fd.append('customerId', customerId);
-      fd.append('documentType', docType);
-      if (submissionId) fd.append('submissionId', submissionId);
-      fd.append('file', file);
-      const res = await fetch('/api/admin/b2b/upload-document', {
-        method: 'POST',
-        headers: { ...authHeaders() },
-        body: fd,
-      });
-      const data = await res.json();
-      if (res.ok && data.success) {
-        const label = DOC_TYPE_OPTIONS.find((o) => o.value === docType)?.label ?? docType;
-        setUploaded((u) => [...u, { type: label, name: file.name }]);
-        toast.success(`Uploaded ${label}`);
-        setFile(null);
-      } else {
-        toast.error(data.error || 'Upload failed');
+      for (const item of ready) {
+        setCurrentUpload(item.name);
+        try {
+          await uploadOne(item);
+          const label =
+            DOC_TYPE_OPTIONS.find((o) => o.value === item.docType)?.label ??
+            item.docType;
+          successfulIds.add(item.id);
+          setUploaded((current) => [
+            ...current,
+            { type: label, name: item.name },
+          ]);
+        } catch (error) {
+          failures.set(
+            item.id,
+            error instanceof Error ? error.message : "Upload failed",
+          );
+        }
       }
-    } catch {
-      toast.error('Upload failed');
+
+      setQueuedFiles((current) =>
+        current
+          .filter((item) => !successfulIds.has(item.id))
+          .map((item) => ({
+            ...item,
+            uploadError: failures.get(item.id),
+          })),
+      );
+
+      if (successfulIds.size > 0) {
+        toast.success(
+          `Uploaded ${successfulIds.size} document${successfulIds.size === 1 ? "" : "s"}`,
+        );
+      }
+      if (failures.size > 0) {
+        toast.error(
+          `${failures.size} upload${failures.size === 1 ? "" : "s"} failed`,
+        );
+      }
     } finally {
       setUploading(false);
+      setCurrentUpload(null);
     }
   };
 
@@ -95,52 +218,243 @@ export function UploadDocumentModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(o) => (o ? onOpenChange(o) : handleClose())}>
-      <DialogContent className="sm:max-w-md">
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) =>
+        nextOpen ? onOpenChange(nextOpen) : handleClose()
+      }
+    >
+      <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
-          <DialogTitle>Upload documents — {clinicName}</DialogTitle>
+          <DialogTitle>
+            Upload client onboarding documents - {clinicName}
+          </DialogTitle>
         </DialogHeader>
 
-        <p className="text-sm text-gray-500">
-          For documents received by email. Pick a type, choose the file, and upload. Repeat for each file.
-        </p>
+        <div className="space-y-4">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Client onboarding pack
+            </p>
 
-        <div className="space-y-3">
-          <select
-            value={docType}
-            onChange={(e) => setDocType(e.target.value as DocType)}
-            className="w-full rounded border border-gray-300 px-2 py-2 text-sm"
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="upload-segment"
+                  className="text-xs font-semibold text-gray-500"
+                >
+                  Segment
+                </Label>
+                <select
+                  id="upload-segment"
+                  value={segment}
+                  onChange={(e) => setSegment(e.target.value)}
+                  className="h-10 w-full rounded-md border border-gray-300 px-2 py-2 text-sm"
+                >
+                  <option value="unjani">Unjani</option>
+                  <option value="smb">SMB</option>
+                  <option value="edu">Education</option>
+                  <option value="enterprise">Enterprise</option>
+                </select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="upload-email-received-at"
+                  className="text-xs font-semibold text-gray-500"
+                >
+                  Email received
+                </Label>
+                <Input
+                  id="upload-email-received-at"
+                  type="datetime-local"
+                  value={emailReceivedAt}
+                  onChange={(event) => setEmailReceivedAt(event.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="upload-email-from"
+                  className="text-xs font-semibold text-gray-500"
+                >
+                  Email from
+                </Label>
+                <Input
+                  id="upload-email-from"
+                  type="email"
+                  value={emailFrom}
+                  onChange={(event) => setEmailFrom(event.target.value)}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="upload-email-subject"
+                  className="text-xs font-semibold text-gray-500"
+                >
+                  Email subject
+                </Label>
+                <Input
+                  id="upload-email-subject"
+                  value={emailSubject}
+                  onChange={(event) => setEmailSubject(event.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+
+          <label
+            htmlFor="upload-files"
+            onDragEnter={(event) => {
+              event.preventDefault();
+              setDragging(true);
+            }}
+            onDragOver={(event) => event.preventDefault()}
+            onDragLeave={(event) => {
+              event.preventDefault();
+              setDragging(false);
+            }}
+            onDrop={handleDrop}
+            className={cn(
+              "flex cursor-pointer flex-col items-center justify-center rounded-lg border border-dashed px-4 py-8 text-center transition",
+              dragging
+                ? "border-circleTel-orange bg-orange-50"
+                : "border-gray-300 bg-gray-50 hover:border-circleTel-orange hover:bg-orange-50",
+            )}
           >
-            {DOC_TYPE_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>
-                {o.label}
-              </option>
-            ))}
-          </select>
+            <PiUploadSimpleBold className="mb-2 h-8 w-8 text-circleTel-orange" />
+            <span className="font-semibold text-gray-900">
+              Drag documents here or browse
+            </span>
+            <span className="mt-1 text-sm text-gray-500">
+              JPG, PNG, or PDF up to 5MB each
+            </span>
+            <input
+              id="upload-files"
+              type="file"
+              multiple
+              accept="image/jpeg,image/png,application/pdf"
+              onChange={handleFileChange}
+              className="sr-only"
+            />
+          </label>
 
-          <input
-            type="file"
-            accept="image/jpeg,image/png,application/pdf"
-            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-            className="w-full text-sm"
-          />
+          {queuedFiles.length > 0 && (
+            <div className="overflow-hidden rounded-md border border-gray-200">
+              <div className="border-b border-gray-100 bg-gray-50 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Documents in this pack ({queuedFiles.length})
+              </div>
+              <div className="max-h-52 divide-y divide-gray-100 overflow-y-auto">
+                {queuedFiles.map((item) => (
+                  <div
+                    key={item.id}
+                    className="grid gap-3 px-3 py-3 md:grid-cols-[minmax(0,1fr)_260px_auto]"
+                  >
+                    <div className="flex min-w-0 items-start gap-3">
+                      <PiFileBold className="mt-0.5 h-5 w-5 flex-none text-gray-400" />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-gray-900">
+                          {item.name}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {item.sizeLabel}
+                        </p>
+                        {item.error && (
+                          <p className="mt-1 flex items-center gap-1 text-xs font-medium text-red-600">
+                            <PiWarningCircleBold className="h-3.5 w-3.5" />
+                            {item.error}
+                          </p>
+                        )}
+                        {item.uploadError && (
+                          <p className="mt-1 flex items-center gap-1 text-xs font-medium text-red-600">
+                            <PiWarningCircleBold className="h-3.5 w-3.5" />
+                            {item.uploadError}
+                          </p>
+                        )}
+                        {currentUpload === item.name && (
+                          <p className="mt-1 text-xs font-medium text-circleTel-orange">
+                            Uploading...
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="space-y-1">
+                      <Label
+                        htmlFor={`queued-document-type-${item.id}`}
+                        className="text-[11px] font-semibold uppercase tracking-wide text-gray-500"
+                      >
+                        Document type
+                      </Label>
+                      <select
+                        id={`queued-document-type-${item.id}`}
+                        value={item.docType}
+                        onChange={(event) =>
+                          updateQueuedFileDocType(
+                            item.id,
+                            event.target.value as DocType,
+                          )
+                        }
+                        disabled={uploading || !item.valid}
+                        className="h-9 w-full rounded-md border border-gray-300 px-2 text-sm disabled:bg-gray-50 disabled:text-gray-400"
+                      >
+                        {DOC_TYPE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className="flex justify-end">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => removeQueuedFile(item.id)}
+                        disabled={uploading}
+                        aria-label={`Remove ${item.name}`}
+                      >
+                        <PiXBold className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
           <Button
-            className="w-full bg-circleTel-orange hover:bg-circleTel-orange-dark text-white"
-            disabled={uploading || !file}
+            className="w-full bg-circleTel-orange text-white hover:bg-circleTel-orange-dark"
+            disabled={uploading || validFileCount === 0}
             onClick={handleUpload}
           >
-            {uploading ? 'Uploading…' : 'Upload this document'}
+            <PiUploadSimpleBold className="h-4 w-4" />
+            {uploading
+              ? currentUpload
+                ? `Uploading ${currentUpload}`
+                : "Uploading..."
+              : `Upload ${validFileCount || "queued"} document${validFileCount === 1 ? "" : "s"}`}
           </Button>
         </div>
 
         {uploaded.length > 0 && (
-          <div className="rounded border border-gray-100 bg-gray-50 p-3 text-sm">
-            <p className="font-semibold text-gray-700 mb-1">Uploaded ({uploaded.length})</p>
+          <div className="rounded-md border border-emerald-100 bg-emerald-50 p-3 text-sm">
+            <p className="mb-1 flex items-center gap-2 font-semibold text-emerald-800">
+              <PiCheckCircleBold className="h-4 w-4" />
+              Uploaded ({uploaded.length})
+            </p>
             <ul className="space-y-1">
               {uploaded.map((u, i) => (
-                <li key={i} className="text-gray-600">
-                  ✓ {u.type} — {u.name}
+                <li
+                  key={`${u.name}-${i}`}
+                  className="truncate text-emerald-700"
+                >
+                  {u.type} - {u.name}
                 </li>
               ))}
             </ul>

--- a/lib/onboarding/__tests__/billing-ready.test.ts
+++ b/lib/onboarding/__tests__/billing-ready.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for maybeMarkBillingReady
- * Verifies the new gate: vetting approved + active service + bank details (drop signature)
+ * Verifies the gate: vetting approved + service order accepted + active service + bank details.
  */
 
 import { maybeMarkBillingReady } from '../billing-ready';
@@ -96,7 +96,16 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
                       error: null,
                     }),
                   }),
@@ -137,7 +146,16 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
                       error: null,
                     }),
                   }),
@@ -198,7 +216,7 @@ describe('maybeMarkBillingReady', () => {
     expect(result).toBe(false);
   });
 
-  it('returns true when vetting approved + active service + bank details present', async () => {
+  it('returns false when service order has not been accepted', async () => {
     const supabase = {
       from: jest.fn((table) => {
         if (table === 'onboarding_submissions') {
@@ -208,7 +226,12 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {},
+                      },
                       error: null,
                     }),
                   }),
@@ -275,10 +298,10 @@ describe('maybeMarkBillingReady', () => {
     } as any as SupabaseClient;
 
     const result = await maybeMarkBillingReady(supabase, 'customer-123');
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
-  it('returns true even when mandate_status is pending (drops signature requirement)', async () => {
+  it('returns true when vetting approved + accepted service order + active service + bank details present', async () => {
     const supabase = {
       from: jest.fn((table) => {
         if (table === 'onboarding_submissions') {
@@ -288,7 +311,107 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
+                      error: null,
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'customer_services') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  maybeSingle: jest.fn().mockResolvedValue({
+                    data: { id: 'svc-1', status: 'active' },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'customer_payment_methods') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest
+                .fn()
+                .mockReturnValue({
+                  eq: jest
+                    .fn()
+                    .mockReturnValue({
+                      eq: jest.fn().mockResolvedValue({
+                        data: [
+                          {
+                            id: 'pm-1',
+                            is_active: true,
+                            method_type: 'debit_order',
+                            mandate_status: 'pending',
+                            encrypted_details: {
+                              account_holder_name: 'Test Clinic',
+                              account_type: 'Cheque',
+                              account_number: '62836392449',
+                              branch_code: '250655',
+                              verified: false,
+                            },
+                          },
+                        ],
+                        error: null,
+                      }),
+                    }),
+                }),
+            }),
+          };
+        }
+        if (table === 'customers') {
+          return {
+            update: jest
+              .fn()
+              .mockReturnValue({
+                eq: jest.fn().mockResolvedValue({ error: null }),
+              }),
+          };
+        }
+        return { select: jest.fn() };
+      }),
+    } as any as SupabaseClient;
+
+    const result = await maybeMarkBillingReady(supabase, 'customer-123');
+    expect(result).toBe(true);
+  });
+
+  it('returns true even when mandate_status is pending if the service order was accepted', async () => {
+    const supabase = {
+      from: jest.fn((table) => {
+        if (table === 'onboarding_submissions') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                order: jest.fn().mockReturnValue({
+                  limit: jest.fn().mockReturnValue({
+                    maybeSingle: jest.fn().mockResolvedValue({
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
                       error: null,
                     }),
                   }),
@@ -370,7 +493,16 @@ describe('maybeMarkBillingReady', () => {
                 order: jest.fn().mockReturnValue({
                   limit: jest.fn().mockReturnValue({
                     maybeSingle: jest.fn().mockResolvedValue({
-                      data: { id: 'sub-1', document_vetting_status: 'approved' },
+                      data: {
+                        id: 'sub-1',
+                        document_vetting_status: 'approved',
+                        service_order_pdf_path: 'service-orders/customer-123/SO.pdf',
+                        submission_data: {
+                          service_order_acceptance: {
+                            accepted_at: '2026-06-30T09:00:00.000Z',
+                          },
+                        },
+                      },
                       error: null,
                     }),
                   }),

--- a/lib/onboarding/__tests__/manual-intake.test.ts
+++ b/lib/onboarding/__tests__/manual-intake.test.ts
@@ -1,0 +1,179 @@
+import { saveManualB2BIntake } from "../manual-intake";
+
+type Operation = {
+  table: string;
+  action: "insert" | "update" | "select";
+  payload?: unknown;
+  filters: Array<{ column: string; value: unknown }>;
+};
+
+function createMockSupabase() {
+  const operations: Operation[] = [];
+
+  const responseFor = (table: string, action: string) => {
+    if (table === "customers" && action === "single") {
+      return Promise.resolve({
+        data: { id: "customer-1", account_number: "CT-2026-00042" },
+        error: null,
+      });
+    }
+    if (table === "onboarding_submissions" && action === "maybeSingle") {
+      return Promise.resolve({ data: null, error: null });
+    }
+    if (table === "onboarding_submissions" && action === "single") {
+      return Promise.resolve({ data: { id: "submission-1" }, error: null });
+    }
+    if (table === "customer_services" && action === "single") {
+      return Promise.resolve({ data: { id: "service-1" }, error: null });
+    }
+    if (table === "customer_payment_methods" && action === "maybeSingle") {
+      return Promise.resolve({ data: null, error: null });
+    }
+    if (table === "customer_payment_methods" && action === "single") {
+      return Promise.resolve({ data: { id: "payment-method-1" }, error: null });
+    }
+    return Promise.resolve({ data: null, error: null });
+  };
+
+  const from = jest.fn((table: string) => {
+    const state: Operation = { table, action: "select", filters: [] };
+    const builder: any = {
+      insert: jest.fn((payload) => {
+        state.action = "insert";
+        state.payload = payload;
+        operations.push(state);
+        return builder;
+      }),
+      update: jest.fn((payload) => {
+        state.action = "update";
+        state.payload = payload;
+        operations.push(state);
+        return builder;
+      }),
+      select: jest.fn(() => {
+        if (!operations.includes(state)) operations.push(state);
+        return builder;
+      }),
+      eq: jest.fn((column, value) => {
+        state.filters.push({ column, value });
+        return builder;
+      }),
+      order: jest.fn((column: string) => {
+        if (table === "onboarding_submissions" && column === "created_at") {
+          throw new Error("onboarding_submissions.created_at does not exist");
+        }
+        return builder;
+      }),
+      limit: jest.fn(() => builder),
+      maybeSingle: jest.fn(() => responseFor(table, "maybeSingle")),
+      single: jest.fn(() => responseFor(table, "single")),
+    };
+    return builder;
+  });
+
+  return { supabase: { from } as any, operations };
+}
+
+describe("saveManualB2BIntake", () => {
+  it("creates a business customer, submission, active service, and debit-order payment method", async () => {
+    const { supabase, operations } = createMockSupabase();
+
+    const result = await saveManualB2BIntake(
+      supabase,
+      {
+        segment: "unjani",
+        business: {
+          businessName: "Unjani Alexandra Clinic",
+          entityType: "Private Company",
+          registrationNumber: "2026/123456/07",
+          vatRegistered: true,
+          vatNumber: "4123456789",
+          registeredAddress: "10 Clinic Road, Alexandra",
+        },
+        contact: {
+          contactName: "Thandi Maseko",
+          email: "thandi@example.co.za",
+          phone: "0821234567",
+        },
+        site: {
+          clinicName: "Unjani Alexandra",
+          province: "Gauteng",
+          siteAddress: "10 Clinic Road, Alexandra",
+        },
+        service: {
+          packageName: "CircleTel ClinicConnect",
+          serviceType: "managed_connectivity",
+          monthlyPrice: 450,
+          activationDate: "2026-07-01",
+          billingDay: "25",
+        },
+        debitOrder: {
+          accountHolderName: "Unjani Alexandra Clinic",
+          bankName: "FNB",
+          accountType: "Cheque",
+          accountNumber: "1234567890",
+          branchCode: "250655",
+        },
+      },
+      { adminId: "admin-1", adminEmail: "admin@example.co.za" },
+    );
+
+    expect(result).toEqual({
+      customerId: "customer-1",
+      accountNumber: "CT-2026-00042",
+      submissionId: "submission-1",
+      createdCustomer: true,
+      createdSubmission: true,
+      serviceId: "service-1",
+      paymentMethodId: "payment-method-1",
+    });
+
+    const customerInsert = operations.find(
+      (op) => op.table === "customers" && op.action === "insert",
+    );
+    expect(customerInsert?.payload).toEqual(
+      expect.objectContaining({
+        account_type: "business",
+        business_name: "Unjani Alexandra Clinic",
+        email: "thandi@example.co.za",
+        phone: "0821234567",
+        onboarding_status: "submitted",
+      }),
+    );
+
+    const submissionInsert = operations.find(
+      (op) => op.table === "onboarding_submissions" && op.action === "insert",
+    );
+    expect(submissionInsert?.payload).toEqual(
+      expect.objectContaining({
+        customer_id: "customer-1",
+        segment: "unjani",
+        status: "submitted",
+        document_vetting_status: "documents_pending",
+        submission_data: expect.objectContaining({
+          capture_method: "admin_manual_intake",
+          captured_by: "admin@example.co.za",
+          step3: expect.objectContaining({ accNumber: "****7890" }),
+        }),
+      }),
+    );
+
+    const paymentInsert = operations.find(
+      (op) => op.table === "customer_payment_methods" && op.action === "insert",
+    );
+    expect(paymentInsert?.payload).toEqual(
+      expect.objectContaining({
+        customer_id: "customer-1",
+        onboarding_submission_id: "submission-1",
+        method_type: "debit_order",
+        display_name: "Debit Order - FNB ****7890",
+        encrypted_details: expect.objectContaining({
+          account_number: "1234567890",
+          branch_code: "250655",
+          verified: false,
+        }),
+        mandate_status: "pending",
+      }),
+    );
+  });
+});

--- a/lib/onboarding/__tests__/onboarding-service-token-purpose.test.ts
+++ b/lib/onboarding/__tests__/onboarding-service-token-purpose.test.ts
@@ -1,0 +1,100 @@
+import { createClient } from '@supabase/supabase-js';
+import { hashToken } from '../token-service';
+import { issueToken, resolveTokenForPurpose } from '../onboarding-service';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(),
+}));
+
+const mockedCreateClient = createClient as jest.Mock;
+
+describe('onboarding token purpose handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+  });
+
+  it('stores service-order signoff token purpose and metadata when issuing a token', async () => {
+    const insert = jest.fn().mockResolvedValue({ error: null });
+    mockedCreateClient.mockReturnValue({
+      from: jest.fn().mockReturnValue({ insert }),
+    });
+
+    const token = await issueToken('customer-1', 'email', {
+      purpose: 'service_order_signoff',
+      onboardingSubmissionId: 'submission-1',
+      metadata: { issued_by: 'admin-1' },
+    });
+
+    expect(token).toEqual(expect.any(String));
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer_id: 'customer-1',
+        token_hash: hashToken(token),
+        sent_via: 'email',
+        purpose: 'service_order_signoff',
+        onboarding_submission_id: 'submission-1',
+        metadata: { issued_by: 'admin-1' },
+      })
+    );
+  });
+
+  it('resolves only matching-purpose active tokens', async () => {
+    const maybeSingle = jest.fn().mockResolvedValue({
+      data: {
+        id: 'token-1',
+        customer_id: 'customer-1',
+        onboarding_submission_id: 'submission-1',
+        purpose: 'service_order_signoff',
+        metadata: { service_order_pdf_path: 'service-orders/order.pdf' },
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        used_at: null,
+      },
+      error: null,
+    });
+    const eq = jest.fn().mockReturnValue({ maybeSingle });
+    mockedCreateClient.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({ eq }),
+      }),
+    });
+
+    const result = await resolveTokenForPurpose('plain-token', 'service_order_signoff');
+
+    expect(eq).toHaveBeenCalledWith('token_hash', hashToken('plain-token'));
+    expect(result).toEqual({
+      customerId: 'customer-1',
+      tokenId: 'token-1',
+      purpose: 'service_order_signoff',
+      onboardingSubmissionId: 'submission-1',
+      metadata: { service_order_pdf_path: 'service-orders/order.pdf' },
+    });
+  });
+
+  it('returns null when the token purpose does not match the requested purpose', async () => {
+    const maybeSingle = jest.fn().mockResolvedValue({
+      data: {
+        id: 'token-1',
+        customer_id: 'customer-1',
+        onboarding_submission_id: null,
+        purpose: 'onboarding',
+        metadata: {},
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        used_at: null,
+      },
+      error: null,
+    });
+    mockedCreateClient.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({ maybeSingle }),
+        }),
+      }),
+    });
+
+    const result = await resolveTokenForPurpose('plain-token', 'service_order_signoff');
+
+    expect(result).toBeNull();
+  });
+});

--- a/lib/onboarding/__tests__/service-order-issuer.test.ts
+++ b/lib/onboarding/__tests__/service-order-issuer.test.ts
@@ -1,0 +1,135 @@
+import { Resend } from 'resend';
+import { issueToken } from '../onboarding-service';
+import { issueServiceOrderForCustomer } from '../service-order-issuer';
+import { uploadFile } from '@/lib/storage/supabase-upload';
+import { generateServiceOrderBlob } from '@/lib/contracts/service-order-pdf';
+
+jest.mock('resend', () => ({
+  Resend: jest.fn(),
+}));
+
+jest.mock('../onboarding-service', () => ({
+  issueToken: jest.fn(),
+}));
+
+jest.mock('@/lib/storage/supabase-upload', () => ({
+  uploadFile: jest.fn(),
+}));
+
+jest.mock('@/lib/contracts/service-order-pdf', () => ({
+  generateServiceOrderBlob: jest.fn(),
+}));
+
+const mockIssueToken = issueToken as jest.MockedFunction<typeof issueToken>;
+const mockUploadFile = uploadFile as jest.MockedFunction<typeof uploadFile>;
+const mockGenerateServiceOrderBlob = generateServiceOrderBlob as jest.MockedFunction<typeof generateServiceOrderBlob>;
+const mockResend = Resend as jest.Mock;
+
+function createSupabaseMock() {
+  const updates: unknown[] = [];
+  const from = jest.fn((table: string) => {
+    const builder: any = {
+      select: jest.fn(() => builder),
+      eq: jest.fn(() => builder),
+      order: jest.fn(() => builder),
+      limit: jest.fn(() => builder),
+      update: jest.fn((payload) => {
+        updates.push(payload);
+        return builder;
+      }),
+      single: jest.fn(() => {
+        if (table === 'customers') {
+          return Promise.resolve({
+            data: {
+              id: 'customer-1',
+              account_number: 'CT-2026-00042',
+              business_name: 'Future Business Client',
+              email: 'client@example.co.za',
+              phone: '0821234567',
+              clinic_details: {
+                province: 'Gauteng',
+                site_address: '10 Business Road',
+              },
+            },
+            error: null,
+          });
+        }
+        if (table === 'onboarding_submissions') {
+          return Promise.resolve({
+            data: {
+              id: 'submission-1',
+              segment: 'enterprise',
+              submitted_at: '2026-06-30T09:00:00.000Z',
+              submission_data: {
+                step5: { paymentDate: '25' },
+              },
+            },
+            error: null,
+          });
+        }
+        if (table === 'customer_services') {
+          return Promise.resolve({
+            data: {
+              monthly_price: 450,
+              activation_date: '2026-07-01',
+            },
+            error: null,
+          });
+        }
+        return Promise.resolve({ data: null, error: null });
+      }),
+    };
+    return builder;
+  });
+  return { supabase: { from } as any, updates };
+}
+
+describe('issueServiceOrderForCustomer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateServiceOrderBlob.mockReturnValue(
+      new Blob(['pdf-bytes'], { type: 'application/pdf' })
+    );
+    mockIssueToken.mockResolvedValue('sign-token');
+    mockUploadFile.mockResolvedValue({
+      success: true,
+      path: 'service-orders/customer-1/SO-CT-2026-00042.pdf',
+    } as any);
+  });
+
+  it('emails a signoff link and attaches the generated service order PDF', async () => {
+    const send = jest.fn().mockResolvedValue({ error: null });
+    mockResend.mockImplementation(() => ({ emails: { send } }));
+    const { supabase } = createSupabaseMock();
+
+    const result = await issueServiceOrderForCustomer(supabase, {
+      customerId: 'customer-1',
+      baseUrl: 'https://circletel.co.za',
+      issuedBy: 'admin@example.co.za',
+      sendEmail: true,
+    });
+
+    expect(result.signoffUrl).toBe('https://circletel.co.za/service-order/sign-token');
+    expect(mockIssueToken).toHaveBeenCalledWith('customer-1', 'email', {
+      purpose: 'service_order_signoff',
+      onboardingSubmissionId: 'submission-1',
+      metadata: expect.objectContaining({
+        service_order_pdf_path: 'service-orders/customer-1/SO-CT-2026-00042.pdf',
+        issued_by: 'admin@example.co.za',
+      }),
+    });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'client@example.co.za',
+        html: expect.stringContaining('https://circletel.co.za/service-order/sign-token'),
+        attachments: [
+          expect.objectContaining({
+            filename: 'SO-CT-2026-00042.pdf',
+            content: expect.any(Buffer),
+            contentType: 'application/pdf',
+          }),
+        ],
+      })
+    );
+  });
+});

--- a/lib/onboarding/billing-ready.ts
+++ b/lib/onboarding/billing-ready.ts
@@ -2,19 +2,18 @@
  * Billing-ready status computation
  * Sets customers.onboarding_status = 'billing_ready' when:
  * - Latest onboarding_submissions.document_vetting_status === 'approved'
+ * - Service Order PDF has been issued and accepted by the customer
  * - At least one customer_services row with status='active'
  * - An active customer_payment_methods (method_type='debit_order', is_active=true)
  *   with encrypted_details containing BOTH account_number AND branch_code
- *
- * (Drops the signature requirement: mandate_status active + verified)
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 /**
- * Check if an onboarding submission's documents are approved, the customer
- * has an active service, and valid bank details on file. If all conditions met,
- * mark the customer billing_ready.
+ * Check if an onboarding submission's documents are approved, the customer has
+ * accepted the Service Order, has an active service, and valid bank details on
+ * file. If all conditions are met, mark the customer billing_ready.
  *
  * Returns true if status was flipped to billing_ready, false otherwise.
  * Safe to call repeatedly — idempotent.
@@ -26,7 +25,7 @@ export async function maybeMarkBillingReady(
   // 1. Get the latest submission for this customer
   const { data: submission, error: subError } = await supabase
     .from('onboarding_submissions')
-    .select('id, document_vetting_status')
+    .select('id, document_vetting_status, service_order_pdf_path, submission_data')
     .eq('customer_id', customerId)
     .order('submitted_at', { ascending: false })
     .limit(1)
@@ -36,6 +35,15 @@ export async function maybeMarkBillingReady(
 
   // Docs must be approved
   if (submission.document_vetting_status !== 'approved') return false;
+
+  const submissionData =
+    submission.submission_data && typeof submission.submission_data === 'object'
+      ? (submission.submission_data as Record<string, any>)
+      : {};
+  const serviceOrderAcceptedAt =
+    submissionData.service_order_acceptance?.accepted_at || submissionData.acceptance?.accepted_at;
+
+  if (!submission.service_order_pdf_path || !serviceOrderAcceptedAt) return false;
 
   // 2. Check for at least one active service
   const { data: activeService } = await supabase

--- a/lib/onboarding/document-upload.ts
+++ b/lib/onboarding/document-upload.ts
@@ -3,32 +3,76 @@
  * upload limits (jpg/png/pdf, <=5MB) and the kyc_documents.document_type enum.
  */
 export const ALLOWED_DOC_TYPES = [
-  'company_registration',
-  'vat_certificate',
-  'tax_certificate',
-  'bank_statement',
-  'id_document',
-  'director_id',
-  'proof_of_address',
-  'shareholder_agreement',
-  'other',
+  "company_registration",
+  "vat_certificate",
+  "tax_certificate",
+  "bank_statement",
+  "id_document",
+  "director_id",
+  "proof_of_address",
+  "shareholder_agreement",
+  "other",
 ] as const;
 
 export type DocType = (typeof ALLOWED_DOC_TYPES)[number];
 
-export const ALLOWED_FILE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'application/pdf'];
+export const ALLOWED_FILE_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "application/pdf",
+];
 export const MAX_DOC_BYTES = 5 * 1024 * 1024;
 
 /** Friendly labels for the admin picker (subset shown in the modal). */
 export const DOC_TYPE_OPTIONS: { value: DocType; label: string }[] = [
-  { value: 'company_registration', label: 'Company registration (CIPC)' },
-  { value: 'vat_certificate', label: 'VAT certificate' },
-  { value: 'tax_certificate', label: 'Tax certificate' },
-  { value: 'bank_statement', label: 'Bank confirmation / statement' },
-  { value: 'id_document', label: 'Owner / Director ID' },
-  { value: 'proof_of_address', label: 'Proof of address' },
-  { value: 'other', label: 'Other' },
+  { value: "company_registration", label: "Company registration (CIPC)" },
+  { value: "vat_certificate", label: "VAT certificate" },
+  { value: "tax_certificate", label: "Tax certificate" },
+  { value: "bank_statement", label: "Bank confirmation / statement" },
+  { value: "id_document", label: "Owner / Director ID" },
+  { value: "proof_of_address", label: "Proof of address" },
+  { value: "other", label: "Other" },
 ];
+
+export interface QueuedDocumentUpload {
+  id: string;
+  file: File;
+  name: string;
+  size: number;
+  sizeLabel: string;
+  valid: boolean;
+  error: string | null;
+}
+
+export function formatDocumentFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kilobytes = bytes / 1024;
+  if (kilobytes < 1024) return `${kilobytes.toFixed(1)} KB`;
+  return `${(kilobytes / 1024).toFixed(1)} MB`;
+}
+
+export function buildDocumentUploadQueue(
+  files: File[],
+): QueuedDocumentUpload[] {
+  return files.map((file, index) => {
+    const validation = validateDocumentUpload({
+      documentType: "company_registration",
+      fileType: file.type,
+      fileSize: file.size,
+    });
+
+    return {
+      id: `${file.name}-${file.size}-${file.lastModified}-${index}`,
+      file,
+      name: file.name,
+      size: file.size,
+      sizeLabel: formatDocumentFileSize(file.size),
+      valid: validation.valid,
+      error: validation.valid ? null : validation.error,
+    };
+  });
+}
 
 export function validateDocumentUpload(input: {
   documentType: string;
@@ -36,13 +80,16 @@ export function validateDocumentUpload(input: {
   fileSize: number;
 }): { valid: true } | { valid: false; error: string } {
   if (!ALLOWED_DOC_TYPES.includes(input.documentType as DocType)) {
-    return { valid: false, error: `Invalid document type: ${input.documentType}` };
+    return {
+      valid: false,
+      error: `Invalid document type: ${input.documentType}`,
+    };
   }
   if (!ALLOWED_FILE_TYPES.includes(input.fileType)) {
-    return { valid: false, error: 'File must be a JPG, PNG, or PDF' };
+    return { valid: false, error: "File must be a JPG, PNG, or PDF" };
   }
   if (input.fileSize > MAX_DOC_BYTES) {
-    return { valid: false, error: 'File must be 5MB or smaller' };
+    return { valid: false, error: "File must be 5MB or smaller" };
   }
   return { valid: true };
 }

--- a/lib/onboarding/manual-intake.ts
+++ b/lib/onboarding/manual-intake.ts
@@ -1,0 +1,404 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { z } from "zod";
+import { addBusinessDays, now } from "@/lib/dates";
+
+const billingDaySchema = z.enum(["1", "15", "20", "25"]);
+
+export const manualB2BIntakeSchema = z.object({
+  customerId: z.string().uuid().optional(),
+  submissionId: z.string().uuid().optional(),
+  segment: z.string().min(2).default("unjani"),
+  business: z.object({
+    businessName: z.string().min(2),
+    entityType: z.string().min(2),
+    registrationNumber: z.string().min(2),
+    vatRegistered: z.boolean().default(false),
+    vatNumber: z.string().optional().nullable(),
+    registeredAddress: z.string().min(5),
+  }),
+  contact: z.object({
+    contactName: z.string().min(2),
+    email: z.string().email(),
+    phone: z.string().min(9),
+  }),
+  site: z
+    .object({
+      clinicName: z.string().min(2).optional(),
+      province: z.string().min(2).optional(),
+      siteAddress: z.string().min(5).optional(),
+      lat: z.string().optional().nullable(),
+      lng: z.string().optional().nullable(),
+    })
+    .default({}),
+  service: z
+    .object({
+      serviceId: z.string().uuid().optional(),
+      packageName: z.string().min(2).default("CircleTel ClinicConnect"),
+      serviceType: z.string().min(2).default("managed_connectivity"),
+      productCategory: z.string().min(2).default("business_connectivity"),
+      monthlyPrice: z.coerce.number().nonnegative().default(450),
+      activationDate: z.string().optional().nullable(),
+      billingDay: billingDaySchema.default("1"),
+      providerName: z.string().optional().nullable(),
+    })
+    .optional(),
+  debitOrder: z
+    .object({
+      paymentMethodId: z.string().uuid().optional(),
+      accountHolderName: z.string().min(2),
+      bankName: z.string().min(2),
+      accountType: z.string().min(2),
+      accountNumber: z.string().min(6),
+      branchCode: z.string().min(5),
+    })
+    .optional(),
+});
+
+export type ManualB2BIntakeInput = z.infer<typeof manualB2BIntakeSchema>;
+
+export interface ManualB2BIntakeAdmin {
+  adminId: string;
+  adminEmail: string;
+}
+
+export interface ManualB2BIntakeResult {
+  customerId: string;
+  accountNumber: string | null;
+  submissionId: string;
+  createdCustomer: boolean;
+  createdSubmission: boolean;
+  serviceId?: string;
+  paymentMethodId?: string;
+}
+
+function splitContactName(name: string): {
+  firstName: string;
+  lastName: string;
+} {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { firstName: "Business", lastName: "Contact" };
+  if (parts.length === 1) return { firstName: parts[0], lastName: "Contact" };
+  return { firstName: parts[0], lastName: parts.slice(1).join(" ") };
+}
+
+function maskAccountNumber(accountNumber: string): string {
+  return `****${accountNumber.slice(-4)}`;
+}
+
+function errorMessage(
+  error: { message?: string } | null | undefined,
+  fallback: string,
+): string {
+  return error?.message || fallback;
+}
+
+function buildClinicDetails(input: ManualB2BIntakeInput) {
+  return {
+    clinic_name: input.site.clinicName ?? input.business.businessName,
+    province: input.site.province ?? null,
+    nurse_owner_name: input.contact.contactName,
+    site_address: input.site.siteAddress ?? input.business.registeredAddress,
+    lat: input.site.lat ?? null,
+    lng: input.site.lng ?? null,
+    capture_method: "admin_manual_intake",
+  };
+}
+
+function buildSubmissionData(
+  input: ManualB2BIntakeInput,
+  admin: ManualB2BIntakeAdmin,
+  capturedAt: string,
+) {
+  const billingDay = input.service?.billingDay ?? "1";
+  return {
+    capture_method: "admin_manual_intake",
+    source: "email",
+    captured_by: admin.adminEmail,
+    captured_by_id: admin.adminId,
+    captured_at: capturedAt,
+    step1: {
+      clinicName: input.site.clinicName ?? input.business.businessName,
+      province: input.site.province ?? "",
+      contact: input.contact.contactName,
+      phone: input.contact.phone,
+      email: input.contact.email,
+      siteAddress: input.site.siteAddress ?? input.business.registeredAddress,
+      lat: input.site.lat ?? undefined,
+      lng: input.site.lng ?? undefined,
+    },
+    step2: {
+      entityName: input.business.businessName,
+      entityType: input.business.entityType,
+      regNumber: input.business.registrationNumber,
+      vat: input.business.vatRegistered ? "Yes" : "No",
+      vatNumber: input.business.vatNumber ?? undefined,
+      regAddress: input.business.registeredAddress,
+    },
+    step3: input.debitOrder
+      ? {
+          accHolder: input.debitOrder.accountHolderName,
+          bank: input.debitOrder.bankName,
+          accType: input.debitOrder.accountType,
+          accNumber: maskAccountNumber(input.debitOrder.accountNumber),
+          branchCode: input.debitOrder.branchCode,
+          mandate: true,
+        }
+      : undefined,
+    step5: {
+      paymentDate: billingDay,
+      soAccept: false,
+    },
+    manual_intake: {
+      segment: input.segment,
+      service_captured: Boolean(input.service),
+      debit_order_captured: Boolean(input.debitOrder),
+      service_order_signoff_status: "pending",
+    },
+  };
+}
+
+export async function saveManualB2BIntake(
+  supabase: SupabaseClient,
+  rawInput: unknown,
+  admin: ManualB2BIntakeAdmin,
+): Promise<ManualB2BIntakeResult> {
+  const input = manualB2BIntakeSchema.parse(rawInput);
+  const capturedAt = now().toISOString();
+  const clinicDetails = buildClinicDetails(input);
+  const { firstName, lastName } = splitContactName(input.contact.contactName);
+
+  const customerPayload = {
+    first_name: firstName,
+    last_name: lastName,
+    email: input.contact.email,
+    phone: input.contact.phone,
+    account_type: "business",
+    status: "active",
+    account_status: "active",
+    business_name: input.business.businessName,
+    business_registration: input.business.registrationNumber,
+    tax_number: input.business.vatRegistered
+      ? (input.business.vatNumber ?? null)
+      : null,
+    onboarding_status: "submitted",
+    clinic_details: clinicDetails,
+  };
+
+  let customerId = input.customerId;
+  let accountNumber: string | null = null;
+  let createdCustomer = false;
+
+  if (customerId) {
+    const { data, error } = await supabase
+      .from("customers")
+      .update(customerPayload)
+      .eq("id", customerId)
+      .select("id, account_number")
+      .single();
+    if (error || !data) {
+      throw new Error(
+        errorMessage(error, "Failed to update business customer"),
+      );
+    }
+    accountNumber = data.account_number ?? null;
+  } else {
+    const { data, error } = await supabase
+      .from("customers")
+      .insert(customerPayload)
+      .select("id, account_number")
+      .single();
+    if (error || !data) {
+      throw new Error(
+        errorMessage(error, "Failed to create business customer"),
+      );
+    }
+    customerId = data.id;
+    accountNumber = data.account_number ?? null;
+    createdCustomer = true;
+  }
+
+  const submissionData = buildSubmissionData(input, admin, capturedAt);
+  let submissionId = input.submissionId;
+  let createdSubmission = false;
+
+  if (!submissionId) {
+    const { data: existing, error: existingError } = await supabase
+      .from("onboarding_submissions")
+      .select("id")
+      .eq("customer_id", customerId)
+      .order("submitted_at", { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle();
+    if (existingError) {
+      throw new Error(
+        errorMessage(existingError, "Failed to find onboarding submission"),
+      );
+    }
+    submissionId = existing?.id;
+  }
+
+  const submissionPayload = {
+    customer_id: customerId,
+    segment: input.segment,
+    status: "submitted",
+    document_vetting_status: "documents_pending",
+    submitted_at: capturedAt,
+    vetting_due_date: addBusinessDays(now(), 2).toISOString(),
+    submission_data: submissionData,
+  };
+
+  if (submissionId) {
+    const { error } = await supabase
+      .from("onboarding_submissions")
+      .update(submissionPayload)
+      .eq("id", submissionId);
+    if (error) {
+      throw new Error(
+        errorMessage(error, "Failed to update onboarding submission"),
+      );
+    }
+  } else {
+    const { data, error } = await supabase
+      .from("onboarding_submissions")
+      .insert(submissionPayload)
+      .select("id")
+      .single();
+    if (error || !data) {
+      throw new Error(
+        errorMessage(error, "Failed to create onboarding submission"),
+      );
+    }
+    submissionId = data.id;
+    createdSubmission = true;
+  }
+
+  let serviceId: string | undefined;
+  if (input.service) {
+    const servicePayload = {
+      customer_id: customerId,
+      package_name: input.service.packageName,
+      service_type: input.service.serviceType,
+      product_category: input.service.productCategory,
+      monthly_price: input.service.monthlyPrice,
+      setup_fee: 0,
+      status: "active",
+      active: true,
+      installation_address:
+        input.site.siteAddress ?? input.business.registeredAddress,
+      activation_date: input.service.activationDate ?? capturedAt.slice(0, 10),
+      provider_name: input.service.providerName ?? null,
+      contract_months: 0,
+      billing_day: Number(input.service.billingDay),
+    };
+    if (input.service.serviceId) {
+      const { error } = await supabase
+        .from("customer_services")
+        .update(servicePayload)
+        .eq("id", input.service.serviceId);
+      if (error) {
+        throw new Error(errorMessage(error, "Failed to update active service"));
+      }
+      serviceId = input.service.serviceId;
+    } else {
+      const { data, error } = await supabase
+        .from("customer_services")
+        .insert(servicePayload)
+        .select("id")
+        .single();
+      if (error || !data) {
+        throw new Error(errorMessage(error, "Failed to create active service"));
+      }
+      serviceId = data.id;
+    }
+  }
+
+  let paymentMethodId: string | undefined;
+  if (input.debitOrder) {
+    const paymentPayload = {
+      customer_id: customerId,
+      onboarding_submission_id: submissionId,
+      method_type: "debit_order",
+      display_name: `Debit Order - ${input.debitOrder.bankName} ${maskAccountNumber(input.debitOrder.accountNumber)}`,
+      last_four: input.debitOrder.accountNumber.slice(-4),
+      encrypted_details: {
+        bank_name: input.debitOrder.bankName,
+        account_holder_name: input.debitOrder.accountHolderName,
+        account_type: input.debitOrder.accountType,
+        account_number: input.debitOrder.accountNumber,
+        branch_code: input.debitOrder.branchCode,
+        verified: false,
+        source: "admin_manual_intake",
+      },
+      mandate_status: "pending",
+      is_primary: true,
+      is_active: true,
+    };
+
+    if (input.debitOrder.paymentMethodId) {
+      const { error } = await supabase
+        .from("customer_payment_methods")
+        .update(paymentPayload)
+        .eq("id", input.debitOrder.paymentMethodId);
+      if (error) {
+        throw new Error(
+          errorMessage(error, "Failed to update debit-order payment method"),
+        );
+      }
+      paymentMethodId = input.debitOrder.paymentMethodId;
+    } else {
+      const { data: existingPm, error: existingPmError } = await supabase
+        .from("customer_payment_methods")
+        .select("id")
+        .eq("onboarding_submission_id", submissionId)
+        .eq("method_type", "debit_order")
+        .maybeSingle();
+      if (existingPmError) {
+        throw new Error(
+          errorMessage(
+            existingPmError,
+            "Failed to find debit-order payment method",
+          ),
+        );
+      }
+
+      if (existingPm?.id) {
+        const { error } = await supabase
+          .from("customer_payment_methods")
+          .update(paymentPayload)
+          .eq("id", existingPm.id);
+        if (error) {
+          throw new Error(
+            errorMessage(error, "Failed to update debit-order payment method"),
+          );
+        }
+        paymentMethodId = existingPm.id;
+      } else {
+        const { data, error } = await supabase
+          .from("customer_payment_methods")
+          .insert(paymentPayload)
+          .select("id")
+          .single();
+        if (error || !data) {
+          throw new Error(
+            errorMessage(error, "Failed to create debit-order payment method"),
+          );
+        }
+        paymentMethodId = data.id;
+      }
+    }
+  }
+
+  if (!customerId || !submissionId) {
+    throw new Error("Manual intake did not produce a customer and submission");
+  }
+
+  return {
+    customerId,
+    accountNumber,
+    submissionId,
+    createdCustomer,
+    createdSubmission,
+    serviceId,
+    paymentMethodId,
+  };
+}

--- a/lib/onboarding/onboarding-service.ts
+++ b/lib/onboarding/onboarding-service.ts
@@ -1,6 +1,22 @@
 import { createClient } from '@supabase/supabase-js';
 import { generateToken, hashToken, tokenExpiry } from './token-service';
 
+export type OnboardingTokenPurpose = 'onboarding' | 'service_order_signoff';
+
+export interface IssueTokenOptions {
+  purpose?: OnboardingTokenPurpose;
+  onboardingSubmissionId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ResolvedPurposeToken {
+  customerId: string;
+  tokenId: string;
+  purpose: OnboardingTokenPurpose;
+  onboardingSubmissionId: string | null;
+  metadata: Record<string, unknown>;
+}
+
 export function svc() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -14,7 +30,11 @@ export function buildMagicLinkUrl(base: string, token: string): string {
 }
 
 /** Issue a fresh single-use token for a customer; returns the plaintext token. */
-export async function issueToken(customerId: string, sentVia: string): Promise<string> {
+export async function issueToken(
+  customerId: string,
+  sentVia: string,
+  options: IssueTokenOptions = {}
+): Promise<string> {
   const supabase = svc();
   const token = generateToken();
   const { error } = await supabase.from('onboarding_tokens').insert({
@@ -23,6 +43,9 @@ export async function issueToken(customerId: string, sentVia: string): Promise<s
     expires_at: tokenExpiry(),
     sent_via: sentVia,
     sent_at: new Date().toISOString(),
+    purpose: options.purpose ?? 'onboarding',
+    onboarding_submission_id: options.onboardingSubmissionId ?? null,
+    metadata: options.metadata ?? {},
   });
   if (error) throw new Error(`Failed to issue token: ${error.message}`);
   return token;
@@ -30,16 +53,33 @@ export async function issueToken(customerId: string, sentVia: string): Promise<s
 
 /** Resolve a plaintext token to a customer id, enforcing expiry + single use. */
 export async function resolveToken(token: string): Promise<{ customerId: string; tokenId: string } | null> {
+  const resolved = await resolveTokenForPurpose(token, 'onboarding');
+  if (!resolved) return null;
+  return { customerId: resolved.customerId, tokenId: resolved.tokenId };
+}
+
+/** Resolve a plaintext token for a specific purpose, enforcing expiry + single use. */
+export async function resolveTokenForPurpose(
+  token: string,
+  purpose: OnboardingTokenPurpose
+): Promise<ResolvedPurposeToken | null> {
   const supabase = svc();
   const { data, error } = await supabase
     .from('onboarding_tokens')
-    .select('id, customer_id, expires_at, used_at')
+    .select('id, customer_id, onboarding_submission_id, purpose, metadata, expires_at, used_at')
     .eq('token_hash', hashToken(token))
     .maybeSingle();
   if (error || !data) return null;
   if (data.used_at) return null;
   if (new Date(data.expires_at).getTime() < Date.now()) return null;
-  return { customerId: data.customer_id, tokenId: data.id };
+  if (data.purpose !== purpose) return null;
+  return {
+    customerId: data.customer_id,
+    tokenId: data.id,
+    purpose: data.purpose,
+    onboardingSubmissionId: data.onboarding_submission_id ?? null,
+    metadata: data.metadata ?? {},
+  };
 }
 
 /** Pre-fill payload for the wizard from the existing customer record. */

--- a/lib/onboarding/service-order-issuer.ts
+++ b/lib/onboarding/service-order-issuer.ts
@@ -1,0 +1,297 @@
+import crypto from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { Resend } from 'resend';
+import { generateServiceOrderBlob, type ServiceOrderInput } from '@/lib/contracts/service-order-pdf';
+import { uploadFile } from '@/lib/storage/supabase-upload';
+import { issueToken } from './onboarding-service';
+import {
+  SERVICE_ORDER_TERMS,
+  SERVICE_ORDER_TERMS_TITLE,
+  SERVICE_ORDER_TERMS_VERSION,
+  getServiceOrderReference,
+  stripHtmlFromTerms,
+} from './service-order-terms';
+
+interface ServiceOrderIssuerOptions {
+  customerId: string;
+  baseUrl?: string;
+  issuedBy: string;
+  sendEmail?: boolean;
+}
+
+export interface ServiceOrderIssueResult {
+  pdfPath: string;
+  pdfSha256: string;
+  submissionId: string;
+  emailed: boolean;
+  signoffUrl?: string;
+}
+
+interface CustomerRow {
+  id: string;
+  account_number: string;
+  business_name: string;
+  email: string;
+  phone: string | null;
+  clinic_details: Record<string, unknown> | null;
+}
+
+interface SubmissionRow {
+  id: string;
+  segment: string | null;
+  submitted_at: string | null;
+  submission_data: Record<string, any> | null;
+}
+
+interface ServiceRow {
+  monthly_price: number | null;
+  activation_date: string | null;
+  package_name?: string | null;
+  service_type?: string | null;
+}
+
+function cleanBaseUrl(baseUrl?: string): string {
+  return (baseUrl || process.env.NEXT_PUBLIC_BASE_URL || 'https://www.circletel.co.za').replace(/\/+$/, '');
+}
+
+export function buildServiceOrderSignoffUrl(baseUrl: string, token: string): string {
+  return `${cleanBaseUrl(baseUrl)}/service-order/${token}`;
+}
+
+function termsHash(reference: string): string {
+  const canonical = JSON.stringify([
+    SERVICE_ORDER_TERMS_TITLE,
+    ...SERVICE_ORDER_TERMS,
+    reference,
+  ]);
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+function buildAcceptance(
+  submission: SubmissionRow,
+  customer: CustomerRow
+): ServiceOrderInput['acceptance'] | undefined {
+  const submissionData = submission.submission_data ?? {};
+  const acceptanceRecord = submissionData.service_order_acceptance ?? submissionData.acceptance;
+  if (!acceptanceRecord?.accepted_at) return undefined;
+
+  const digits = (customer.phone || '').replace(/\D/g, '');
+  const maskedPhone =
+    digits.length >= 7 ? `${digits.slice(0, 3)} *** ${digits.slice(-4)}` : undefined;
+
+  return {
+    acceptedAtIso: acceptanceRecord.accepted_at,
+    ip: acceptanceRecord.ip || undefined,
+    termsVersion: acceptanceRecord.terms_version || undefined,
+    termsHash: acceptanceRecord.terms_hash || undefined,
+    termsSnapshot: Array.isArray(acceptanceRecord.terms_snapshot)
+      ? acceptanceRecord.terms_snapshot
+      : undefined,
+    linkSentVia: acceptanceRecord.link_sent_via || undefined,
+    linkSentAtIso: acceptanceRecord.link_sent_at || undefined,
+    maskedPhone,
+    submissionId: submission.id,
+  };
+}
+
+function buildPdfInput(
+  customer: CustomerRow,
+  submission: SubmissionRow,
+  service: ServiceRow
+): ServiceOrderInput {
+  const submissionData = submission.submission_data ?? {};
+  const step5 = submissionData.step5 ?? {};
+  const clinicDetails = customer.clinic_details ?? {};
+  const segment = submission.segment ?? 'unjani';
+  const customerLabel = segment === 'unjani' ? 'Clinic' : 'Business';
+  const serviceReference = getServiceOrderReference(segment);
+  const serviceName =
+    service.package_name ||
+    (segment === 'unjani'
+      ? 'CircleTel ClinicConnect — Managed Connectivity'
+      : 'CircleTel Business Connectivity Service');
+
+  return {
+    accountNumber: customer.account_number,
+    clinicName: customer.business_name,
+    clinicAddress:
+      String(clinicDetails.site_address || submissionData.step1?.siteAddress || 'Not provided'),
+    clinicProvince: String(clinicDetails.province || submissionData.step1?.province || 'Not provided'),
+    clinicEmail: customer.email,
+    clinicPhone: customer.phone || undefined,
+    customerLabel,
+    serviceName,
+    serviceReference,
+    monthlyFeeExclVat: Number(service.monthly_price ?? 450),
+    vatPercentage: 15,
+    billingDay: (step5.paymentDate || '1') as '1' | '15' | '20' | '25',
+    activationDate: service.activation_date || new Date().toISOString(),
+    submittedAt: submission.submitted_at || new Date().toISOString(),
+    acceptance: buildAcceptance(submission, customer),
+  };
+}
+
+function serviceOrderEmailHtml(input: {
+  customer: CustomerRow;
+  accountNumber: string;
+  monthlyFee: number;
+  signoffUrl: string;
+}) {
+  return `
+    <h2>CircleTel Service Order</h2>
+    <p>Dear ${input.customer.business_name},</p>
+    <p>Your Service Order is ready for sign-off.</p>
+    <div style="background-color:#f5f5f5;padding:16px;border-radius:8px;margin:16px 0;">
+      <p style="margin:8px 0;"><strong>Account Number:</strong> ${input.accountNumber}</p>
+      <p style="margin:8px 0;"><strong>Monthly Fee:</strong> R${input.monthlyFee.toFixed(2)} ex VAT</p>
+    </div>
+    <p><a href="${input.signoffUrl}" style="display:inline-block;background:#E87A1E;color:#ffffff;padding:12px 18px;border-radius:6px;text-decoration:none;font-weight:700;">Review and sign off</a></p>
+    <p>The generated PDF is attached for your records.</p>
+    <p>Regards,<br>CircleTel</p>
+  `;
+}
+
+export async function issueServiceOrderForCustomer(
+  supabase: SupabaseClient,
+  options: ServiceOrderIssuerOptions
+): Promise<ServiceOrderIssueResult> {
+  const { data: customer, error: customerError } = await supabase
+    .from('customers')
+    .select('id, account_number, business_name, email, phone, clinic_details')
+    .eq('id', options.customerId)
+    .single();
+  if (customerError || !customer) {
+    throw new Error(customerError?.message || 'Customer not found');
+  }
+
+  const { data: submission, error: submissionError } = await supabase
+    .from('onboarding_submissions')
+    .select('id, segment, submission_data, submitted_at')
+    .eq('customer_id', options.customerId)
+    .order('submitted_at', { ascending: false })
+    .limit(1)
+    .single();
+  if (submissionError || !submission) {
+    throw new Error(submissionError?.message || 'No onboarding submission found for this customer');
+  }
+
+  const { data: service, error: serviceError } = await supabase
+    .from('customer_services')
+    .select('monthly_price, activation_date, package_name, service_type')
+    .eq('customer_id', options.customerId)
+    .order('activation_date', { ascending: false })
+    .limit(1)
+    .single();
+  if (serviceError || !service) {
+    throw new Error(serviceError?.message || 'No active service found for this customer');
+  }
+
+  const customerRow = customer as CustomerRow;
+  const submissionRow = submission as SubmissionRow;
+  const serviceRow = service as ServiceRow;
+  const pdfInput = buildPdfInput(customerRow, submissionRow, serviceRow);
+  const pdfBlob = generateServiceOrderBlob(pdfInput);
+  const pdfBuffer = Buffer.from(await pdfBlob.arrayBuffer());
+  const pdfSha256 = crypto.createHash('sha256').update(pdfBuffer).digest('hex');
+  const filename = `SO-${customerRow.account_number}.pdf`;
+
+  const pdfFile = new File([pdfBlob], `${filename.replace(/\.pdf$/, '')}-${Date.now()}.pdf`, {
+    type: 'application/pdf',
+  });
+  const uploadResult = await uploadFile(pdfFile, {
+    bucket: 'kyc-documents',
+    folder: `service-orders/${options.customerId}`,
+    maxSizeBytes: 5 * 1024 * 1024,
+    allowedTypes: ['application/pdf'],
+    supabaseClient: supabase,
+  });
+  if (!uploadResult.success || !uploadResult.path) {
+    throw new Error(uploadResult.error || 'Failed to upload service order PDF');
+  }
+
+  const existingSubmissionData = submissionRow.submission_data ?? {};
+  const accepted = Boolean(existingSubmissionData.service_order_acceptance?.accepted_at || existingSubmissionData.acceptance?.accepted_at);
+  const issuedAt = new Date().toISOString();
+  const { error: updateError } = await supabase
+    .from('onboarding_submissions')
+    .update({
+      service_order_pdf_path: uploadResult.path,
+      service_order_issued_at: issuedAt,
+      submission_data: {
+        ...existingSubmissionData,
+        service_order_pdf_sha256: pdfSha256,
+        service_order_status: accepted ? 'accepted' : 'pending_signoff',
+        service_order_issued_by: options.issuedBy,
+        service_order_issued_at: issuedAt,
+      },
+    })
+    .eq('id', submissionRow.id);
+  if (updateError) {
+    throw new Error(updateError.message || 'Failed to update submission service order');
+  }
+
+  let emailed = false;
+  let signoffUrl: string | undefined;
+  if (options.sendEmail !== false) {
+    const token = await issueToken(options.customerId, 'email', {
+      purpose: 'service_order_signoff',
+      onboardingSubmissionId: submissionRow.id,
+      metadata: {
+        service_order_pdf_path: uploadResult.path,
+        issued_by: options.issuedBy,
+      },
+    });
+    signoffUrl = buildServiceOrderSignoffUrl(cleanBaseUrl(options.baseUrl), token);
+    const resend = new Resend(process.env.RESEND_API_KEY);
+    const { error: emailError } = await resend.emails.send({
+      from: 'billing@notify.circletel.co.za',
+      to: customerRow.email,
+      subject: `CircleTel Service Order ${customerRow.account_number}`,
+      html: serviceOrderEmailHtml({
+        customer: customerRow,
+        accountNumber: customerRow.account_number,
+        monthlyFee: Number(serviceRow.monthly_price ?? 450),
+        signoffUrl,
+      }),
+      attachments: [
+        {
+          filename,
+          content: pdfBuffer,
+          contentType: 'application/pdf',
+        },
+      ],
+    });
+    if (emailError) {
+      throw new Error(emailError.message || 'Failed to send service order email');
+    }
+    emailed = true;
+  }
+
+  return {
+    pdfPath: uploadResult.path,
+    pdfSha256,
+    submissionId: submissionRow.id,
+    emailed,
+    signoffUrl,
+  };
+}
+
+export function buildServiceOrderAcceptanceRecord(input: {
+  tokenId: string;
+  ip: string | null;
+  userAgent: string | null;
+  segment?: string | null;
+}) {
+  const acceptedAt = new Date().toISOString();
+  const reference = getServiceOrderReference(input.segment);
+  return {
+    accepted_at: acceptedAt,
+    ip: input.ip,
+    user_agent: input.userAgent,
+    token_id: input.tokenId,
+    terms_version: SERVICE_ORDER_TERMS_VERSION,
+    terms_hash: termsHash(reference),
+    terms_snapshot: stripHtmlFromTerms(SERVICE_ORDER_TERMS),
+    service_reference: reference,
+  };
+}

--- a/lib/onboarding/service-order-terms.ts
+++ b/lib/onboarding/service-order-terms.ts
@@ -84,8 +84,15 @@ export function convertTermsToPlainText(terms: string[]): string[] {
 export const SERVICE_ORDER_MSA_REFERENCE =
   'This Service Order is issued back-to-back with, and incorporates by reference, the Unjani Master Service Agreement between CircleTel and the Unjani Clinic Network.';
 
+export const SERVICE_ORDER_STANDARD_REFERENCE =
+  'This Service Order is issued under CircleTel standard business service terms and the customer-specific commercial terms recorded in this Service Order.';
+
 /**
  * MSA reference text (shown in UI)
  */
 export const SERVICE_ORDER_MSA_REFERENCE_UI =
   'These terms are back-to-back with the Master Service Agreement between CircleTel and Unjani Clinics NPC (the "MSA"). In the event of any conflict, the MSA prevails.';
+
+export function getServiceOrderReference(segment?: string | null): string {
+  return segment === 'unjani' ? SERVICE_ORDER_MSA_REFERENCE : SERVICE_ORDER_STANDARD_REFERENCE;
+}


### PR DESCRIPTION
## Summary
Brings the **`/admin/b2b/manual-intake`** admin-assisted B2B onboarding feature to `main` as an **isolated, conflict-free unit**. The staging branch (`codex/manual-onboarding-stepper`, PR #588) carried this same feature bundled with unrelated offers/payment/checkout work that conflicts with main; this PR cherry-picks **only** the manual-intake feature so it can ship cleanly.

**15 files** — the new wizard page + API route + onboarding service layer, plus one sidebar nav line.

### What it adds
- **6-step admin wizard**: Customer & Business → Contact & Site → Billable Service → Documents → Debit Order → Review — with real customer search/prefill and the document-upload modal.
- **v1.0 UI polish**: inline field validation + per-step "Please fix N items" error summary (with focus management), wired debit **mandate** gate, required-items **% progress bar**, "Step X of 6" **chip**, **discard-confirm** dialog, and Complete/Incomplete **review-card tags**. Accessibility: `aria-invalid` + `aria-describedby` on all validated fields.
- **Service layer + API**: `lib/onboarding/{manual-intake,billing-ready,service-order-issuer,service-order-terms}` and `POST/GET /api/admin/b2b/manual-intake` (writes `customers`, `onboarding_submissions`, optional `customer_services` + `customer_payment_methods`).
- Sidebar entry under **B2B Customers → Manual Onboarding**.
- Design decisions: `registrationNumber` required-only (no CIPC regex — doubles as owner ID), single address textareas, `siteAddress` required.

## Test Plan
- [x] **Type-check**: 0 errors across all 15 touched files (against `main`).
- [x] **Tests**: 18/18 pass — `manual-intake`, `billing-ready`, `service-order-issuer`, `onboarding-service-token-purpose`, and the API `route` suite (permission gate, payload validation, customer search/prefill, domain service create-flow).
- [x] **Visual QA**: the same wizard was QA-confirmed on staging.
- [x] **Conflict-free** against `main` (the feature files don't touch the divergent offers/payment areas).
- [ ] Reviewer: confirm before merge.

Supersedes PR #588 for the manual-intake feature (that PR's remaining payment/offers/checkout reconciliation is a separate release task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)