### PR TITLE
feat(coverage): Home / Work-from-home / Business segment support in coverage check

### DIFF
--- a/app/api/coverage/lead/route.ts
+++ b/app/api/coverage/lead/route.ts
@@ -15,9 +15,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Determine customer type from coverageType parameter
-    // Database enum has: 'consumer', 'smme', 'enterprise'
-    // Map: residential -> consumer, business -> smme (covers both SME and enterprise)
+    // Determine customer type from coverageType parameter.
+    // Database enum has: 'consumer', 'smme', 'enterprise' (no soho value).
+    // Map: business -> smme; residential AND wfh -> consumer.
+    // The wfh segment lives in the URL/order state, not on the lead row.
     const customerType = coverageType === 'business' ? 'smme' : 'consumer';
 
     let finalCoordinates: { lat: number; lng: number } | null = coordinates ? { lat: coordinates.lat, lng: coordinates.lng } : null;

--- a/app/api/coverage/packages/route.ts
+++ b/app/api/coverage/packages/route.ts
@@ -5,6 +5,7 @@ import { coverageAggregationService } from '@/lib/coverage/aggregation-service';
 import { Coordinates } from '@/lib/coverage/types';
 import { CoverageLogger } from '@/lib/analytics/coverage-logger';
 import { apiLogger } from '@/lib/logging';
+import { normalizeSegment, customerTypesForSegment, sortPackagesForSegment } from '@/lib/coverage/customer-segments';
 
 // ============================================================================
 // TYPES
