### PR TITLE
fix(billing): gate recurring invoices on billing_start_date to honour clinic extensions

### DIFF
--- a/lib/billing/__tests__/billing-eligibility.test.ts
+++ b/lib/billing/__tests__/billing-eligibility.test.ts
@@ -1,0 +1,48 @@
+import { isBeforeBillingStart } from '../billing-eligibility';
+
+describe('Billing Eligibility — isBeforeBillingStart', () => {
+  // Semantics: true means "suppress billing" (run is before the deferral date).
+
+  it('returns false when billing_start_date is null (no deferral → bill)', () => {
+    expect(isBeforeBillingStart(null, new Date('2026-07-01T04:00:00Z'))).toBe(false);
+  });
+
+  it('returns false when billing_start_date is undefined (no deferral → bill)', () => {
+    expect(isBeforeBillingStart(undefined, new Date('2026-07-01T04:00:00Z'))).toBe(false);
+  });
+
+  it('returns false when billing_start_date is empty string (treated as no deferral)', () => {
+    expect(isBeforeBillingStart('', new Date('2026-07-01T04:00:00Z'))).toBe(false);
+  });
+
+  it('returns true when the run date is before billing_start_date (suppress)', () => {
+    // Extension to 1 Aug; cron runs 1 Jul → must skip.
+    expect(isBeforeBillingStart('2026-08-01', new Date('2026-07-01T04:00:00Z'))).toBe(true);
+  });
+
+  it('returns false ON the billing_start_date (bills from that date)', () => {
+    // Cron runs 1 Aug, start is 1 Aug → not before → bill.
+    expect(isBeforeBillingStart('2026-08-01', new Date('2026-08-01T04:00:00Z'))).toBe(false);
+  });
+
+  it('returns false when the run date is after billing_start_date (bill)', () => {
+    expect(isBeforeBillingStart('2026-08-01', new Date('2026-09-01T04:00:00Z'))).toBe(false);
+  });
+
+  it('compares by date only, ignoring time-of-day on the run date', () => {
+    // Late-night run on the start date still counts as "on/after" → bill.
+    expect(isBeforeBillingStart('2026-08-01', new Date('2026-08-01T23:59:59Z'))).toBe(false);
+    // One day before, any time → suppress.
+    expect(isBeforeBillingStart('2026-08-01', new Date('2026-07-31T23:59:59Z'))).toBe(true);
+  });
+
+  it('tolerates a full ISO timestamp in billing_start_date (uses date part)', () => {
+    expect(isBeforeBillingStart('2026-08-01T00:00:00Z', new Date('2026-07-01T04:00:00Z'))).toBe(true);
+    expect(isBeforeBillingStart('2026-08-01T00:00:00Z', new Date('2026-08-15T04:00:00Z'))).toBe(false);
+  });
+
+  it('handles year boundaries via lexical ISO comparison', () => {
+    expect(isBeforeBillingStart('2027-01-01', new Date('2026-12-31T04:00:00Z'))).toBe(true);
+    expect(isBeforeBillingStart('2027-01-01', new Date('2027-01-01T04:00:00Z'))).toBe(false);
+  });
+});

