### PR TITLE
Fix manual-intake document upload + vetting reflect (3 fixes)

### DIFF
--- a/app/admin/b2b/manual-intake/page.tsx
+++ b/app/admin/b2b/manual-intake/page.tsx
@@ -672,18 +672,9 @@ export default function ManualB2BIntakePage() {
     setMandateAuthorised(false);
   }
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-
-    const submitter =
-      "submitter" in event.nativeEvent
-        ? (event.nativeEvent as SubmitEvent).submitter
-        : null;
-    const submitIntent =
-      submitter instanceof HTMLButtonElement
-        ? submitter.dataset.intent
-        : "save";
-
+  async function persistIntake(
+    submitIntent: "save" | "vetting",
+  ): Promise<IntakeResult | null> {
     if (!customerReady || !contactReady) {
       const target: IntakeStepId = !customerReady ? "customer" : "contact";
       setActiveStep(target);
@@ -691,7 +682,7 @@ export default function ManualB2BIntakePage() {
       toast.error(
         "Complete customer, contact, and site details before saving onboarding.",
       );
-      return;
+      return null;
     }
 
     if (submitIntent === "vetting" && !allRequiredReady) {
@@ -705,7 +696,7 @@ export default function ManualB2BIntakePage() {
       toast.error(
         "Complete all required onboarding items before submitting for vetting.",
       );
-      return;
+      return null;
     }
 
     setSaving(true);
@@ -797,13 +788,42 @@ export default function ManualB2BIntakePage() {
           : "Business customer updated",
       );
       if (allRequiredReady) setActiveStep("review");
+      return intake;
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Manual onboarding failed",
       );
+      return null;
     } finally {
       setSaving(false);
     }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const submitter =
+      "submitter" in event.nativeEvent
+        ? (event.nativeEvent as SubmitEvent).submitter
+        : null;
+    const submitIntent =
+      submitter instanceof HTMLButtonElement &&
+      submitter.dataset.intent === "vetting"
+        ? "vetting"
+        : "save";
+    await persistIntake(submitIntent);
+  }
+
+  // Documents attach to a saved customer (kyc_documents.customer_id). If the
+  // onboarding hasn't been saved yet, save it first (creating the customer),
+  // then open the uploader. persistIntake handles the "prerequisites missing"
+  // case with its own toast + step jump, so this is never a silent no-op.
+  async function handleOpenUploader() {
+    if (canUploadDocuments) {
+      setUploadOpen(true);
+      return;
+    }
+    const intake = await persistIntake("save");
+    if (intake?.customerId) setUploadOpen(true);
   }
 
   const ActiveIcon = activeStepMeta.icon;
@@ -1399,19 +1419,22 @@ export default function ManualB2BIntakePage() {
               <div className="space-y-6">
                 <button
                   type="button"
-                  className="flex cursor-pointer flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-9 text-center transition hover:border-circleTel-orange hover:bg-orange-50"
-                  onClick={() => {
-                    if (canUploadDocuments) setUploadOpen(true);
-                  }}
-                  disabled={!canUploadDocuments}
+                  className="flex w-full cursor-pointer flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-9 text-center transition hover:border-circleTel-orange hover:bg-orange-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={handleOpenUploader}
+                  disabled={saving}
                 >
                   <PiUploadSimpleBold className="h-9 w-9 text-circleTel-orange" />
                   <span className="mt-3 font-semibold text-gray-950">
-                    Open the document uploader
+                    {canUploadDocuments
+                      ? "Open the document uploader"
+                      : saving
+                        ? "Saving onboarding…"
+                        : "Save & open the document uploader"}
                   </span>
                   <span className="mt-1 text-sm text-gray-500">
-                    Drag and drop PDF, JPG, or PNG files, then classify each
-                    document inside this client onboarding pack.
+                    {canUploadDocuments
+                      ? "Drag and drop PDF, JPG, or PNG files, then classify each document inside this client onboarding pack."
+                      : "We'll save this onboarding first (creating the customer record), then open the uploader so documents can attach."}
                   </span>
                 </button>
 
@@ -1424,7 +1447,7 @@ export default function ManualB2BIntakePage() {
                       <p className="text-sm text-gray-500">
                         {canUploadDocuments
                           ? documentCustomerName
-                          : "Save this onboarding first to create an upload target."}
+                          : "The onboarding saves automatically when you upload, then documents attach here."}
                       </p>
                     </div>
                     <StatusPill
@@ -1479,11 +1502,15 @@ export default function ManualB2BIntakePage() {
                 <Button
                   type="button"
                   className="w-full bg-circleTel-orange text-white hover:bg-circleTel-orange-dark"
-                  disabled={!canUploadDocuments}
-                  onClick={() => setUploadOpen(true)}
+                  disabled={saving}
+                  onClick={handleOpenUploader}
                 >
                   <PiUploadSimpleBold className="h-4 w-4" />
-                  Upload documents
+                  {canUploadDocuments
+                    ? "Upload documents"
+                    : saving
+                      ? "Saving…"
+                      : "Save & upload documents"}
                 </Button>
               </div>
             )}