@@ -51,6 +52,7 @@ interface ServicePackage {
   metadata?: Record<string, unknown> | null;
   compatible_providers?: string[];
   active: boolean;
+  customer_type?: string;
 }
 
 interface NetworkProvider {
@@ -108,7 +110,7 @@ export async function GET(request: NextRequest) {
     const supabase = await createClient();
     const { searchParams } = new URL(request.url);
     const leadId = searchParams.get('leadId');
-    const coverageType = searchParams.get('type') || 'residential'; // Get coverage type from URL
+    const coverageType = normalizeSegment(searchParams.get('type')); // 'residential' | 'wfh' | 'business'
 
     if (!leadId) {
       return NextResponse.json(
@@ -324,13 +326,13 @@ export async function GET(request: NextRequest) {
       // Get available packages for the mapped product categories
       // Note: When no mappings exist, availableServices contains service_type values (e.g., 'SkyFibre', 'HomeFibreConnect')
       // When mappings exist, productCategories contains product_category values (e.g., 'wireless', 'fibre_consumer')
-      // Filter by customer_type based on coverage type
-      // Note: service_packages.customer_type is VARCHAR with values: 'business', 'consumer'
-      // coverage_leads.customer_type is ENUM with values: 'consumer', 'smme', 'enterprise'
-      const packageCustomerType = coverageType === 'business' ? 'business' : 'consumer';
+      // Filter by customer_type based on segment.
+      // service_packages.customer_type: 'consumer' | 'business' | 'both' | 'soho'
+      // coverage_leads.customer_type is a separate ENUM: 'consumer' | 'smme' | 'enterprise'
+      const packageCustomerTypes = customerTypesForSegment(coverageType);
 
       apiLogger.info('[Packages API] Querying packages with', {
-        packageCustomerType,
+        packageCustomerTypes,
         productCategories,
         usingMappings: !!(mappings && mappings.length > 0),
         query: mappings && mappings.length > 0
@@ -346,7 +348,7 @@ export async function GET(request: NextRequest) {
             ? `product_category.in.(${productCategories.join(',')})`
             : `service_type.in.(${productCategories.join(',')})`
         )
-        .eq('customer_type', packageCustomerType)
+        .in('customer_type', packageCustomerTypes)
         .eq('active', true)
         .order('price', { ascending: true });
 
@@ -396,6 +398,7 @@ export async function GET(request: NextRequest) {
             id: pkg.id,
             name: pkg.name,
             service_type: pkg.service_type,
+            customer_type: pkg.customer_type,
             product_category: pkg.product_category,
             speed_down: pkg.speed_down,
             speed_up: pkg.speed_up,
@@ -430,12 +433,15 @@ export async function GET(request: NextRequest) {
             });
           }
         }
+
+        // WFH: lead with SOHO (WorkConnect) packages
+        availablePackages = sortPackagesForSegment(coverageType, availablePackages);
       }
 
       // Log for debugging
       apiLogger.info('Coverage check', {
         coverageType,
-        packageCustomerType,
+        packageCustomerTypes,
         availableServices,
         productCategories,
         packagesFound: availablePackages.length

--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -21,6 +21,7 @@ import { ServiceAddressSection } from '@/components/order/checkout/ServiceAddres
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { createClient } from '@/lib/supabase/client';
 import {
   ORDER_PROCESSING_FEE_AMOUNT,
@@ -66,6 +67,13 @@ export default function CheckoutPage() {
 
   const pkg = orderState.orderData.package?.selectedPackage;
   const coverage = orderState.orderData.coverage;
+
+  // SOHO (WorkConnect) can be signed up personally or as a business — user chooses.
+  const isSohoPackage = pkg?.customer_type === 'soho';
+  const [sohoAccountType, setSohoAccountType] = useState<'personal' | 'business'>('personal');
+  const derivedAccountType: 'personal' | 'business' = isSohoPackage
+    ? sohoAccountType
+    : coverage?.coverageType === 'business' ? 'business' : 'personal';
 
   const [serviceAddress, setServiceAddress] = useState(coverage?.address ?? '');
   const [serviceCoordinates, setServiceCoordinates] = useState(coverage?.coordinates);
@@ -151,7 +159,7 @@ export default function CheckoutPage() {
           lastName: result.customer.last_name,
           phone: result.customer.phone,
           isAuthenticated: true,
-          accountType: coverage?.coverageType === 'business' ? 'business' : 'personal',
+          accountType: derivedAccountType,
           termsAccepted: true,
         },
       });
@@ -197,7 +205,7 @@ export default function CheckoutPage() {
         lastName,
         phone,
         isAuthenticated: true,
-        accountType: coverage?.coverageType === 'business' ? 'business' : 'personal',
+        accountType: derivedAccountType,
         termsAccepted: false,
       },
     });
@@ -295,7 +303,7 @@ export default function CheckoutPage() {
         delivery_address: finalDeliveryAddress,
         coordinates: serviceCoordinates,
         installation_location_type: propertyType,
-        account_type: coverage?.coverageType === 'business' ? 'business' : 'personal',
+        account_type: derivedAccountType,
         coverage_lead_id: coverage?.leadId,
         metadata: confirmedSkyFibreOrderability
           ? { skyfibre_orderability: confirmedSkyFibreOrderability }
@@ -528,6 +536,29 @@ export default function CheckoutPage() {
                   email={customer?.email || user?.email || ''}
                   onSignOut={handleSignOut}
                 />
+
+                {isSohoPackage && (
+                  <div className="mt-5">
+                    <p className="text-sm font-bold text-circleTel-navy mb-2">I&apos;m signing up as</p>
+                    <RadioGroup
+                      value={sohoAccountType}
+                      onValueChange={(v) => setSohoAccountType(v as 'personal' | 'business')}
+                      className="flex gap-6"
+                    >
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="personal" id="soho-personal" />
+                        <Label htmlFor="soho-personal">Personal</Label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="business" id="soho-business" />
+                        <Label htmlFor="soho-business">Business</Label>
+                      </div>
+                    </RadioGroup>
+                    <p className="text-xs text-gray-500 mt-1">
+                      WorkConnect can be billed to you personally or to your business.
+                    </p>
+                  </div>
+                )}
 
                 {/* Collect missing profile details (Google OAuth users) */}
                 {(!customer?.first_name || !customer?.phone) && (

--- a/app/packages/[leadId]/page.tsx
+++ b/app/packages/[leadId]/page.tsx
@@ -25,6 +25,8 @@ import {
 } from '@/components/ui/tooltip';
 import { extractBenefits, extractAdditionalInfo } from '@/lib/products/feature-formatter';
 import { ENTERTAINMENT_BUNDLES, type EntertainmentBundle } from '@/lib/data/entertainment-bundles';
+import { SegmentToggle } from '@/components/coverage/SegmentToggle';
+import { normalizeSegment, type CoverageSegment } from '@/lib/coverage/customer-segments';
 
 interface Package {
   id: string;
@@ -68,7 +70,7 @@ function PackagesContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const leadId = params.leadId as string;
-  const coverageType = searchParams.get('type') || 'residential';
+  const coverageType = normalizeSegment(searchParams.get('type'));
   const bundleId = searchParams.get('bundle')
   const activeBundle: EntertainmentBundle | null = bundleId
     ? (ENTERTAINMENT_BUNDLES.find(b => b.id === bundleId) ?? null)
@@ -357,6 +359,15 @@ function PackagesContent() {
     router.push('/#coverage');
   };
 
+  const handleSegmentChange = (segment: CoverageSegment) => {
+    if (segment === coverageType) return;
+    setSelectedPackage(null);
+    setShowAllPackages(false);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('type', segment);
+    router.replace(`/packages/${leadId}?${params.toString()}`, { scroll: false });
+  };
+
   // Map ServiceType to package filtering logic
   // Note: SkyFibre packages use service_type='SkyFibre' and product_category='connectivity'
   const getFilteredPackages = () => {
@@ -385,14 +396,16 @@ function PackagesContent() {
       return packages.filter(p => {
         const serviceType = (p.service_type || '').toLowerCase();
         const productCategory = (p.product_category || '').toLowerCase();
-        // Include: wireless, skyfibre, or connectivity (for SkyFibre products)
+        // Include: wireless, skyfibre, workconnect, or connectivity (for SkyFibre products)
         // Exclude: LTE and 5G (they have their own tabs)
-        const isWireless = serviceType.includes('wireless') || 
+        const isWireless = serviceType.includes('wireless') ||
                           serviceType.includes('skyfibre') ||
+                          serviceType.includes('workconnect') ||
                           productCategory.includes('wireless') ||
+                          productCategory === 'soho' ||
                           // SkyFibre products use connectivity category
                           (serviceType.includes('skyfibre') && productCategory === 'connectivity');
-        const isNotMobile = !serviceType.includes('lte') && 
+        const isNotMobile = !serviceType.includes('lte') &&
                            !serviceType.includes('5g') &&
                            !productCategory.includes('lte') &&
                            !productCategory.includes('5g');
@@ -447,11 +460,13 @@ function PackagesContent() {
     wireless: packages.filter(p => {
       const serviceType = (p.service_type || '').toLowerCase();
       const productCategory = (p.product_category || '').toLowerCase();
-      const isWireless = serviceType.includes('wireless') || 
+      const isWireless = serviceType.includes('wireless') ||
                         serviceType.includes('skyfibre') ||
+                        serviceType.includes('workconnect') ||
                         productCategory.includes('wireless') ||
+                        productCategory === 'soho' ||
                         (serviceType.includes('skyfibre') && productCategory === 'connectivity');
-      const isNotMobile = !serviceType.includes('lte') && 
+      const isNotMobile = !serviceType.includes('lte') &&
                          !serviceType.includes('5g') &&
                          !productCategory.includes('lte') &&
                          !productCategory.includes('5g');
@@ -479,6 +494,8 @@ function PackagesContent() {
         return 'blue';  // Wireless/LTE
       } else if (serviceType.includes('5g')) {
         return 'yellow';  // 5G
+      } else if (serviceType.includes('workconnect') || serviceType === 'soho') {
+        return 'orange';  // WorkConnect
       }
       return 'pink';  // Default
     };
@@ -602,6 +619,14 @@ function PackagesContent() {
               <p className="text-gray-600">
                 Choose the perfect package for your connectivity needs
               </p>
+            </div>
+
+            {/* Segment Toggle: Home / Work from Home / Business */}
+            <div className="mb-6">
+              <SegmentToggle
+                activeSegment={coverageType}
+                onSegmentChange={handleSegmentChange}
+              />
             </div>
 
             {/* Service Toggle */}

--- a/app/packages/[leadId]/page.tsx
+++ b/app/packages/[leadId]/page.tsx
@@ -26,12 +26,13 @@ import {
 import { extractBenefits, extractAdditionalInfo } from '@/lib/products/feature-formatter';
 import { ENTERTAINMENT_BUNDLES, type EntertainmentBundle } from '@/lib/data/entertainment-bundles';
 import { SegmentToggle } from '@/components/coverage/SegmentToggle';
-import { normalizeSegment, type CoverageSegment } from '@/lib/coverage/customer-segments';
+import { normalizeSegment, isQuoteOnlyPackage, type CoverageSegment } from '@/lib/coverage/customer-segments';
 
 interface Package {
   id: string;
   name: string;
   service_type: string;
+  customer_type?: string;
   product_category?: string;
   speed_down: number;
   speed_up: number;
@@ -231,6 +232,7 @@ function PackagesContent() {
       id: pkg.id,
       name: pkg.name,
       service_type: pkg.service_type,
+      customer_type: pkg.customer_type,
       product_category: pkg.product_category,
       speed_down: pkg.speed_down,
       speed_up: pkg.speed_up,
@@ -268,12 +270,19 @@ function PackagesContent() {
   };
 
   const handleContinue = () => {
+    if (selectedPackage && isQuoteOnlyPackage(selectedPackage)) {
+      // Business packages onboard via the B2B quote pipeline, not self-checkout
+      router.push(`/quotes/request?packageId=${selectedPackage.id}&leadId=${leadId}`);
+      return;
+    }
+
     if (selectedPackage) {
       // Convert Package to PackageDetails and save to context
       const packageDetails: PackageDetails = {
         id: selectedPackage.id,
         name: selectedPackage.name,
         service_type: selectedPackage.service_type,
+        customer_type: selectedPackage.customer_type,
         product_category: selectedPackage.product_category,
         speed_down: selectedPackage.speed_down,
         speed_up: selectedPackage.speed_up,
@@ -416,6 +425,10 @@ function PackagesContent() {
   };
 
   const filteredPackages = getFilteredPackages();
+
+  const continueLabel = selectedPackage && isQuoteOnlyPackage(selectedPackage)
+    ? 'Request a Quote'
+    : undefined;
 
   // Auto-select first package for the current service
   useEffect(() => {
@@ -809,6 +822,7 @@ function PackagesContent() {
                     }}
                     recommended={filteredPackages.indexOf(selectedPackage) === 0}
                     onOrderClick={handleContinue}
+                    orderButtonLabel={continueLabel}
                   />
                 </div>
               )}
@@ -895,6 +909,7 @@ function PackagesContent() {
           }}
           recommended={filteredPackages.indexOf(selectedPackage) === 0}
           onOrderClick={handleContinue}
+          orderButtonLabel={continueLabel}
         />
       )}
 
@@ -928,7 +943,7 @@ function PackagesContent() {
                 className="flex-1 sm:flex-none bg-circleTel-orange hover:bg-orange-600 text-white min-h-[44px]"
                 size="default"
               >
-                Continue →
+                {continueLabel ? `${continueLabel} →` : 'Continue →'}
               </Button>
             </div>
           </div>

--- a/app/packages/[leadId]/page.tsx
+++ b/app/packages/[leadId]/page.tsx
@@ -494,7 +494,7 @@ function PackagesContent() {
         return 'blue';  // Wireless/LTE
       } else if (serviceType.includes('5g')) {
         return 'yellow';  // 5G
-      } else if (serviceType.includes('workconnect') || serviceType === 'soho') {
+      } else if (serviceType.includes('workconnect') || serviceType.includes('soho')) {
         return 'orange';  // WorkConnect
       }
       return 'pink';  // Default
@@ -702,6 +702,8 @@ function PackagesContent() {
                             return 'blue';
                           } else if (serviceType.includes('5g')) {
                             return 'yellow';
+                          } else if (serviceType.includes('workconnect') || serviceType.includes('soho')) {
+                            return 'orange';
                           }
                           return 'pink';
                         };

--- a/app/quotes/request/page.tsx
+++ b/app/quotes/request/page.tsx
@@ -35,7 +35,7 @@ interface AgentInfo {
 interface CoverageResult {
   lead_id: string;
   address: string;
-  coordinates: { lat: number; lng: number };
+  coordinates: { lat: number; lng: number } | null;
   available: boolean;
   packages: any[];
 }
@@ -51,6 +51,8 @@ function QuoteRequestFormContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const token = searchParams?.get('token');
+  const prefillPackageId = searchParams?.get('packageId');
+  const prefillLeadId = searchParams?.get('leadId');
 
   const [step, setStep] = useState<Step>('coverage');
   const [loading, setLoading] = useState(false);
@@ -101,6 +103,44 @@ function QuoteRequestFormContent() {
       console.error('Token validation error:', err);
     }
   };
+
+  // Prefill from the coverage-check results page (business package deep link)
+  useEffect(() => {
+    if (!prefillPackageId || !prefillLeadId) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const [leadRes, pkgRes] = await Promise.all([
+          fetch(`/api/coverage/lead?leadId=${prefillLeadId}`),
+          fetch(`/api/coverage/packages?leadId=${prefillLeadId}&type=business`),
+        ]);
+        if (!leadRes.ok || !pkgRes.ok) return; // best-effort: fall back to blank form
+        const lead = await leadRes.json();
+        const pkgData = await pkgRes.json();
+        if (cancelled) return;
+        const packages = pkgData.packages || [];
+        setCoverageResult({
+          lead_id: prefillLeadId,
+          address: lead.address || pkgData.address || '',
+          coordinates: pkgData.coordinates || null,
+          available: true,
+          packages,
+        });
+        setAddress(lead.address || '');
+        if (packages.some((p: { id: string }) => p.id === prefillPackageId)) {
+          setSelectedPackages([{ package_id: prefillPackageId, item_type: 'primary', quantity: 1 }]);
+        }
+        setStep('details');
+      } catch {
+        // best-effort prefill; user can run the in-form coverage check instead
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefillPackageId, prefillLeadId]);
 
   const handleCoverageCheck = async () => {
     if (!address.trim()) {

--- a/components/coverage/SegmentToggle.tsx
+++ b/components/coverage/SegmentToggle.tsx
@@ -1,0 +1,55 @@
+'use client';
+import React from 'react';
+import { PiHouseBold, PiBriefcaseBold, PiBuildingsBold } from 'react-icons/pi';
+import { cn } from '@/lib/utils';
+import type { CoverageSegment } from '@/lib/coverage/customer-segments';
+
+const SEGMENTS: Array<{
+  value: CoverageSegment;
+  label: string;
+  shortLabel: string;
+  icon: React.ElementType;
+}> = [
+  { value: 'residential', label: 'Home', shortLabel: 'Home', icon: PiHouseBold },
+  { value: 'wfh', label: 'Work from Home', shortLabel: 'SOHO', icon: PiBriefcaseBold },
+  { value: 'business', label: 'Business', shortLabel: 'Business', icon: PiBuildingsBold },
+];
+
+interface SegmentToggleProps {
+  activeSegment: CoverageSegment;
+  onSegmentChange: (segment: CoverageSegment) => void;
+}
+
+/**
+ * Home / Work-from-home / Business switcher for the package results page.
+ * Light-theme sibling of the homepage hero segment pills.
+ */
+export function SegmentToggle({ activeSegment, onSegmentChange }: SegmentToggleProps) {
+  return (
+    <div className="inline-flex items-center gap-1 bg-gray-100 rounded-xl p-1">
+      {SEGMENTS.map((segment) => {
+        const Icon = segment.icon;
+        const isActive = activeSegment === segment.value;
+        return (
+          <button
+            key={segment.value}
+            type="button"
+            onClick={() => onSegmentChange(segment.value)}
+            aria-pressed={isActive}
+            className={cn(
+              'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all',
+              'focus:outline-none focus:ring-2 focus:ring-circleTel-orange focus:ring-offset-1',
+              isActive
+                ? 'bg-white text-circleTel-orange shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            )}
+          >
+            <Icon className="w-4 h-4" />
+            <span className="hidden sm:inline">{segment.label}</span>
+            <span className="sm:hidden">{segment.shortLabel}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/home/NewHero.tsx
+++ b/components/home/NewHero.tsx
@@ -6,6 +6,7 @@ import { AddressAutocomplete } from '@/components/coverage/AddressAutocomplete';
 import { InteractiveCoverageMapModal } from '@/components/coverage/InteractiveCoverageMapModal';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { heroSegmentToUrlType } from '@/lib/coverage/customer-segments';
 
 export type SegmentType = 'business' | 'wfh' | 'home';
 
@@ -106,10 +107,11 @@ export function NewHero({ activeSegment: externalSegment, onSegmentChange }: New
     if (!address.trim()) return;
     setIsChecking(true);
     try {
+      const urlType = heroSegmentToUrlType(activeSegment);
       sessionStorage.setItem('circletel_coverage_address', JSON.stringify({
         address: address.trim(),
         coordinates,
-        type: activeSegment === 'business' ? 'business' : 'residential',
+        type: urlType,
         addressComponents,
         timestamp: new Date().toISOString(),
       }));
@@ -120,14 +122,13 @@ export function NewHero({ activeSegment: externalSegment, onSegmentChange }: New
         body: JSON.stringify({
           address: address.trim(),
           coordinates,
-          coverageType: activeSegment === 'business' ? 'business' : 'residential',
+          coverageType: urlType,
         }),
       });
 
       if (!response.ok) throw new Error('Failed to create coverage lead');
       const data = await response.json();
-      const packageType = activeSegment === 'business' ? 'business' : 'residential';
-      window.location.href = `/packages/${data.leadId}?type=${packageType}`;
+      window.location.href = `/packages/${data.leadId}?type=${urlType}`;
     } catch (error) {
       console.error('Coverage check failed:', error);
       alert('Coverage check failed. Please try again.');

--- a/components/ui/package-detail-sidebar.tsx
+++ b/components/ui/package-detail-sidebar.tsx
@@ -56,6 +56,7 @@ export interface PackageDetailSidebarProps {
   // Actions
   onOrderClick?: () => void;
   onClose?: () => void;
+  orderButtonLabel?: string;
 
   // Styling
   className?: string;
@@ -116,6 +117,7 @@ export function PackageDetailSidebar({
   recommended = false,
   onOrderClick,
   onClose,
+  orderButtonLabel = 'Order Now',
   className,
   isOpen = true,
 }: PackageDetailSidebarProps) {
@@ -317,7 +319,7 @@ export function PackageDetailSidebar({
             className="w-full bg-circleTel-navy hover:bg-circleTel-navy/90 text-white font-semibold py-4 rounded-lg transition-colors text-lg shadow-md hover:shadow-lg"
             size="lg"
           >
-            Order Now
+            {orderButtonLabel}
           </Button>
         )}
       </div>

--- a/jest.config.js
+++ b/jest.config.js
@@ -78,8 +78,8 @@ const customJestConfig = {
   testPathIgnorePatterns: [
     '/node_modules/',
     '/.next/',
-    '/coverage/',
-    '/dist/',
+    '<rootDir>/coverage/',
+    '<rootDir>/dist/',
   ],
 
   // Verbose output

--- a/lib/coverage/__tests__/customer-segments.test.ts
+++ b/lib/coverage/__tests__/customer-segments.test.ts
@@ -1,0 +1,80 @@
+import {
+  normalizeSegment,
+  customerTypesForSegment,
+  sortPackagesForSegment,
+  isQuoteOnlyPackage,
+  heroSegmentToUrlType,
+} from '../customer-segments';
+
+describe('normalizeSegment', () => {
+  it('passes through valid segments', () => {
+    expect(normalizeSegment('residential')).toBe('residential');
+    expect(normalizeSegment('wfh')).toBe('wfh');
+    expect(normalizeSegment('business')).toBe('business');
+  });
+
+  it('falls back to residential for null, undefined, and unknown values', () => {
+    expect(normalizeSegment(null)).toBe('residential');
+    expect(normalizeSegment(undefined)).toBe('residential');
+    expect(normalizeSegment('')).toBe('residential');
+    expect(normalizeSegment('soho')).toBe('residential');
+    expect(normalizeSegment('BUSINESS')).toBe('residential');
+  });
+});
+
+describe('customerTypesForSegment', () => {
+  it('residential sees consumer and both', () => {
+    expect(customerTypesForSegment('residential')).toEqual(['consumer', 'both']);
+  });
+
+  it('wfh sees soho, consumer, and both', () => {
+    expect(customerTypesForSegment('wfh')).toEqual(['soho', 'consumer', 'both']);
+  });
+
+  it('business sees business and both', () => {
+    expect(customerTypesForSegment('business')).toEqual(['business', 'both']);
+  });
+});
+
+describe('sortPackagesForSegment', () => {
+  const pkgs = [
+    { id: 'a', customer_type: 'consumer', price: 100 },
+    { id: 'b', customer_type: 'soho', price: 900 },
+    { id: 'c', customer_type: 'consumer', price: 50 },
+    { id: 'd', customer_type: 'soho', price: 700 },
+  ];
+
+  it('puts soho packages first (each group price-ascending) for wfh', () => {
+    const sorted = sortPackagesForSegment('wfh', pkgs);
+    expect(sorted.map((p) => p.id)).toEqual(['d', 'b', 'c', 'a']);
+  });
+
+  it('does not mutate the input array', () => {
+    const copy = [...pkgs];
+    sortPackagesForSegment('wfh', pkgs);
+    expect(pkgs).toEqual(copy);
+  });
+
+  it('returns packages unchanged for residential and business', () => {
+    expect(sortPackagesForSegment('residential', pkgs)).toEqual(pkgs);
+    expect(sortPackagesForSegment('business', pkgs)).toEqual(pkgs);
+  });
+});
+
+describe('isQuoteOnlyPackage', () => {
+  it('is true only for business packages', () => {
+    expect(isQuoteOnlyPackage({ customer_type: 'business' })).toBe(true);
+    expect(isQuoteOnlyPackage({ customer_type: 'soho' })).toBe(false);
+    expect(isQuoteOnlyPackage({ customer_type: 'consumer' })).toBe(false);
+    expect(isQuoteOnlyPackage({ customer_type: 'both' })).toBe(false);
+    expect(isQuoteOnlyPackage({})).toBe(false);
+  });
+});
+
+describe('heroSegmentToUrlType', () => {
+  it('maps hero segments to URL types', () => {
+    expect(heroSegmentToUrlType('home')).toBe('residential');
+    expect(heroSegmentToUrlType('wfh')).toBe('wfh');
+    expect(heroSegmentToUrlType('business')).toBe('business');
+  });
+});

--- a/lib/coverage/customer-segments.ts
+++ b/lib/coverage/customer-segments.ts
@@ -1,0 +1,53 @@
+/**
+ * Customer segment logic for the public coverage check.
+ *
+ * The `?type=` URL param carries the segment chosen on the homepage hero
+ * (Home / Work from home / Business). `service_packages.customer_type`
+ * ('consumer' | 'business' | 'both' | 'soho') is the governing filter field
+ * — `market_segment` is inconsistently populated and must NOT be used.
+ */
+
+export type CoverageSegment = 'residential' | 'wfh' | 'business';
+
+const SEGMENT_CUSTOMER_TYPES: Record<CoverageSegment, string[]> = {
+  residential: ['consumer', 'both'],
+  wfh: ['soho', 'consumer', 'both'],
+  business: ['business', 'both'],
+};
+
+export function normalizeSegment(type: string | null | undefined): CoverageSegment {
+  return type === 'business' || type === 'wfh' ? type : 'residential';
+}
+
+export function customerTypesForSegment(segment: CoverageSegment): string[] {
+  return SEGMENT_CUSTOMER_TYPES[segment];
+}
+
+/**
+ * WFH results lead with SOHO (WorkConnect) packages; within each group the
+ * API's price-ascending order is preserved. Other segments are untouched.
+ */
+export function sortPackagesForSegment<T extends { customer_type?: string; price: number }>(
+  segment: CoverageSegment,
+  packages: T[]
+): T[] {
+  if (segment !== 'wfh') return packages;
+  return [...packages].sort((a, b) => {
+    const aSoho = a.customer_type === 'soho' ? 0 : 1;
+    const bSoho = b.customer_type === 'soho' ? 0 : 1;
+    return aSoho - bSoho || a.price - b.price;
+  });
+}
+
+/**
+ * Business packages (BizFibreConnect, SkyFibre SME, …) onboard via the B2B
+ * quote/KYC pipeline, never consumer self-checkout.
+ */
+export function isQuoteOnlyPackage(pkg: { customer_type?: string }): boolean {
+  return pkg.customer_type === 'business';
+}
+
+/** Maps the hero's SegmentType ('home' | 'wfh' | 'business') to the URL type. */
+export function heroSegmentToUrlType(segment: 'home' | 'wfh' | 'business'): CoverageSegment {
+  return segment === 'home' ? 'residential' : segment;
+}

--- a/lib/order/types.ts
+++ b/lib/order/types.ts
@@ -136,6 +136,7 @@ export interface PackageDetails {
   speed: string;
   type?: 'fibre' | 'wireless' | 'mobile';
   service_type?: string;
+  customer_type?: string;
   product_category?: string;
   speed_down?: number;
   speed_up?: number;

--- a/supabase/migrations/20260702100000_soho_service_type_mapping.sql
+++ b/supabase/migrations/20260702100000_soho_service_type_mapping.sql
@@ -1,0 +1,29 @@
+-- WorkConnect (customer_type='soho', product_category='soho') rides MTN Fixed
+-- Wireless Broadband. Map FWB technical types to the 'soho' product category so
+-- /api/coverage/packages includes WorkConnect wherever FWB coverage exists.
+-- Live code filters by customer_type, so these rows only surface packages for
+-- the new 'wfh' segment.
+
+-- 1) The product_category CHECK constraint predates SOHO products; widen it.
+ALTER TABLE service_type_mapping
+  DROP CONSTRAINT IF EXISTS service_type_mapping_product_category_check;
+ALTER TABLE service_type_mapping
+  ADD CONSTRAINT service_type_mapping_product_category_check
+  CHECK ((product_category)::text = ANY (ARRAY[
+    'SkyFibre', 'HomeFibreConnect', 'BizFibreConnect', 'LTE', '5G', 'wireless',
+    'fibre_consumer', 'fibre_business', 'lte', '5g', 'fibre', 'connectivity',
+    'soho'
+  ]::text[]));
+
+-- 2) Map MTN FWB technical types to the soho product category (idempotent).
+INSERT INTO service_type_mapping (technical_type, provider, product_category, priority, active, notes)
+SELECT v.technical_type, v.provider, v.product_category, v.priority, v.active, v.notes
+FROM (VALUES
+  ('Fixed Wireless Broadband', 'mtn', 'soho', 6, true, 'WorkConnect SOHO packages over MTN FWB'),
+  ('uncapped_wireless', 'mtn', 'soho', 6, true, 'WorkConnect SOHO packages over MTN FWB')
+) AS v(technical_type, provider, product_category, priority, active, notes)
+WHERE NOT EXISTS (
+  SELECT 1 FROM service_type_mapping m
+  WHERE m.technical_type = v.technical_type
+    AND m.product_category = v.product_category
+);


### PR DESCRIPTION
## Summary

Vox-style segment support in the public coverage check. The homepage hero's three segments (Home / Work from Home / Business) now drive real product filtering, business products become sellable via the quote pipeline, and the previously unreachable WorkConnect (SOHO) inventory goes live.

**Spec:** `docs/superpowers/specs/2026-07-02-segment-aware-coverage-check-design.md` · **Plan:** `docs/superpowers/plans/2026-07-02-segment-aware-coverage-check.md` (both on a docs branch, not in this PR)

### Segment model

| Segment | `?type=` | `service_packages.customer_type` filter | Notes |
|---|---|---|---|
| Home | `residential` (default/fallback) | `consumer`, `both` | unchanged behaviour |
| Work from Home | `wfh` (new) | `soho`, `consumer`, `both` | WorkConnect listed first |
| Business | `business` | `business`, `both` | CTA = Request a Quote |

### Changes

- **`lib/coverage/customer-segments.ts`** (new): single source of segment logic — `normalizeSegment`, `customerTypesForSegment`, `sortPackagesForSegment`, `isQuoteOnlyPackage`, `heroSegmentToUrlType`. 10 unit tests.
- **`/api/coverage/packages`**: `.eq('customer_type', …)` → `.in(…)` filter sets; `customer_type` exposed per package; SOHO-first sort for WFH. Coverage detection, mapping resolution, and BizFibre fibre-status filtering untouched.
- **Results page** (`/packages/[leadId]`): Home/WFH/Business pill toggle refetches the same lead (no coverage re-check); WorkConnect now matches the Wireless tab filters; badge colours cover WorkConnect in both render paths.
- **Business purchase path**: `customer_type='business'` packages show "Request a Quote" (sidebar, mobile overlay, floating CTA) and deep-link to `/quotes/request?packageId=&leadId=` — they can never enter consumer checkout. The quote form prefills (address + package, jump to details step) best-effort from those params.
- **Checkout**: `derivedAccountType` centralises the three account-type sites; WorkConnect (soho) packages get an explicit Personal/Business radio (default Personal) that flows into `consumer_orders.account_type`.
- **DB migration** `20260702100000_soho_service_type_mapping.sql` (**already applied** to the shared DB, idempotent): widens the `service_type_mapping.product_category` CHECK to allow `soho`, and maps MTN FWB technical types → `soho` so WorkConnect is reachable through coverage mapping.

### Verification

- Jest: 10/10 (`lib/coverage`); type-check clean in all touched files (repo's pre-existing errors untouched); pre-push scoped check green.
- Live QA (local + **staging.circletel.co.za** after cherry-pick deploy, run 28585503524 ✅): residential=13 consumer / wfh=16 with 3 WorkConnect first / business=11 / unknown type → residential fallback / `customer_type` present.
- Visual QA on staging by @jdeweedata: Business tab, quote CTA, VAT-correct pricing confirmed.
- Subagent-driven task reviews per commit + final whole-branch review: zero open findings.

### Notes for reviewers

- Staging already runs these exact commits (cherry-picked cleanly; a staging merge was impossible due to the pre-existing main↔staging divergence in offers/payment files — that reconciliation remains a separate task).
- Out of scope by design: B2B KYC pipeline, payment amounts, RICA, `/business/*` pages, `coverage_leads` enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)