### PR TITLE
fix(homepage): remove refund/SLA-implying claims from closing band copy

### DIFF
--- a/components/home/HomeLanding20260607.tsx
+++ b/components/home/HomeLanding20260607.tsx
@@ -109,12 +109,12 @@ const BUSINESS_PROOF = [
 
 const CLOSING_CTA: Record<SegmentType, { headline: string; sub: string }> = {
   home: {
-    headline: 'Uncapped internet, sorted this week.',
-    sub: 'Check your address, pick your plan, and we handle the install. No contracts, R0 setup — if you’re not happy, you can walk away anytime.',
+    headline: 'Uncapped internet, minus the runaround.',
+    sub: 'Check your address, pick your plan, and we handle the install. Month-to-month plans with no long-term contracts.',
   },
   wfh: {
     headline: 'Never say “sorry, my internet dropped” again.',
-    sub: 'Check your address, pick your plan, and we handle the install. No contracts, R0 setup — and support that answers when your workday depends on it.',
+    sub: 'Check your address, pick your plan, and we handle the install. Month-to-month plans — and support that answers when your workday depends on it.',
   },
   business: {
     headline: 'One provider. One bill. Your office runs.',


### PR DESCRIPTION
## Summary
The closing band copy shipped in #602 made commercial promises with real cost exposure, flagged by Jeffrey:
- "walk away anytime" — reads as an unconditional refund right (invites cancellations after install costs are sunk, pro-rata disputes)
- "R0 setup" — blanket fee waiver across all products
- "sorted this week" — an install SLA we don't control

Replaced with claims that are structurally true: **month-to-month plans, no long-term contracts**. One file, copy-only, no logic changes.

Note: staging was NOT updated for this fix — it has diverged with unmerged work (offers/R149/publishing) and a non-FF push was blocked. Production is the exposure; this goes straight to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVc3gj4aMuFjvUuQYdCcni