--- a/lib/billing/billing-eligibility.ts
+++ b/lib/billing/billing-eligibility.ts
@@ -1,0 +1,39 @@
+/**
+ * Billing Eligibility Helper
+ *
+ * Guards recurring invoice generation against an explicit billing-start / deferral
+ * date on the service (customer_services.billing_start_date).
+ *
+ * Context: the monthly-invoice cron bills every active service on its billing_day.
+ * A clinic can be live but in an agreed free/extension period, which `onboarding_status`
+ * cannot express (it sits at 'pending' both when a clinic should pay and when its billing
+ * has been deferred). `billing_start_date` is that missing signal — see the migration
+ * 20260702130000_customer_services_add_billing_start_date.sql.
+ */
+
+/**
+ * True when a service's billing has been deferred to a future date and the current
+ * run is before it — i.e. the service must NOT be invoiced yet.
+ *
+ * @param billingStartDate - ISO date string (YYYY-MM-DD) or null. NULL = no deferral.
+ * @param runDate - the billing run date (typically `new Date()` in the cron).
+ * @returns true if billing should be suppressed (run is before billingStartDate).
+ *
+ * Notes:
+ * - NULL billingStartDate → false (bill normally). This keeps legacy consumers and
+ *   already-billing clinics unaffected.
+ * - Comparison is a lexical compare of YYYY-MM-DD strings, which is correct for ISO
+ *   dates. The service bills ON the start date (start === run → not before → billable).
+ */
+export function isBeforeBillingStart(
+  billingStartDate: string | null | undefined,
+  runDate: Date
+): boolean {
+  if (!billingStartDate) return false;
+
+  // Normalise both sides to YYYY-MM-DD for a date-only comparison.
+  const start = billingStartDate.slice(0, 10);
+  const run = runDate.toISOString().slice(0, 10);
+
+  return start > run;
+}

--- a/lib/billing/monthly-invoice-generator.ts
+++ b/lib/billing/monthly-invoice-generator.ts
@@ -25,6 +25,7 @@ import { computeVatInclusiveAmounts, formatInvoiceNumber, nextInvoiceSequence } 
 import { processPayNowForInvoice } from '@/lib/billing/paynow-billing-service';
 import { computeProRata } from '@/lib/onboarding/prorata';
 import { shouldEmitRecurringInvoice } from '@/lib/billing/new-clinic-billing-helper';
+import { isBeforeBillingStart } from '@/lib/billing/billing-eligibility';
 import { billingLogger } from '@/lib/logging';
 
 // =============================================================================
