### PR TITLE
fix(billing): credit-note apply wrote to non-existent payment_reference column

### DIFF
--- a/lib/billing/compliant-billing-service.ts
+++ b/lib/billing/compliant-billing-service.ts
@@ -386,8 +386,7 @@ export class CompliantBillingService {
       .from('customer_invoices')
       .update({
         amount_paid: newAmountPaid,
-        status: newStatus,
-        payment_reference: `Credit Note: ${creditNote.credit_note_number}`
+        status: newStatus
       })
       .eq('id', originalInvoice.id);
 

--- a/scripts/apply-kayamandi-credit-note.ts
+++ b/scripts/apply-kayamandi-credit-note.ts
@@ -1,0 +1,56 @@
+/**
+ * One-off remediation (2026-07-08): Kayamandi CT-2026-00022 June double-debit.
+ *
+ * INV-2026-00016 (R276 pro-rata) was collected in BOTH the 29-Jun and 01-Jul
+ * NetCash batches -> R276 over-collected on the Esterkula (FNB ****5967) account.
+ * Finance decision: net the R276 credit against the July invoice INV-2026-00027
+ * (R450), leaving R174 to collect via a manual NetCash debit (action 2026-07-13).
+ *
+ * This script creates + applies credit note CN-2026-00002 (R276) against
+ * INV-2026-00027, taking it to amount_paid=276 / status=partial (R174 remaining
+ * = total_amount - amount_paid).
+ *
+ * Run: set -a && source .env.local && set +a && npx tsx scripts/apply-kayamandi-credit-note.ts
+ */
+import { CompliantBillingService } from '@/lib/billing/compliant-billing-service';
+
+const INV_00027 = '2bb90197-2bcf-488a-b7e4-f60bc518e5c3'; // Kayamandi July R450 invoice
+
+async function main() {
+  const creditNote = await CompliantBillingService.createCreditNote(
+    {
+      original_invoice_id: INV_00027,
+      line_items: [
+        {
+          description:
+            'Credit for duplicate debit of INV-2026-00016 (R276) collected in both the 29-Jun and 01-Jul 2026 NetCash batches. Offsets July invoice INV-2026-00027.',
+          quantity: 1,
+          unit_price: 276.0,
+          amount: 276.0, // VAT-inclusive
+          type: 'adjustment',
+        },
+      ],
+      reason:
+        'Duplicate debit collection of INV-2026-00016 (R276) across the 29-Jun and 01-Jul 2026 NetCash batches; credit offsets July invoice INV-2026-00027.',
+      reason_category: 'billing_error',
+      notes:
+        'Netting per finance decision 2026-07-08: apply R276 June over-collection credit against the July R450 invoice, leaving R174 to collect via debit order (action date 2026-07-13).',
+      auto_apply: true,
+    },
+    {
+      user_email: 'claude-code@circletel.co.za',
+      user_role: 'system',
+      reason: 'Kayamandi June double-debit remediation',
+    }
+  );
+
+  console.log('Credit note created + applied:');
+  console.log(JSON.stringify(creditNote, null, 2));
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('FAILED:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Problem

`CompliantBillingService.applyCreditNote()` updated `customer_invoices.payment_reference` — **a column that does not exist** on that table (verified against the live schema). Every credit-note *application* therefore threw `Failed to update invoice`. Credit notes could be **created** but never **applied**, so no credit ever reduced an invoice balance.

This is the same "writes to non-existent columns silently" class of defect flagged in the 2026-07-02 debit-rail audit.

## Fix

Drop the bad `payment_reference` write. `amount_paid` + `status` are the authoritative fields; the credit-note linkage is already preserved via `credit_notes.original_invoice_id` and the `invoice_audit_log` entry written by `applyCreditNote`.

```diff
       .update({
         amount_paid: newAmountPaid,
         status: newStatus,
-        payment_reference: `Credit Note: ${creditNote.credit_note_number}`
       })
```

## Included: Kayamandi remediation record

`scripts/apply-kayamandi-credit-note.ts` is the one-off script already run against prod to remediate Kayamandi (CT-2026-00022): the June R276 pro-rata (INV-2026-00016) was debited twice (29-Jun + 01-Jul NetCash batches). **CN-2026-00002** (R276) was created and applied against the July invoice **INV-2026-00027**, netting it from R450 → **R174 remaining**. Kept in-repo as an audit trail of the financial action.

## Verification

- Ran the fixed path in prod: CN-2026-00002 → `status=applied`; INV-2026-00027 → `status=partial`, `amount_paid=276.00` (remaining R174). Confirmed via direct DB read.
- Scope: 1-line deletion in the service + additive script. No behaviour change beyond making credit-note application succeed.

## Note
`customer_invoices.amount_due` is not decremented on payment anywhere in this system (a pre-existing quirk — e.g. INV-2026-00016 sits at `amount_due=276` while fully paid). This PR does not change that; authoritative remaining is `total_amount - amount_paid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)