### PR TITLE
Salvage: portal console shell + docs + DB/CI fixes from stranded local branch

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -6,19 +6,37 @@ Scope: Superpowers-gated workflow pipeline, blast radius minimization, confirm-b
 
 ## Superpowers Pipeline (MANDATORY)
 
-Every task flows through 6 stages. Each stage has a mandatory skill gate — you MUST invoke the skill via the `Skill` tool before proceeding. Skipping a gate is a rule violation equivalent to writing placeholder code.
+Every task flows through these stages. Each stage has a mandatory gate — you MUST satisfy it before proceeding. Skipping a gate is a rule violation equivalent to writing placeholder code.
 
 ```
-START → PLAN → IMPLEMENT → VERIFY → SHIP → LEARN
-  |       |        |          |        |       |
-  v       v        v          v        v       v
- brainstorming  writing-plans  TDD    verification  finishing-branch  compound
- debugging      executing-plans  parallel-agents  code-review
+BRANCH → START → PLAN → IMPLEMENT → VERIFY → SHIP → LEARN
+   |       |       |        |          |        |       |
+   v       v       v        v          v        v       v
+ clean   brainstorming  writing-plans  TDD    verification  finishing-branch  compound
+ branch  debugging      executing-plans  parallel-agents  code-review
 ```
+
+### Stage 0: BRANCH — Isolate the Work (MANDATORY)
+
+**Before reading files or writing a single line, guarantee a clean, dedicated branch.**
+
+Never commit feature or fix work onto `main` or `staging` — both are deploy targets. One branch = one logical change; don't pile unrelated work onto an existing feature branch.
+
+1. **Check current state**: `git branch --show-current` and `git status --short`.
+2. **Tree must be clean before branching.** If there are uncommitted changes that don't belong to this task, stop and ask — stash or commit them first. Do not branch on top of a dirty, unrelated tree.
+3. **If on `main`/`staging`, or on a branch unrelated to this task, create a fresh branch off up-to-date `main`:**
+   ```bash
+   git checkout main && git pull
+   git checkout -b <prefix>/<short-kebab-description>
+   ```
+4. **Branch prefix** (match existing history): `feat/` · `fix/` · `docs/` · `chore/` · `refactor/`.
+5. **For work that must stay isolated from an in-progress branch**, prefer a git worktree — **INVOKE `superpowers:using-git-worktrees`** instead of switching branches in place.
+
+Skipping this gate pollutes the active branch and tree, exactly as a stray uncommitted file does. Treat it as a rule violation.
 
 ### Stage 1: START — Understand & Design
 
-**Before ANY work begins:**
+**Before ANY work begins (on the branch created in Stage 0):**
 
 1. Read all relevant files
 2. **INVOKE `superpowers:brainstorming`** for new features/pages/components

--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -64,7 +64,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Check admin user exists
         run: node scripts/check-admin-user.js
@@ -121,7 +121,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Start test server
         run: |
@@ -207,7 +207,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Run type check (auth files only)
         run: npx tsc --noEmit lib/auth/**/*.ts lib/supabase/**/*.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ No "it should work" — prove it works
 9. **Confirm understanding** — Ask questions when requirements are unclear.
 10. **Know the system** — Read `docs/architecture/SYSTEM_OVERVIEW.md` first.
 11. **Respect file placement** — See `.claude/rules/file-organization.md`.
+12. **Branch first** — Create a dedicated `feat/|fix/|docs/|chore/` branch off a clean tree before any new work; never commit feature/fix work onto `main` or `staging`. See `.claude/rules/workflow.md` (Stage 0).
 
 **Remember: Think first, explain second, code third.**
 
@@ -99,6 +100,7 @@ No "it should work" — prove it works
 
 ## Workflow Rules
 
+- **Branch before you build.** Before reading or writing anything for a new feature/fix, confirm the tree is clean and you're on a dedicated branch (`feat/|fix/|docs/|chore/<short-kebab>` off up-to-date `main`). Never work directly on `main` or `staging`. If the tree has unrelated uncommitted changes, stop and ask before branching. This is Stage 0 of the pipeline — see `.claude/rules/workflow.md`.
 - Before writing any code, read the files you intend to modify and their immediate callers.
 - If a task touches more than one file, enter Plan Mode first. Do not skip this.
 - State your assumptions explicitly before proceeding. If uncertain, ask — do not guess.

--- a/app/admin/AdminLayoutClient.tsx
+++ b/app/admin/AdminLayoutClient.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { Sidebar } from '@/components/admin/layout/Sidebar';
 import { AdminHeader } from '@/components/admin/layout/AdminHeader';
+import { ConsoleShell } from '@/components/backend';
 import { createClient } from '@/lib/supabase/client';
 import dynamic from 'next/dynamic';
 
@@ -144,40 +145,39 @@ export default function AdminLayout({
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col lg:flex-row print:block">
-      {/* Sidebar - Hidden on mobile when closed, overlay when open */}
-      <Sidebar
-        isOpen={sidebarOpen}
-        onToggle={() => setSidebarOpen(!sidebarOpen)}
-        user={user}
-      />
-
-      {/* Mobile backdrop overlay */}
-      {sidebarOpen && (
-        <div
-          className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden"
-          onClick={() => setSidebarOpen(false)}
-        />
-      )}
-
-      {/* Main content - Full width on mobile, adjusted for sidebar on desktop */}
-      <div className="flex-1 flex flex-col min-h-screen w-full lg:ml-0">
-        <AdminHeader
-          onMenuClick={() => setSidebarOpen(!sidebarOpen)}
-          user={user}
-          onLogout={handleLogout}
-          sidebarOpen={sidebarOpen}
-        />
-
-        <main className="flex-1 p-4 sm:p-6 lg:p-8 w-full">
-          <div className="max-w-full mx-auto">
-            {children}
-          </div>
-        </main>
-      </div>
+    <>
+      <ConsoleShell
+        sidebar={
+          <>
+            <Sidebar
+              isOpen={sidebarOpen}
+              onToggle={() => setSidebarOpen(!sidebarOpen)}
+              user={user}
+            />
+            {sidebarOpen && (
+              <div
+                className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+                onClick={() => setSidebarOpen(false)}
+              />
+            )}
+          </>
+        }
+        topbar={
+          <AdminHeader
+            onMenuClick={() => setSidebarOpen(!sidebarOpen)}
+            user={user}
+            onLogout={handleLogout}
+            sidebarOpen={sidebarOpen}
+          />
+        }
+        mainClassName="w-full"
+        contentClassName="w-full"
+      >
+        <div className="mx-auto max-w-full">{children}</div>
+      </ConsoleShell>
 
       {/* Agentation: Visual UI feedback for AI coding agents (dev-only) */}
       {process.env.NODE_ENV === 'development' && <Agentation />}
-    </div>
+    </>
   );
 }

--- a/app/business/dashboard/layout.tsx
+++ b/app/business/dashboard/layout.tsx
@@ -19,6 +19,7 @@ import {
   BusinessDashboardSidebar,
   BusinessMobileNav,
 } from '@/components/business-dashboard/navigation';
