### PR TITLE
fix(partner-landing): honest EarnMore pilot copy — 10% recurring, real terms

### DIFF
--- a/app/become-a-partner/page.tsx
+++ b/app/become-a-partner/page.tsx
@@ -7,8 +7,6 @@ import { CommissionCalculator } from '@/components/partner-landing/CommissionCal
 import { BenefitCards } from '@/components/partner-landing/BenefitCards';
 import { NetworkCredibility } from '@/components/partner-landing/NetworkCredibility';
 import { HowItWorks } from '@/components/partner-landing/HowItWorks';
-import { Leaderboard } from '@/components/partner-landing/Leaderboard';
-import { PartnerTestimonials } from '@/components/partner-landing/PartnerTestimonials';
 import { FAQSection } from '@/components/partner-landing/FAQSection';
 import { FinalCTA } from '@/components/partner-landing/FinalCTA';
 
@@ -32,13 +30,8 @@ export default function BecomeAPartnerPage() {
         {/* 5. How It Works - 3 simple steps */}
         <HowItWorks />
 
-        {/* 5. Leaderboard - Social proof (real earnings) */}
-        <Leaderboard />
-
-        {/* 6. Testimonials - Partner stories */}
-        <PartnerTestimonials />
-
-        {/* 7. FAQ - Objection handling */}
+        {/* 6. FAQ - Objection handling (real programme terms; social proof returns
+            when the pilot produces real partners and payouts) */}
         <FAQSection />
 
         {/* 8. Final CTA - Close with dual CTAs */}

--- a/components/partner-landing/BenefitCards.tsx
+++ b/components/partner-landing/BenefitCards.tsx
@@ -4,39 +4,39 @@ import { PiDeviceMobileBold, PiHeadphonesBold, PiLightningBold, PiMoneyBold, PiU
 const benefits = [
   {
     icon: PiMoneyBold,
-    title: 'High Commissions',
-    stat: '30%',
-    description: 'recurring commission on every customer you refer.',
+    title: 'Recurring Commission',
+    stat: '10%',
+    description: 'of your referrals\' monthly bills, paid every month they stay connected.',
   },
   {
     icon: PiWifiHighBold,
-    title: 'Full Product Range',
-    stat: 'Fibre, LTE, 5G',
-    description: 'home, business, and rural connectivity solutions.',
+    title: 'Multi-Technology Range',
+    stat: 'Fibre, FWA, LTE/5G',
+    description: 'home and business connectivity — you earn on every qualifying package.',
   },
   {
     icon: PiDeviceMobileBold,
     title: 'Work From Anywhere',
     stat: '100%',
-    description: 'remote. Share links via WhatsApp, social media, or in person.',
+    description: 'remote. Refer via WhatsApp, notice boards, or in person.',
   },
   {
     icon: PiUsersBold,
-    title: 'Dedicated Support',
-    stat: '1-on-1',
-    description: 'partner manager to help you close deals faster.',
+    title: 'Direct Access',
+    stat: 'Pilot',
+    description: 'founding partners deal directly with the team that runs the programme.',
   },
   {
     icon: PiHeadphonesBold,
     title: 'Local Support',
     stat: 'SA-based',
-    description: 'South African support team. No overseas call centres.',
+    description: 'South African support team looks after your referrals. No overseas call centres.',
   },
   {
     icon: PiLightningBold,
-    title: 'Fast Onboarding',
-    stat: '5 min',
-    description: 'to sign up and get your unique referral link.',
+    title: 'Simple Start',
+    stat: '1 form',
+    description: 'apply once — we onboard founding partners personally.',
   },
 ];
 

--- a/components/partner-landing/CommissionCalculator.tsx
+++ b/components/partner-landing/CommissionCalculator.tsx
@@ -4,8 +4,8 @@ import { PiCalculatorBold, PiMoneyBold, PiTrendUpBold, PiUsersBold } from 'react
 import { useState } from 'react';
 import { Slider } from '@/components/ui/slider';
 
-// Simplified commission rate - 30% recurring
-const COMMISSION_RATE = 0.30;
+// Pilot programme rate: 10% of MRR, recurring, on qualifying packages
+const COMMISSION_RATE = 0.10;
 
 function calculateCommission(packageValue: number, numCustomers: number): {
   monthlyCommission: number;
@@ -24,7 +24,7 @@ function calculateCommission(packageValue: number, numCustomers: number): {
 }
 
 export function CommissionCalculator() {
-  const [packageValue, setPackageValue] = useState(699);
+  const [packageValue, setPackageValue] = useState(999);
   const [numCustomers, setNumCustomers] = useState(10);
 
   const result = calculateCommission(packageValue, numCustomers);
@@ -60,13 +60,13 @@ export function CommissionCalculator() {
                 <Slider
                   value={[packageValue]}
                   onValueChange={(value) => setPackageValue(value[0])}
-                  min={399}
+                  min={599}
                   max={1999}
                   step={100}
                   className="mb-2"
                 />
                 <div className="flex justify-between text-xs text-gray-400">
-                  <span>R399</span>
+                  <span>R599</span>
                   <span>R1,999</span>
                 </div>
               </div>
@@ -99,7 +99,7 @@ export function CommissionCalculator() {
               <div className="bg-green-50 rounded-xl p-4 border border-green-100">
                 <div className="flex items-center gap-2">
                   <div className="w-8 h-8 rounded-full bg-green-100 flex items-center justify-center">
-                    <span className="text-green-600 font-bold text-sm">30%</span>
+                    <span className="text-green-600 font-bold text-sm">10%</span>
                   </div>
                   <div className="text-sm text-gray-600">
                     <strong className="text-gray-900">Recurring commission</strong> on every customer, every month
@@ -154,7 +154,7 @@ export function CommissionCalculator() {
 
         {/* Bottom Note */}
         <p className="text-center text-white/70 text-sm mt-6">
-          * Based on 30% recurring commission. Actual earnings depend on customer retention.
+          * Based on 10% recurring commission on the monthly subscription of qualifying packages. Commission is paid on collected payments — actual earnings depend on your referrals staying connected and paid up. Ts&amp;Cs apply.
         </p>
       </div>
     </section>

--- a/components/partner-landing/FAQSection.tsx
+++ b/components/partner-landing/FAQSection.tsx
@@ -5,28 +5,32 @@ import { useState } from 'react';
 
 const faqs = [
   {
-    question: 'Do I need any experience to join?',
-    answer: 'Nope! If you can share a link and chat to people, you\'re qualified. We provide all the training and support you need to succeed.',
+    question: 'What does "founding partner pilot" mean?',
+    answer: 'We are launching the programme with a small first group so every partner gets personal onboarding and a direct line to the team. Founding partners keep their commission terms as the programme grows.',
   },
   {
-    question: 'What can I sell through the programme?',
-    answer: 'Everything CircleTel offers—Fibre packages from R399/month, LTE and 5G for areas without fibre, and business connectivity solutions. You earn on all of it.',
+    question: 'How much do I earn, exactly?',
+    answer: '10% of your referral\'s monthly subscription, every month, for as long as they stay connected. A referral on a R999/month package earns you R99 a month — ten of those is R999 a month, ongoing.',
   },
   {
     question: 'When exactly do I get paid?',
-    answer: 'Commissions are paid after your customer\'s first full billing cycle completes, then monthly thereafter. You can track earnings in real-time via your partner dashboard — no guessing, no waiting around.',
+    answer: 'Monthly, by the 5th, for the previous month\'s collected payments. Your referral pays their March bill; your commission is in your account by 5 April. Balances under R200 roll over to the next month so you\'re never paid in cents.',
+  },
+  {
+    question: 'What can I refer people to?',
+    answer: 'Qualifying CircleTel packages across fibre, fixed-wireless and LTE/5G — for homes and businesses. We\'ll give you the current qualifying list when you join; you earn the same 10% on all of them.',
+  },
+  {
+    question: 'Do I need any experience to join?',
+    answer: 'No. If you know people who need reliable internet — tenants, neighbours, clients, a community group — you have what the programme needs. We handle quotes, installation and support.',
   },
   {
     question: 'Is there a contract or lock-in?',
-    answer: 'No. You can pause or stop at any time. No minimums, no penalties. Some partners do this full-time, others just share their link when it comes up naturally.',
-  },
-  {
-    question: 'What support do I get?',
-    answer: 'You get a dedicated partner manager, WhatsApp support, marketing materials, and access to our partner community. We\'re here to help you succeed.',
+    answer: 'No. You can pause or stop at any time. No minimums, no penalties — and commission already earned still gets paid.',
   },
   {
     question: 'Can I do this alongside my current job?',
-    answer: 'Absolutely! Most of our partners have other jobs or businesses. This is perfect side-income that grows over time as your referrals stay connected.',
+    answer: 'Yes — it\'s designed as side income. Property managers, IT freelancers and community admins are a natural fit, because one referral network can produce many connections.',
   },
 ];
 

--- a/components/partner-landing/FinalCTA.tsx
+++ b/components/partner-landing/FinalCTA.tsx
@@ -17,7 +17,7 @@ export function FinalCTA() {
 
           {/* Subheadline */}
           <p className="text-white/90 mb-8 max-w-2xl mx-auto text-lg">
-            Join 200+ partners already earning with CircleTel. Sign up takes 5 minutes.
+            Founding partner spots are limited. Applying takes five minutes.
           </p>
 
           {/* Benefits */}
@@ -32,7 +32,7 @@ export function FinalCTA() {
             </div>
             <div className="flex items-center gap-2 text-white/90">
               <PiCheckCircleBold className="h-5 w-5 text-circleTel-orange" />
-              <span>Paid monthly</span>
+              <span>Paid monthly, by the 5th</span>
             </div>
           </div>
 
@@ -43,7 +43,7 @@ export function FinalCTA() {
                 size="lg"
                 className="bg-circleTel-orange hover:bg-circleTel-orange-dark text-white px-10 py-6 text-lg font-bold rounded-xl shadow-xl hover:shadow-2xl transition-all duration-300"
               >
-                Join 200+ partners
+                Apply to join the pilot
                 <PiArrowRightBold className="ml-2 h-5 w-5" />
               </Button>
             </Link>

--- a/components/partner-landing/HowItWorks.tsx
+++ b/components/partner-landing/HowItWorks.tsx
@@ -5,20 +5,20 @@ const steps = [
   {
     number: 1,
     icon: PiLinkBold,
-    title: 'Get your unique link',
-    description: 'Sign up and get your personal referral link that tracks every customer you bring in.',
+    title: 'Apply for the pilot',
+    description: 'Tell us about yourself and your network. Property managers, community admins and IT freelancers are a natural fit.',
   },
   {
     number: 2,
     icon: PiShareBold,
-    title: 'Share it everywhere',
-    description: 'WhatsApp, Facebook, in person—the more people who click, the more you earn.',
+    title: 'Refer people you know',
+    description: 'WhatsApp, notice boards, in person — we track every referral and handle the quotes, installation and support.',
   },
   {
     number: 3,
     icon: PiMoneyBold,
-    title: 'Earn monthly commission',
-    description: 'Get paid every month for as long as your referrals stay connected. Passive income, sorted.',
+    title: 'Earn 10% every month',
+    description: 'Paid by the 5th of each month for the previous month, for as long as your referrals stay connected.',
   },
 ];
 

--- a/components/partner-landing/NetworkCredibility.tsx
+++ b/components/partner-landing/NetworkCredibility.tsx
@@ -4,13 +4,13 @@ import { PiCheckCircleBold, PiMapPinBold, PiHeadphonesBold, PiUsersBold } from '
 const stats = [
   {
     icon: PiMapPinBold,
-    value: '200+',
-    label: 'suburbs covered',
+    value: 'Multi-tech',
+    label: 'fibre, fixed-wireless and LTE/5G under one roof',
   },
   {
     icon: PiUsersBold,
-    value: '94%',
-    label: 'customer retention',
+    value: 'Month-to-month',
+    label: 'no lock-in contracts — an easy yes for your referrals',
   },
   {
     icon: PiHeadphonesBold,

--- a/components/partner-landing/PartnerHero.tsx
+++ b/components/partner-landing/PartnerHero.tsx
@@ -20,14 +20,14 @@ export function PartnerHero() {
         <div className="text-center max-w-5xl mx-auto mb-8 sm:mb-12">
           <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-circleTel-orange/10 border border-circleTel-orange/30 text-white mb-6">
             <div className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
-            <span className="text-sm font-medium">Partner Programme Now Open</span>
+            <span className="text-sm font-medium">Founding Partner Pilot — limited spots</span>
           </div>
 
           <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-7xl font-bold text-white mb-4 sm:mb-6 leading-tight px-2">
-            Build <span className="text-circleTel-orange">recurring income</span> — no business required
+            Earn <span className="text-circleTel-orange">10% of every bill</span>, every month
           </h1>
           <p className="text-lg sm:text-xl md:text-2xl text-white/90 mb-6 sm:mb-8 px-2 max-w-3xl mx-auto">
-            Earn up to 30% commission every month, for as long as your customers stay connected.
+            Refer people to CircleTel and earn 10% of their monthly subscription — paid every month, for as long as they stay connected.
           </p>
         </div>
 
@@ -36,10 +36,10 @@ export function PartnerHero() {
           <div className="bg-white rounded-xl sm:rounded-2xl shadow-2xl p-6 sm:p-8 md:p-10">
             <div className="text-center mb-6">
               <h2 className="text-2xl sm:text-3xl font-bold text-circleTel-navy mb-2">
-                Start earning today
+                Apply to become a founding partner
               </h2>
               <p className="text-circleTel-grey600">
-                No experience needed. No upfront costs. Just your network and a smartphone.
+                We are onboarding a small first group personally. No upfront costs — just your network and a smartphone.
               </p>
             </div>
 
@@ -49,7 +49,7 @@ export function PartnerHero() {
                   size="lg"
                   className="bg-circleTel-orange hover:bg-circleTel-orange-dark text-white font-bold text-lg px-10 py-6 rounded-xl transition-all shadow-lg hover:shadow-xl w-full"
                 >
-                  Sign up now
+                  Apply now
                   <PiArrowRightBold className="ml-2 h-5 w-5" />
                 </Button>
               </Link>
@@ -78,15 +78,15 @@ export function PartnerHero() {
             <div className="w-16 h-16 bg-circleTel-orange rounded-full flex items-center justify-center mb-3">
               <PiMoneyBold className="w-8 h-8 text-white" />
             </div>
-            <h3 className="text-lg font-semibold mb-1">Up to 30% commission</h3>
-            <p className="text-white/80 text-sm">Recurring monthly payments</p>
+            <h3 className="text-lg font-semibold mb-1">10% recurring commission</h3>
+            <p className="text-white/80 text-sm">On the monthly bill, month after month</p>
           </div>
           <div className="flex flex-col items-center text-white">
             <div className="w-16 h-16 bg-circleTel-orange rounded-full flex items-center justify-center mb-3">
               <PiUsersBold className="w-8 h-8 text-white" />
             </div>
-            <h3 className="text-lg font-semibold mb-1">200+ active partners</h3>
-            <p className="text-white/80 text-sm">Join our growing network</p>
+            <h3 className="text-lg font-semibold mb-1">Founding partner spots</h3>
+            <p className="text-white/80 text-sm">A small pilot group with direct access to the team</p>
           </div>
           <div className="flex flex-col items-center text-white">
             <div className="w-16 h-16 bg-circleTel-orange rounded-full flex items-center justify-center mb-3">


### PR DESCRIPTION
## Why

The become-a-partner page marketed a programme that doesn't exist yet: **up to 30% commission**, **R2.5M paid out this year**, a **leaderboard of top earners**, **200+ active partners**, and **testimonials from partners 'since 2023'** — while in reality EarnMore is pre-launch with zero formal partners and no payout engine. These claims are a CPA/compliance risk and would poison partner trust at launch.

The real programme structure was decided 2026-07-04 (documented in the second-brain EarnMore page): **10% of MRR, recurring, on qualifying (≥30% GM) products, paid on collected revenue by the 5th of the following month, R200 rollover threshold, closed founding-partner pilot.**

## What changed (copy only, 8 files)

- **PartnerHero** — headline now leads with the real number ('Earn 10% of every bill, every month'); 'Founding Partner Pilot — limited spots' badge; apply CTAs; fabricated '200+ active partners' stat replaced
- **CommissionCalculator** — rate 0.30 → 0.10; slider min R399 → R599 (no R399 plan exists); footnote states collected-revenue basis + Ts&Cs
- **BenefitCards** — 30% → 10%; 'dedicated partner manager' → honest pilot-scale 'direct access'; '5 min signup' → application
- **NetworkCredibility** — unverifiable '94% retention' / '200+ suburbs' → verifiable differentiators (multi-tech range, month-to-month no lock-in)
- **HowItWorks** — apply → refer → 'paid by the 5th of each month'
- **FAQSection** — rewritten around real terms: exact earnings math, payout timing with example, R200 rollover, pilot explanation; removed fake 'partner dashboard' and 'R399 fibre' claims
- **FinalCTA** — 'Join 200+ partners' → 'Apply to join the pilot'
- **page.tsx** — removed Leaderboard + PartnerTestimonials (fabricated social proof; sections return when the pilot produces real numbers)

## Notes

- 7 unused partner-landing components (StickyCTA, CommissionStructure, PartnershipModels, SuccessMetrics, TrustBadges, WhatIsSection, ConfusedSection) are dead code — not imported anywhere. Some still contain the old 30% claims. Left untouched to keep this PR surgical; consider deleting them in a cleanup PR.
- Copy-only change; no logic touched beyond the calculator constant and slider bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVc3gj4aMuFjvUuQYdCcni