### PR TITLE
feat(homepage): conversion fix-now batch — hero coverage form, consumer metadata, WhatsApp CTAs, segment-aware closing band

### DIFF
--- a/__tests__/app/home-offer-attribution.test.ts
+++ b/__tests__/app/home-offer-attribution.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { offerSlugFromParams } from '@/app/(marketing)/page';
+import { offerSlugFromParams } from '@/components/home/HomePageClient';
 
 describe('home offer attribution helper', () => {
   it('extracts offer slug from URLSearchParams', () => {

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,90 +1,46 @@
-'use client';
+import { Suspense } from 'react';
+import { type Metadata } from 'next';
+import { HomePageClient } from '@/components/home/HomePageClient';
 
-import React, { useEffect, useState, useCallback } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { HomeLanding20260607 } from '@/components/home/HomeLanding20260607';
-import type { SegmentType } from '@/components/home/NewHero';
-
-// Valid segment values
-const VALID_SEGMENTS: SegmentType[] = ['business', 'wfh', 'home'];
-
-function isValidSegment(value: string | null): value is SegmentType {
-  return value !== null && VALID_SEGMENTS.includes(value as SegmentType);
-}
-
-// Pure helper to extract offer slug from URLSearchParams
-export function offerSlugFromParams(params: URLSearchParams): string | null {
-  return params.get('offer');
-}
+// Consumer-first metadata for the homepage — overrides the B2B default in app/layout.tsx.
+// Message match: SEO/ad traffic landing on `/` is predominantly residential + WFH intent.
+export const metadata: Metadata = {
+  title: 'CircleTel — Uncapped Fibre & Wireless Internet from R899/mo',
+  description:
+    'Fast, uncapped internet for homes, remote workers and small businesses. No contracts, R0 setup, professional installation. Check coverage at your address in 30 seconds.',
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    title: 'CircleTel — Uncapped Fibre & Wireless Internet from R899/mo',
+    description:
+      'Fast, uncapped internet for homes, remote workers and small businesses. No contracts, R0 setup. Check coverage at your address in 30 seconds.',
+    url: 'https://www.circletel.co.za',
+    siteName: 'CircleTel',
+    images: [
+      {
+        url: '/og-image.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'CircleTel — Uncapped Fibre & Wireless Internet',
+      },
+    ],
+    locale: 'en_ZA',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'CircleTel — Uncapped Fibre & Wireless Internet from R899/mo',
+    description:
+      'Fast, uncapped internet for homes, remote workers and small businesses. No contracts, R0 setup. Check coverage at your address in 30 seconds.',
+    images: ['/og-image.jpg'],
+  },
+};
 
 export default function Home() {
-  const searchParams = useSearchParams();
-  const [isRedirecting, setIsRedirecting] = useState(false);
-
-  // Get initial segment from URL or default to 'home'
-  const urlSegment = searchParams.get('segment');
-  const initialSegment: SegmentType = isValidSegment(urlSegment) ? urlSegment : 'home';
-  const [activeSegment, setActiveSegment] = useState<SegmentType>(initialSegment);
-
-  // Sync segment state with URL param on mount
-  useEffect(() => {
-    const urlSegment = searchParams.get('segment');
-    if (isValidSegment(urlSegment) && urlSegment !== activeSegment) {
-      setActiveSegment(urlSegment);
-    }
-  }, [searchParams, activeSegment]);
-
-  // Carry offer attribution from /offers CTAs (read-only Plan 2: client-side only, no DB write).
-  useEffect(() => {
-    const offer = offerSlugFromParams(searchParams);
-    if (offer) sessionStorage.setItem('circletel_offer_slug', offer);
-  }, [searchParams]);
-
-  // Update URL when segment changes
-  const handleSegmentChange = useCallback((segment: SegmentType) => {
-    setActiveSegment(segment);
-
-    // Update URL without full page reload
-    const url = new URL(window.location.href);
-    if (segment === 'home') {
-      // Remove param for default segment to keep URL clean
-      url.searchParams.delete('segment');
-    } else {
-      url.searchParams.set('segment', segment);
-    }
-    window.history.replaceState({}, '', url.toString());
-  }, []);
-
-  // Detect OAuth redirect and forward to callback page
-  useEffect(() => {
-    if (typeof window !== 'undefined' && window.location.hash) {
-      const hashParams = new URLSearchParams(window.location.hash.substring(1));
-      const accessToken = hashParams.get('access_token');
-
-      if (accessToken && !isRedirecting) {
-        setIsRedirecting(true);
-        // Forward to callback with hash and add next parameter for order flow
-        window.location.href = `/auth/callback?next=/order/checkout${window.location.hash}`;
-      }
-    }
-  }, [isRedirecting]);
-
-  // Show loading state while redirecting
-  if (isRedirecting) {
-    return (
-      <div className="min-h-screen bg-white flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-circleTel-orange mx-auto mb-4"></div>
-          <p className="text-gray-600">Redirecting...</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <HomeLanding20260607
-      activeSegment={activeSegment}
-      onSegmentChange={handleSegmentChange}
-    />
+    <Suspense fallback={null}>
+      <HomePageClient />
+    </Suspense>
   );
 }

--- a/components/common/WhatsAppFloatingButton.tsx
+++ b/components/common/WhatsAppFloatingButton.tsx
@@ -1,11 +1,44 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { FaWhatsapp } from 'react-icons/fa';
 import { getWhatsAppLink } from '@/lib/constants/contact';
 
 export function WhatsAppFloatingButton() {
   const pathname = usePathname();
+  // Hide while the coverage-check form is on screen so the float never
+  // occludes the primary CTA (observed overlapping "Find my plan" on mobile).
+  const [formInView, setFormInView] = useState(false);
+
+  useEffect(() => {
+    setFormInView(false);
+    let observer: IntersectionObserver | null = null;
+    let cancelled = false;
+    let attempts = 0;
+
+    // The form is client-rendered, so it may mount after this effect runs —
+    // retry briefly until it exists (or give up on pages without it).
+    const attach = () => {
+      if (cancelled) return;
+      const form = document.getElementById('coverage-checker');
+      if (form) {
+        observer = new IntersectionObserver(
+          ([entry]) => setFormInView(entry.isIntersecting),
+          { threshold: 0.1 }
+        );
+        observer.observe(form);
+        return;
+      }
+      if (attempts++ < 20) setTimeout(attach, 250);
+    };
+    attach();
+
+    return () => {
+      cancelled = true;
+      observer?.disconnect();
+    };
+  }, [pathname]);
 
   // Hide on admin, partner, auth, and quote routes
   const shouldHide =
@@ -22,7 +55,9 @@ export function WhatsAppFloatingButton() {
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Chat with CircleTel on WhatsApp"
-      className="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-[#25D366] text-white shadow-lg transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-[#25D366] focus:ring-offset-2 print:hidden"
+      className={`fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-[#25D366] text-white shadow-lg transition-all hover:scale-110 focus:outline-none focus:ring-2 focus:ring-[#25D366] focus:ring-offset-2 print:hidden ${
+        formInView ? 'pointer-events-none scale-0 opacity-0' : 'scale-100 opacity-100'
+      }`}
     >
       <FaWhatsapp className="h-7 w-7" />
     </a>

--- a/components/home/HomeLanding20260607.tsx
+++ b/components/home/HomeLanding20260607.tsx
@@ -5,9 +5,11 @@ import {
   PiArrowRightBold,
   PiCheckCircleBold,
   PiMapPinBold,
-  PiPhoneBold,
   PiShieldCheckBold,
 } from 'react-icons/pi';
+import { FaWhatsapp } from 'react-icons/fa';
+
+import { getWhatsAppLink } from '@/lib/constants/contact';
 
 import { AddressAutocomplete } from '@/components/coverage/AddressAutocomplete';
 import { InteractiveCoverageMapModal } from '@/components/coverage/InteractiveCoverageMapModal';
@@ -147,6 +149,7 @@ export function HomeLanding20260607({
   const [coordinates, setCoordinates] = React.useState<{ lat: number; lng: number } | null>(null);
   const [addressComponents, setAddressComponents] = React.useState<Record<string, string>>({});
   const [isChecking, setIsChecking] = React.useState(false);
+  const [checkError, setCheckError] = React.useState(false);
   const [showMapModal, setShowMapModal] = React.useState(false);
 
   const activeConfig = SEGMENT_CONFIG[activeSegment];
@@ -201,6 +204,7 @@ export function HomeLanding20260607({
     if (!nextAddress.trim()) return;
 
     setIsChecking(true);
+    setCheckError(false);
 
     try {
       const coverageType = activeSegment === 'business' ? 'business' : 'residential';
@@ -233,7 +237,7 @@ export function HomeLanding20260607({
       window.location.href = `/packages/${data.leadId}?type=${coverageType}`;
     } catch (error) {
       console.error('Coverage check failed:', error);
-      alert('Coverage check failed. Please try again.');
+      setCheckError(true);
       setIsChecking(false);
     }
   };
@@ -285,33 +289,9 @@ export function HomeLanding20260607({
             R0 setup, and professional installation without the usual runaround.
           </p>
 
-          <div className="mt-8 flex flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              size="xl"
-              className="rounded-full bg-circleTel-orange px-7 text-white shadow-xl shadow-circleTel-orange/25 hover:bg-circleTel-orange-dark"
-              onClick={() => scrollToSection('coverage-checker')}
-            >
-              Check coverage
-              <PiArrowRightBold className="h-4 w-4" />
-            </Button>
-            <Button
-              type="button"
-              size="xl"
-              className="rounded-full bg-white px-7 text-circleTel-navy hover:bg-white/90"
-              onClick={() => scrollToSection('plans')}
-            >
-              View packages
-            </Button>
-          </div>
-
-        </div>
-      </section>
-
-      <section id="coverage-checker" className="relative z-10 -mt-14 px-4">
-        <div className="container mx-auto">
           <form
-            className="grid gap-3 rounded-3xl border border-circleTel-lightNeutral bg-white p-4 shadow-2xl shadow-circleTel-navy/15 md:grid-cols-[minmax(0,1fr)_auto_auto] md:items-end md:p-5"
+            id="coverage-checker"
+            className="mt-9 grid max-w-3xl gap-3 rounded-3xl border border-circleTel-lightNeutral bg-white p-4 shadow-2xl shadow-circleTel-midnight-navy/40 md:grid-cols-[minmax(0,1fr)_auto_auto] md:items-end md:p-5"
             onSubmit={(event) => {
               event.preventDefault();
               void runCoverageCheck();
@@ -350,7 +330,34 @@ export function HomeLanding20260607({
             >
               Use map
             </Button>
+
+            {checkError && (
+              <p className="text-sm leading-6 text-red-600 md:col-span-3" role="alert">
+                We couldn&apos;t run the coverage check right now.{' '}
+                <a
+                  href={getWhatsAppLink(`Hi CircleTel, please check coverage at: ${address}`)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-semibold text-circleTel-orange-accessible underline"
+                >
+                  WhatsApp us your address
+                </a>{' '}
+                and we&apos;ll confirm coverage for you, or try again in a minute.
+              </p>
+            )}
           </form>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              size="xl"
+              className="rounded-full bg-white px-7 text-circleTel-navy hover:bg-white/90"
+              onClick={() => scrollToSection('plans')}
+            >
+              View packages
+            </Button>
+          </div>
+
         </div>
       </section>
 
@@ -464,9 +471,13 @@ export function HomeLanding20260607({
             size="xl"
             className="rounded-full bg-circleTel-midnight-navy px-7 text-white hover:bg-circleTel-navy"
           >
-            <a href="mailto:sales@circletel.co.za">
-              Get my quote
-              <PiPhoneBold className="h-4 w-4" />
+            <a
+              href={getWhatsAppLink('Hi CircleTel, I would like a quote')}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Get my quote on WhatsApp
+              <FaWhatsapp className="h-4 w-4" />
             </a>
           </Button>
         </div>

--- a/components/home/HomeLanding20260607.tsx
+++ b/components/home/HomeLanding20260607.tsx
@@ -107,6 +107,21 @@ const BUSINESS_PROOF = [
   },
 ];
 
+const CLOSING_CTA: Record<SegmentType, { headline: string; sub: string }> = {
+  home: {
+    headline: 'Uncapped internet, sorted this week.',
+    sub: 'Check your address, pick your plan, and we handle the install. No contracts, R0 setup — if you’re not happy, you can walk away anytime.',
+  },
+  wfh: {
+    headline: 'Never say “sorry, my internet dropped” again.',
+    sub: 'Check your address, pick your plan, and we handle the install. No contracts, R0 setup — and support that answers when your workday depends on it.',
+  },
+  business: {
+    headline: 'One provider. One bill. Your office runs.',
+    sub: 'Tell us where you are and what your team needs — we’ll send a quote on WhatsApp today, no meetings required.',
+  },
+};
+
 interface HomeLanding20260607Props {
   activeSegment: SegmentType;
   onSegmentChange: (segment: SegmentType) => void;
@@ -460,26 +475,49 @@ export function HomeLanding20260607({
         <div className="container mx-auto flex flex-col gap-6 px-4 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="max-w-3xl font-heading text-4xl font-extrabold leading-none tracking-[-0.03em] text-white md:text-5xl">
-              Ready to stop babysitting your connection?
+              {CLOSING_CTA[activeSegment].headline}
             </h2>
             <p className="mt-4 max-w-2xl text-white/85">
-              Check coverage, get the right plan, and let CircleTel handle the setup.
+              {CLOSING_CTA[activeSegment].sub}
             </p>
           </div>
-          <Button
-            asChild
-            size="xl"
-            className="rounded-full bg-circleTel-midnight-navy px-7 text-white hover:bg-circleTel-navy"
-          >
-            <a
-              href={getWhatsAppLink('Hi CircleTel, I would like a quote')}
-              target="_blank"
-              rel="noopener noreferrer"
+          {activeSegment === 'business' ? (
+            <Button
+              asChild
+              size="xl"
+              className="rounded-full bg-circleTel-midnight-navy px-7 text-white hover:bg-circleTel-navy"
             >
-              Get my quote on WhatsApp
-              <FaWhatsapp className="h-4 w-4" />
-            </a>
-          </Button>
+              <a
+                href={getWhatsAppLink('Hi CircleTel, I would like a quote for my business')}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Get my quote on WhatsApp
+                <FaWhatsapp className="h-4 w-4" />
+              </a>
+            </Button>
+          ) : (
+            <div className="flex flex-col items-start gap-3">
+              <Button
+                type="button"
+                size="xl"
+                className="rounded-full bg-circleTel-midnight-navy px-7 text-white hover:bg-circleTel-navy"
+                onClick={() => scrollToSection('coverage-checker')}
+              >
+                Check my coverage
+                <PiArrowRightBold className="h-4 w-4" />
+              </Button>
+              <a
+                href={getWhatsAppLink('Hi CircleTel, I have a question about your plans')}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm font-semibold text-white/90 underline underline-offset-4 hover:text-white"
+              >
+                <FaWhatsapp className="h-4 w-4" />
+                Rather chat? WhatsApp us
+              </a>
+            </div>
+          )}
         </div>
       </section>
 

--- a/components/home/HomePageClient.tsx
+++ b/components/home/HomePageClient.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { HomeLanding20260607 } from '@/components/home/HomeLanding20260607';
+import type { SegmentType } from '@/components/home/NewHero';
+
+// Valid segment values
+const VALID_SEGMENTS: SegmentType[] = ['business', 'wfh', 'home'];
+
+function isValidSegment(value: string | null): value is SegmentType {
+  return value !== null && VALID_SEGMENTS.includes(value as SegmentType);
+}
+
+// Pure helper to extract offer slug from URLSearchParams
+export function offerSlugFromParams(params: URLSearchParams): string | null {
+  return params.get('offer');
+}
+
+export function HomePageClient() {
+  const searchParams = useSearchParams();
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  // Get initial segment from URL or default to 'home'
+  const urlSegment = searchParams.get('segment');
+  const initialSegment: SegmentType = isValidSegment(urlSegment) ? urlSegment : 'home';
+  const [activeSegment, setActiveSegment] = useState<SegmentType>(initialSegment);
+
+  // Sync segment state with URL param on mount
+  useEffect(() => {
+    const urlSegment = searchParams.get('segment');
+    if (isValidSegment(urlSegment) && urlSegment !== activeSegment) {
+      setActiveSegment(urlSegment);
+    }
+  }, [searchParams, activeSegment]);
+
+  // Carry offer attribution from /offers CTAs (read-only Plan 2: client-side only, no DB write).
+  useEffect(() => {
+    const offer = offerSlugFromParams(searchParams);
+    if (offer) sessionStorage.setItem('circletel_offer_slug', offer);
+  }, [searchParams]);
+
+  // Update URL when segment changes
+  const handleSegmentChange = useCallback((segment: SegmentType) => {
+    setActiveSegment(segment);
+
+    // Update URL without full page reload
+    const url = new URL(window.location.href);
+    if (segment === 'home') {
+      // Remove param for default segment to keep URL clean
+      url.searchParams.delete('segment');
+    } else {
+      url.searchParams.set('segment', segment);
+    }
+    window.history.replaceState({}, '', url.toString());
+  }, []);
+
+  // Detect OAuth redirect and forward to callback page
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.location.hash) {
+      const hashParams = new URLSearchParams(window.location.hash.substring(1));
+      const accessToken = hashParams.get('access_token');
+
+      if (accessToken && !isRedirecting) {
+        setIsRedirecting(true);
+        // Forward to callback with hash and add next parameter for order flow
+        window.location.href = `/auth/callback?next=/order/checkout${window.location.hash}`;
+      }
+    }
+  }, [isRedirecting]);
+
+  // Show loading state while redirecting
+  if (isRedirecting) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-circleTel-orange mx-auto mb-4"></div>
+          <p className="text-gray-600">Redirecting...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <HomeLanding20260607
+      activeSegment={activeSegment}
+      onSegmentChange={handleSegmentChange}
+    />
+  );
+}

--- a/docs/audits/2026-07-04_conversion-design-audit.md
+++ b/docs/audits/2026-07-04_conversion-design-audit.md
@@ -1,0 +1,109 @@
+# CircleTel Conversion & Design System Audit — 2026-07-04
+
+**Scope:** DESIGN.md tokens, tailwind.config.ts, homepage (`components/home/HomeLanding20260607.tsx`), package results (`app/packages/[leadId]/page.tsx`), SEO town pages (`app/locations/[town]/page.tsx`), live site metadata.
+
+**Job-to-be-Done:** *When I land on a CircleTel page from search or an ad, I want to confirm CircleTel works at my address and pick a package, so I can order internet without phoning around.*
+
+Job steps: Define (am I in the right place?) → Locate (does it cover me?) → Prepare (compare packages) → Execute (order) → Confirm.
+
+---
+
+## What's working — don't break these
+
+1. **Address-first funnel.** Homepage → coverage check → `/packages/{leadId}` filtered to what's actually available is the correct ISP conversion architecture. Most SA ISPs make users browse packages *before* the coverage check; you don't.
+2. **The token foundation is genuinely good.** A dedicated accessible orange for text (`#AE5B16`), orange reserved as the sole CTA color, WhatsApp green quarantined, one type scale. This is better discipline than most design systems.
+3. **Town SEO pages are conversion-aware**: coverage-conditional pitch, coverage badge, WhatsApp + coverage-check CTAs. This is the right template for intent-matched landings.
+4. **Segment routing** (`?segment=home|wfh|business`) and offer-slug carry exist as plumbing for traffic-source personalization.
+
+---
+
+## Findings (severity 4 = blocker … 1 = minor)
+
+### [Sev 3] Page titles/meta don't match landing intent — message match broken at the SERP
+**Job step blocked:** Define
+**Finding:** The homepage is `'use client'` with no metadata export, so every page inherits the root layout title: *"CircleTel — One Provider. One Bill. Your Office Runs."* — a B2B tagline. A consumer searching "uncapped home internet Centurion" clicks a B2B-titled result, or lands on a homepage whose hero defaults to the consumer segment while the `<title>`/SERP snippet said "office". Message mismatch between ad/SERP and page is a top documented cause of instant bounce.
+**Principle:** JTBD forces of progress — weak *pull*, raised *anxiety* ("wrong company?"); Jakob's Law (users judge in the first seconds against expectation set by the link).
+**Recommendation:** Per-route `generateMetadata` — consumer title for `/`, `/locations/*`, `/deals`; B2B title for `/business`, `/enterprise`. If SEO/ads carry `?segment=`, make the hero H1 and coverage-input placeholder match that segment *server-side* (or at least before paint), not just tab state.
+**Impact:** Lower bounce from SEO traffic; higher coverage-check starts. **Effort:** Low–medium.
+
+### [Sev 3] The hero's primary CTA scrolls to the form instead of *being* the form
+**Job step blocked:** Locate
+**Finding:** Hero CTA "Check coverage" scroll-jumps to the coverage card below the fold edge. The single business-critical action (address entry) is one interaction further than it needs to be, and on mobile the overlap card may sit fully below the fold.
+**Principle:** Fitts's Law (distance to target) + friction analysis — every extra interaction before the commitment point costs completions.
+**Recommendation:** Put the address autocomplete directly in the hero (the current floating card design works — move it up into the hero container). Keep "View packages" as secondary.
+**Impact:** More coverage checks started per visit — the top of your funnel. **Effort:** Low.
+
+### [Sev 3] Final CTA is `mailto:sales@circletel.co.za`
+**Job step blocked:** Execute
+**Finding:** The closing orange band's "Get my quote" opens the user's mail client. On mobile and on machines without a configured mail app this is a dead end; it's also untrackable and inconsistent with the WhatsApp-first support principle in DESIGN.md.
+**Principle:** Nielsen #7 (efficiency) + forces of progress (anxiety/habit — composing a cold email is high-friction); your own design rule: "Include a WhatsApp contact path on every customer-facing page."
+**Recommendation:** Replace with coverage check (consumer) or WhatsApp deep link / short lead form (business). Given the March 2026 campaign learning (leads died in follow-up), route quote requests into a tracked channel (Zoho ticket / coverage lead), never a mailbox.
+**Impact:** Recovers bottom-of-page intent that currently evaporates. **Effort:** Low.
+
+### [Sev 3] Package results page: choice overload, no guided recommendation
+**Job step blocked:** Prepare → Execute
+**Finding:** `/packages/{leadId}` shows up to 8 cards per tab across 4 service tabs (fibre/LTE/5G/wireless), and "auto-selects" the *first* package — an arbitrary default, not a recommendation. The user arrived saying "home / work-from-home / business" but that segment doesn't curate or rank the list.
+**Principle:** Hick's Law (decision time and abandonment grow with options) + Tesler's Law (the system knows the segment and address; the user shouldn't do the filtering work).
+**Recommendation:** Rank by segment fit and mark one card **"Recommended for [working from home]"** (navy featured treatment per DESIGN.md pricing-card spec). Collapse tabs the address doesn't support. Keep "show all" as the escape hatch.
+**Impact:** Faster package selection, fewer stalls at the comparison step — likely the single biggest CRO lever in the funnel. **Effort:** Medium.
+
+### [Sev 3] Two competing token systems — DESIGN.md is not what ships
+**Job step blocked:** all (indirect — consistency and iteration speed)
+**Finding:** Drift between the spec and the code:
+- DESIGN.md: page background `#F9FAFB`, "never pure white". Homepage: `bg-white`.
+- Ad-hoc colors not in any token set: `#F3F7FF`, `#DDE8FF` (business-proof section).
+- `tailwind.config.ts` carries a whole **`webafrica` palette (pink!)**, "Secondary Palette" oranges (`burnt/warm/bright-orange`), legacy aliases, plus a parallel `ui.*` scale duplicating DESIGN.md's neutrals.
+- Buttons: DESIGN.md says `rounded-xl` (20px); homepage uses `rounded-full` everywhere.
+- H1: spec 3.75rem/700; homepage 5.375rem/extrabold/-0.04em.
+**Principle:** Nielsen #4 (consistency); your own Rule 7 (one pattern, never a blend). Every drift makes the next page a coin-flip and makes A/B iteration noisy.
+**Recommendation:** Decide which is canonical (the shipped homepage look is stronger — extrabold, rounded-full, tighter tracking), update DESIGN.md to match, then delete `webafrica`, secondary oranges, and legacy aliases from tailwind config so agents *can't* pick the wrong token. Add `#F3F7FF`/`#DDE8FF` as named tokens or replace with `primary-light`/neutral.
+**Impact:** Consistent pages, cheaper/faster CRO experiments, on-brand agent output. **Effort:** Medium (mostly deletion).
+
+### [Sev 2] Coverage-check failure = browser `alert()`
+**Job step blocked:** Locate (error path)
+**Finding:** `alert('Coverage check failed. Please try again.')` — no diagnosis, no alternative path, and the lead is lost.
+**Principle:** Nielsen #9 (error recovery). Errors at the funnel's first commitment point deserve the most care, not the least.
+**Recommendation:** Inline error state on the form with a WhatsApp fallback ("Can't check right now — WhatsApp us your address and we'll confirm within the hour") so a system failure still captures the lead.
+**Impact:** Converts outage minutes into leads instead of bounces. **Effort:** Low.
+
+### [Sev 2] Hero copy sells effort, not the offer
+**Job step blocked:** Define
+**Finding:** "Internet that works as hard as you do" is mood copy; price/speed anchors are below two full sections. SA ISP shoppers compare on **price × speed × uncapped × no contract** — your subhead has three of these but no price anchor.
+**Principle:** Front-load value (first words carry the scan); forces of progress — a concrete offer strengthens *pull*.
+**Recommendation:** Test a concrete hero: "Uncapped home internet from **R899/mo** — no contracts, R0 setup." Keep the current line as the business-segment variant.
+**Impact:** Stronger SERP-to-hero scent, more coverage checks. **Effort:** Trivial (A/B — the `ab-test-setup` skill applies).
+
+### [Sev 2] No WhatsApp path on the homepage
+**Finding:** Town pages have WhatsApp CTAs; the homepage (per code read) has none — despite DESIGN.md mandating one on every customer-facing page and WhatsApp being your proven-cheapest channel (R41.80/conversation).
+**Recommendation:** Ship the DESIGN.md floating WhatsApp button (fixed bottom-right, `#25D366`) site-wide via the marketing layout.
+**Effort:** Trivial.
+
+### [Sev 1] Segment/offer personalization is plumbing without payoff
+`?offer=` slug goes to sessionStorage and the lead API ignores it (Plan 3 pending); segment changes only the input placeholder. Fine to defer, but note: attribution you don't persist can't inform the follow-up problem that killed the March campaign. Bump Plan 3's priority.
+
+---
+
+## Prioritized plan
+
+**Fix now (low effort, direct funnel impact)**
+1. Replace `mailto:` CTA with tracked channel (Sev 3)
+2. Address input into the hero (Sev 3)
+3. Per-route metadata / message match (Sev 3)
+4. WhatsApp float site-wide (Sev 2)
+5. Inline coverage-check error with WhatsApp fallback (Sev 2)
+
+**Plan next (high impact, medium effort)**
+6. Recommended-package ranking on `/packages/{leadId}` (Sev 3)
+7. Token reconciliation: canonicalize shipped style into DESIGN.md, purge webafrica/legacy palettes (Sev 3)
+
+**Quick wins (batch)**
+8. Hero price-anchor copy A/B (Sev 2)
+9. Persist offer slug on the lead (Sev 1 → feeds follow-up automation)
+
+**Reconsider / defer**
+- Full visual redesign or new palette: **not needed.** The orange/navy system is distinctive and conversion-appropriate (high-contrast single CTA color). The problem is drift and funnel mechanics, not the design language.
+
+## Not verifiable from code — check in analytics/testing
+- Actual fold position of the coverage card on common mobile viewports
+- Whether GA4/conversion events fire on coverage-check start/complete and package select (no tracking calls seen in the audited components)
+- Real bounce rate by landing page × source to confirm the message-match finding


### PR DESCRIPTION
## Summary

Implements the "fix now" batch from the conversion/design audit (`docs/audits/2026-07-04_conversion-design-audit.md`), plus two follow-ups found during staging review. All changes verified on staging.

### 1. Message match — consumer metadata on `/` (cdd2aede)
- `app/(marketing)/page.tsx` split into a server page + `components/home/HomePageClient.tsx`
- Homepage gets consumer-first title/OG/Twitter: *"Uncapped Fibre & Wireless Internet from R899/mo"* — overrides the B2B default that previously served SEO traffic a mismatched title
- `offerSlugFromParams` moved with the client code; test import updated

### 2. Coverage form in the hero (cdd2aede)
- Address input + "Find my plan" now render inside the hero, above the fold on desktop and mobile
- Redundant "Check coverage" scroll button removed; "View packages" kept as secondary CTA

### 3. Error recovery + tracked CTAs (cdd2aede)
- Coverage-check failure: browser `alert()` replaced with an inline error + WhatsApp fallback pre-filled with the typed address (captures the lead even during an outage)
- Closing-band `mailto:sales@` CTA replaced with `getWhatsAppLink()` per the contact-details rule

### 4. WhatsApp float overlap fix (2ac13923)
- Reported from a real device: the float covered "Find my plan" on mobile
- Float now hides via IntersectionObserver while `#coverage-checker` is in view, fades back after scrolling past

### 5. Segment-aware closing CTA band (9cdcca29)
- home: "Uncapped internet, sorted this week." + no-contract risk reversal, coverage-first CTA
- wfh: dropped-call pain headline, same CTA pair
- business: "One provider. One bill. Your office runs." + WhatsApp quote CTA
- Fixes the copy/CTA mismatch (sub said "check coverage", button offered a quote)

## Verification
- `__tests__/app/home-offer-attribution.test.ts` passes
- Type-check clean on all touched files (repo's pre-existing errors untouched)
- All three segments verified rendering correct copy/CTAs on staging (desktop + 390x844 mobile viewport)
- Known non-issue: dev-only hydration warning from the Zoho cookie-banner script racing Next dev streaming — reproduces on untouched pages (e.g. /check-coverage) and does not occur in production builds


- Branch is based on `origin/staging` (not main) so the staging push was a fast-forward that preserved the unmerged billing/vetting/coverage-segment work already on staging. Merging to main will bring ONLY the 3 homepage commits if done after those staging commits merge — otherwise this PR's diff vs main will show the staging commits too. If the billing/vetting work isn't ready for main, say so and I'll rebase this branch onto origin/main instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVc3gj4aMuFjvUuQYdCcni
## Notes for reviewer
Branch was rebased onto `origin/main` after the billing/vetting staging work merged via PRs #593–#599 — this PR now contains only the 3 homepage commits. Staging still runs the same changes (deployed and verified there first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVc3gj4aMuFjvUuQYdCcni