+import { ConsoleShell } from '@/components/backend';
 
 export default function BusinessDashboardLayout({
   children,
@@ -104,62 +105,58 @@ export default function BusinessDashboardLayout({
     (currentUser?.user_metadata as any)?.company_name || 'Your Business';
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
-      {/* Header */}
-      <BusinessDashboardHeader
-        displayName={displayName}
-        companyName={companyName}
-        email={currentUser?.email || ''}
-        onSignOut={handleSignOut}
-      />
-
-      {/* Main content area */}
-      <div className="flex flex-1">
-        {/* Sidebar - desktop only */}
-        <BusinessDashboardSidebar
-          collapsed={sidebarCollapsed}
-          onToggleCollapse={handleSidebarToggle}
-        />
-
-        {/* Page content */}
-        <main className="flex-1 min-w-0">
-          <div className="p-4 sm:p-6 lg:p-8 pb-24 lg:pb-8">
-            <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
-          </div>
-        </main>
-      </div>
-
-      {/* Footer - hidden on mobile */}
-      <footer className="hidden lg:block border-t bg-white/80 backdrop-blur-sm mt-auto">
-        <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-gray-600">
-            <p>&copy; 2025 CircleTel Business. All rights reserved.</p>
-            <div className="flex gap-6">
-              <Link
-                href="/privacy-policy"
-                className="hover:text-circleTel-orange transition-colors"
-              >
-                Privacy Policy
-              </Link>
-              <Link
-                href="/terms-of-service"
-                className="hover:text-circleTel-orange transition-colors"
-              >
-                Terms of Service
-              </Link>
-              <Link
-                href="/contact"
-                className="hover:text-circleTel-orange transition-colors"
-              >
-                Contact Us
-              </Link>
+    <>
+      <ConsoleShell
+        topbar={
+          <BusinessDashboardHeader
+            displayName={displayName}
+            companyName={companyName}
+            email={currentUser?.email || ''}
+            onSignOut={handleSignOut}
+          />
+        }
+        sidebar={
+          <BusinessDashboardSidebar
+            collapsed={sidebarCollapsed}
+            onToggleCollapse={handleSidebarToggle}
+          />
+        }
+        contentClassName="pb-24 lg:pb-8"
+        footer={
+          <footer className="hidden border-t bg-white/80 backdrop-blur-sm lg:block">
+            <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
+              <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-gray-600">
+                <p>&copy; 2025 CircleTel Business. All rights reserved.</p>
+                <div className="flex gap-6">
+                  <Link
+                    href="/privacy-policy"
+                    className="hover:text-circleTel-orange transition-colors"
+                  >
+                    Privacy Policy
+                  </Link>
+                  <Link
+                    href="/terms-of-service"
+                    className="hover:text-circleTel-orange transition-colors"
+                  >
+                    Terms of Service
+                  </Link>
+                  <Link
+                    href="/contact"
+                    className="hover:text-circleTel-orange transition-colors"
+                  >
+                    Contact Us
+                  </Link>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      </footer>
+          </footer>
+        }
+      >
+        <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
+      </ConsoleShell>
 
       {/* Mobile bottom navigation */}
       <BusinessMobileNav />
-    </div>
+    </>
   );
 }

--- a/app/dashboard/DashboardLayoutClient.tsx
+++ b/app/dashboard/DashboardLayoutClient.tsx
@@ -11,6 +11,7 @@ import {
   MobileBottomNav,
   DashboardNavProvider,
 } from '@/components/dashboard/navigation';
+import { ConsoleShell } from '@/components/backend';
 
 export default function DashboardLayout({
   children,
@@ -144,62 +145,58 @@ export default function DashboardLayout({
 
   return (
     <DashboardNavProvider>
-      <div className="min-h-screen bg-gray-50 flex flex-col">
-        {/* Header with tabs (desktop) */}
-        <DashboardHeader
-          displayName={displayName}
-          email={currentUser?.email || ''}
-          onSignOut={handleSignOut}
-        />
-
-        {/* Main content area */}
-        <div className="flex flex-1">
-          {/* Context-aware sidebar - desktop only */}
-          <DashboardSidebar
-            collapsed={sidebarCollapsed}
-            onToggleCollapse={handleSidebarToggle}
-          />
-
-          {/* Page content */}
-          <main className="flex-1 min-w-0">
-            <div className="p-4 sm:p-6 lg:p-8 pb-24 lg:pb-8">
-              <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
-            </div>
-          </main>
-        </div>
-
-        {/* Footer - hidden on mobile to avoid overlap with bottom nav */}
-        <footer className="hidden lg:block border-t bg-white/80 backdrop-blur-sm mt-auto">
-          <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
-            <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-circleTel-secondaryNeutral">
-              <p>&copy; 2025 CircleTel. All rights reserved.</p>
-              <div className="flex gap-6">
-                <Link
-                  href="/privacy-policy"
-                  className="hover:text-circleTel-orange transition-colors"
-                >
-                  Privacy Policy
-                </Link>
-                <Link
-                  href="/terms-of-service"
-                  className="hover:text-circleTel-orange transition-colors"
-                >
-                  Terms of Service
-                </Link>
-                <Link
-                  href="/contact"
-                  className="hover:text-circleTel-orange transition-colors"
-                >
-                  Contact Us
-                </Link>
+      <>
+        <ConsoleShell
+          topbar={
+            <DashboardHeader
+              displayName={displayName}
+              email={currentUser?.email || ''}
+              onSignOut={handleSignOut}
+            />
+          }
+          sidebar={
+            <DashboardSidebar
+              collapsed={sidebarCollapsed}
+              onToggleCollapse={handleSidebarToggle}
+            />
+          }
+          contentClassName="pb-24 lg:pb-8"
+          footer={
+            <footer className="hidden border-t bg-white/80 backdrop-blur-sm lg:block">
+              <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
+                <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-circleTel-secondaryNeutral">
+                  <p>&copy; 2025 CircleTel. All rights reserved.</p>
+                  <div className="flex gap-6">
+                    <Link
+                      href="/privacy-policy"
+                      className="hover:text-circleTel-orange transition-colors"
+                    >
+                      Privacy Policy
+                    </Link>
+                    <Link
+                      href="/terms-of-service"
+                      className="hover:text-circleTel-orange transition-colors"
+                    >
+                      Terms of Service
+                    </Link>
+                    <Link
+                      href="/contact"
+                      className="hover:text-circleTel-orange transition-colors"
+                    >
+                      Contact Us
+                    </Link>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        </footer>
+            </footer>
+          }
+        >
+          <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
+        </ConsoleShell>
 
         {/* Mobile bottom navigation */}
         <MobileBottomNav />
-      </div>
+      </>
     </DashboardNavProvider>
   );
 }

--- a/app/partner/PartnerLayoutClient.tsx
+++ b/app/partner/PartnerLayoutClient.tsx
@@ -9,6 +9,7 @@ import {
   PartnerSidebar,
   PartnerMobileNav,
 } from '@/components/partners/navigation';
+import { ConsoleShell } from '@/components/backend';
 
 interface Partner {
   id: string;
@@ -180,31 +181,29 @@ export default function PartnersLayout({
   // Approved partner - show full portal
   return (
     <PartnerNavProvider>
-      <div className="min-h-screen bg-gray-50 flex flex-col">
-        {/* Header with tabs (desktop) */}
-        <PartnerHeader
-          displayName={displayName}
-          email={partner.email || user?.email || ''}
-          onSignOut={handleSignOut}
-        />
-
-        {/* Main content area */}
-        <div className="flex flex-1">
-          {/* Context-aware sidebar - desktop only */}
-          <PartnerSidebar
-            collapsed={sidebarCollapsed}
-            onToggleCollapse={handleSidebarToggle}
-          />
-
-          {/* Page content */}
-          <main className="flex-1 min-w-0">
-            <div className="p-4 sm:p-6 lg:p-8 pb-24 lg:pb-8">{children}</div>
-          </main>
-        </div>
+      <>
+        <ConsoleShell
+          topbar={
+            <PartnerHeader
+              displayName={displayName}
+              email={partner.email || user?.email || ''}
+              onSignOut={handleSignOut}
+            />
+          }
+          sidebar={
+            <PartnerSidebar
+              collapsed={sidebarCollapsed}
+              onToggleCollapse={handleSidebarToggle}
+            />
+          }
+          contentClassName="pb-24 lg:pb-8"
+        >
+          {children}
+        </ConsoleShell>
 
         {/* Mobile bottom navigation */}
         <PartnerMobileNav />
-      </div>
+      </>
     </PartnerNavProvider>
   );
 }

--- a/app/portal/PortalLayoutClient.tsx
+++ b/app/portal/PortalLayoutClient.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { PortalAuthProvider, usePortalAuth } from '@/lib/portal/portal-auth-provider';
+import { ConsoleShell } from '@/components/backend';
 import {
   PiSquaresFourBold,
   PiBuildings,
@@ -184,24 +185,26 @@ function PortalContent({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <PortalNav />
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {children}
-      </main>
-      <footer className="border-t bg-white mt-auto">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex flex-col sm:flex-row justify-between items-center gap-4 text-sm text-gray-500">
-            <p>&copy; 2026 CircleTel. All rights reserved.</p>
-            <div className="flex gap-6">
-              <Link href="/privacy-policy" className="hover:text-circleTel-orange">Privacy Policy</Link>
-              <Link href="/terms-of-service" className="hover:text-circleTel-orange">Terms of Service</Link>
-              <Link href="/contact" className="hover:text-circleTel-orange">Support</Link>
+    <ConsoleShell
+      topbar={<PortalNav />}
+      contentClassName="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8"
+      footer={
+        <footer className="mt-auto border-t bg-white">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+            <div className="flex flex-col sm:flex-row justify-between items-center gap-4 text-sm text-gray-500">
+              <p>&copy; 2026 CircleTel. All rights reserved.</p>
+              <div className="flex gap-6">
+                <Link href="/privacy-policy" className="hover:text-circleTel-orange">Privacy Policy</Link>
+                <Link href="/terms-of-service" className="hover:text-circleTel-orange">Terms of Service</Link>
+                <Link href="/contact" className="hover:text-circleTel-orange">Support</Link>
+              </div>
             </div>
           </div>
-        </div>
-      </footer>
-    </div>
+        </footer>
+      }
+    >
+      {children}
+    </ConsoleShell>
   );
 }
 

--- a/components/backend/ActivityTimeline.tsx
+++ b/components/backend/ActivityTimeline.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export interface ActivityTimelineItem {
+  id: string;
+  title: string;
+  description?: React.ReactNode;
+  timestamp?: string;
+  category?: string;
+  icon?: React.ReactNode;
+}
+
+interface ActivityTimelineProps {
+  items: ActivityTimelineItem[];
+  emptyLabel?: string;
+  className?: string;
+}
+
+export function ActivityTimeline({ items, emptyLabel = 'No activity yet', className }: ActivityTimelineProps) {
+  if (items.length === 0) {
+    return <p className={cn('py-6 text-sm text-gray-500', className)}>{emptyLabel}</p>;
+  }
+
+  return (
+    <ol className={cn('space-y-0', className)}>
+      {items.map((item, index) => (
+        <li key={item.id} className="relative flex gap-3 pb-5 last:pb-0">
+          {index < items.length - 1 && <span className="absolute left-4 top-8 h-full w-px bg-gray-200" aria-hidden="true" />}
+          <div className="z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+            {item.icon ?? <span className="h-2 w-2 rounded-full bg-current" />}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-sm font-semibold text-gray-900">{item.title}</p>
+              {item.category && <span className="text-xs text-gray-500">{item.category}</span>}
+            </div>
+            {item.timestamp && <p className="mt-0.5 text-xs text-gray-500">{item.timestamp}</p>}
+            {item.description && <div className="mt-2 text-sm text-gray-600">{item.description}</div>}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/components/backend/ChartPanel.tsx
+++ b/components/backend/ChartPanel.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { PiCaretRightBold } from 'react-icons/pi';
+import { cn } from '@/lib/utils';
+
+interface ChartPanelProps {
+  title: string;
+  subtitle?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function ChartPanel({ title, subtitle, action, children, className }: ChartPanelProps) {
+  return (
+    <section className={cn('min-h-[240px] rounded-lg border border-gray-200 bg-white shadow-sm', className)}>
+      <div className="flex items-start justify-between gap-4 px-4 py-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-sm font-semibold text-gray-950">{title}</h2>
+          {subtitle && <p className="mt-0.5 truncate text-xs text-gray-500">{subtitle}</p>}
+        </div>
+        {action ?? <PiCaretRightBold className="mt-0.5 h-4 w-4 shrink-0 text-gray-500" />}
+      </div>
+      <div className="px-4 pb-4">{children}</div>
+    </section>
+  );
+}

--- a/components/backend/ConsoleNav.tsx
+++ b/components/backend/ConsoleNav.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { PiCaretRightBold } from 'react-icons/pi';
+import { cn } from '@/lib/utils';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import type { ConsoleNavItem, ConsoleNavSection } from './console-types';
+import { isConsoleNavItemActive } from './console-utils';
+
+interface ConsoleNavProps {
+  sections: ConsoleNavSection[];
+  collapsed?: boolean;
+  header?: React.ReactNode;
+  footer?: React.ReactNode;
+  className?: string;
+}
+
+function NavItem({ item, collapsed, pathname }: { item: ConsoleNavItem; collapsed?: boolean; pathname: string }) {
+  const active = isConsoleNavItemActive(pathname, item);
+  const Icon = item.icon;
+  const hasChildren = !!item.children?.length;
+
+  const content = (
+    <Link
+      href={item.disabled || !item.href ? '#' : item.href}
+      aria-disabled={item.disabled}
+      className={cn(
+        'group flex min-h-9 items-center rounded-md px-2.5 py-2 text-sm font-medium outline-none transition',
+        collapsed ? 'justify-center' : 'gap-2.5',
+        active
+          ? 'bg-gray-100 text-gray-950'
+          : 'text-gray-600 hover:bg-gray-50 hover:text-gray-950 focus-visible:bg-gray-50 focus-visible:ring-2 focus-visible:ring-circleTel-orange/25',
+        item.disabled && 'pointer-events-none opacity-50'
+      )}
+    >
+      {Icon && (
+        <Icon
+          className={cn(
+            'h-4 w-4 shrink-0',
+            active ? 'text-gray-950' : 'text-gray-500 group-hover:text-gray-800'
+          )}
+        />
+      )}
+      {!collapsed && (
+        <>
+          <span className="min-w-0 flex-1 truncate">{item.label}</span>
+          {item.badge && (
+            <span className="rounded-full bg-circleTel-orange-light px-2 py-0.5 text-xs font-semibold text-circleTel-orange-accessible">
+              {item.badge}
+            </span>
+          )}
+          {hasChildren && <PiCaretRightBold className="h-3.5 w-3.5 text-gray-400" />}
+        </>
+      )}
+    </Link>
+  );
+
+  if (!collapsed) {
+    return content;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{content}</TooltipTrigger>
+      <TooltipContent side="right" sideOffset={8} className="font-medium">
+        {item.label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function ConsoleNav({ sections, collapsed, header, footer, className }: ConsoleNavProps) {
+  const pathname = usePathname();
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <aside
+        className={cn(
+          'hidden shrink-0 border-r border-gray-200 bg-white transition-all duration-200 lg:flex lg:flex-col print:hidden',
+          collapsed ? 'w-16' : 'w-60',
+          className
+        )}
+      >
+        {header && <div className="border-b border-gray-100 p-3">{header}</div>}
+        <nav className="min-h-0 flex-1 overflow-y-auto p-2">
+          {sections.map((section, sectionIndex) => (
+            <div key={section.label ?? `section-${sectionIndex}`} className={cn(sectionIndex > 0 && 'mt-4')}>
+              {section.label && !collapsed && (
+                <p className="px-2.5 pb-1.5 pt-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+                  {section.label}
+                </p>
+              )}
+              <div className="space-y-1">
+                {section.items.map((item) => (
+                  <div key={`${section.label ?? 'main'}-${item.label}`}>
+                    <NavItem item={item} collapsed={collapsed} pathname={pathname} />
+                    {!collapsed && item.children?.length && isConsoleNavItemActive(pathname, item) && (
+                      <div className="ml-4 mt-1 space-y-1 border-l border-gray-100 pl-2">
+                        {item.children.map((child) => (
+                          <NavItem key={child.label} item={child} pathname={pathname} />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </nav>
+        {footer && <div className="border-t border-gray-100 p-3">{footer}</div>}
+      </aside>
+    </TooltipProvider>
+  );
+}

--- a/components/backend/ConsoleShell.tsx
+++ b/components/backend/ConsoleShell.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface ConsoleShellProps {
+  topbar?: React.ReactNode;
+  sidebar?: React.ReactNode;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  className?: string;
+  mainClassName?: string;
+  contentClassName?: string;
+}
+
+export function ConsoleShell({
+  topbar,
+  sidebar,
+  children,
+  footer,
+  className,
+  mainClassName,
+  contentClassName,
+}: ConsoleShellProps) {
+  return (
+    <div className={cn('min-h-screen bg-gray-50 text-gray-900 flex flex-col lg:flex-row print:block', className)}>
+      {sidebar}
+      <div className="flex min-h-screen min-w-0 flex-1 flex-col">
+        {topbar}
+        <main className={cn('min-w-0 flex-1', mainClassName)}>
+          <div className={cn('p-4 sm:p-6 lg:p-8', contentClassName)}>{children}</div>
+        </main>
+        {footer}
+      </div>
+    </div>
+  );
+}

--- a/components/backend/ConsoleTopbar.tsx
+++ b/components/backend/ConsoleTopbar.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { PiMagnifyingGlassBold } from 'react-icons/pi';
+import { cn } from '@/lib/utils';
+
+interface ConsoleTopbarProps {
+  brand?: React.ReactNode;
+  title?: string;
+  subtitle?: string;
+  leadingAction?: React.ReactNode;
+  center?: React.ReactNode;
+  actions?: React.ReactNode;
+  searchPlaceholder?: string;
+  showSearch?: boolean;
+  className?: string;
+}
+
+export function ConsoleTopbar({
+  brand,
+  title,
+  subtitle,
+  leadingAction,
+  center,
+  actions,
+  searchPlaceholder = 'Search...',
+  showSearch = true,
+  className,
+}: ConsoleTopbarProps) {
+  return (
+    <header className={cn('sticky top-0 z-40 border-b border-gray-200 bg-white print:hidden', className)}>
+      <div className="flex h-14 items-center gap-3 px-4 sm:px-6 lg:px-8">
+        {leadingAction}
+        {brand}
+        {(title || subtitle) && (
+          <div className="min-w-0">
+            {title && <h1 className="truncate text-sm font-semibold text-gray-900">{title}</h1>}
+            {subtitle && <p className="hidden truncate text-xs text-gray-500 sm:block">{subtitle}</p>}
+          </div>
+        )}
+        {center && <div className="hidden min-w-0 flex-1 justify-center lg:flex">{center}</div>}
+        {showSearch && (
+          <div className="ml-auto hidden w-full max-w-sm md:block">
+            <label className="relative block">
+              <span className="sr-only">Search</span>
+              <PiMagnifyingGlassBold className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+              <input
+                type="search"
+                placeholder={searchPlaceholder}
+                className="h-9 w-full rounded-md border border-gray-200 bg-gray-50 pl-9 pr-3 text-sm outline-none transition focus:border-circleTel-orange focus:ring-2 focus:ring-circleTel-orange/15"
+              />
+            </label>
+          </div>
+        )}
+        {actions && <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>}
+      </div>
+    </header>
+  );
+}

--- a/components/backend/DataTable.tsx
+++ b/components/backend/DataTable.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { PiCaretDownBold, PiCaretUpBold } from 'react-icons/pi';
+import { cn } from '@/lib/utils';
+import { EmptyState, LoadingState } from './states';
+import type { DataTableColumn, DataTableSortState } from './console-types';
+import { getNextDataTableSort } from './console-utils';
+
+interface DataTableProps<T> {
+  columns: DataTableColumn<T>[];
+  rows: T[];
+  getRowId?: (row: T, index: number) => string;
+  rowActions?: (row: T) => React.ReactNode;
+  loading?: boolean;
+  emptyTitle?: string;
+  emptyDescription?: string;
+  sort?: DataTableSortState | null;
+  onSortChange?: (sort: DataTableSortState | null) => void;
+  className?: string;
+}
+
+function alignmentClass(align?: DataTableColumn<unknown>['align']) {
+  if (align === 'right') return 'text-right';
+  if (align === 'center') return 'text-center';
+  return 'text-left';
+}
+
+export function DataTable<T>({
+  columns,
+  rows,
+  getRowId,
+  rowActions,
+  loading,
+  emptyTitle = 'No records found',
+  emptyDescription,
+  sort = null,
+  onSortChange,
+  className,
+}: DataTableProps<T>) {
+  const hasActions = !!rowActions;
+
+  return (
+    <div className={cn('overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm', className)}>
+      {loading ? (
+        <LoadingState message="Loading records..." className="min-h-[240px]" />
+      ) : rows.length === 0 ? (
+        <EmptyState title={emptyTitle} description={emptyDescription} icon={<span aria-hidden />} className="text-xs" />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full caption-bottom text-sm">
+            <thead className="border-b border-gray-200 bg-gray-50">
+              <tr>
+                {columns.map((column) => {
+                  const activeSort = sort?.columnId === column.id ? sort.direction : null;
+                  const SortIcon = activeSort === 'asc' ? PiCaretUpBold : PiCaretDownBold;
+                  const sortable = column.sortable && !!onSortChange;
+
+                  return (
+                    <th
+                      key={column.id}
+                      className={cn(
+                        'h-10 whitespace-nowrap px-3 text-xs font-semibold text-gray-500',
+                        alignmentClass(column.align),
+                        column.headerClassName
+                      )}
+                    >
+                      {sortable ? (
+                        <button
+                          type="button"
+                          onClick={() => onSortChange?.(getNextDataTableSort(sort, column.id))}
+                          className={cn(
+                            'inline-flex items-center gap-1 rounded-sm outline-none transition hover:text-gray-900 focus-visible:ring-2 focus-visible:ring-circleTel-orange/25',
+                            column.align === 'right' && 'ml-auto',
+                            column.align === 'center' && 'mx-auto'
+                          )}
+                        >
+                          {column.header}
+                          <SortIcon className={cn('h-3.5 w-3.5', activeSort ? 'text-circleTel-orange' : 'text-gray-300')} />
+                        </button>
+                      ) : (
+                        column.header
+                      )}
+                    </th>
+                  );
+                })}
+                {hasActions && <th className="h-10 px-3 text-right text-xs font-semibold text-gray-500">Actions</th>}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.map((row, rowIndex) => (
+                <tr key={getRowId?.(row, rowIndex) ?? rowIndex} className="transition-colors hover:bg-gray-50">
+                  {columns.map((column) => (
+                    <td
+                      key={column.id}
+                      className={cn(
+                        'whitespace-nowrap px-3 py-2.5 text-sm text-gray-700',
+                        alignmentClass(column.align),
+                        column.className
+                      )}
+                    >
+                      {column.cell?.(row) ?? column.accessor?.(row) ?? null}
+                    </td>
+                  ))}
+                  {hasActions && <td className="whitespace-nowrap px-3 py-2.5 text-right">{rowActions?.(row)}</td>}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/backend/EntityHeader.tsx
+++ b/components/backend/EntityHeader.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Link from 'next/link';
+import { PiCaretRightBold } from 'react-icons/pi';
+import { cn } from '@/lib/utils';
+import { StatusBadge, type StatusVariant } from './StatusBadge';
+
+interface EntityHeaderBreadcrumb {
+  label: string;
+  href?: string;
+}
+
+interface EntityHeaderProps {
+  breadcrumbs?: EntityHeaderBreadcrumb[];
+  title: string;
+  eyebrow?: string;
+  meta?: React.ReactNode;
+  status?: { label: string; variant?: StatusVariant };
+  tabs?: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function EntityHeader({
+  breadcrumbs,
+  title,
+  eyebrow,
+  meta,
+  status,
+  tabs,
+  actions,
+  className,
+}: EntityHeaderProps) {
+  return (
+    <header className={cn('border-b border-gray-200 bg-white', className)}>
+      <div className="px-4 py-4 sm:px-6 lg:px-8">
+        {breadcrumbs?.length ? (
+          <nav aria-label="Breadcrumb" className="mb-3">
+            <ol className="flex flex-wrap items-center gap-1.5 text-xs font-medium text-gray-500">
+              {breadcrumbs.map((item, index) => (
+                <li key={`${item.label}-${index}`} className="flex items-center gap-1.5">
+                  {index > 0 && <PiCaretRightBold className="h-3 w-3 text-gray-300" aria-hidden="true" />}
+                  {item.href ? (
+                    <Link href={item.href} className="hover:text-circleTel-orange">
+                      {item.label}
+                    </Link>
+                  ) : (
+                    <span className="text-gray-900">{item.label}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
+        ) : null}
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            {eyebrow && <p className="text-xs font-medium text-gray-500">{eyebrow}</p>}
+            <div className="mt-1 flex flex-wrap items-center gap-3">
+              <h1 className="font-heading text-2xl font-semibold tracking-normal text-gray-950">{title}</h1>
+              {status && <StatusBadge status={status.label} variant={status.variant ?? 'neutral'} />}
+            </div>
+            {meta && <div className="mt-2 text-sm text-gray-500">{meta}</div>}
+          </div>
+          {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
+        </div>
+        {tabs && <div className="mt-4">{tabs}</div>}
+      </div>
+    </header>
+  );
+}

--- a/components/backend/FilterToolbar.tsx
+++ b/components/backend/FilterToolbar.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface FilterToolbarProps {
+  children: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function FilterToolbar({ children, action, className }: FilterToolbarProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm sm:flex-row sm:items-center sm:justify-between',
+        className
+      )}
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center">{children}</div>
+      {action && <div className="flex shrink-0 items-center gap-2">{action}</div>}
+    </div>
+  );
+}

--- a/components/backend/InspectorPanel.tsx
+++ b/components/backend/InspectorPanel.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
+
+interface InspectorPanelProps {
+  title?: string;
+  children: React.ReactNode;
+  tabs?: React.ReactNode;
+  trigger?: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+  contentClassName?: string;
+}
+
+function InspectorContent({
+  title,
+  tabs,
+  children,
+  contentClassName,
+}: Pick<InspectorPanelProps, 'title' | 'tabs' | 'children' | 'contentClassName'>) {
+  return (
+    <>
+      {title && (
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+          <h2 className="text-lg font-semibold text-gray-950">{title}</h2>
+        </div>
+      )}
+      {tabs && <div className="border-b border-gray-200 px-5">{tabs}</div>}
+      <div className={cn('p-5', contentClassName)}>{children}</div>
+    </>
+  );
+}
+
+export function InspectorPanel({
+  title = 'Details',
+  children,
+  tabs,
+  trigger,
+  open,
+  onOpenChange,
+  className,
+  contentClassName,
+}: InspectorPanelProps) {
+  return (
+    <>
+      <aside className={cn('hidden xl:block w-[360px] shrink-0 border-l border-gray-200 bg-white', className)}>
+        <div className="sticky top-14 max-h-[calc(100vh-3.5rem)] overflow-y-auto">
+          <InspectorContent title={title} tabs={tabs} contentClassName={contentClassName}>
+            {children}
+          </InspectorContent>
+        </div>
+      </aside>
+      <div className="xl:hidden">
+        <Sheet open={open} onOpenChange={onOpenChange}>
+          {trigger && (
+            <SheetTrigger asChild>
+              {trigger}
+            </SheetTrigger>
+          )}
+          {!trigger && (
+            <SheetTrigger asChild>
+              <Button variant="outline" size="sm">
+                {title}
+              </Button>
+            </SheetTrigger>
+          )}
+          <SheetContent side="right" className="w-full overflow-y-auto p-0 sm:max-w-md">
+            <SheetHeader className="sr-only">
+              <SheetTitle>{title}</SheetTitle>
+            </SheetHeader>
+            <InspectorContent title={title} tabs={tabs} contentClassName={contentClassName}>
+              {children}
+            </InspectorContent>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </>
+  );
+}

--- a/components/backend/MetricPanel.tsx
+++ b/components/backend/MetricPanel.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface MetricPanelProps {
+  label: string;
+  value: React.ReactNode;
+  description?: React.ReactNode;
+  trend?: React.ReactNode;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function MetricPanel({ label, value, description, trend, icon, className }: MetricPanelProps) {
+  return (
+    <div className={cn('rounded-lg border border-gray-200 bg-white p-4 shadow-sm', className)}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-medium text-gray-500">{label}</p>
+          <div className="mt-1 text-2xl font-semibold tracking-tight text-gray-950 tabular-nums">{value}</div>
+        </div>
+        {icon && <div className="flex h-8 w-8 items-center justify-center rounded-md bg-gray-50 text-gray-500">{icon}</div>}
+      </div>
+      {(description || trend) && (
+        <div className="mt-3 flex items-center justify-between gap-3 text-xs text-gray-500">
+          {description && <span className="truncate">{description}</span>}
+          {trend && <span className="shrink-0 font-medium">{trend}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/backend/__tests__/console-components.test.tsx
+++ b/components/backend/__tests__/console-components.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import {
+  ChartPanel,
+  DataTable,
+  FilterToolbar,
+  InspectorPanel,
+  MetricPanel,
+} from '@/components/backend';
+
+describe('console backend components', () => {
+  it('uses dense table spacing and empty state copy', () => {
+    const table = DataTable({
+      columns: [
+        { id: 'name', header: 'Name', accessor: (row: { name: string }) => row.name },
+        { id: 'status', header: 'Status', accessor: (row: { status: string }) => row.status },
+      ],
+      rows: [],
+      emptyTitle: 'No customers found',
+      emptyDescription: 'Adjust your filters and try again.',
+    });
+
+    expect(React.isValidElement(table)).toBe(true);
+    expect(table.props.className).toContain('rounded-lg');
+    expect(JSON.stringify(table)).toContain('No customers found');
+    expect(JSON.stringify(table)).toContain('text-xs');
+  });
+
+  it('keeps inspector panels sticky on desktop and sheet-backed on mobile', () => {
+    const inspector = InspectorPanel({
+      title: 'Details',
+      open: true,
+      onOpenChange: jest.fn(),
+      children: <div>Notes</div>,
+    });
+
+    expect(React.isValidElement(inspector)).toBe(true);
+    expect(JSON.stringify(inspector)).toContain('hidden xl:block');
+    expect(JSON.stringify(inspector)).toContain('xl:hidden');
+    expect(JSON.stringify(inspector)).toContain('Details');
+  });
+
+  it('provides flat panel primitives for filters and metrics', () => {
+    const filterToolbar = FilterToolbar({ children: <button>Filter</button> });
+    const metricPanel = MetricPanel({ label: 'Requests', value: '665' });
+    const chartPanel = ChartPanel({ title: 'Edge Requests', children: <div>chart</div> });
+
+    expect(filterToolbar.props.className).toContain('rounded-lg');
+    expect(metricPanel.props.className).toContain('border-gray-200');
+    expect(chartPanel.props.className).toContain('min-h');
+  });
+});

--- a/components/backend/__tests__/console-utils.test.ts
+++ b/components/backend/__tests__/console-utils.test.ts
@@ -1,0 +1,51 @@
+import {
+  flattenConsoleNavItems,
+  getNextDataTableSort,
+  isConsoleNavItemActive,
+} from '@/components/backend/console-utils';
+import type { ConsoleNavItem } from '@/components/backend/console-types';
+
+const navItems: ConsoleNavItem[] = [
+  { label: 'Dashboard', href: '/admin', exact: true },
+  {
+    label: 'Customers',
+    href: '/admin/customers',
+    children: [
+      { label: 'All Customers', href: '/admin/customers', exact: true },
+      { label: 'Billing', href: '/admin/customers/billing' },
+    ],
+  },
+];
+
+describe('console backend utilities', () => {
+  it('treats exact nav items as exact matches only', () => {
+    expect(isConsoleNavItemActive('/admin', navItems[0])).toBe(true);
+    expect(isConsoleNavItemActive('/admin/dashboard', navItems[0])).toBe(false);
+  });
+
+  it('treats parent nav items as active when a child route matches', () => {
+    expect(isConsoleNavItemActive('/admin/customers/billing/overdue', navItems[1])).toBe(true);
+    expect(isConsoleNavItemActive('/admin/products', navItems[1])).toBe(false);
+  });
+
+  it('flattens nested nav items for command/search surfaces', () => {
+    expect(flattenConsoleNavItems(navItems)).toEqual([
+      expect.objectContaining({ label: 'Dashboard', href: '/admin' }),
+      expect.objectContaining({ label: 'Customers', href: '/admin/customers' }),
+      expect.objectContaining({ label: 'All Customers', href: '/admin/customers' }),
+      expect.objectContaining({ label: 'Billing', href: '/admin/customers/billing' }),
+    ]);
+  });
+
+  it('cycles sortable table state from desc to asc to cleared', () => {
+    expect(getNextDataTableSort(null, 'created_at')).toEqual({
+      columnId: 'created_at',
+      direction: 'desc',
+    });
+    expect(getNextDataTableSort({ columnId: 'created_at', direction: 'desc' }, 'created_at')).toEqual({
+      columnId: 'created_at',
+      direction: 'asc',
+    });
+    expect(getNextDataTableSort({ columnId: 'created_at', direction: 'asc' }, 'created_at')).toBeNull();
+  });
+});

--- a/components/backend/console-types.ts
+++ b/components/backend/console-types.ts
@@ -1,0 +1,36 @@
+import type React from 'react';
+import type { IconType } from 'react-icons';
+
+export interface ConsoleNavItem {
+  label: string;
+  href?: string;
+  icon?: IconType;
+  badge?: string | number;
+  disabled?: boolean;
+  exact?: boolean;
+  description?: string;
+  children?: ConsoleNavItem[];
+}
+
+export interface ConsoleNavSection {
+  label?: string | null;
+  items: ConsoleNavItem[];
+}
+
+export type DataTableSortDirection = 'asc' | 'desc';
+
+export interface DataTableSortState {
+  columnId: string;
+  direction: DataTableSortDirection;
+}
+
+export interface DataTableColumn<T> {
+  id: string;
+  header: React.ReactNode;
+  accessor?: (row: T) => React.ReactNode;
+  cell?: (row: T) => React.ReactNode;
+  sortable?: boolean;
+  className?: string;
+  headerClassName?: string;
+  align?: 'left' | 'center' | 'right';
+}

--- a/components/backend/console-utils.ts
+++ b/components/backend/console-utils.ts
@@ -1,0 +1,35 @@
+import type { ConsoleNavItem, DataTableSortState } from './console-types';
+
+function hrefMatches(pathname: string, href: string, exact?: boolean) {
+  if (exact) {
+    return pathname === href;
+  }
+
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function isConsoleNavItemActive(pathname: string, item: ConsoleNavItem): boolean {
+  const selfActive = item.href ? hrefMatches(pathname, item.href, item.exact) : false;
+  const childActive = item.children?.some((child) => isConsoleNavItemActive(pathname, child)) ?? false;
+
+  return selfActive || childActive;
+}
+
+export function flattenConsoleNavItems(items: ConsoleNavItem[]): ConsoleNavItem[] {
+  return items.flatMap((item) => [item, ...(item.children ? flattenConsoleNavItems(item.children) : [])]);
+}
+
+export function getNextDataTableSort(
+  current: DataTableSortState | null,
+  columnId: string
+): DataTableSortState | null {
+  if (!current || current.columnId !== columnId) {
+    return { columnId, direction: 'desc' };
+  }
+
+  if (current.direction === 'desc') {
+    return { columnId, direction: 'asc' };
+  }
+
+  return null;
+}

--- a/components/backend/index.ts
+++ b/components/backend/index.ts
@@ -1,6 +1,6 @@
 /**
- * Unified backend UI kit — shared component primitives for the admin (`/admin/*`)
- * and consumer (`/dashboard/*`) dashboards. Reference look: app/dashboard/billing.
+ * Unified backend UI kit — shared component primitives for the logged-in console
+ * surfaces. Reference look: hybrid console from docs/design/BACKEND_UI_KIT.md.
  * See docs/design/BACKEND_UI_KIT.md for the spec.
  */
 export { StatCard } from './StatCard';
@@ -18,3 +18,26 @@ export {
   TabsContent,
 } from './ConsoleTabs';
 export type { ConsoleTabItem } from './ConsoleTabs';
+export { ConsoleShell } from './ConsoleShell';
+export { ConsoleTopbar } from './ConsoleTopbar';
+export { ConsoleNav } from './ConsoleNav';
+export { FilterToolbar } from './FilterToolbar';
+export { DataTable } from './DataTable';
+export { MetricPanel } from './MetricPanel';
+export { ChartPanel } from './ChartPanel';
+export { EntityHeader } from './EntityHeader';
+export { InspectorPanel } from './InspectorPanel';
+export { ActivityTimeline } from './ActivityTimeline';
+export type { ActivityTimelineItem } from './ActivityTimeline';
+export type {
+  ConsoleNavItem,
+  ConsoleNavSection,
+  DataTableColumn,
+  DataTableSortDirection,
+  DataTableSortState,
+} from './console-types';
+export {
+  flattenConsoleNavItems,
+  getNextDataTableSort,
+  isConsoleNavItemActive,
+} from './console-utils';

--- a/docs/design/BACKEND_UI_KIT.md
+++ b/docs/design/BACKEND_UI_KIT.md
@@ -1,9 +1,9 @@
 # Backend UI Kit
 
-Shared component primitives for the **admin** (`/admin/*`) and **consumer** (`/dashboard/*`) dashboards. One kit, one look — so both surfaces feel like the same product.
+Shared component primitives for the **admin** (`/admin/*`), **consumer** (`/dashboard/*`), **partner** (`/partner/*`), **business customer** (`/business/dashboard/*`), and **portal** (`/portal/*`) dashboards. One kit, one look, so every logged-in surface feels like the same product.
 
 - **Home:** `components/backend/` — import from `@/components/backend`.
-- **Reference look:** the consumer billing dashboard (`app/dashboard/billing/page.tsx`) — functional minimalism: white surfaces, soft gray borders, restrained orange accent, generous spacing, `tabular-nums` numbers.
+- **Reference look:** hybrid console. Use Vercel-style density for navigation, filters, lists, metrics, and charts; use Gaiia-style workbenches for entity detail pages with an optional right inspector.
 - **Tokens:** reuse `tailwind.config.ts` (`circleTel.*`), `app/globals.css`, `DESIGN.md`, `lib/design-system.ts`. Do not invent new tokens.
 
 ## Principles
@@ -12,13 +12,25 @@ Shared component primitives for the **admin** (`/admin/*`) and **consumer** (`/d
 - **Orange is an accent** — `circleTel-orange` only for active state, primary CTA, links, focus. Never body text on white.
 - **One token, one meaning** — status colours come only from `StatusBadge`/`getStatusVariant`. No per-page status hex.
 - **Predictable states** — every list/data view uses `LoadingState` / `EmptyState` / `ErrorState`.
+- **Dense console typography** — Inter for UI/data text, Manrope only for entity/page headings. Console titles are 20-24px; rows, labels, and metadata are 12-14px with `tabular-nums` for numbers.
+- **Flat portal surfaces** — logged-in pages prefer `rounded-md`/`rounded-lg`, gray borders, and light shadows. Avoid gradients and decorative card grids inside operational screens.
 
 ## Components
 
 | Component | Use for |
 |-----------|---------|
+| `ConsoleShell` | Shared logged-in page frame: sidebar + sticky topbar + content + optional footer. |
+| `ConsoleTopbar` | Compact 56px topbar with brand/title/search/actions slots. |
+| `ConsoleNav` | Collapsible 64px/240px vertical nav with tooltip support and nested active states. |
 | `PageHeader` | List/index page title + subtitle + actions. (Detail pages → `DetailPageHeader`.) |
+| `EntityHeader` | Detail/workbench header with breadcrumbs, status, actions, tabs, and metadata. |
 | `StatCard` | Metric cards. Replaces inline stat `<div>`s, admin `StatCard`, and `ModernStatCard`. |
+| `MetricPanel` | Compact one-metric panel for observability/dashboard grids. |
+| `ChartPanel` | Flat chart container with compact header and optional action. |
+| `FilterToolbar` | Dense search/filter/action strip above lists and tables. |
+| `DataTable` | Compact table with sorting hooks, loading/empty states, row actions, and dense rows. |
+| `InspectorPanel` | Sticky right detail panel on desktop; sheet/drawer on tablet and mobile. |
+| `ActivityTimeline` | Notes/activity feed inside inspectors and detail sidebars. |
 | `StatusBadge` + `getStatusVariant` | Every status pill. Map raw DB strings with `getStatusVariant()`. |
 | `SectionCard` | Card with a header for grouped content. |
 | `InfoRow` | Key/value rows in detail panels. |
@@ -32,8 +44,13 @@ import {
   PageHeader, StatCard, StatusBadge, getStatusVariant,
   LoadingState, EmptyState, ErrorState,
   Tabs, ConsoleTabsList, ConsoleTabsContent,
+  ConsoleShell, DataTable, FilterToolbar, InspectorPanel,
 } from '@/components/backend';
 import { PiFileTextBold } from 'react-icons/pi';
+
+<ConsoleShell topbar={<Header />} sidebar={<Sidebar />}>
+  <PageHeader title="Invoices" subtitle="Manage billing" />
+</ConsoleShell>
 
 <PageHeader title="Invoices" subtitle="Manage billing" actions={<Button>New</Button>} />
 
@@ -54,18 +71,34 @@ import { PiFileTextBold } from 'react-icons/pi';
   : rows.map(/* … */)}
 ```
 
+## Console layout migration
+
+The first adoption phase moves shared shells onto `ConsoleShell` without changing auth guards, route configs, API calls, or page content. Current shell adopters:
+
+- `app/admin/AdminLayoutClient.tsx`
+- `app/dashboard/DashboardLayoutClient.tsx`
+- `app/partner/PartnerLayoutClient.tsx`
+- `app/business/dashboard/layout.tsx`
+- `app/portal/PortalLayoutClient.tsx`
+
+Next page migrations should replace local table/stat/filter/detail markup with the primitives above. Do not redesign public marketing pages or checkout acquisition pages as part of this console kit.
+
 ## Status variants
 
 `success` (paid/active/approved) · `warning` (pending/unpaid/scheduled) · `error` (failed/overdue/cancelled) · `info` (new/draft) · `neutral` (fallback). All bordered pills (`bg-*-100 text-*-800 border-*-200`).
 
 ## Migrating a page
 
-1. Header markup → `PageHeader`.
-2. Stat divs / `ModernStatCard` → `StatCard`.
-3. Local `getStatusBadge()` → `StatusBadge` + `getStatusVariant`.
-4. Loading/empty/error blocks → `LoadingState` / `EmptyState` / `ErrorState`.
-5. Tabs → `ConsoleTabsList` / `ConsoleTabsContent` (where tabs exist).
-6. `npm run type-check:memory`; visual-diff against the billing reference.
+1. Shell frame -> `ConsoleShell` (already done for the top-level portal layouts).
+2. Header markup -> `PageHeader` for list pages or `EntityHeader` for detail/workbench pages.
+3. Filter rows -> `FilterToolbar`.
+4. Local tables -> `DataTable`.
+5. Stat divs / `ModernStatCard` -> `StatCard` or `MetricPanel`.
+6. Local `getStatusBadge()` -> `StatusBadge` + `getStatusVariant`.
+7. Right detail areas -> `InspectorPanel` + `ActivityTimeline`.
+8. Loading/empty/error blocks -> `LoadingState` / `EmptyState` / `ErrorState`.
+9. Tabs -> `ConsoleTabsList` / `ConsoleTabsContent` for overview/list pages, `UnderlineTabs` for detail sub-nav.
+10. `npm run type-check:memory`; take Playwright screenshots for the route being migrated.
 
 ## Back-compat
 

--- a/docs/superpowers/plans/2026-07-02-segment-aware-coverage-check.md
+++ b/docs/superpowers/plans/2026-07-02-segment-aware-coverage-check.md
@@ -1,0 +1,987 @@
+# Segment-Aware Coverage Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the coverage check serve all three customer segments (Home / Work-from-home / Business): surface SOHO and business packages, let users switch segment on the results page, route business packages to the quote flow, and let SOHO buyers sign up as personal or business.
+
+**Architecture:** A new pure module `lib/coverage/customer-segments.ts` owns all segment logic (URL type ⇄ customer_type filter sets, SOHO-first ordering, quote-only detection). The existing `/api/coverage/packages` route swaps its binary `.eq('customer_type', …)` for `.in(…)` using that module and returns `customer_type` per package. UI consumes the module: hero sends `type=wfh`, results page gets a segment toggle, business package CTAs deep-link to `/quotes/request`, checkout shows a personal/business choice for SOHO packages. One data migration adds `service_type_mapping` rows so `product_category='soho'` is reachable from MTN Fixed Wireless coverage.
+
+**Tech Stack:** Next.js 15 App Router, TypeScript, Supabase (shared staging+prod DB, project `agyjovdugmtopasyvlng`), Jest, react-icons/pi, Tailwind.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-segment-aware-coverage-check-design.md`
+
+## Global Constraints
+
+- Branch: create `feat/segment-coverage-check` off `origin/main` in a **fresh worktree** (the main working tree at `/home/circletel` has unrelated uncommitted changes — do NOT build on it). Use the superpowers:using-git-worktrees skill.
+- `service_packages.customer_type` values are exactly: `'consumer' | 'business' | 'both' | 'soho'`. `market_segment` must NOT be used for filtering.
+- URL segment values are exactly: `'residential' | 'wfh' | 'business'`. Unknown/missing values fall back to `'residential'`.
+- No changes to: B2B KYC pipeline, payments, RICA, `/business/*` marketing pages, `coverage_leads` enum.
+- Type check before every commit: `npm run type-check:memory` must not introduce NEW errors (repo has ~295 pre-existing errors; only files you touched must be clean — the pre-push hook enforces this).
+- Tests run with Jest: `npx jest <path>`.
+- DB migrations on this project are applied MANUALLY (no CI migration step). Staging and prod share ONE Supabase database.
+- Follow existing file style: 2-space indent, single quotes, `PiXxxBold` icons from `react-icons/pi`, `cn()` from `@/lib/utils`.
+
+---
+
+### Task 0: Branch setup
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Create worktree + branch off origin/main**
+
+```bash
+cd /home/circletel
+git fetch origin main
+git worktree add .worktrees/segment-coverage -b feat/segment-coverage-check origin/main
+cd /home/circletel/.worktrees/segment-coverage
+npm install
+```
+
+Expected: worktree created, `git status` clean, branch `feat/segment-coverage-check`.
+All subsequent tasks run inside `/home/circletel/.worktrees/segment-coverage`.
+
+---
+
+### Task 1: Pure segment module (`customer-segments.ts`)
+
+**Files:**
+- Create: `lib/coverage/customer-segments.ts`
+- Test: `lib/coverage/__tests__/customer-segments.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (pure module, no imports).
+- Produces (used by Tasks 3–8):
+  - `type CoverageSegment = 'residential' | 'wfh' | 'business'`
+  - `normalizeSegment(type: string | null | undefined): CoverageSegment`
+  - `customerTypesForSegment(segment: CoverageSegment): string[]`
+  - `sortPackagesForSegment<T extends { customer_type?: string; price: number }>(segment: CoverageSegment, packages: T[]): T[]`
+  - `isQuoteOnlyPackage(pkg: { customer_type?: string }): boolean`
+  - `heroSegmentToUrlType(segment: 'home' | 'wfh' | 'business'): CoverageSegment`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/coverage/__tests__/customer-segments.test.ts`:
+
+```typescript
+import {
+  normalizeSegment,
+  customerTypesForSegment,
+  sortPackagesForSegment,
+  isQuoteOnlyPackage,
+  heroSegmentToUrlType,
+} from '../customer-segments';
+
+describe('normalizeSegment', () => {
+  it('passes through valid segments', () => {
+    expect(normalizeSegment('residential')).toBe('residential');
+    expect(normalizeSegment('wfh')).toBe('wfh');
+    expect(normalizeSegment('business')).toBe('business');
+  });
+
+  it('falls back to residential for null, undefined, and unknown values', () => {
+    expect(normalizeSegment(null)).toBe('residential');
+    expect(normalizeSegment(undefined)).toBe('residential');
+    expect(normalizeSegment('')).toBe('residential');
+    expect(normalizeSegment('soho')).toBe('residential');
+    expect(normalizeSegment('BUSINESS')).toBe('residential');
+  });
+});
+
+describe('customerTypesForSegment', () => {
+  it('residential sees consumer and both', () => {
+    expect(customerTypesForSegment('residential')).toEqual(['consumer', 'both']);
+  });
+
+  it('wfh sees soho, consumer, and both', () => {
+    expect(customerTypesForSegment('wfh')).toEqual(['soho', 'consumer', 'both']);
+  });
+
+  it('business sees business and both', () => {
+    expect(customerTypesForSegment('business')).toEqual(['business', 'both']);
+  });
+});
+
+describe('sortPackagesForSegment', () => {
+  const pkgs = [
+    { id: 'a', customer_type: 'consumer', price: 100 },
+    { id: 'b', customer_type: 'soho', price: 900 },
+    { id: 'c', customer_type: 'consumer', price: 50 },
+    { id: 'd', customer_type: 'soho', price: 700 },
+  ];
+
+  it('puts soho packages first (each group price-ascending) for wfh', () => {
+    const sorted = sortPackagesForSegment('wfh', pkgs);
+    expect(sorted.map((p) => p.id)).toEqual(['d', 'b', 'c', 'a']);
+  });
+
+  it('does not mutate the input array', () => {
+    const copy = [...pkgs];
+    sortPackagesForSegment('wfh', pkgs);
+    expect(pkgs).toEqual(copy);
+  });
+
+  it('returns packages unchanged for residential and business', () => {
+    expect(sortPackagesForSegment('residential', pkgs)).toEqual(pkgs);
+    expect(sortPackagesForSegment('business', pkgs)).toEqual(pkgs);
+  });
+});
+
+describe('isQuoteOnlyPackage', () => {
+  it('is true only for business packages', () => {
+    expect(isQuoteOnlyPackage({ customer_type: 'business' })).toBe(true);
+    expect(isQuoteOnlyPackage({ customer_type: 'soho' })).toBe(false);
+    expect(isQuoteOnlyPackage({ customer_type: 'consumer' })).toBe(false);
+    expect(isQuoteOnlyPackage({ customer_type: 'both' })).toBe(false);
+    expect(isQuoteOnlyPackage({})).toBe(false);
+  });
+});
+
+describe('heroSegmentToUrlType', () => {
+  it('maps hero segments to URL types', () => {
+    expect(heroSegmentToUrlType('home')).toBe('residential');
+    expect(heroSegmentToUrlType('wfh')).toBe('wfh');
+    expect(heroSegmentToUrlType('business')).toBe('business');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest lib/coverage/__tests__/customer-segments.test.ts`
+Expected: FAIL — `Cannot find module '../customer-segments'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/coverage/customer-segments.ts`:
+
+```typescript
+/**
+ * Customer segment logic for the public coverage check.
+ *
+ * The `?type=` URL param carries the segment chosen on the homepage hero
+ * (Home / Work from home / Business). `service_packages.customer_type`
+ * ('consumer' | 'business' | 'both' | 'soho') is the governing filter field
+ * — `market_segment` is inconsistently populated and must NOT be used.
+ */
+
+export type CoverageSegment = 'residential' | 'wfh' | 'business';
+
+const SEGMENT_CUSTOMER_TYPES: Record<CoverageSegment, string[]> = {
+  residential: ['consumer', 'both'],
+  wfh: ['soho', 'consumer', 'both'],
+  business: ['business', 'both'],
+};
+
+export function normalizeSegment(type: string | null | undefined): CoverageSegment {
+  return type === 'business' || type === 'wfh' ? type : 'residential';
+}
+
+export function customerTypesForSegment(segment: CoverageSegment): string[] {
+  return SEGMENT_CUSTOMER_TYPES[segment];
+}
+
+/**
+ * WFH results lead with SOHO (WorkConnect) packages; within each group the
+ * API's price-ascending order is preserved. Other segments are untouched.
+ */
+export function sortPackagesForSegment<T extends { customer_type?: string; price: number }>(
+  segment: CoverageSegment,
+  packages: T[]
+): T[] {
+  if (segment !== 'wfh') return packages;
+  return [...packages].sort((a, b) => {
+    const aSoho = a.customer_type === 'soho' ? 0 : 1;
+    const bSoho = b.customer_type === 'soho' ? 0 : 1;
+    return aSoho - bSoho || a.price - b.price;
+  });
+}
+
+/**
+ * Business packages (BizFibreConnect, SkyFibre SME, …) onboard via the B2B
+ * quote/KYC pipeline, never consumer self-checkout.
+ */
+export function isQuoteOnlyPackage(pkg: { customer_type?: string }): boolean {
+  return pkg.customer_type === 'business';
+}
+
+/** Maps the hero's SegmentType ('home' | 'wfh' | 'business') to the URL type. */
+export function heroSegmentToUrlType(segment: 'home' | 'wfh' | 'business'): CoverageSegment {
+  return segment === 'home' ? 'residential' : segment;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest lib/coverage/__tests__/customer-segments.test.ts`
+Expected: PASS — 5 suites, all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/coverage/customer-segments.ts lib/coverage/__tests__/customer-segments.test.ts
+git commit -m "feat(coverage): pure customer-segment module (residential/wfh/business)"
+```
+
+---
+
+### Task 2: DB migration — make `soho` product category reachable
+
+WorkConnect rides MTN Fixed Wireless Broadband, but `service_type_mapping` has no row producing `product_category='soho'`, so the packages API can never include WorkConnect. Add two mapping rows. Safe to apply immediately: the live prod code filters `customer_type` with `.eq('consumer'|'business')`, which excludes soho packages regardless.
+
+**Files:**
+- Create: `supabase/migrations/20260702100000_soho_service_type_mapping.sql`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `service_type_mapping` rows `('Fixed Wireless Broadband' | 'uncapped_wireless', provider 'mtn') → 'soho'` that Task 3's unchanged mapping query picks up.
+
+- [ ] **Step 1: Write the migration**
+
+Create `supabase/migrations/20260702100000_soho_service_type_mapping.sql`:
+
+```sql
+-- WorkConnect (customer_type='soho', product_category='soho') rides MTN Fixed
+-- Wireless Broadband. Map FWB technical types to the 'soho' product category so
+-- /api/coverage/packages includes WorkConnect wherever FWB coverage exists.
+-- Live code filters by customer_type, so these rows only surface packages for
+-- the new 'wfh' segment.
+INSERT INTO service_type_mapping (technical_type, provider, product_category, priority, active, notes)
+SELECT v.technical_type, v.provider, v.product_category, v.priority, v.active, v.notes
+FROM (VALUES
+  ('Fixed Wireless Broadband', 'mtn', 'soho', 6, true, 'WorkConnect SOHO packages over MTN FWB'),
+  ('uncapped_wireless', 'mtn', 'soho', 6, true, 'WorkConnect SOHO packages over MTN FWB')
+) AS v(technical_type, provider, product_category, priority, active, notes)
+WHERE NOT EXISTS (
+  SELECT 1 FROM service_type_mapping m
+  WHERE m.technical_type = v.technical_type
+    AND m.product_category = v.product_category
+);
+```
+
+- [ ] **Step 2: Apply manually to the shared DB**
+
+This project has NO CI migration step. Apply via the Supabase MCP `apply_migration` tool (name: `soho_service_type_mapping`) or the SQL editor, running the exact SQL above.
+
+- [ ] **Step 3: Verify**
+
+Run (Supabase MCP `execute_sql`):
+
+```sql
+SELECT technical_type, provider, product_category, priority, active
+FROM service_type_mapping WHERE product_category = 'soho';
+```
+
+Expected: exactly 2 rows, both active, priority 6. Re-running the migration inserts 0 rows (idempotent).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260702100000_soho_service_type_mapping.sql
+git commit -m "feat(coverage): map MTN FWB technical types to soho product category"
+```
+
+---
+
+### Task 3: Packages API — segment filter sets + `customer_type` in response
+
+**Files:**
+- Modify: `app/api/coverage/packages/route.ts` (imports ~line 7, `ServicePackage` interface ~line 39–54, `coverageType` ~line 111, customer-type filter ~lines 327–351, response mapping ~lines 374–410, sort after BizFibre filter ~line 432)
+
+**Interfaces:**
+- Consumes: `normalizeSegment`, `customerTypesForSegment`, `sortPackagesForSegment` from `@/lib/coverage/customer-segments` (Task 1).
+- Produces: each package in the JSON `packages[]` response now includes `customer_type?: string`. Consumed by Tasks 5, 6, 7, 8.
+
+- [ ] **Step 1: Add import and extend types**
+
+After the existing import block (line 7, `import { apiLogger } from '@/lib/logging';`), add:
+
+```typescript
+import { normalizeSegment, customerTypesForSegment, sortPackagesForSegment } from '@/lib/coverage/customer-segments';
+```
+
+In `interface ServicePackage` (~line 39), after `service_type: string;` add:
+
+```typescript
+  customer_type?: string;
+```
+
+(`PackageWithProvider extends Omit<ServicePackage, 'compatible_providers' | 'active'>` picks it up automatically.)
+
+- [ ] **Step 2: Normalize the segment param**
+
+Replace (line 111):
+
+```typescript
+    const coverageType = searchParams.get('type') || 'residential'; // Get coverage type from URL
+```
+
+with:
+
+```typescript
+    const coverageType = normalizeSegment(searchParams.get('type')); // 'residential' | 'wfh' | 'business'
+```
+
+- [ ] **Step 3: Replace the binary customer-type filter**
+
+Replace (lines 327–330):
+
+```typescript
+      // Filter by customer_type based on coverage type
+      // Note: service_packages.customer_type is VARCHAR with values: 'business', 'consumer'
+      // coverage_leads.customer_type is ENUM with values: 'consumer', 'smme', 'enterprise'
+      const packageCustomerType = coverageType === 'business' ? 'business' : 'consumer';
+```
+
+with:
+
+```typescript
+      // Filter by customer_type based on segment.
+      // service_packages.customer_type: 'consumer' | 'business' | 'both' | 'soho'
+      // coverage_leads.customer_type is a separate ENUM: 'consumer' | 'smme' | 'enterprise'
+      const packageCustomerTypes = customerTypesForSegment(coverageType);
+```
+
+In the `apiLogger.info('[Packages API] Querying packages with', …)` call (~line 332), replace the `packageCustomerType,` field with `packageCustomerTypes,`.
+
+In the packages query (~line 349), replace:
+
+```typescript
+        .eq('customer_type', packageCustomerType)
+```
+
+with:
+
+```typescript
+        .in('customer_type', packageCustomerTypes)
+```
+
+- [ ] **Step 4: Return `customer_type` per package and sort for WFH**
+
+In the `availablePackages = packages.map(...)` return object (~line 395, after `service_type: pkg.service_type,`), add:
+
+```typescript
+            customer_type: pkg.customer_type,
+```
+
+After the BizFibre filter/decorate block closes (~line 432, immediately after the closing `}` of `if (!lat || !lng) { … } else { … }`), add:
+
+```typescript
+        // WFH: lead with SOHO (WorkConnect) packages
+        availablePackages = sortPackagesForSegment(coverageType, availablePackages);
+```
+
+In the final `apiLogger.info('Coverage check', …)` (~line 436), replace `packageCustomerType,` with `packageCustomerTypes,`.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep "app/api/coverage/packages"`
+Expected: no output (no errors in this file). If the full check OOMs, use `npm run type-check:memory`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/coverage/packages/route.ts
+git commit -m "feat(coverage): filter packages by segment customer-type sets, expose customer_type"
+```
+
+---
+
+### Task 4: Hero sends `type=wfh`; lead route comment
+
+**Files:**
+- Modify: `components/home/NewHero.tsx` (lines ~105–136)
+- Modify: `app/api/coverage/lead/route.ts` (comment, lines 18–21)
+
+**Interfaces:**
+- Consumes: `heroSegmentToUrlType` from `@/lib/coverage/customer-segments`.
+- Produces: redirects to `/packages/[leadId]?type=residential|wfh|business`; sessionStorage `circletel_coverage_address.type` uses the same values.
+
+- [ ] **Step 1: Update NewHero serialization**
+
+In `components/home/NewHero.tsx`, add to imports (after line 8, `import { cn } from '@/lib/utils';`):
+
+```typescript
+import { heroSegmentToUrlType } from '@/lib/coverage/customer-segments';
+```
+
+In `handleCheckCoverage` (lines 105–136), replace the three segment serialisations:
+
+```typescript
+      const urlType = heroSegmentToUrlType(activeSegment);
+      sessionStorage.setItem('circletel_coverage_address', JSON.stringify({
+        address: address.trim(),
+        coordinates,
+        type: urlType,
+        addressComponents,
+        timestamp: new Date().toISOString(),
+      }));
+
+      const response = await fetch('/api/coverage/lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          address: address.trim(),
+          coordinates,
+          coverageType: urlType,
+        }),
+      });
+
+      if (!response.ok) throw new Error('Failed to create coverage lead');
+      const data = await response.json();
+      window.location.href = `/packages/${data.leadId}?type=${urlType}`;
+```
+
+(This replaces lines 109–130: the old `type: activeSegment === 'business' ? …` object, the old `coverageType:` ternary, and the old `const packageType = …` + redirect.)
+
+- [ ] **Step 2: Update lead route comment**
+
+In `app/api/coverage/lead/route.ts`, replace lines 18–21:
+
+```typescript
+    // Determine customer type from coverageType parameter
+    // Database enum has: 'consumer', 'smme', 'enterprise'
+    // Map: residential -> consumer, business -> smme (covers both SME and enterprise)
+    const customerType = coverageType === 'business' ? 'smme' : 'consumer';
+```
+
+with:
+
+```typescript
+    // Determine customer type from coverageType parameter.
+    // Database enum has: 'consumer', 'smme', 'enterprise' (no soho value).
+    // Map: business -> smme; residential AND wfh -> consumer.
+    // The wfh segment lives in the URL/order state, not on the lead row.
+    const customerType = coverageType === 'business' ? 'smme' : 'consumer';
+```
+
+- [ ] **Step 3: Type-check the touched files**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "NewHero|coverage/lead"`
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/home/NewHero.tsx app/api/coverage/lead/route.ts
+git commit -m "feat(coverage): hero WFH segment sends type=wfh"
+```
+
+---
+
+### Task 5: SegmentToggle component + results-page wiring + WorkConnect tab visibility
+
+**Files:**
+- Create: `components/coverage/SegmentToggle.tsx`
+- Modify: `app/packages/[leadId]/page.tsx` (imports ~line 8–27, `coverageType` line 71, new handler after `handleCheckAnotherAddress` ~line 358, render above `ServiceToggle` ~line 607, wireless filters lines 384–400 and 447–459, badge colors ~line 671–682)
+
+**Interfaces:**
+- Consumes: `CoverageSegment`, `normalizeSegment` from `@/lib/coverage/customer-segments`; API `customer_type` field (Task 3).
+- Produces: `SegmentToggle({ activeSegment: CoverageSegment, onSegmentChange: (s: CoverageSegment) => void })`; URL `?type=` changes drive refetch via the existing `useEffect([leadId, coverageType])`.
+
+- [ ] **Step 1: Create the SegmentToggle component**
+
+Create `components/coverage/SegmentToggle.tsx`:
+
+```tsx
+'use client';
+import React from 'react';
+import { PiHouseBold, PiBriefcaseBold, PiBuildingsBold } from 'react-icons/pi';
+import { cn } from '@/lib/utils';
+import type { CoverageSegment } from '@/lib/coverage/customer-segments';
+
+const SEGMENTS: Array<{
+  value: CoverageSegment;
+  label: string;
+  shortLabel: string;
+  icon: React.ElementType;
+}> = [
+  { value: 'residential', label: 'Home', shortLabel: 'Home', icon: PiHouseBold },
+  { value: 'wfh', label: 'Work from Home', shortLabel: 'SOHO', icon: PiBriefcaseBold },
+  { value: 'business', label: 'Business', shortLabel: 'Business', icon: PiBuildingsBold },
+];
+
+interface SegmentToggleProps {
+  activeSegment: CoverageSegment;
+  onSegmentChange: (segment: CoverageSegment) => void;
+}
+
+/**
+ * Home / Work-from-home / Business switcher for the package results page.
+ * Light-theme sibling of the homepage hero segment pills.
+ */
+export function SegmentToggle({ activeSegment, onSegmentChange }: SegmentToggleProps) {
+  return (
+    <div className="inline-flex items-center gap-1 bg-gray-100 rounded-xl p-1">
+      {SEGMENTS.map((segment) => {
+        const Icon = segment.icon;
+        const isActive = activeSegment === segment.value;
+        return (
+          <button
+            key={segment.value}
+            type="button"
+            onClick={() => onSegmentChange(segment.value)}
+            aria-pressed={isActive}
+            className={cn(
+              'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all',
+              'focus:outline-none focus:ring-2 focus:ring-circleTel-orange focus:ring-offset-1',
+              isActive
+                ? 'bg-white text-circleTel-orange shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            )}
+          >
+            <Icon className="w-4 h-4" />
+            <span className="hidden sm:inline">{segment.label}</span>
+            <span className="sm:hidden">{segment.shortLabel}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Wire it into the packages page**
+
+In `app/packages/[leadId]/page.tsx`:
+
+Add imports (after line 18, `import { NoCoverageOptions } …`):
+
+```typescript
+import { SegmentToggle } from '@/components/coverage/SegmentToggle';
+import { normalizeSegment, type CoverageSegment } from '@/lib/coverage/customer-segments';
+```
+
+Replace line 71:
+
+```typescript
+  const coverageType = searchParams.get('type') || 'residential';
+```
+
+with:
+
+```typescript
+  const coverageType = normalizeSegment(searchParams.get('type'));
+```
+
+Add a handler after `handleCheckAnotherAddress` (after its closing `};`, ~line 358):
+
+```typescript
+  const handleSegmentChange = (segment: CoverageSegment) => {
+    if (segment === coverageType) return;
+    setSelectedPackage(null);
+    setShowAllPackages(false);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('type', segment);
+    router.replace(`/packages/${leadId}?${params.toString()}`, { scroll: false });
+  };
+```
+
+(The existing `useEffect(() => { fetchPackages(); }, [leadId, coverageType])` at line 100 refetches automatically when the URL type changes.)
+
+Render the toggle above the ServiceToggle. Replace (~lines 607–608):
+
+```tsx
+            {/* Service Toggle */}
+            <div className="mb-8">
+```
+
+with:
+
+```tsx
+            {/* Segment Toggle: Home / Work from Home / Business */}
+            <div className="mb-6">
+              <SegmentToggle
+                activeSegment={coverageType}
+                onSegmentChange={handleSegmentChange}
+              />
+            </div>
+
+            {/* Service Toggle */}
+            <div className="mb-8">
+```
+
+- [ ] **Step 3: Make WorkConnect visible on the Wireless tab**
+
+WorkConnect has `service_type='WorkConnect'`, `product_category='soho'` — it matches no tab today. In BOTH the `getFilteredPackages()` wireless branch (~line 390) and the `packageCounts.wireless` filter (~line 450), replace the `isWireless` expression:
+
+```typescript
+        const isWireless = serviceType.includes('wireless') || 
+                          serviceType.includes('skyfibre') ||
+                          productCategory.includes('wireless') ||
+                          (serviceType.includes('skyfibre') && productCategory === 'connectivity');
+```
+
+with:
+
+```typescript
+        const isWireless = serviceType.includes('wireless') ||
+                          serviceType.includes('skyfibre') ||
+                          serviceType.includes('workconnect') ||
+                          productCategory.includes('wireless') ||
+                          productCategory === 'soho' ||
+                          (serviceType.includes('skyfibre') && productCategory === 'connectivity');
+```
+
+(Apply the identical replacement in both locations — they must stay in sync.)
+
+In `getBadgeColor()` (~line 671), add a WorkConnect branch before the final fallback — replace:
+
+```typescript
+                          } else if (serviceType.includes('5g')) {
+                            return 'yellow';
+                          }
+                          return 'pink';
+```
+
+with:
+
+```typescript
+                          } else if (serviceType.includes('5g')) {
+                            return 'yellow';
+                          } else if (serviceType.includes('workconnect') || serviceType === 'soho') {
+                            return 'orange';
+                          }
+                          return 'pink';
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "SegmentToggle|packages/\[leadId\]"`
+Expected: no output.
+
+- [ ] **Step 5: Verify in the running app**
+
+```bash
+npm run dev:memory
+```
+
+Visit an existing results URL (grab a leadId from a fresh homepage check or `SELECT id FROM coverage_leads ORDER BY created_at DESC LIMIT 1`), e.g. `http://localhost:3000/packages/<leadId>?type=residential`:
+- Toggle shows three pills; clicking Business updates the URL to `?type=business` and the package grid changes (BizFibre/SkyFibre SME at a fibre-covered address).
+- Clicking Work from Home shows WorkConnect first (Wireless tab) where MTN FWB coverage exists.
+- Selected package clears on switch.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/coverage/SegmentToggle.tsx "app/packages/[leadId]/page.tsx"
+git commit -m "feat(packages): segment toggle on results page + WorkConnect wireless-tab visibility"
+```
+
+---
+
+### Task 6: Business packages → "Request a Quote" CTA
+
+**Files:**
+- Modify: `app/packages/[leadId]/page.tsx` (`Package` interface ~line 29–56, `handlePackageSelect` ~line 222, `handleContinue` ~line 268, sidebar usage ~line 784, mobile overlay usage ~line 870, continue button ~line 900–904)
+- Modify: `components/ui/package-detail-sidebar.tsx` (props ~line 57 & 117, button text ~line 320)
+- Modify: `lib/order/types.ts` (`PackageDetails` interface, line 130)
+
+**Interfaces:**
+- Consumes: `isQuoteOnlyPackage` from `@/lib/coverage/customer-segments`; `customer_type` on API packages (Task 3).
+- Produces: `PackageDetails.customer_type?: string` (consumed by Task 8); quote deep-link `/quotes/request?packageId=<uuid>&leadId=<uuid>` (consumed by Task 7); `PackageDetailSidebar`/`MobilePackageDetailOverlay` accept optional `orderButtonLabel?: string` (default `'Order Now'`).
+
+- [ ] **Step 1: Carry `customer_type` through the types**
+
+In `app/packages/[leadId]/page.tsx`, `interface Package` (~line 32, after `service_type: string;`), add:
+
+```typescript
+  customer_type?: string;
+```
+
+In `lib/order/types.ts`, `interface PackageDetails` (line 130, after `service_type?: string;`), add:
+
+```typescript
+  customer_type?: string;
+```
+
+In `app/packages/[leadId]/page.tsx`, BOTH `packageDetails` object literals — in `handlePackageSelect` (~line 228) and `handleContinue` (~line 271) — after `service_type: …,` add:
+
+```typescript
+      customer_type: pkg.customer_type,
+```
+
+(in `handleContinue` the source variable is `selectedPackage`, so: `customer_type: selectedPackage.customer_type,`)
+
+- [ ] **Step 2: Branch `handleContinue` to the quote flow**
+
+Add to the page's segment imports (Task 5 import line):
+
+```typescript
+import { normalizeSegment, isQuoteOnlyPackage, type CoverageSegment } from '@/lib/coverage/customer-segments';
+```
+
+At the top of `handleContinue` (line 268), insert before `if (selectedPackage) {`:
+
+```typescript
+    if (selectedPackage && isQuoteOnlyPackage(selectedPackage)) {
+      // Business packages onboard via the B2B quote pipeline, not self-checkout
+      router.push(`/quotes/request?packageId=${selectedPackage.id}&leadId=${leadId}`);
+      return;
+    }
+```
+
+- [ ] **Step 3: Label the CTAs**
+
+In `components/ui/package-detail-sidebar.tsx`:
+- Add `orderButtonLabel?: string;` to the props interface next to `onOrderClick?: () => void;` (line 57). If `MobilePackageDetailOverlay` (same file) has its own props interface with `onOrderClick`, add it there too.
+- Add `orderButtonLabel = 'Order Now',` to the destructured params next to `onOrderClick,` (line 117; and the overlay's equivalent).
+- Replace the hardcoded button text at line 320 (`Order Now`) with `{orderButtonLabel}`. Run `grep -n "Order Now" components/ui/package-detail-sidebar.tsx` and replace every occurrence that renders a CTA; if the overlay delegates to `PackageDetailSidebar`, pass the prop through.
+
+In `app/packages/[leadId]/page.tsx`, define once near `filteredPackages` (~line 405):
+
+```typescript
+  const continueLabel = selectedPackage && isQuoteOnlyPackage(selectedPackage)
+    ? 'Request a Quote'
+    : undefined;
+```
+
+- At the `PackageDetailSidebar` usage (~line 784) and `MobilePackageDetailOverlay` usage (~line 870), add: `orderButtonLabel={continueLabel}`.
+- At the bottom continue button (~line 900–904), replace the literal `Continue →` with `{continueLabel ? `${continueLabel} →` : 'Continue →'}`.
+
+- [ ] **Step 4: Type-check**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "packages/\[leadId\]|package-detail-sidebar|order/types"`
+Expected: no output.
+
+- [ ] **Step 5: Verify in the running app**
+
+On `?type=business` at a fibre-connected address: select a BizFibre package → sidebar and bottom CTAs read "Request a Quote"; clicking navigates to `/quotes/request?packageId=…&leadId=…`. On `?type=residential`: CTA still reads "Order Now"/"Continue →" and goes to `/order/checkout`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "app/packages/[leadId]/page.tsx" components/ui/package-detail-sidebar.tsx lib/order/types.ts
+git commit -m "feat(packages): business packages route to quote request instead of checkout"
+```
+
+---
+
+### Task 7: Quote request page — prefill from `packageId` + `leadId`
+
+**Files:**
+- Modify: `app/quotes/request/page.tsx` (interface `CoverageResult` ~line 36–42, new params + effect after the token-validation `useEffect` ~line 88–100)
+
+**Interfaces:**
+- Consumes: `GET /api/coverage/lead?leadId=` (returns the lead row incl. `address`); `GET /api/coverage/packages?leadId=&type=business` (returns `{ packages, address, coordinates }`); deep-link params from Task 6.
+- Produces: pre-populated `coverageResult` + `selectedPackages`, form starting at the `details` step.
+
+- [ ] **Step 1: Allow null coordinates**
+
+Change `interface CoverageResult` (line ~36):
+
+```typescript
+  coordinates: { lat: number; lng: number };
+```
+
+to:
+
+```typescript
+  coordinates: { lat: number; lng: number } | null;
+```
+
+(The submit handler already optional-chains `coverageResult?.coordinates`.)
+
+- [ ] **Step 2: Add the prefill effect**
+
+In `QuoteRequestFormContent`, after `const token = searchParams?.get('token');` (~line 54), add:
+
+```typescript
+  const prefillPackageId = searchParams?.get('packageId');
+  const prefillLeadId = searchParams?.get('leadId');
+```
+
+After the token-validation `useEffect` (~line 94), add:
+
+```typescript
+  // Prefill from the coverage-check results page (business package deep link)
+  useEffect(() => {
+    if (!prefillPackageId || !prefillLeadId) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const [leadRes, pkgRes] = await Promise.all([
+          fetch(`/api/coverage/lead?leadId=${prefillLeadId}`),
+          fetch(`/api/coverage/packages?leadId=${prefillLeadId}&type=business`),
+        ]);
+        if (!leadRes.ok || !pkgRes.ok) return; // best-effort: fall back to blank form
+        const lead = await leadRes.json();
+        const pkgData = await pkgRes.json();
+        if (cancelled) return;
+        const packages = pkgData.packages || [];
+        setCoverageResult({
+          lead_id: prefillLeadId,
+          address: lead.address || pkgData.address || '',
+          coordinates: pkgData.coordinates || null,
+          available: true,
+          packages,
+        });
+        setAddress(lead.address || '');
+        if (packages.some((p: { id: string }) => p.id === prefillPackageId)) {
+          setSelectedPackages([{ package_id: prefillPackageId, item_type: 'primary', quantity: 1 }]);
+        }
+        setStep('details');
+      } catch {
+        // best-effort prefill; user can run the in-form coverage check instead
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefillPackageId, prefillLeadId]);
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep "quotes/request"`
+Expected: no output.
+
+- [ ] **Step 4: Verify in the running app**
+
+Open `/quotes/request?packageId=<business pkg uuid>&leadId=<lead uuid>` (use the deep link from Task 6's verification). Expected: form opens on the **details** step, address shown; on the packages step the deep-linked package is already selected. Opening plain `/quotes/request` still starts at the coverage step.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/quotes/request/page.tsx
+git commit -m "feat(quotes): prefill quote request from coverage-check deep link"
+```
+
+---
+
+### Task 8: Checkout — SOHO personal/business account choice
+
+**Files:**
+- Modify: `app/order/checkout/page.tsx` (state near `pkg` line 67, three `accountType` derivations at lines 154, 200, 298, radio UI in the confirm step after `OrderingAsCard` ~line 528)
+
+**Interfaces:**
+- Consumes: `PackageDetails.customer_type` (Task 6); existing `pkg = orderState.orderData.package?.selectedPackage` (line 67); `RadioGroup`/`RadioGroupItem` from `@/components/ui/radio-group`, `Label` from `@/components/ui/label` (add imports if not present — check the file's import block first).
+- Produces: `consumer_orders.account_type` reflects the user's explicit choice for SOHO packages; segment-derived default otherwise.
+
+- [ ] **Step 1: Add state + derived account type**
+
+After line 67 (`const pkg = orderState.orderData.package?.selectedPackage;`), add:
+
+```typescript
+  // SOHO (WorkConnect) can be signed up personally or as a business — user chooses.
+  const isSohoPackage = pkg?.customer_type === 'soho';
+  const [sohoAccountType, setSohoAccountType] = useState<'personal' | 'business'>('personal');
+  const derivedAccountType: 'personal' | 'business' = isSohoPackage
+    ? sohoAccountType
+    : coverage?.coverageType === 'business' ? 'business' : 'personal';
+```
+
+(If `coverage` is declared after line 67, place this block immediately after the `coverage` declaration instead — it must come after both `pkg` and `coverage`.)
+
+- [ ] **Step 2: Use it at all three sites**
+
+Replace at line 154 and line 200:
+
+```typescript
+          accountType: coverage?.coverageType === 'business' ? 'business' : 'personal',
+```
+
+with:
+
+```typescript
+          accountType: derivedAccountType,
+```
+
+Replace at line 298:
+
+```typescript
+        account_type: coverage?.coverageType === 'business' ? 'business' : 'personal',
+```
+
+with:
+
+```typescript
+        account_type: derivedAccountType,
+```
+
+- [ ] **Step 3: Render the choice in the confirm step**
+
+Inside the confirm step's white card, directly after the `<OrderingAsCard … />` element (~line 528, before the "Collect missing profile details" block), add:
+
+```tsx
+                {isSohoPackage && (
+                  <div className="mt-5">
+                    <p className="text-sm font-bold text-circleTel-navy mb-2">I&apos;m signing up as</p>
+                    <RadioGroup
+                      value={sohoAccountType}
+                      onValueChange={(v) => setSohoAccountType(v as 'personal' | 'business')}
+                      className="flex gap-6"
+                    >
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="personal" id="soho-personal" />
+                        <Label htmlFor="soho-personal">Personal</Label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="business" id="soho-business" />
+                        <Label htmlFor="soho-business">Business</Label>
+                      </div>
+                    </RadioGroup>
+                    <p className="text-xs text-gray-500 mt-1">
+                      WorkConnect can be billed to you personally or to your business.
+                    </p>
+                  </div>
+                )}
+```
+
+Check the import block: `Label` is already imported; add `import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';` if absent.
+
+- [ ] **Step 4: Type-check**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep "order/checkout"`
+Expected: no output.
+
+- [ ] **Step 5: Verify in the running app**
+
+WFH segment → select a WorkConnect package → checkout confirm step shows the "I'm signing up as" radio (defaults Personal). Select Business, place a test order far enough to inspect the `/api/orders/create` request payload in devtools: `account_type: 'business'`. A consumer package shows no radio and sends `personal`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/order/checkout/page.tsx
+git commit -m "feat(checkout): explicit personal/business account choice for SOHO packages"
+```
+
+---
+
+### Task 9: Final verification + ship to staging
+
+**Files:** none new.
+
+- [ ] **Step 1: Full test + type-check pass**
+
+```bash
+npx jest lib/coverage
+npm run type-check:memory
+```
+
+Expected: coverage tests green; type-check introduces no NEW errors in touched files (compare against `origin/main` if unsure — the pre-push hook also enforces this).
+
+- [ ] **Step 2: Manual QA sweep (local dev)**
+
+Run through this matrix at (a) a fibre-connected address and (b) a wireless-only address:
+
+| Segment | Expect |
+|---|---|
+| Home | consumer packages only; checkout CTA; no WorkConnect |
+| Work from Home | WorkConnect listed FIRST on Wireless tab; consumer packages after; SOHO radio at checkout |
+| Business | BizFibre (fibre-connected only) + SkyFibre SME; CTA = Request a Quote → prefilled quote form |
+
+Plus: segment toggle switches without re-checking coverage; unknown `?type=garbage` behaves as Home; plain `/quotes/request` unaffected.
+
+- [ ] **Step 3: Push to staging**
+
+```bash
+git push origin feat/segment-coverage-check:staging
+```
+
+Watch the staging deploy (`gh run list --branch staging --limit 3`), then repeat the QA matrix on the staging URL. Staging deploys precede prod for testing AND admin training (project rule).
+
+- [ ] **Step 4: PR to main**
+
+Use the superpowers:finishing-a-development-branch skill. PR body summarises the segment model table from the spec and links `docs/superpowers/specs/2026-07-02-segment-aware-coverage-check-design.md`.

--- a/docs/superpowers/specs/2026-06-11-clinic-onboarding-dashboard-v3-design.md
+++ b/docs/superpowers/specs/2026-06-11-clinic-onboarding-dashboard-v3-design.md
@@ -1,0 +1,107 @@
+# Clinic Onboarding Dashboard v3.0 — Design
+
+**Date:** 2026-06-11
+**Route:** `/admin/unjani/onboarding`
+**Supersedes:** the current 370-line `app/admin/unjani/onboarding/page.tsx` (basic table)
+**Source mockup:** `CircleTel_Clinic_Onboarding_Dashboard_v3_0.html` (design review artifact, simulated data)
+
+## Goal
+
+Rebuild the clinic onboarding pipeline page as a sales-ops dashboard: at-a-glance KPIs, a clickable stage funnel, charts, a rich filterable table, a read-only Kanban view, and a clinic detail drawer — wired to **real** backend data.
+
+## Scope decisions (locked)
+
+1. **Data:** Build the full v3.0 layout on existing data **plus** a new lightweight `owner` field. **Defer** ISP-displacement savings (no data source): omit the "Saving p/m" column, the "Top displacement savings" chart, and the drawer "Commercials" block.
+2. **Interactivity:** "Wire what exists, route the rest." Inline actions where an endpoint exists (assign owner, send/resend invite, confirm mandate, issue service order); navigate for actions without an endpoint (vet documents → `/admin/b2b/vetting`, schedule install). **Kanban is read-only** (no drag-to-advance) — stage is derived from workflow state, not directly settable.
+3. **Third chart slot:** replace the deferred savings chart with **"Oldest in stage"** (clinics waiting longest) — actionable on real data.
+
+## Non-goals (v1)
+
+- ISP/cost/speed/savings data, the savings chart, drawer commercials.
+- Drag-to-advance Kanban; new workflow-transition endpoints.
+- A stage-transition audit log (see SLA caveat).
+
+## Architecture
+
+Thin page + focused co-located components (the current single file is doing too much for the v3.0 surface):
+
+```
+app/admin/unjani/onboarding/
+  page.tsx                    # layout + data fetch via hook, composes pieces, view toggle
+  components/
+    stages.ts                 # shared 7-stage config: id, label, brand color, SLA target (days), action
+    useOnboardingPipeline.ts  # fetch + client-side filter/sort/search/selection state
+    OnboardingKpis.tsx        # 5 KPI cards (unified-kit StatCard)
+    StageFunnel.tsx           # 7 clickable stage tiles + overdue flags → sets stage filter
+    StageDonut.tsx            # lightweight inline SVG donut (no chart-lib dependency)
+    ProvinceBars.tsx          # CSS horizontal bars from real province counts
+    OldestInStage.tsx         # third panel: clinics waiting longest
+    PipelineFilters.tsx       # search + province/SLA/owner selects + active stage chip + bulk bar
+    PipelineTable.tsx         # rows: checkbox, clinic, stage pill+progress dots, SLA, owner, next action
+    PipelineKanban.tsx        # read-only 7-column board; click card → drawer
+    ClinicDrawer.tsx          # slide-in detail: contact + onboarding timeline (no commercials)
+```
+
+**Styling:** map the mockup onto the existing **unified backend UI kit** (`components/backend/*`: StatCard, SectionCard, StatusBadge, PageHeader) and brand tokens — orange `#E87A1E`, navy `#1B2A4A` (NOT the mockup's `#F5841E`/`#13274A`). Donut and bars are hand-rolled SVG/CSS to match the mockup with no new dependency. Respect `prefers-reduced-motion`.
+
+## Stage model
+
+Backend `determineStage` already returns these; map 1:1 to the mockup labels and define once in `stages.ts`:
+
+| Backend stage | Label | SLA target (working days) | Primary action |
+|---|---|---|---|
+| `pending` | Awaiting invite | 5 | Send invite (inline) |
+| `invited` | Invited | 5 | Send reminder (inline, resend link) |
+| `submitted` | Docs submitted | 3 | Vet documents (navigate → /admin/b2b/vetting) |
+| `changes_requested` | Changes requested | 3 | Phone nurse (drawer shows contact) |
+| `docs_approved` | Docs approved | 4 | Send mandate link (inline) |
+| `mandate_active` | Mandate active | 4 | Schedule install (navigate) |
+| `billing_ready` | Ready to install | 5 | Raise service order (inline → issue-service-order) |
+
+## Data flow
+
+- **`GET /api/admin/b2b/onboarding-pipeline`** (extend existing): per clinic add `nurse_owner_name`, `phone`, `email`, `area_type` (from `clinic_details` + `customers`), and `owner` (joined name from `admin_users` via the new FK). Keep returning `clinics`, `stageCounts`, `overdueCount`. KPI / province / donut / oldest-in-stage aggregates are computed **client-side** from `clinics`.
+- **`POST /api/admin/b2b/onboarding-pipeline/assign-owner`** (new; admin-auth + `kyc:verify`): body `{ customerIds: string[], ownerId: string | null }` → sets `customers.onboarding_owner_id`. Supports single and bulk. Audit-logged.
+- **Bulk invite:** reuse existing `POST /api/admin/unjani/send-onboarding-batch`. **Single invite/resend:** reuse existing `send-link`.
+- **CSV export:** client-side from the loaded (filtered) clinic list. Columns: account, clinic, province, nurse, phone, email, stage, SLA status, owner. (No savings columns.)
+
+## Backend / schema change (single migration)
+
+`supabase/migrations/<ts>_onboarding_owner.sql`:
+```sql
+ALTER TABLE customers
+  ADD COLUMN IF NOT EXISTS onboarding_owner_id uuid REFERENCES admin_users(id);
+CREATE INDEX IF NOT EXISTS idx_customers_onboarding_owner
+  ON customers(onboarding_owner_id);
+```
+Owner options for the assign dropdown come from active `admin_users` (those with `kyc:verify` / sales-admin permission).
+
+## SLA handling (honest approximation)
+
+- **Vetting stage:** real countdown from `vetting_due_date` (already set to `addBusinessDays(submitted_at, 2)`). `overdue` already returned by the API.
+- **Other stages:** we do NOT store "stage entered at" timestamps, so per-stage "X of Y days" uses `customers.updated_at` as the best-available stage-entry proxy, compared against the `stages.ts` target. This is clearly an approximation; the UI labels it as "in stage" rather than implying a hard SLA. A precise per-stage SLA needs a stage-transition log (future, out of scope).
+- The **"Overdue SLA"** KPI counts only clinics whose real `sla.overdue` is true (i.e. vetting overdue), to avoid overstating breaches from the approximation.
+
+## KPIs (5 cards, all from real data)
+
+Active pipeline (count) · Overdue SLA (real `sla.overdue` count) · Ready to install (`billing_ready` count) · Pipeline MRR at activation (`count × R450`) · Active clinics (count with a started onboarding) — savings KPI dropped.
+
+## Error / empty / loading states
+
+- Loading: skeleton rows + skeleton KPI cards (reuse existing `Skeleton`).
+- Fetch error: unified-kit `ErrorState` with retry (the page previously surfaced "Failed to fetch pipeline" — keep a real error path).
+- Empty filtered result: existing empty-state pattern ("No clinics match these filters").
+
+## Testing / verification
+
+- `npm run type-check:memory` clean (scoped pre-push hook will gate).
+- Migration applied to Supabase; `assign-owner` route returns 200 and persists.
+- Pipeline API returns the extended shape (nurse/phone/email/owner) — verify via authenticated fetch.
+- Browser-verify on staging (deploy-staging label): page renders, funnel filters the table, owner assign persists, Kanban opens drawer, CSV downloads, no console errors (esp. no Radix Select empty-value — owner/SLA selects use sentinels).
+- Confirm 21 real clinics render (all currently `pending` → "Awaiting invite").
+
+## Risks / dependencies
+
+- All 21 clinics currently sit in one stage (`pending`); funnel/donut will look sparse until onboarding progresses — expected, not a bug.
+- `admin_users` is the owner source; if sales reps aren't admin users, the assign list may be short initially (acceptable; can broaden later).
+- Reuse, don't duplicate: check `components/backend/*` exports before adding any new shared primitive.

--- a/docs/superpowers/specs/2026-07-02-segment-aware-coverage-check-design.md
+++ b/docs/superpowers/specs/2026-07-02-segment-aware-coverage-check-design.md
@@ -1,0 +1,162 @@
+# Segment-Aware Coverage Check (Home / Work-from-home / Business)
+
+**Date:** 2026-07-02
+**Status:** Approved design, pending implementation plan
+**Owner:** Jeffrey
+
+## Problem
+
+The public coverage check currently serves residential products only in practice.
+The homepage hero (`components/home/NewHero.tsx`) already offers three segments —
+Home, Work from home, Business — but:
+
+1. **SOHO inventory is unreachable.** The "Work from home" segment maps to
+   `type=residential`, and `/api/coverage/packages` filters with an exact
+   `customer_type = 'consumer' | 'business'` match. The 3 active WorkConnect
+   packages (`customer_type='soho'`, R799/R1,099/R1,499) never display anywhere.
+   Packages with `customer_type='both'` are equally invisible.
+2. **No segment switch after coverage check.** Once on `/packages/[leadId]`,
+   the user cannot flip between home and business results without redoing the
+   coverage check (compare Vox's My Home / My Business toggle).
+3. **Business packages have no correct purchase path.** If shown, business
+   packages (BizFibreConnect R1,899+) would flow into consumer self-checkout,
+   which skips B2B KYC/contract handling.
+4. **Segment is not linked to signup.** The order flow's
+   `accountType: 'personal' | 'business'` (`lib/order/types.ts`) is independent
+   of the chosen segment, so SOHO's "business or personal depending on how the
+   user signs up" logic has no home.
+
+## Current state (verified 2026-07-02)
+
+- `service_packages.customer_type` CHECK constraint allows
+  `'consumer' | 'business' | 'both' | 'soho'`. Active counts: consumer 13,
+  business 12, soho 3.
+- `market_segment` column exists but is inconsistently populated (null, smme,
+  residential, enterprise, soho, b2b-managed). **Not used for filtering.**
+- `/api/coverage/packages` (route.ts:330) maps
+  `coverageType === 'business' ? 'business' : 'consumer'` and uses `.eq()`.
+- `/api/coverage/lead` maps business → lead `customer_type='smme'`, else
+  `'consumer'` (`coverage_leads.customer_type` enum: consumer/smme/enterprise).
+- `/quotes/request` page exists, lets a user select packages
+  (`package_id`) and submits to `/api/quotes`. No URL prefill support yet.
+- Hero segment config: `SegmentType = 'business' | 'wfh' | 'home'`
+  (NewHero.tsx:10–43); `wfh` currently serialises to `residential`.
+
+## Design
+
+### 1. Segment model — one source of truth
+
+The `?type=` URL/API param becomes a 3-value segment. `customer_type` on
+`service_packages` is the governing filter field; `market_segment` is ignored.
+
+| Segment (hero + URL) | `?type=` | Package filter (`customer_type IN`) | Ordering |
+|---|---|---|---|
+| Home | `residential` | `consumer`, `both` | unchanged |
+| Work from home | `wfh` (new) | `soho`, `consumer`, `both` | SOHO first, then price |
+| Business | `business` | `business`, `both` | unchanged |
+
+`residential` remains the fallback for missing/unknown values (backwards
+compatible with existing links and stored sessions).
+
+### 2. API changes
+
+**`/api/coverage/packages`** (`app/api/coverage/packages/route.ts`)
+- Replace the binary customer-type mapping with the filter sets above:
+  `.in('customer_type', [...])` instead of `.eq(...)`.
+- For `type=wfh`, sort results so `customer_type='soho'` packages lead.
+- Everything else unchanged: coverage detection (MTN/DFA/PostGIS fallback),
+  `service_type_mapping` category resolution, BizFibre fibre-status filtering,
+  provider logo enrichment.
+
+**`/api/coverage/lead`** (`app/api/coverage/lead/route.ts`)
+- Accept `coverageType='wfh'` and map it to lead `customer_type='consumer'`.
+  No enum migration: the segment travels in the URL and order state, not the
+  lead row.
+
+### 3. Results page — segment switcher
+
+`app/packages/[leadId]/page.tsx`:
+- New small `SegmentToggle` component (Home / Work from home / Business pills,
+  reusing the hero's segment config/icons) rendered above the existing
+  Fibre/LTE/5G `ServiceToggle`.
+- Switching updates `?type=` (router.replace, no scroll reset) and refetches
+  `/api/coverage/packages` for the **same leadId/address** — no coverage
+  re-check.
+- `NewHero.tsx`: the `wfh` segment serialises to `type=wfh` instead of
+  `residential`.
+
+### 4. Purchase paths — driven by the package, not the viewed segment
+
+Per-package CTA, keyed on the package's `customer_type`:
+
+- **`consumer` / `soho` / `both`** → existing self-checkout (OrderContext →
+  `/order/checkout`). Unchanged.
+- **`business`** → CTA becomes **"Request a quote"**, linking to
+  `/quotes/request?packageId=<id>&leadId=<leadId>`. The quote page reads these
+  params to pre-select the package and prefill address/coverage context from
+  the lead. BizFibreConnect never enters consumer checkout.
+
+### 5. SOHO signup: personal vs business
+
+- The chosen segment is written into `OrderContext` coverage state
+  (`coverageType` already exists there).
+- At the account step, `accountType` is **pre-selected** from the segment:
+  - Home → `personal`
+  - Business → `business` (only reachable for a hypothetical future
+    self-checkout business package of type `both`)
+  - WFH → default `personal`, with an explicit, visible personal/business
+    choice when the selected package is `customer_type='soho'`.
+- `accountType` remains user-changeable; the segment sets the default only.
+  Downstream (invoicing/RICA) already keys off `accountType`.
+
+### 6. Out of scope
+
+- `/business/*` marketing pages, B2B KYC pipeline, payments, RICA changes.
+- `coverage_leads` enum migration (no `soho` lead type).
+- `market_segment` column cleanup.
+- Business self-checkout (possible later phase if quote volume justifies it).
+- Homepage hero visual redesign (segments already exist there).
+
+## Alternatives considered
+
+- **Full business self-checkout now** — rejected: touches payment amounts,
+  RICA, contracts; B2B onboards via quotes/KYC today.
+- **Separate `segment` param alongside `type`** — rejected: two overlapping
+  params invite drift. Extending `type` keeps one pattern.
+- **SOHO-only results for WFH** — rejected: only 3 products, no fallback when
+  WorkConnect is unavailable at an address.
+
+## Error handling
+
+- Unknown `?type=` values fall back to `residential` (both API and page).
+- Segment switch refetch reuses the existing loading/error states of
+  `PackagesContent`; a failed refetch keeps the previous segment's results and
+  shows the existing error UI.
+- `/quotes/request` with an invalid/expired `packageId` or `leadId` degrades to
+  the current blank form (prefill is best-effort).
+
+## Testing
+
+- **API**: unit tests for the type→filter-set mapping, including `both`
+  visibility in all three segments, `soho` visible only under `wfh`, and
+  fallback for unknown types.
+- **UI**: packages page — segment toggle refetch, SOHO-first ordering under
+  WFH, business cards render "Request a quote" CTA with correct href.
+- **Quote prefill**: `/quotes/request?packageId=&leadId=` pre-selects the
+  package.
+- **Order flow**: accountType pre-selection per segment; SOHO package shows the
+  explicit personal/business choice.
+- Manual staging pass across all three segments at a fibre-covered and a
+  wireless-only address before PR to main.
+
+## Blast radius (~7 files + tests)
+
+| File | Change |
+|---|---|
+| `app/api/coverage/packages/route.ts` | filter sets + soho ordering |
+| `app/api/coverage/lead/route.ts` | accept `wfh` |
+| `components/home/NewHero.tsx` | `wfh` serialises to `type=wfh` |
+| `app/packages/[leadId]/page.tsx` | SegmentToggle + refetch + business CTA |
+| `components/coverage/SegmentToggle.tsx` (new) | pill toggle |
+| `app/quotes/request/page.tsx` | URL prefill (`packageId`, `leadId`) |
+| `components/order/*` (account step) | accountType default from segment |

--- a/docs/superpowers/specs/2026-07-02-segment-aware-coverage-check-design.md
+++ b/docs/superpowers/specs/2026-07-02-segment-aware-coverage-check-design.md
@@ -149,14 +149,19 @@ Per-package CTA, keyed on the package's `customer_type`:
 - Manual staging pass across all three segments at a fibre-covered and a
   wireless-only address before PR to main.
 
-## Blast radius (~7 files + tests)
+## Blast radius (~9 files + 1 data migration + tests)
 
 | File | Change |
 |---|---|
-| `app/api/coverage/packages/route.ts` | filter sets + soho ordering |
-| `app/api/coverage/lead/route.ts` | accept `wfh` |
+| `lib/coverage/customer-segments.ts` (new) | pure segment logic module + unit tests |
+| `supabase/migrations/20260702100000_soho_service_type_mapping.sql` (new) | map MTN FWB technical types → `product_category='soho'` (without this, WorkConnect is unreachable via the coverage mapping) |
+| `app/api/coverage/packages/route.ts` | filter sets + soho ordering + `customer_type` in response |
+| `app/api/coverage/lead/route.ts` | accept `wfh` (comment only — already maps to consumer) |
 | `components/home/NewHero.tsx` | `wfh` serialises to `type=wfh` |
-| `app/packages/[leadId]/page.tsx` | SegmentToggle + refetch + business CTA |
+| `app/packages/[leadId]/page.tsx` | SegmentToggle + refetch + business CTA + WorkConnect visible on Wireless tab (its `service_type`/`product_category` matched no tab filter) |
 | `components/coverage/SegmentToggle.tsx` (new) | pill toggle |
+| `components/ui/package-detail-sidebar.tsx` | optional `orderButtonLabel` prop |
 | `app/quotes/request/page.tsx` | URL prefill (`packageId`, `leadId`) |
-| `components/order/*` (account step) | accountType default from segment |
+| `lib/order/types.ts` + `app/order/checkout/page.tsx` | `PackageDetails.customer_type`; SOHO personal/business choice |
+
+Implementation plan: `docs/superpowers/plans/2026-07-02-segment-aware-coverage-check.md`

--- a/supabase/migrations/20260607120000_security_advisor_safe_fixes.sql
+++ b/supabase/migrations/20260607120000_security_advisor_safe_fixes.sql
@@ -1,0 +1,22 @@
+-- Security Advisor (database-linter) safe remediations — 2026-06-07
+--
+-- Resolves three ERROR-level findings. All affected objects are read ONLY by the
+-- service-role server client (lib/supabase/server), which bypasses RLS, so these
+-- changes do not affect application behaviour.
+--
+-- NOT included (deliberate):
+--   * public.cms_blog_posts  — intentional SECURITY DEFINER view giving anon a
+--     controlled, status='published' window into the `payload` schema. Switching
+--     to security_invoker would break public blog reads. Left as-is.
+--   * public.spatial_ref_sys — PostGIS system table owned by supabase_admin;
+--     cannot ALTER as the postgres role. Known false positive.
+
+-- 0013_rls_disabled_in_public: enable RLS (deny-all to anon/authenticated;
+-- service-role continues to bypass — the only consumer of these tables).
+ALTER TABLE public.tarana_device_counts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sources ENABLE ROW LEVEL SECURITY;
+
+-- 0010_security_definer_view: run the view with the caller's permissions/RLS.
+-- This view reads only public-schema tables and is queried solely server-side
+-- (lib/hardware-catalogue/queries.ts) via the service-role client.
+ALTER VIEW public.v_hardware_product_detail SET (security_invoker = on);


### PR DESCRIPTION
## What this is

Salvage of the genuinely-new, non-superseded work that was stranded (unpushed) on the local `fix/offers-build-time-db` branch and its worktrees. Cherry-picked cleanly onto current `main` with provenance (`-x`).

A full audit of the 62 local-only commits found that **35 were already on `main`** (identical patches, merged under other SHAs) and several more were **superseded** by newer PRs. This branch carries only the 7 that are new *and* still relevant.

## Commits (7)

**Feature**
- `feat: unify portal console shell` — new `components/backend/*` module (ConsoleNav, ConsoleShell, ConsoleTopbar, DataTable, EntityHeader, InspectorPanel, MetricPanel, ChartPanel, ActivityTimeline + types/utils/tests) and refactors the 5 backend layouts (admin/business/dashboard/partner/portal) onto it.

**Docs**
- `docs(spec): Clinic Onboarding Dashboard v3.0 design`
- `docs(spec)` + `docs(plan): segment-aware coverage check (home/wfh/business)`
- `docs(workflow): add Stage 0 branch-first discipline`

**Infra / DB**
- `fix(db): Supabase Security Advisor safe remediations` — enables RLS on `tarana_device_counts` + `sources`, sets `security_invoker` on `v_hardware_product_detail`. ⚠️ **DB migration** — runs on next deploy; documented behavior-safe (only consumer is the service-role client, which bypasses RLS).
- `ci: add --legacy-peer-deps to API integration test installs` — `main`'s `api-integration-tests.yml` still uses bare `npm ci` at 3 steps and breaks on the react@19 ERESOLVE conflict.

## Verification

- Each commit cherry-picked cleanly onto `origin/main` (dry-run tested in isolation first).
- `type-check:memory`: salvage branch = 237 errors, `origin/main` baseline = 237 errors → **0 new type errors introduced**. All changed files (`components/backend/*`, the 5 layouts) are type-clean; the 237 are pre-existing repo debt.

## Deliberately NOT included

- **Vetting** (`render document live`, `blocking mismatch gate`) — already on `main` as newer SHAs (`76223c4d`, `92a45dca`) and further refined by #592/#593.
- **Debit-order pipeline W1–W5** + emandate fix + W5 test — constituent fixes already re-landed individually on `main` (#550, #595, #599, BatchFileUpload). The monolithic commit conflicts and would re-introduce superseded code.
- **Ubicloud CI rollout** — edits MTN workflow files that were deleted on `main`. Obsolete.
- **3 secret-scrub commits** — the Zoho + Netcash secrets were rotated, so the values still on `main` are dead. Scrub is cosmetic; can follow separately.
- **`wip: snapshot uncommitted work`** — 199-file junk-drawer commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
