### PR TITLE
Manual intake: don't POST empty debit order on save (400 fix)

### DIFF
--- a/app/admin/b2b/manual-intake/page.tsx
+++ b/app/admin/b2b/manual-intake/page.tsx
@@ -702,6 +702,17 @@ export default function ManualB2BIntakePage() {
     setSaving(true);
     setResult(null);
 
+    // Only send debitOrder when its fields actually satisfy the schema (min
+    // lengths). includeDebitOrder defaults on, so a mid-wizard save (before the
+    // Debit Order step) would otherwise post an empty debit object and 400.
+    const debitDetailsComplete =
+      form.includeDebitOrder &&
+      form.accountHolderName.trim().length >= 2 &&
+      form.bankName.trim().length >= 2 &&
+      form.accountType.trim().length >= 2 &&
+      form.accountNumber.trim().length >= 6 &&
+      form.branchCode.trim().length >= 5;
+
     const payload = {
       customerId: trimOrUndefined(form.customerId),
       submissionId: trimOrUndefined(form.submissionId),
@@ -734,7 +745,7 @@ export default function ManualB2BIntakePage() {
         activationDate: trimOrUndefined(form.activationDate),
         billingDay: form.billingDay,
       },
-      debitOrder: form.includeDebitOrder
+      debitOrder: debitDetailsComplete
         ? {
             paymentMethodId: trimOrUndefined(form.paymentMethodId),
             accountHolderName: form.accountHolderName.trim(),


### PR DESCRIPTION
## Summary
Fixes `POST /api/admin/b2b/manual-intake` returning **400 `validation_failed`** when saving mid-wizard — which blocked the document uploader (the auto-save-on-upload could never create the customer).

`includeDebitOrder` defaults **true**, and the save payload sent a `debitOrder` object whenever it was true. Saving before the Debit Order step (e.g. when uploading documents on step 4) posted a debit object of **empty strings**, which the schema rejects (`accountHolderName≥2`, `accountNumber≥6`, `branchCode≥5`).

Now `debitOrder` is only included when its fields actually satisfy the schema mins; otherwise it's omitted (the field is optional). Fixes the reported upload failure and the pre-existing draft-save-before-debit 400. Single file, client-side.

## Test Plan
- [x] Type-check clean; pre-push scoped type-check green.
- [x] **Staging QA (deploy green)**: on a fresh onboarding with Customer + Contact filled, clicking the uploader auto-saves (no 400) and opens the modal.
- [ ] Reviewer confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)