### PR TITLE
chore(security): gitleaks pre-commit hook + CI secret scan

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Shared pre-commit hook (tracked; enabled via core.hooksPath=.githooks).
+# Auto-wired on `npm install`/`npm ci` by the "prepare" script in package.json.
+#
+# Blocks secrets from entering a commit — the root cause of the 2026-07 incident
+# where Zoho/Netcash secrets reached `main`. Mirrors the machine-global hook.
+#
+# Escape hatch (verified false positives only, logged):
+#   GITLEAKS_SKIP=1 git commit …      # skip the scan
+#   git commit --no-verify            # skip ALL hooks (discouraged)
+
+if [ "${GITLEAKS_SKIP:-0}" = "1" ]; then
+  echo "⚠️  GITLEAKS_SKIP=1 — secret scan bypassed ($(git config user.email))"
+  exit 0
+fi
+
+if command -v gitleaks >/dev/null 2>&1; then
+  CFG=""
+  [ -f "$(git rev-parse --show-toplevel)/.gitleaks.toml" ] && \
+    CFG="--config $(git rev-parse --show-toplevel)/.gitleaks.toml"
+  if ! gitleaks git --pre-commit --staged --redact --no-banner $CFG 2>/dev/null; then
+    echo ""
+    echo "🚫 COMMIT BLOCKED — gitleaks found a secret in staged changes."
+    echo "   Remove/rotate it, or (verified false positive only) add to .gitleaks.toml"
+    echo "   or:  GITLEAKS_SKIP=1 git commit …"
+    exit 1
+  fi
+else
+  echo "⚠️  gitleaks not installed — secret scan skipped."
+  echo "   Install: https://github.com/gitleaks/gitleaks"
+fi
+exit 0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,16 @@
+name: gitleaks
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so a secret in any pushed commit is caught
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,4 +13,5 @@ jobs:
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# circletel gitleaks config. Used by .githooks/pre-commit AND the CI workflow.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "circletel false-positive allowlist"
+paths = [
+  '''(^|/)\.env\.example$''',
+  '''(^|/)\.env\.sample$''',
+  '''(^|/)\.env\.template$''',
+  '''(^|/)[^/]*\.example\.[^/]+$''',
+]
+regexes = [
+  '''(?i)your[_-]?(api[_-]?)?(key|token|secret)[_-]?here''',
+  '''(?i)^(changeme|placeholder|xxxxxxxx+)$''',
+  '''(?i)(sk|pk)_(test|live)_0{8,}''',
+]


### PR DESCRIPTION
## What & why

After the 2026-07 audit found rotated-but-committed secrets sitting on `main`, this wires **gitleaks** secret scanning into circletel so it can't recur.

circletel uses a repo-local `core.hooksPath=.githooks`, so the machine-global pre-commit hook doesn't reach it — this adds circletel's own copy.

## Changes
- **`.githooks/pre-commit`** — runs `gitleaks git --pre-commit --staged` and **blocks the commit** on a finding. Auto-enabled by the existing `prepare` script on `npm install`/`npm ci`. Escape hatch for verified false positives: `GITLEAKS_SKIP=1 git commit …`.
- **`.gitleaks.toml`** — extends the default ruleset; allowlists `.env.example`-style sample files and narrowly-specific placeholders (no broad word matches that could hide real secrets).
- **`.github/workflows/gitleaks.yml`** — full-history scan on PR + push to `main` as a visible backstop.

## Verified
- Hook **blocks** a real-format GitHub PAT and a realistic AWS key; **allows** clean commits and `.env.example` placeholders.
- Requires the `gitleaks` binary locally (already installed on the VPS at `/usr/local/bin/gitleaks`; hook warns and no-ops if absent so it never hard-breaks a machine without it).

## Note
This is a **non-blocking** check in CI (branch protection is intentionally not enabled, to keep Hermes/deploy pushes working). The real enforcement is the local pre-commit; CI is the visible backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