@@ -43,6 +44,7 @@ export interface ServiceToBill {
   monthly_price: number;
   billing_day: number;
   last_invoice_date: string | null;
+  billing_start_date: string | null;
   status: string;
   activation_date: string | null;
   customer: {
@@ -259,6 +261,7 @@ export class MonthlyInvoiceGenerator {
         monthly_price,
         billing_day,
         last_invoice_date,
+        billing_start_date,
         activation_date,
         status,
         customer:customers(
@@ -304,9 +307,24 @@ export class MonthlyInvoiceGenerator {
         : service.package,
     })) as ServiceToBill[];
 
-    // GATE: Exclude customers in onboarding flow unless they are billing_ready.
+    // GATE 1: Deferral date. A service with a future billing_start_date is in an
+    // approved free/extension period and must not be invoiced yet. Applies regardless
+    // of onboarding state (covers clinics seeded without an onboarding_submissions row).
+    const runDate = new Date();
+    const notDeferred = transformed.filter(service => {
+      if (isBeforeBillingStart(service.billing_start_date, runDate)) {
+        billingLogger.info('MonthlyInvoice: Skipping service — billing deferred', {
+          serviceId: service.id,
+          billingStartDate: service.billing_start_date,
+        });
+        return false;
+      }
+      return true;
+    });
+
+    // GATE 2: Exclude customers in onboarding flow unless they are billing_ready.
     // Legacy customers (no onboarding_submission) continue to bill normally.
-    const customerIds = transformed.map(s => s.customer_id);
+    const customerIds = notDeferred.map(s => s.customer_id);
     if (customerIds.length > 0) {
       const { data: onboardingByCustomer } = await supabase
         .from('onboarding_submissions')
@@ -314,7 +332,7 @@ export class MonthlyInvoiceGenerator {
         .in('customer_id', customerIds);
       const inOnboardingSet = new Set((onboardingByCustomer || []).map(row => row.customer_id));
 
-      return transformed.filter(service => {
+      return notDeferred.filter(service => {
         const inOnboarding = inOnboardingSet.has(service.customer_id);
         // If NOT in onboarding: bill (legacy customer)
         if (!inOnboarding) return true;
@@ -323,7 +341,7 @@ export class MonthlyInvoiceGenerator {
       });
     }
 
-    return transformed;
+    return notDeferred;
   }
 
   /**

--- a/supabase/migrations/20260702130000_customer_services_add_billing_start_date.sql
+++ b/supabase/migrations/20260702130000_customer_services_add_billing_start_date.sql
@@ -1,0 +1,18 @@
+-- Add an explicit billing-start / deferral date to customer services.
+--
+-- Why: the monthly-invoice cron (lib/billing/monthly-invoice-generator.ts) bills
+-- every active service on its billing_day. It had no way to represent a clinic that
+-- is live but in a free/extension period, so on 2026-07-01 it auto-invoiced 11
+-- not-yet-onboarded Unjani clinics (some in an agreed extension). `onboarding_status`
+-- could not distinguish "should pay now" from "extension granted" because both sat at
+-- 'pending'. This column is that missing signal.
+--
+-- Semantics: NULL = bill normally (default; legacy consumers + already-billing clinics
+-- are unaffected). A date in the future = suppress recurring invoices until that date.
+-- The cron compares it to the run date; see lib/billing/billing-eligibility.ts.
+
+ALTER TABLE customer_services
+  ADD COLUMN IF NOT EXISTS billing_start_date date;
+
+COMMENT ON COLUMN customer_services.billing_start_date IS
+  'Optional date from which recurring billing may begin. NULL = bill normally. A future date suppresses monthly invoices until reached (used for approved free/extension periods). Honoured by lib/billing/monthly-invoice-generator.ts via isBeforeBillingStart().';


### PR DESCRIPTION
## Problem

The monthly-invoice cron (`generate-monthly-invoices`, `lib/billing/monthly-invoice-generator.ts`) bills **every active service on its `billing_day`**. It had no way to represent a clinic that is live but in an agreed **free/extension period**.

On **1 July 2026** it auto-invoiced **11 not-yet-onboarded Unjani clinics** R450 each with live PayNow email+SMS links — several of which were on approved extensions (Oukasie was the one flagged by the Unjani partner). Root cause:

- `onboarding_status` cannot distinguish *"should pay now"* from *"extension granted"* — both sit at `pending`.
- The existing gate treats a customer **not** in `onboarding_submissions` as a **legacy customer → always bill**. The clinics were seeded directly as `customers` + `customer_services` without a submission row, so they fell through and billed.

Flipping them to `billing_ready` is the wrong lever — `createInvoice` stamps `billing_ready` invoices as `payment_collection_method='debit_order'`, which would push them into the debit batch with no mandate.

## Fix

Introduce the missing concept: **`customer_services.billing_start_date`** (nullable `date`).

- `NULL` → bill normally (legacy consumers + already-billing clinics **unaffected**)
- future date → suppress recurring invoices until reached

New pure, unit-tested helper **`isBeforeBillingStart()`** (`lib/billing/billing-eligibility.ts`), wired as **GATE 1** in `getServicesDueForBilling` ahead of the existing onboarding gate. It applies regardless of onboarding state, so it also covers directly-seeded clinics. Future extensions need **no code change** — ops just sets a date.

## Scope / behaviour change

- Only services with a **future** `billing_start_date` change behaviour (get skipped). Everything currently billing is untouched (NULL date).
- **Migration applied to the shared DB.** The 5 approved-extension clinics (Oukasie, Sicelo, Phoenix, Alexandra, Chloorkop) backfilled to `2026-08-01`. Their July invoices were **voided separately**; billing resumes 1 Aug automatically.

## Known limitation (deliberate)

This is opt-*out*: a brand-new clinic seeded with no `billing_start_date` still bills by default on its `billing_day`. Fully fail-closed billing (opt-in `billing_active`) is a larger change that would disturb the onboarding/debit machinery — recommended as a **separate follow-up**, not bundled here.

## Tests

- `lib/billing/__tests__/billing-eligibility.test.ts` — 9/9 pass (null/undefined/empty, before/on/after date, time-of-day, ISO-timestamp tolerance, year boundary).
- Type-check clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)