### PR TITLE
fix(billing): consumers bill monthly — scope new-clinic delay to clinic/corporate

### DIFF
--- a/lib/billing/__tests__/new-clinic-billing.test.ts
+++ b/lib/billing/__tests__/new-clinic-billing.test.ts
@@ -1,60 +1,65 @@
-import { shouldEmitRecurringInvoice } from '../new-clinic-billing-helper';
+import { shouldEmitRecurringInvoice, isClinicBillingCategory } from '../new-clinic-billing-helper';
+
+// Clinic/corporate product categories carry the new-clinic delay. Consumer
+// services (residential/null/etc.) always bill monthly. These existing
+// delay-logic tests therefore run against a clinic category.
+const CLINIC = 'corporate';
 
 describe('New Clinic Billing Rules', () => {
-  describe('shouldEmitRecurringInvoice', () => {
+  describe('shouldEmitRecurringInvoice — clinic/corporate services', () => {
     // Cohort boundary: original = activation_date <= 2026-06-01
     // New = activation_date > 2026-06-01
 
     it('returns true for original-cohort clinic (activation <= 2026-06-01) on any billing_day', () => {
       const activation = '2026-06-01';
       const billingDay = new Date('2026-07-15'); // 44 days after activation
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(true);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(true);
     });
 
     it('returns true for original-cohort clinic on first billing_day after activation', () => {
       const activation = '2026-05-20';
       const billingDay = new Date('2026-06-01'); // first day of next month
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(true);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(true);
     });
 
     it('returns false for new-clinic (activation > 2026-06-01) before activation + 1 month', () => {
       const activation = '2026-06-15'; // new clinic
       const billingDay = new Date('2026-07-10'); // 25 days after activation, before activation + 1 month
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(false);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(false);
     });
 
     it('returns true for new-clinic on exactly activation + 1 month', () => {
       const activation = '2026-06-15'; // new clinic
       const billingDay = new Date('2026-07-15'); // exactly 1 month after activation
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(true);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(true);
     });
 
     it('returns true for new-clinic on billing_day after activation + 1 month', () => {
       const activation = '2026-06-15'; // new clinic
       const billingDay = new Date('2026-08-01'); // well after activation + 1 month
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(true);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(true);
     });
 
     it('returns false for new-clinic on first day of next month after mid-month activation', () => {
       const activation = '2026-06-20'; // mid-month activation
       const billingDay = new Date('2026-07-01'); // first day of next month, but < 12 days from activation
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(false);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(false);
     });
 
     it('returns true for new-clinic on first day of month after activation + 1 month', () => {
       const activation = '2026-06-20'; // mid-month activation
       const billingDay = new Date('2026-07-20'); // same day next month
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(true);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(true);
     });
 
     it('correctly handles edge case: new clinic activation on last day of month (June)', () => {
       const activation = '2026-06-30'; // last day of June (new clinic)
       // Adding 1 month to June 30 gives July 30
       const billingDay = new Date('2026-07-30T00:00:00Z'); // exactly 1 month later
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(true);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(true);
 
       const billingDayBefore = new Date('2026-07-29T00:00:00Z'); // 1 day before 1 month
-      expect(shouldEmitRecurringInvoice(activation, billingDayBefore)).toBe(false);
+      expect(shouldEmitRecurringInvoice(activation, billingDayBefore, CLINIC)).toBe(false);
     });
 
     it('correctly handles edge case: new clinic activation on last day of month', () => {
@@ -62,10 +67,10 @@ describe('New Clinic Billing Rules', () => {
       const activation = '2026-07-31'; // last day of July
       // Adding 1 month to July 31 gives August 31
       const billingDay = new Date('2026-08-31T00:00:00Z'); // exactly 1 month later
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(true);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(true);
 
       const billingDayBefore = new Date('2026-08-30T00:00:00Z'); // 1 day before 1 month
-      expect(shouldEmitRecurringInvoice(activation, billingDayBefore)).toBe(false);
+      expect(shouldEmitRecurringInvoice(activation, billingDayBefore, CLINIC)).toBe(false);
     });
 
     it('correctly handles month-clamp edge case: Aug 31 → Sept 30 (month overflow)', () => {
@@ -73,10 +78,53 @@ describe('New Clinic Billing Rules', () => {
       const activation = '2026-08-31'; // last day of August
       // Adding 1 month should clamp to September 30 (Sept has only 30 days)
       const billingDay = new Date('2026-09-30T00:00:00Z'); // clamped 1 month later
-      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(true);
+      expect(shouldEmitRecurringInvoice(activation, billingDay, CLINIC)).toBe(true);
 
       const billingDayBefore = new Date('2026-09-29T00:00:00Z'); // 1 day before clamped 1 month
-      expect(shouldEmitRecurringInvoice(activation, billingDayBefore)).toBe(false);
+      expect(shouldEmitRecurringInvoice(activation, billingDayBefore, CLINIC)).toBe(false);
+    });
+
+    it('applies the delay for the business_connectivity clinic category too', () => {
+      const activation = '2026-06-15';
+      const billingDay = new Date('2026-07-01'); // before activation + 1 month
+      expect(shouldEmitRecurringInvoice(activation, billingDay, 'business_connectivity')).toBe(false);
+    });
+  });
+
+  describe('shouldEmitRecurringInvoice — consumer services always bill monthly', () => {
+    // The regression this fixes: Ashwyn (5g/null) and Raymund (5g/residential)
+    // activated after 2026-06-01 and were wrongly suppressed for July.
+
+    it('bills a residential service activated after the cohort boundary, before activation + 1 month', () => {
+      const activation = '2026-06-04'; // Raymund
+      const billingDay = new Date('2026-07-01'); // would be suppressed if treated as a clinic
+      expect(shouldEmitRecurringInvoice(activation, billingDay, 'residential')).toBe(true);
+    });
+
+    it('bills a service with null product_category (Ashwyn) regardless of activation date', () => {
+      const activation = '2026-06-03'; // Ashwyn, 5g, product_category null
+      const billingDay = new Date('2026-07-01');
+      expect(shouldEmitRecurringInvoice(activation, billingDay, null)).toBe(true);
+    });
+
+    it('treats a missing product_category argument as consumer (bills normally)', () => {
+      const activation = '2026-06-20';
+      const billingDay = new Date('2026-07-01');
+      expect(shouldEmitRecurringInvoice(activation, billingDay)).toBe(true);
+    });
+  });
+
+  describe('isClinicBillingCategory', () => {
+    it('is true only for clinic/corporate categories', () => {
+      expect(isClinicBillingCategory('corporate')).toBe(true);
+      expect(isClinicBillingCategory('business_connectivity')).toBe(true);
+    });
+
+    it('is false for consumer categories and empty values', () => {
+      expect(isClinicBillingCategory('residential')).toBe(false);
+      expect(isClinicBillingCategory(null)).toBe(false);
+      expect(isClinicBillingCategory(undefined)).toBe(false);
+      expect(isClinicBillingCategory('')).toBe(false);
     });
   });
 });

--- a/lib/billing/monthly-invoice-generator.ts
+++ b/lib/billing/monthly-invoice-generator.ts
@@ -41,6 +41,7 @@ export interface ServiceToBill {
   package_id: string | null;
   package_name: string;
   service_type: string;
+  product_category: string | null;
   monthly_price: number;
   billing_day: number;
   last_invoice_date: string | null;
@@ -258,6 +259,7 @@ export class MonthlyInvoiceGenerator {
         package_id,
         package_name,
         service_type,
+        product_category,
         monthly_price,
         billing_day,
         last_invoice_date,
@@ -385,10 +387,11 @@ export class MonthlyInvoiceGenerator {
         };
       }
 
-      // 2b. Task F: New-clinic billing delay — suppress recurring invoices until ~1 month after activation
+      // 2b. Task F: New-clinic billing delay (CLINIC/CORPORATE ONLY) — suppress recurring
+      // invoices until ~1 month after activation. Consumer services always bill monthly.
       // Allow pro-rata first invoice (last_invoice_date === null), but suppress full recurring until billing_day >= activation + 1 month
       const isFirstInvoice = service.last_invoice_date === null;
-      if (!isFirstInvoice && !shouldEmitRecurringInvoice(service.activation_date, new Date())) {
+      if (!isFirstInvoice && !shouldEmitRecurringInvoice(service.activation_date, new Date(), service.product_category)) {
         const skipReason = `New clinic: recurring invoice suppressed until ~1 month after activation (${service.activation_date})`;
         billingLogger.info('MonthlyInvoice: Skipping new-clinic recurring invoice', {
           serviceId: service.id,

--- a/lib/billing/new-clinic-billing-helper.ts
+++ b/lib/billing/new-clinic-billing-helper.ts
@@ -3,7 +3,12 @@
  *
  * Task F: New clinics get their first FULL recurring bill ~1 month after activation.
  *
- * Cohort Rules:
+ * Scope: this delay is CLINIC/CORPORATE-ONLY. Consumer/residential services always
+ * bill on their normal monthly cycle — see isClinicBillingCategory below. (Applying
+ * the delay to consumers silently skipped a full month of billing for 5G/fixed-wireless
+ * customers activated mid-month — the regression this scoping fixes.)
+ *
+ * Cohort Rules (clinic/corporate services only):
  * - ORIGINAL: activation_date <= 2026-06-01 → billing per existing pro-rata logic (no change)
  * - NEW: activation_date > 2026-06-01 → first recurring invoice delayed ~1 month after activation
  *
@@ -11,6 +16,22 @@
  * (for the partial activation month). For new clinics, it should SUPPRESS full recurring
  * invoices until billing_day >= activation_date + 1 calendar month.
  */
+
+/**
+ * Product categories that receive the new-clinic billing delay.
+ * Unjani clinics use these; consumer/residential services do not.
+ */
+const CLINIC_BILLING_CATEGORIES = new Set(['corporate', 'business_connectivity']);
+
+/**
+ * True when a service's product_category is a clinic/corporate category subject to
+ * the new-clinic billing delay. Consumer categories (residential, null, etc.) → false.
+ *
+ * @param productCategory - customer_services.product_category value
+ */
+export function isClinicBillingCategory(productCategory: string | null | undefined): boolean {
+  return productCategory != null && CLINIC_BILLING_CATEGORIES.has(productCategory);
+}
 
 /**
  * Add one calendar month to a UTC date, clamping to the last day of the target month
@@ -39,13 +60,25 @@ function addOneMonthUTC(d: Date): Date {
  *
  * @param activationDate - ISO string (YYYY-MM-DD) of service activation
  * @param billingDay - Date object of the current billing cycle
+ * @param productCategory - customer_services.product_category; the delay applies
+ *   ONLY to clinic/corporate categories. Consumer/residential services always bill.
  * @returns true if invoice should be emitted, false if it should be skipped
  *
  * Logic:
+ * - If not a clinic/corporate service: return true (consumers always bill monthly)
  * - If activation <= 2026-06-01: return true (original cohort, bill normally)
  * - If activation > 2026-06-01: return true only if billingDay >= activation + 1 month
  */
-export function shouldEmitRecurringInvoice(activationDate: string | null, billingDay: Date): boolean {
+export function shouldEmitRecurringInvoice(
+  activationDate: string | null,
+  billingDay: Date,
+  productCategory: string | null = null
+): boolean {
+  // The new-clinic delay is clinic/corporate-only. Consumer services always bill.
+  if (!isClinicBillingCategory(productCategory)) {
+    return true;
+  }
+
   if (!activationDate) {
     // No activation date; treat as original cohort (allow billing)
     return true;


### PR DESCRIPTION
## Problem
Task F's new-clinic billing delay (\`shouldEmitRecurringInvoice\`, commit ff4e03dc) was keyed only on \`activation_date > 2026-06-01\` with **no service-type scoping**. Two consumer 5G customers activated 3–4 Jun 2026 were silently skipped for their July invoice:
- Ashwyn Watkins (CT-2026-00001, R449)
- Raymund Watson (CT-2026-00032, R649)

Shaun Robertson (CT-2025-00012, activated Nov 2025) was the control — billed normally because he's pre-cohort-boundary. Every future consumer activated day 2–31 of a month would lose their first full month the same way.

## Fix
Scope the delay to **clinic/corporate services only** (\`product_category\` ∈ {corporate, business_connectivity} — the Unjani clinics). Consumer/residential services always bill on their normal monthly cycle. Threads \`product_category\` through the generator's query, \`ServiceToBill\` type, and the gate call site.

## Tests
- \`lib/billing/__tests__/new-clinic-billing.test.ts\`: 16/16 passing. Existing clinic-delay cases retained (now pass a clinic category); added consumer cases (residential/null → always bill) + \`isClinicBillingCategory\` unit tests.
- Full type-check clean on both touched files.

## Data remediation (already applied to prod, separate from this deploy)
The two missing July invoices were created via the fixed generator and the customers notified by email + WhatsApp:
- INV-2026-00035 (Ashwyn, R449), INV-2026-00036 (Raymund, R649)
- Shaun's existing INV-2026-00019 email resent (had never been emailed) + WhatsApp
This PR ensures the **August+ cron** applies the fix automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)