### PR TITLE
fix(types): resolve pre-existing type errors flagged in PR #600 CI

### DIFF
--- a/app/(marketing)/soho/SOHOContent.tsx
+++ b/app/(marketing)/soho/SOHOContent.tsx
@@ -55,6 +55,7 @@ const WHY_CIRCLETEL = [
 
 interface SOHOContentProps {
   plans: Plan[];
+  productSlugs?: string[];
 }
 
 export default function SOHOContent({ plans }: SOHOContentProps) {

--- a/app/admin/mits-cpq/page.tsx
+++ b/app/admin/mits-cpq/page.tsx
@@ -145,25 +145,25 @@ export default function MITSCPQDashboard() {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <StatCard
-            icon={<FileText className="h-5 w-5" />}
+            icon={<PiFileTextBold className="h-5 w-5" />}
             label="Total Quotes"
             value={stats.total}
             description={`${stats.submitted} submitted`}
           />
           <StatCard
-            icon={<Clock className="h-5 w-5" />}
+            icon={<PiClockBold className="h-5 w-5" />}
             label="In Progress"
             value={stats.inProgress}
             description="Drafts pending completion"
           />
           <StatCard
-            icon={<CheckCircle className="h-5 w-5" />}
+            icon={<PiCheckCircleBold className="h-5 w-5" />}
             label="Submitted"
             value={stats.submitted}
             description="Quotes sent to customers"
           />
           <StatCard
-            icon={<FileText className="h-5 w-5" />}
+            icon={<PiFileTextBold className="h-5 w-5" />}
             label="This Month Revenue"
             value={`R${stats.monthlyRevenue.toLocaleString('en-ZA', { maximumFractionDigits: 0 })}`}
             description="ARR from new quotes"

--- a/app/admin/products/[id]/edit/page.tsx
+++ b/app/admin/products/[id]/edit/page.tsx
@@ -204,7 +204,7 @@ export default function EditProductPage() {
         toast({
           variant: 'destructive',
           title: 'Error',
-          description: error.message || 'Failed to load product',
+          description: error instanceof Error ? error.message : 'Failed to load product',
         });
         router.push('/admin/products');
       } finally {
@@ -291,7 +291,7 @@ export default function EditProductPage() {
       toast({
         variant: 'destructive',
         title: 'Error',
-        description: error.message || 'Failed to update product',
+        description: error instanceof Error ? error.message : 'Failed to update product',
       });
     } finally {
       setSaving(false);

--- a/app/admin/products/[id]/page.tsx
+++ b/app/admin/products/[id]/page.tsx
@@ -459,7 +459,7 @@ export default function ProductDetailPage() {
                 </div>
 
                 {/* Detailed Cost Breakdown from metadata */}
-                {product.metadata?.cost_breakdown && (
+                {!!product.metadata?.cost_breakdown && (
                   <div className="p-4 bg-slate-50 rounded-lg border border-slate-200">
                     <p className="text-sm font-medium text-gray-900 mb-3">Cost Breakdown (Monthly)</p>
                     <div className="space-y-2 text-sm">
@@ -482,10 +482,10 @@ export default function ProductDetailPage() {
                         </span>
                       </div>
                     )}
-                    {product.metadata?.margin_percent && (
+                    {!!product.metadata?.margin_percent && (
                       <div className="mt-1 flex justify-between text-sm">
                         <span className="text-gray-600">Documented Margin</span>
-                        <span className="font-mono text-green-700">{product.metadata.margin_percent}%</span>
+                        <span className="font-mono text-green-700">{String(product.metadata.margin_percent)}%</span>
                       </div>
                     )}
                   </div>
@@ -495,8 +495,8 @@ export default function ProductDetailPage() {
                 {product.metadata?.margin_type === 'commission_only' && (
                   <div className="p-4 bg-amber-50 rounded-lg border border-amber-200">
                     <p className="text-sm font-medium text-amber-900 mb-1">Commission-Only Product</p>
-                    <p className="text-xs text-amber-700">{product.metadata?.cost_note}</p>
-                    {product.metadata?.estimated_commission_monthly && (
+                    <p className="text-xs text-amber-700">{String(product.metadata?.cost_note ?? '')}</p>
+                    {!!product.metadata?.estimated_commission_monthly && (
                       <p className="text-sm font-medium text-amber-900 mt-2">
                         Est. commission: {formatPrice(product.metadata.estimated_commission_monthly as number)}/mo
                       </p>


### PR DESCRIPTION
Fixes the 12 TypeScript errors that appear as annotations on every PR's type-check job (surfaced on #600).

- **app/admin/mits-cpq/page.tsx** — `FileText`/`Clock`/`CheckCircle` were never imported; the file imports Pi icons, so usages now use `PiFileTextBold`/`PiClockBold`/`PiCheckCircleBold`.
- **app/admin/products/[id]/page.tsx** — `product.metadata` values are `unknown`; coerced with `!!` guards and `String()` before rendering as ReactNode.
- **app/admin/products/[id]/edit/page.tsx** — `catch (error: unknown)` accessed `.message` directly; now narrowed with `instanceof Error` (per `.claude/rules/type-guards-optionals.md`).
- **app/(marketing)/soho/SOHOContent.tsx** — page passes `productSlugs` but the prop interface lacked it; added as optional.

Verified: `npx tsc --noEmit` no longer reports errors in these files (repo-wide count 237 → 225; the remainder are in untouched files, mostly `unknown` catch errors — happy to sweep those in a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVc3gj4aMuFjvUuQYdCcni