--- a/app/admin/b2b/vetting/[submissionId]/page.tsx
+++ b/app/admin/b2b/vetting/[submissionId]/page.tsx
@@ -35,7 +35,7 @@ import {
   LoadingState,
   StatusBadge,
 } from '@/components/backend';
-import { requiredDocsFor, type DocRequirement } from '@/lib/onboarding/document-requirements';
+import { requiredDocsFor, documentMatchesRequirement, type DocRequirement } from '@/lib/onboarding/document-requirements';
 import { cn } from '@/lib/utils';
 import {
   buildAutomatedChecks,
@@ -254,8 +254,8 @@ export default function B2BVettingDetailPage({
       .map((requirement) => ({
         requirement,
         document:
-          submission.documents.find(
-            (document) => document.document_type === requirement.type
+          submission.documents.find((document) =>
+            documentMatchesRequirement(document.document_type, requirement)
           ) ?? null,
       }));
   }, [submission, step2?.entityType, step2?.vat]);

--- a/app/api/admin/kyc/verify/route.ts
+++ b/app/api/admin/kyc/verify/route.ts
@@ -133,9 +133,7 @@ export async function POST(request: NextRequest) {
         const required = requiredDocsFor(submission.segment as any, {
           vatRegistered: step2?.vat === 'Yes',
           entityType: step2?.entityType || '',
-        })
-          .filter((r) => r.required)
-          .map((r) => r.type);
+        }).filter((r) => r.required);
 
         // Fetch this submission's documents
         const { data: submissionDocs, error: docsError } = await supabase

--- a/components/admin/onboarding/UploadDocumentModal.tsx
+++ b/components/admin/onboarding/UploadDocumentModal.tsx
@@ -69,7 +69,7 @@ export function UploadDocumentModal({
   const [dragging, setDragging] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [currentUpload, setCurrentUpload] = useState<string | null>(null);
-  const [uploaded, setUploaded] = useState<{ type: string; name: string }[]>(
+  const [uploaded, setUploaded] = useState<{ docType: DocType; name: string }[]>(
     [],
   );
 
@@ -172,13 +172,10 @@ export function UploadDocumentModal({
         setCurrentUpload(item.name);
         try {
           await uploadOne(item);
-          const label =
-            DOC_TYPE_OPTIONS.find((o) => o.value === item.docType)?.label ??
-            item.docType;
           successfulIds.add(item.id);
           setUploaded((current) => [
             ...current,
-            { type: label, name: item.name },
+            { docType: item.docType, name: item.name },
           ]);
         } catch (error) {
           failures.set(
@@ -215,7 +212,7 @@ export function UploadDocumentModal({
 
   const handleClose = () => {
     onUploaded(uploaded.length);
-    onUploadedTypes?.(uploaded.map((u) => u.type as DocType));
+    onUploadedTypes?.(uploaded.map((u) => u.docType));
     reset();
     onOpenChange(false);
   };
@@ -457,7 +454,9 @@ export function UploadDocumentModal({
                   key={`${u.name}-${i}`}
                   className="truncate text-emerald-700"
                 >
-                  {u.type} - {u.name}
+                  {DOC_TYPE_OPTIONS.find((o) => o.value === u.docType)?.label ??
+                    u.docType}{" "}
+                  - {u.name}
                 </li>
               ))}
             </ul>

--- a/lib/onboarding/__tests__/document-requirements.test.ts
+++ b/lib/onboarding/__tests__/document-requirements.test.ts
@@ -1,0 +1,80 @@
+import {
+  requiredDocsFor,
+  documentMatchesRequirement,
+  computeVettingStatus,
+} from "@/lib/onboarding/document-requirements";
+
+const companyCtx = { vatRegistered: false, entityType: "Private Company" };
+const directorReq = requiredDocsFor("unjani", companyCtx).find(
+  (r) => r.label === "Director / owner ID",
+)!;
+
+describe("documentMatchesRequirement (owner/director ID alias)", () => {
+  it("matches the canonical director_id type", () => {
+    expect(documentMatchesRequirement("director_id", directorReq)).toBe(true);
+  });
+
+  it("matches the id_document alias (what the upload picker writes)", () => {
+    expect(documentMatchesRequirement("id_document", directorReq)).toBe(true);
+  });
+
+  it("does not match an unrelated type", () => {
+    expect(documentMatchesRequirement("bank_statement", directorReq)).toBe(false);
+  });
+
+  it("has no aliases on a non-ID requirement", () => {
+    const bank = requiredDocsFor("unjani", companyCtx).find(
+      (r) => r.type === "bank_statement",
+    )!;
+    expect(documentMatchesRequirement("id_document", bank)).toBe(false);
+    expect(documentMatchesRequirement("bank_statement", bank)).toBe(true);
+  });
+});
+
+describe("computeVettingStatus (alias-aware approval rollup)", () => {
+  const reqs = requiredDocsFor("unjani", companyCtx).filter((r) => r.required);
+  // company_registration, director_id(+id_document), bank_statement, proof_of_address
+
+  const approvedExceptDirector = [
+    { document_type: "company_registration", verification_status: "approved" },
+    { document_type: "bank_statement", verification_status: "approved" },
+    { document_type: "proof_of_address", verification_status: "approved" },
+  ];
+
+  it("approves when the director slot is filled by an approved id_document", () => {
+    expect(
+      computeVettingStatus(reqs, [
+        ...approvedExceptDirector,
+        { document_type: "id_document", verification_status: "approved" },
+      ]),
+    ).toBe("approved");
+  });
+
+  it("approves when the director slot is filled by an approved director_id", () => {
+    expect(
+      computeVettingStatus(reqs, [
+        ...approvedExceptDirector,
+        { document_type: "director_id", verification_status: "approved" },
+      ]),
+    ).toBe("approved");
+  });
+
+  it("is under_review when the director doc is missing", () => {
+    expect(computeVettingStatus(reqs, approvedExceptDirector)).toBe(
+      "under_review",
+    );
+  });
+
+  it("is rejected when the id_document (director slot) is rejected", () => {
+    expect(
+      computeVettingStatus(reqs, [
+        ...approvedExceptDirector,
+        { document_type: "id_document", verification_status: "rejected" },
+      ]),
+    ).toBe("rejected");
+  });
+
+  it("is documents_pending when nothing is uploaded", () => {
+    expect(computeVettingStatus(reqs, [])).toBe("documents_pending");
+  });
+});

--- a/lib/onboarding/document-requirements.ts
+++ b/lib/onboarding/document-requirements.ts
@@ -10,6 +10,21 @@ export interface DocRequirement {
   type: KycDocType;
   label: string;
   required: boolean;
+  /** Extra kyc_document_type values that also satisfy this requirement. The enum
+   *  carries both `id_document` and `director_id` for the owner/director ID, and
+   *  uploads use either — so the slot must accept both. */
+  aliases?: KycDocType[];
+}
+
+/** True when an uploaded document's type satisfies a requirement (incl. aliases). */
+export function documentMatchesRequirement(
+  documentType: string,
+  requirement: DocRequirement,
+): boolean {
+  return (
+    documentType === requirement.type ||
+    (requirement.aliases?.includes(documentType as KycDocType) ?? false)
+  );
 }
 
 export interface EntityContext {
@@ -22,10 +37,10 @@ export function requiredDocsFor(_segment: B2BSegment, ctx: EntityContext): DocRe
   const isSoleProp = ctx.entityType === 'Sole Proprietor';
   const docs: DocRequirement[] = [];
   if (isSoleProp) {
-    docs.push({ type: 'director_id', label: 'Owner ID document', required: true });
+    docs.push({ type: 'director_id', label: 'Owner ID document', required: true, aliases: ['id_document'] });
   } else {
     docs.push({ type: 'company_registration', label: 'CIPC registration certificate', required: true });
-    docs.push({ type: 'director_id', label: 'Director / owner ID', required: true });
+    docs.push({ type: 'director_id', label: 'Director / owner ID', required: true, aliases: ['id_document'] });
   }
   docs.push({ type: 'bank_statement', label: 'Bank confirmation letter or statement', required: true });
   docs.push({ type: 'proof_of_address', label: 'Proof of business address', required: true });
@@ -39,13 +54,14 @@ export type VettingStatus = 'not_started' | 'documents_pending' | 'under_review'
 
 interface DocStatusRow { document_type: string; verification_status: string }
 
-/** Roll up per-document statuses into the account-level vetting status. */
-export function computeVettingStatus(requiredTypes: string[], docs: DocStatusRow[]): VettingStatus {
+/** Roll up per-document statuses into the account-level vetting status.
+ *  Alias-aware: a requirement is satisfied by its `type` OR any of its `aliases`. */
+export function computeVettingStatus(requirements: DocRequirement[], docs: DocStatusRow[]): VettingStatus {
   if (docs.length === 0) return 'documents_pending';
-  const requiredSet = new Set(requiredTypes);
-  const statusByType = new Map(docs.map(d => [d.document_type, d.verification_status]));
-  if (requiredTypes.some(t => statusByType.get(t) === 'rejected')) return 'rejected';
-  const allApproved = requiredTypes.every(t => statusByType.get(t) === 'approved');
+  const statusFor = (req: DocRequirement): string | undefined =>
+    docs.find(d => documentMatchesRequirement(d.document_type, req))?.verification_status;
+  if (requirements.some(req => statusFor(req) === 'rejected')) return 'rejected';
+  const allApproved = requirements.every(req => statusFor(req) === 'approved');
   if (allApproved) return 'approved';
   return 'under_review';
 }


### PR DESCRIPTION
## Summary
Three fixes to the B2B document upload / vetting flow, all reported from live prod today, verified on staging. Off current `main`, conflict-free.

1. **Uploader dead-click before save** (`app/admin/b2b/manual-intake/page.tsx`)
   The Documents-step uploader was `disabled` until the onboarding was saved (needs `customerId` to attach `kyc_documents`) but with no feedback — clicking did nothing. Extracted `persistIntake()` from `handleSubmit` (behaviour-preserving); new `handleOpenUploader` auto-saves the onboarding first (creating the customer) then opens the modal, or toasts + jumps to the incomplete step. Dropzone/button always clickable with clear labels.

2. **Reflect-back reports labels instead of enum values** (`components/admin/onboarding/UploadDocumentModal.tsx`)
   The modal stored the friendly label (e.g. `"Owner / Director ID"`) and passed it — cast as `DocType` — to `onUploadedTypes`. The checklist matches enum values (`id_document`), so an in-session upload never flipped its row to Received. Now stores/reports the enum `docType`; label derived only for display. Regression from #590.

3. **Vetting owner/director-ID slot enum mismatch** (`lib/onboarding/document-requirements.ts`, vetting page, `app/api/admin/kyc/verify/route.ts`)
   The enum carries both `id_document` (24 rows) and `director_id` (14 rows) for the owner/director ID; uploads write `id_document` but the vetting requirement matched `director_id` exactly → showed "Missing" and blocked account approval. Added `DocRequirement.aliases` + shared `documentMatchesRequirement()`; owner/director-ID slot accepts both; `computeVettingStatus` is alias-aware. **No data migration** — both enum values stay valid.

## Test Plan
- [x] **Unit tests:** 9 new alias tests (`document-requirements.test.ts`) — id_document/director_id both satisfy the slot; approval rollup alias-aware. Existing checklist (6) + route (5) + workbench (7) suites still green.
- [x] Type-check clean on all touched files; pre-push scoped type-check green.
- [x] **Staging QA confirmed** (user screenshots): wizard shows Owner/Director ID = Received (1/4); vetting workbench shows the ID (no longer Missing), MISSING 4→3.
- [ ] Reviewer: confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)