### PR TITLE
feat(revenue-assurance): network-management roadmap + unified service→identifier mapping

### DIFF
--- a/docs/architecture/NETWORK_VISIBILITY_BRIDGES.md
+++ b/docs/architecture/NETWORK_VISIBILITY_BRIDGES.md
@@ -2,6 +2,8 @@
 
 **Date:** 2026-07-09 · **Status:** verified live · **Scope:** how CircleTel sees active sites across the on-site device stack.
 
+> **Whitelabel alignment:** these bridges are Seam-3 (Integration Gateway) integrations — they will conform to the `lib/integrations/core/` adapter contract and resolve credentials via the tenant config layer (not `process.env`). See `docs/superpowers/specs/2026-07-09-whitelabel-alignment-network-billing.md`.
+
 ## 1. Site topology — three device layers
 
 Every **managed** site (Unjani clinic, business connectivity) has the same stack:

--- a/docs/architecture/NETWORK_VISIBILITY_BRIDGES.md
+++ b/docs/architecture/NETWORK_VISIBILITY_BRIDGES.md
@@ -1,0 +1,89 @@
+# Network Visibility Bridges — Tarana / TCS + Tri-Bridge Runbook
+
+**Date:** 2026-07-09 · **Status:** verified live · **Scope:** how CircleTel sees active sites across the on-site device stack.
+
+## 1. Site topology — three device layers
+
+Every **managed** site (Unjani clinic, business connectivity) has the same stack:
+
+```
+Uplink (Tarana RN  |  MTN LTE/5G router)  →  MikroTik  →  Reyee AP(s) (indoor ± outdoor)
+     │                                          │                │
+    TCS bridge                              (TDX-locked)      Ruijie Cloud
+     └──────────────── Interstellio (L3 PPPoE / RADIUS) ──────────┘
+```
+
+- **Consumer SIM** customers (e.g. bare MTN 5G router sold to an end-user) have **no MikroTik/Reyee** — reconcile via the MTN SIM report only.
+- The **MikroTik is CircleTel-owned but not directly visible** (TDX captive-portal script holds admin; the L2TP edge-proxy management system is built but has 0 routers enrolled). See §5.
+
+## 2. The three working bridges (verified 2026-07-09)
+
+CircleTel can see live sites from three independent, read-only bridges. **The MikroTik is "bracketed":** TCS sees the layer above it, Ruijie the layer below it, Interstellio the L3 session through it — so Tarana-clinic liveness is fully observable **without** MikroTik access.
+
+### 2.1 TCS — Tarana Cloud Suite (last-mile radio)
+- **Code:** `lib/tarana/client.ts` + `lib/tarana/auth.ts`
+- **Auth:** cookie-session — logs in with `TARANA_USERNAME`/`TARANA_PASSWORD` (in `.env`) → captures httpOnly `idToken`/`accessToken`/`userId`; browser-like headers + `X-Caller-Name: operator-portal` required (Istio gateway).
+- **Base:** `https://portal.tcs.taranawireless.com` · Access as **MTN Operator 219**; CircleTel = **retailerId 1020 ("Circle Tel SA")** → RN view scoped to our own devices.
+- **What you get (working):**
+  - `getAllDeviceStatusesNqs('RN')` → `Map<serial, online>` — our Remote Nodes with live up/down (verified: **9 RNs, 6 online**).
+  - `getDeviceBySerial(serial)` → deep per-RN detail: `linkState`, `losRange`, `sectorName`, `band`, `carriers`, `softwareVersion`, `uptimeSeconds`, mgmt `ip` + `endpoints` (web/ssh/grpc), `linkDisconnectDurationMillis`, reboot reasons.
+  - Base-node inventory: 709 rows in `tarana_base_stations` (SkyFibre coverage).
+- **Broken/param-nit (fix later):** `getDeviceCounts()` → 400; `getAllRemoteNodes()` → 500 (needs region/site params); `getNetworkHierarchy()` → empty.
+- **Gotcha:** RN records carry **no clinic identifier** — `hostName` is a generated Tarana ID, `address` is null, `locationId` is an opaque hash, `sectorName` is the BN not the site. Mapping RN serial → clinic requires an external install cross-reference (see §4).
+
+### 2.2 Interstellio / NebularStack (L3 subscriber / RADIUS)
+- **Code:** `lib/interstellio/client.ts` — `getInterstellioClient()` auto-inits from `INTERSTELLIO_API_TOKEN` (in `.env`).
+- **Base:** `subscriber-za.nebularstack.com` (+ identity/telemetry). Domain `circletel.co.za`.
+- **What you get (working):**
+  - `listSubscribers({ l: 50 })` — **max limit 50** (larger → 400). Verified: 25 subscribers, **14 `CT-UNJ-*` clinics, all enabled**, each with `name` = clinic name, `last_seen`, `static_ip4`, `service`/`profile`/`package`.
+  - `isSessionActive(id)` — live session state (verified true for several clinics).
+  - `getSubscriberUsage(id, granularity, {start,end})`, `getCDRRecords(...)`, `getSubscriberStatus(id)`.
+  - The Unjani clinics' **managed connectivity itself** is on Interstellio (PPPoE), so `last_seen` ≈ "clinic/MikroTik online". 9 of 14 seen within the hour at probe time.
+- **Broken:** `getSubscriberCount()` → 404 on stale path `/v1/subscriber/count`. Use `listSubscribers` / `getTotalSubscriberCount` (`/v1/subscribers/count`).
+
+### 2.3 Ruijie Cloud (in-clinic Wi-Fi AP)
+- **Code:** `lib/ruijie/client.ts` (see `ruijie-network-management-state` memory + roadmap). Cloud-eu, OAuth token. 25 devices / 22 online. Reboot + eWeb tunnel + device logs work; live CPU/mem/radio telemetry is **not** implemented (Phase 0 fix).
+
+## 3. Unified active-signal mapping — `service_network_identifiers`
+
+One table maps every source's identifier to a `customer_services` row (migration `20260709160000_create_service_network_identifiers.sql`).
+
+| identifier_type | source | backfilled | notes |
+|---|---|---|---|
+| `ruijie_sn` | Ruijie AP SN → site → service | 23 | via `corporate_sites.service_id` |
+| `interstellio_uuid` | CT-UNJ subscriber UUID → clinic | 16 (14 clinics + 2 SkyFibre) | matched on subscriber `name` → `corporate_sites.site_name` (verified 1:1) |
+| `tarana_serial` | RN serial → clinic | **0 — pending** | no clinic id in TCS; needs install cross-reference (§4) |
+| `msisdn` / `iccid` | MTN SIM → consumer 5G service | 0 — pending | needs SIM numbers from MTN |
+
+**Coverage (2026-07-09):** 25 active services · **22 mapped (88%)** · **14 with 2+ independent sources** (Ruijie AP + Interstellio session — cross-verified liveness) · 39 identifiers total.
+
+Backfills applied directly to the shared prod DB (data ops, not migrations) — same convention as the Ruijie/Interstellio backfills.
+
+## 4. Known gaps
+
+- **Tarana RN → clinic mapping** — 9 RNs (6 online) are an unmapped active-signal pool. TCS carries no clinic identifier on the RN; do **not** guess-map (wrong RN→clinic corrupts reconciliation). Resolve via the Unjani install/hardware register (serial → clinic) or a `hostName`/`address` convention.
+- **Consumer 5G MSISDN** — Ashwyn/Raymund unmapped; needs SIM numbers from MTN (see the RA report-reconciliation spec).
+- **Endpoint drift** — TCS `getDeviceCounts`/`getAllRemoteNodes`/`getNetworkHierarchy` and Interstellio `getSubscriberCount` have stale params; low-priority cleanup.
+
+## 5. MikroTik (bracketed, not directly reachable)
+
+Fully-built L2TP edge-proxy management system (`lib/mikrotik/*`, proxy `34.35.85.28:8443`, `mikrotik_routers` registry, 30-min sync) but **0 routers enrolled** — the gap is device **enrollment** (TDX-access), not build. Enrolling one router = insert via `POST /api/admin/network/mikrotik` (`identity`, `mac_address`, **`management_ip`** = L2TP tunnel IP, pppoe + router creds) **once** the router is on the L2TP tunnel and the proxy can RouterOS-auth it. De-risk with a bench/spare unit first. See the `mikrotik-access-state` memory for the full enrollment trace.
+
+## 6. How to run a reachability probe
+
+Bridges read creds at module load → **source `.env` before `tsx`**:
+
+```bash
+set -a && source .env && set +a && npx tsx scripts/<probe>.ts
+```
+
+Minimal examples:
+```ts
+// Tarana RN status
+import { getAllDeviceStatusesNqs } from '@/lib/tarana/client'
+const rn = await getAllDeviceStatusesNqs('RN')      // Map<serial, online>
+
+// Interstellio clinics
+import { getInterstellioClient } from '@/lib/interstellio'
+const res = await getInterstellioClient().listSubscribers({ l: 50 })  // max 50
+```

--- a/docs/plans/2026-07-09-in-app-network-management-roadmap.md
+++ b/docs/plans/2026-07-09-in-app-network-management-roadmap.md
@@ -4,6 +4,8 @@
 **Owner:** CircleTel platform
 **Goal:** Run and manage the entire device fleet from inside the CircleTel admin app — a real NOC — built on the live Ruijie Cloud API (and, later, MikroTik + other vendors).
 
+> **Whitelabel alignment (Seam 3 — Integration Gateway):** the vendor-neutral `NetworkDeviceAdapter` (Phase 0/6 below) is an *implementation of* the future `lib/integrations/core/` adapter contract (`authenticate/healthCheck/capabilities`), not a parallel abstraction; the `ruijie/tarana/mikrotik_sync_logs` tables consolidate into `integration_runs`; credentials resolve via the tenant config layer, not `process.env`; per-tenant enable/disable via the feature registry. See `docs/superpowers/specs/2026-07-09-whitelabel-alignment-network-billing.md`.
+
 ---
 
 ## 1. Vision & Scope

--- a/docs/plans/2026-07-09-in-app-network-management-roadmap.md
+++ b/docs/plans/2026-07-09-in-app-network-management-roadmap.md
@@ -1,0 +1,211 @@
+# In-App Network Management — Feature & Roadmap
+
+**Date:** 2026-07-09
+**Owner:** CircleTel platform
+**Goal:** Run and manage the entire device fleet from inside the CircleTel admin app — a real NOC — built on the live Ruijie Cloud API (and, later, MikroTik + other vendors).
+
+---
+
+## 1. Vision & Scope
+
+Today CircleTel can *see* the fleet (inventory + online/offline) inside the app. "Full in-app network management" means the app becomes the single pane of glass to:
+
+1. **Monitor** — live health, performance, alerts, SLA (no logging into Ruijie Cloud).
+2. **Operate** — reboot, remote console, config changes, firmware, port/PoE control.
+3. **Provision** — onboard a new site/device end-to-end (bind → assign to customer → push config).
+4. **Monetize** — guest WiFi / captive portal / vouchers (the CloudWiFi WaaS product) and per-user PPSK.
+5. **Expose** — let B2B customers self-serve a read-only view of their own sites (portal).
+
+Scope covers the **Ruijie/Reyee fleet first** (55 live devices across Unjani, Newgen, CircleTel projects), with a vendor-abstraction seam so **MikroTik** (already partially scaffolded) and future vendors slot in without rework.
+
+### The network is TWO layers — cover both
+
+| Layer | Source | Signal | Status |
+|---|---|---|---|
+| **Hardware (L1/L2)** | Ruijie APs, MikroTik | device up/down, CPU, radio, ports | This roadmap (device-centric) |
+| **Subscriber / AAA (L3)** | **Interstellio RADIUS (NebularStack)** | who's authenticated, session state, **data usage, service profile, credit/quota, active/inactive** | **Already integrated** — `lib/interstellio/client.ts` (mature: subscribers CRUD, sessions incl. disconnect, usage/CDR, profiles, credit, webhooks), admin routes under `/api/admin/integrations/interstellio/*`, webhook receiver. Under-leveraged. |
+
+Interstellio is the **subscriber-connectivity truth** and the backbone of Revenue Assurance (§6a). Thread it through the phases as an explicit AAA dimension rather than a separate effort:
+- **Phase 1** — per-customer session/usage visibility; wire Interstellio **webhooks** (session down, quota exceeded) into alerting (event-driven, not polling).
+- **Phase 2** — surface existing control actions: `disconnectSession`, `enable/disableSubscriber`, `changeSubscriberProfile`.
+- **Phase 3** — `createSubscriber`/`changeProfile` on order activation.
+
+**Liveness caution:** mirror the Ruijie Phase-0 discipline — spike-verify our Interstellio token/endpoints actually return the subscribers/usage/CDR the console dashboard shows before depending on it (the dashboard proves the platform has data, not that our client still pulls it).
+
+---
+
+## 2. Current State (verified 2026-07-09)
+
+**Working & live:**
+- OAuth token, project tree, **25 deduped devices, 22 online** — verified against `cloud-eu`.
+- **Sync cron running every 30 min** (`ruijie_sync_logs`, `triggered_by=cron`, cache fresh) → device list/detail pages show current data.
+- **Device management logs** (`getDeviceLogs`) — returns real entries.
+- Admin UI: `/admin/network` hub, `/devices`, `/devices/[sn]` (6 tabs), `/health`, `/map`, `/analytics`, `/outages`.
+- Wired controls: **remote reboot** + **eWeb tunnel** (remote web console), both audit-logged (`ruijie_audit_log`, 4,758 rows).
+- All routes admin-auth gated (session cookie → `admin_users`).
+
+**Broken / gaps (must fix before building on top) — corrected root cause after code review 2026-07-09:**
+- **CPU/Memory never fetched** — `getDeviceMetrics` hardcodes CPU/mem/radio/uptime to `null` and only derives `online_clients`. The documented **§2.6.6 CPU/Memory endpoint** (`/logbizagent/logbiz/api/sys/current_performance`) is simply **not implemented**. → implement it (Phase 0).
+- **Radio channels have no documented cloud endpoint** (eWeb-tunnel only) — accept null, fix the UI so it doesn't show empty 0% bars.
+- **Traffic returns zero** — uses the correct documented endpoint; needs the spike to confirm genuine-zero vs a request-param issue.
+- **NOT a bug (earlier assumption corrected):** there is **no unhandled-rejection defect** — all client fns try/catch and return empty; that crash was a test-script artifact. `ruijieFetch` does dump 60KB HTML on 404s though — cap it.
+- **Cache stores status only** — no metrics time series; Phase 0 adds `ruijie_device_metrics`.
+- **MikroTik subsystem** exists in code but is unverified/likely inert.
+
+See `docs/plans/2026-07-09-phase0-network-foundation-spec.md` for the full Phase 0 spec.
+
+**Architecture principles to keep:**
+- Cache table (`ruijie_device_cache`) for list/status, refreshed by cron; **live pass-through** for on-demand ops. This is sound — keep it.
+- Background jobs already scaffolded in `lib/inngest/functions/ruijie-*` (sync, health-monitor, offline-alerts, tunnel-cleanup, token-refresh) — wire/verify rather than rebuild.
+- Every mutating action → `ruijie_audit_log`. Keep this invariant for all new controls.
+
+---
+
+## 3. Roadmap
+
+Each phase is independently shippable. Effort is T-shirt (S ≈ 1–2 days, M ≈ 3–5 days, L ≈ 1–2 wks).
+
+### Phase 0 — Fix the foundation *(blocking, do first)* — **M**
+Without this, every new dashboard inherits blank data.
+- Capture the exact failing metrics/traffic request; compare to the Ruijie Cloud API Document (device CPU/memory §2.6.6, flow trend §2.6.2, STA list §2.5). Determine correct endpoint/params for RAP-series on `cloud-eu`.
+- Fix the **unhandled rejection** in `getDeviceMetrics` (guard the sub-fetch, return partial cleanly).
+- Decide: fetch metrics **live on open** (current) vs **persist to cache on sync** (enables history + alerting). Recommend: persist a metrics snapshot per sync so we get trend data for free.
+- **Success:** Overview/Radio tabs show real CPU/mem/radio for an online AP; traffic chart shows non-zero for a site with traffic.
+
+### Phase 1 — Complete monitoring & NOC — **L**
+Turn "we can see devices" into "we get told when something breaks."
+- Wire & verify the **offline-alerts** and **health-monitor** Inngest functions → notify finance/ops (email + WhatsApp, reuse existing channels) on device down / degraded.
+- Per-device **historical charts** (CPU/mem/clients/traffic) from persisted snapshots (Phase 0 dependency).
+- **Fleet health dashboard**: uptime %, offline count, worst-N devices, per-project rollups (Unjani vs Newgen vs CircleTel).
+- **Connected-client visibility** confirmed working (verify against a device with active users).
+- Tie device-down events into the existing **Outages** module (auto-suggest an incident when N devices at a site drop).
+- **Success:** an AP going offline produces an alert within one sync cycle and appears on the health dashboard.
+
+### Phase 2 — Remote operations — **L**
+Everything an engineer would log into Ruijie Cloud to do.
+- Reboot (✅ exists) + eWeb tunnel (✅ exists) — promote to a consistent "Actions" surface.
+- **Switch port + PoE control** (API §2.6.7/2.6.8 + `/conf/switch/device/{sn}/poe`) — remotely power-cycle a PoE camera/AP at a clinic. High operational value.
+- **Batch CLI** / **config cloning** (help-center features) — push a config to one or many devices.
+- **Firmware upgrade** scheduling.
+- All gated by RBAC (see §4) + audit-logged + confirm dialogs (reboot pattern already exists).
+- **Success:** ops can power-cycle a specific switch port and push a CLI snippet to a device group from the app.
+
+### Phase 3 — Provisioning & zero-touch onboarding — **M/L**
+Collapse "new site" into an app workflow.
+- **Add device** by SN/QR → bind to a Ruijie project → assign to a CircleTel customer/corporate site (reuse `DeviceCustomerLink` + `corporate_sites`).
+- **Config templates** per product (SkyFibre, CloudWiFi, Unjani clinic standard) applied on bind.
+- Link into existing **onboarding** flow so a provisioned device is tied to the order/contract.
+- **Success:** onboarding a new clinic AP (bind → assign → template) is done entirely in-app.
+
+### Phase 4 — Guest WiFi, captive portal & vouchers — **L**
+Directly monetizes the **CloudWiFi WaaS** product.
+- **Voucher management** (API §2.3): create voucher packages, generate/issue vouchers, query usage.
+- **Captive portal** config + **PPSK / auth-account** management (API §2.4/§4): per-user WiFi credentials, add/delete/renew, usage dashboard.
+- Ties to billing: voucher batches / WaaS seats as sellable units.
+- **Success:** a WaaS site's guest-WiFi vouchers are issued and tracked from the app.
+
+### Phase 5 — Customer-facing self-service — **M**
+Leverage existing `/portal/sites` scaffolding.
+- Read-only per-customer network view: their sites, uptime, current status, basic usage.
+- Scoped by RLS/ownership so a B2B customer sees only their own devices.
+- **Success:** a B2B customer logs into the portal and sees their site health without contacting support.
+
+### Phase 6 — Multi-vendor abstraction & whitelabel — **L**
+- Introduce a vendor-neutral device interface; make Ruijie one adapter, **MikroTik** a second (verify/complete the existing `mikrotik` routes).
+- This is the network-management pillar of the **whitelabel ISP-in-a-box** platform (see `whitelabel-platform-baseline-design`) — a strong differentiator no competitor bundles.
+- **Success:** the same device UI drives a MikroTik router and a Ruijie AP.
+
+---
+
+## 4. Cross-Cutting Concerns
+
+- **RBAC** — remote-control actions (reboot, port/PoE, CLI, firmware) must be role-gated (`lib/rbac/permissions.ts`), not just "any admin." Read vs operate vs provision tiers.
+- **Audit** — every mutating call → `ruijie_audit_log` (keep the existing pattern). Customer-facing actions too.
+- **Rate limits / safety** — tunnel tenant cap (10), reboot confirm dialogs, batch-action guardrails (don't reboot a whole project by accident).
+- **Region/endpoint correctness** — Phase 0 must document the verified `cloud-eu` endpoint set in `.claude/rules/` so it isn't rediscovered.
+- **Cron mechanism** — sync is firing; confirm the alerting Inngest functions actually fire in prod before relying on them for pages (historically Inngest crons were suspect here).
+
+---
+
+## 5. Sequencing (DECIDED 2026-07-09)
+
+**Approach: Balanced / comprehensive** — build the full NOC in phase order, no single track favored:
+
+```
+Phase 0 → 1 → 2 → 3 → 4 → 5 → 6
+(fix)   (monitor)(operate)(provision)(monetize)(self-serve)(multi-vendor)
+```
+
+**Non-negotiable first:** Phase 0 — everything else shows blank data without it.
+
+Each phase ships independently, so value lands continuously rather than in one big-bang release.
+
+---
+
+## 6. Locked Decisions (2026-07-09)
+
+1. **Primary objective — Balanced / comprehensive.** Full NOC, phases 0→6 in order.
+2. **Metrics — persist snapshots on each sync.** Phase 0 stores CPU/mem/radio/clients per device every 30-min sync into a metrics history table → historical charts (Phase 1) and threshold alerting come for free. Requires a new `ruijie_device_metrics` (or similar) time-series table + retention policy.
+3. **MikroTik — in scope.** The vendor-abstraction seam (Phase 6) is part of this effort; verify/complete the existing `app/api/admin/network/mikrotik/*` subsystem as the second adapter. Design the device interface vendor-neutral from Phase 1 onward so it isn't retrofitted.
+4. Customer-facing depth (Phase 5): start read-only; self-service actions revisited then.
+
+---
+
+## 6a. Adjacent Workstream — Revenue Assurance (separate module, depends on Phase 1)
+
+**Decision (2026-07-09): Revenue Assurance is its own feature/module, NOT a network-management phase** — but it is built on the network inventory and starts once Phase 1 lands a trustworthy active-service signal.
+
+**What it does:** three-way reconciliation to catch revenue leakage. The "active service" signal is **technology-dependent** (see model below); billing/invoicing are the other two legs.
+
+### Service-Active Detection Model (per technology)
+
+Every install — Tarana, 5G, LTE — **always has a Reyee/Ruijie AP**, and the AP only reaches Ruijie Cloud *through the customer's uplink*. So **"Reyee AP online" is the universal service-active heartbeat across ALL technologies** (uplink down → AP offline).
+
+| Customer type | Uplink | On Interstellio RADIUS? | Active-service signals |
+|---|---|---|---|
+| **Tarana** (fixed wireless) | Tarana radio | ✅ Yes (L3) | Interstellio (subscriber + **usage + service profile + credit/quota**) + Tarana device state (`lib/tarana/client.ts`) + Reyee AP online |
+| **5G** | MTN Router (SIM) | ❌ No (auths on MTN) | **Reyee AP online = primary** + MTN (limited) |
+| **LTE** | MTN Router (SIM) | ❌ No (auths on MTN) | **Reyee AP online = primary** + MTN (limited) |
+
+**Consequences:**
+- For **5G/LTE**, the Reyee AP is the **only CircleTel-controlled active signal** → **Ruijie Phase 0 reliability is the revenue-assurance backbone for the entire 5G/LTE base**, not just NOC polish. No usage/tier data available (lives on MTN).
+- For **Tarana**, Interstellio adds the rich layer (usage, tier, quota) enabling full leakage detection.
+
+| Source of truth | Domain | Data |
+|---|---|---|
+| Active on network | Reyee AP (universal) + Interstellio (Tarana only) + Tarana device | `ruijie_device_cache.status`; `lib/interstellio/client.ts` (`listSubscribers`, `getSubscriberUsage`, `getCDRRecords`, `getCreditStatus`); `lib/tarana/client.ts` (`getAllDeviceStatusesNqs`) |
+| Should be billed | Billing | `service_packages`, active-service records, `corporate_sites`, `customers` |
+| Actually invoiced/collected | Finance | `customer_invoices`, NetCash |
+
+### ⛔ Prerequisite gap — device/subscriber → customer mapping is incomplete
+Reconciliation is only as good as the mapping. Current state (verified 2026-07-09):
+- **Ruijie:** 29 cached APs → 15 linked to a site, **0 to an order, 14 unlinked**. Half the fleet has no customer/service mapping.
+- **Tarana:** device online-status exists, but **no device→customer link**.
+- **Interstellio:** subscriber-username ↔ customer mapping not established.
+
+**This mapping layer is the true "Phase 0" of Revenue Assurance** — every active install's device/subscriber must resolve to a customer + service + billed package before any exception report is trustworthy. Backfill + enforce-at-provisioning (Phase 3 hook).
+
+**First build slice + the mapping solution:** `docs/plans/2026-07-09-ra-report-reconciliation-spec.md` — a **reusable report-upload reconciliation engine** (upload → column-map → reconcile → typed exceptions → email+WhatsApp to network manager / service lead / executive), with **cellular SIM (MTN) as report type #1**. It introduces `service_network_identifiers` — one unified table mapping every source's identifier (msisdn/iccid/interstellio_uuid/ruijie_sn/tarana_serial) to a `customer_services` row — which resolves the mapping-backfill prerequisite for ALL sources, not just cellular. This is the pragmatic active-signal for the consumer cellular base (no pollable signal; static-IP polling rejected as uneconomic — carrier CGNAT).
+
+**Exception types surfaced:**
+- **Active-but-unbilled** → revenue leakage, recover cash *(priority — Interstellio shows the subscriber authenticating + consuming data with no matching active invoice; cf the Unjani legacy-hole, Task F consumer-hole, Cosmo-never-collected incidents)*
+- **Billed-but-inactive** → dispute / churn risk (invoiced but subscriber disabled / zero sessions / zero usage)
+- **Tier mismatch** → Interstellio **Service Profile** ≠ billed package
+- **Usage-based leakage** → data over FUP/quota (Fair Usage / Credit Profiles / quota-exceeded auth-fails) not billed as overage
+
+**Key join key:** Interstellio subscriber username (e.g. `CT-UNJ-002@circletel.co.za`, `NewExGenCT-Rivonia@circletel.co.za`) ⋈ CircleTel customer/service records — a mapping that must be established/verified as part of this module.
+
+**Why separate:** two of its three inputs (billing truth, invoice/collection reconciliation + dispute workflow) are a finance domain of their own; and "all active services" spans every network vendor, not just Ruijie — so it consumes the **vendor-neutral active-services inventory** built here (the Phase 6 abstraction seam), making it the highest-value consumer of that seam rather than a subset of it.
+
+**Dependency:** requires Phase 0 (telemetry fixed) + Phase 1 (reliable active/online signal + vendor-neutral inventory) before it can be trusted. Gets its own spec → plan cycle when Phase 1 is done.
+
+---
+
+## 7. Immediate Next Step
+
+Phase 0 is the gate. It needs its own spec → plan cycle before implementation:
+- Diagnose the exact failing Ruijie metrics/traffic endpoint on `cloud-eu` for RAP-series (capture request/response, compare to API doc §2.5/§2.6.2/§2.6.6).
+- Fix the `getDeviceMetrics` unhandled rejection.
+- Design the `ruijie_device_metrics` time-series table + wire persistence into the sync path.
+- Design the vendor-neutral device interface (so MikroTik slots in later).
+- Document the verified `cloud-eu` endpoint set in `.claude/rules/`.

--- a/docs/plans/2026-07-09-phase0-network-foundation-spec.md
+++ b/docs/plans/2026-07-09-phase0-network-foundation-spec.md
@@ -1,0 +1,146 @@
+# Phase 0 Spec — Network Management Foundation Fix
+
+**Date:** 2026-07-09
+**Parent roadmap:** `docs/plans/2026-07-09-in-app-network-management-roadmap.md`
+**Status:** Ready for spike → plan → implement
+**Blocking:** all subsequent network-management phases + the Revenue Assurance module
+
+---
+
+## 1. Context & Corrected Root Cause
+
+The device detail page's Overview/Radio/traffic tabs render blank. Investigation of `lib/ruijie/client.ts` (2026-07-09) corrected the earlier assumptions:
+
+| Earlier assumption | Reality (verified in code) |
+|---|---|
+| "getDeviceMetrics has an unhandled-rejection bug" | ❌ False. `getDeviceMetrics` (client.ts:326-353), `getDeviceClients` (:409), `getNetworkTraffic` (:789), `getAppFlow` (:838) **all try/catch and return empty on error.** The crash I saw was my own test-script bug (undefined device when env wasn't preloaded). |
+| "CPU/mem 404s / is a bug" | ❌ Partly. `getDeviceMetrics` **hardcodes CPU/mem/radio/uptime to `null`** (getEmptyMetrics, :355) and only derives `online_clients` from the STA API. Comment says perf data "requires eWeb tunnel." |
+| "The client uses wrong China-NOC endpoints" | ❌ False. The `/logbizagent/logbiz/api/*` paths it uses (sta_users, flow/show/hour) **are the documented international endpoints** (API doc §2.5.1, §2.6.2). |
+
+**Actual root causes of the blank telemetry:**
+
+1. **CPU/Memory is never fetched.** The Ruijie Cloud API documents **§2.6.6 Get Device CPU and Memory** at `GET /logbizagent/logbiz/api/sys/current_performance` — the client **never calls it**. This is the primary fix: implement it.
+2. **Radio channel/utilization** has **no documented cloud endpoint** (eWeb-tunnel only). Accept as null; adjust the UI so it doesn't show empty progress bars, OR source later via eWeb (out of scope for Phase 0).
+3. **Traffic/clients returning zero** — these use the correct documented endpoints; need the spike to confirm whether the zeros are *genuine* (no clients/traffic at test time) or a *request-param* issue (e.g. flow endpoint needs a building/time param). No endpoint change assumed until the spike says so.
+4. **Noise:** `ruijieFetch` (:44-46) logs `await response.text()` on any non-OK — for HTML 404 pages that's 60KB per error. Cap it.
+5. **No metrics history.** The cache stores only the latest status; even once CPU/mem works, there's nowhere to persist a time series for trends/alerts.
+
+---
+
+## 2. Goal & Success Criteria
+
+**Goal:** the app shows real per-device performance where the cloud API can provide it, persists a metrics time series for history/alerting, and exposes a vendor-neutral device interface so MikroTik can slot in later — all without breaking the working inventory/status/logs/reboot/tunnel paths.
+
+**Done means (all verified, evidence required):**
+1. Opening an **online RAP2200(F)** device detail page shows a **non-null CPU% and Memory%** (sourced from §2.6.6).
+2. `ruijie_device_metrics` table exists and **accumulates one snapshot per online device per 30-min sync** (verified: row count grows across two sync cycles).
+3. Radio tab no longer shows misleading empty 0% bars when data is unavailable (shows "Not available via cloud — eWeb only").
+4. A `NetworkDeviceAdapter` interface exists; the Ruijie implementation satisfies it and the app still builds (`npm run type-check:memory` clean for touched files).
+5. `ruijieFetch` error logs are capped (≤500 chars); no 60KB HTML dumps.
+6. `.claude/rules/ruijie-cloud-api.md` documents the verified cloud-eu endpoint set (which telemetry is/ isn't obtainable).
+7. Existing device list, status, logs, reboot, tunnel flows still work (regression check).
+
+**Out of scope (later phases):** alerting/notifications (Phase 1), historical charts UI (Phase 1), remote ops beyond existing reboot/tunnel (Phase 2), radio via eWeb scraping, MikroTik implementation (only the interface here).
+
+---
+
+## 3. Tasks
+
+### Task 0.1 — Diagnostic spike *(GATE — informs 0.2/0.3)* — **S**
+Write `scripts/diagnose-ruijie-telemetry.ts` (throwaway; delete or move to `scripts/diagnostics/` after). For 3 representative online devices — a **RAP2200(F)** (indoor AP, group 9058218), a **RAP62-OD** (outdoor AP, group 9124474 `UnjanihAPaxS`), and an **NBS switch** (Newgen group 8902292) — call each documented endpoint directly via `ruijieFetch` and record the raw `code`/shape:
+
+| Capability | Endpoint (doc §) | Method |
+|---|---|---|
+| CPU/Memory | `/logbizagent/logbiz/api/sys/current_performance` (§2.6.6) | GET |
+| Flow trend | `/logbizagent/logbiz/api/flow/show/hour` (§2.6.2) | POST `{groupId}` |
+| Client online | `/logbizagent/logbiz/api/sta/sta_users` (§2.5.1) | POST `{groupId,pageIndex}` |
+| Device detail (uptime?) | `/service/api/device/{sn}` (§2.6.3) | GET |
+| Switch port status | `/service/api/conf/switch/device/{sn}/ports` (§2.6.7) | GET |
+
+**Run with:** `set -a && source .env.local && set +a && npx tsx scripts/diagnose-ruijie-telemetry.ts`
+**Deliverable:** a findings table (endpoint × device-type → works / empty / 404 + the exact param that works). This decides exactly what 0.2/0.3 implement. **Do not implement 0.2 before this is done.**
+
+### Task 0.2 — Implement CPU/Memory (+ uptime if available) — **M**
+In `lib/ruijie/client.ts`:
+- Add a typed call to `/logbizagent/logbiz/api/sys/current_performance` for the device SN.
+- Populate `metrics.cpu_usage` / `metrics.memory_usage` in `getDeviceMetrics` (keep the existing STA `online_clients` logic; keep try/catch + empty-on-error).
+- If the spike shows `/service/api/device/{sn}` returns uptime/lastOnline, populate `uptime_seconds`.
+- Update `DeviceMetrics` type in `lib/ruijie/types.ts` only if new fields are needed (reuse existing null-able fields first).
+- **Radio:** if spike confirms no cloud source, leave null and update `app/admin/network/devices/[sn]/page.tsx` Radio tab to render an explicit "Not available via cloud API (eWeb only)" state instead of 0% bars.
+
+### Task 0.3 — Traffic correctness + log hygiene — **S**
+- Apply whatever param fix the spike identified for `/flow/show/hour` (or confirm zeros are genuine and leave as-is).
+- In `ruijieFetch` (client.ts:44-46), truncate the error body to 500 chars before throwing/logging: `error.slice(0, 500)`.
+
+### Task 0.4 — Metrics persistence (time series) — **M**
+- **New migration** `supabase/migrations/<ts>_create_ruijie_device_metrics.sql`:
+  ```sql
+  create table if not exists ruijie_device_metrics (
+    id            bigint generated always as identity primary key,
+    sn            text not null,
+    captured_at   timestamptz not null default now(),
+    cpu_usage     numeric,
+    memory_usage  numeric,
+    online_clients integer,
+    uptime_seconds bigint,
+    status        text,
+    source        text not null default 'ruijie',   -- vendor tag for multi-vendor
+    raw           jsonb
+  );
+  create index on ruijie_device_metrics (sn, captured_at desc);
+  -- RLS: service-role only (matches ruijie_device_cache convention)
+  alter table ruijie_device_metrics enable row level security;
+  ```
+  Apply **manually to the shared prod DB** (project convention: Ruijie migrations are applied by hand, no CI step — see `ruijie_device_cache` history).
+- Extend the sync path (`lib/inngest/functions/ruijie-sync.ts` + a helper in `lib/ruijie/sync-service.ts`) to, after `upsertDevices`, loop **online** devices and insert one `ruijie_device_metrics` snapshot each (call the 0.2 metrics fetch). **Rate-limit**: 100-200ms between per-device calls (≤55 devices → ~10s added to a 30-min cron; acceptable). Wrap per-device in try/catch so one failure doesn't abort the batch or the sync log.
+- **Retention:** add a delete of rows older than 90 days to the existing `ruijie-tunnel-cleanup` (or a small step in sync) — keep it simple, no new cron.
+
+### Task 0.5 — Vendor-neutral device interface — **S/M**
+- Add `lib/network/adapter.ts` defining `NetworkDeviceAdapter` (vendor-neutral):
+  ```ts
+  interface NetworkDeviceAdapter {
+    vendor: 'ruijie' | 'mikrotik';
+    listDevices(): Promise<NetworkDevice[]>;
+    getDevice(sn: string): Promise<NetworkDevice | null>;
+    getMetrics(sn: string, groupId?: string): Promise<DeviceMetrics>;
+    getClients(sn: string, groupId: string): Promise<NetworkClient[]>;
+    getLogs(sn: string): Promise<NetworkLogEntry[]>;
+    reboot(sn: string): Promise<{ success: boolean }>;
+  }
+  ```
+- Provide `RuijieAdapter` that delegates to the existing `lib/ruijie/client.ts` functions (thin wrapper — **no behavior change**). Do **not** refactor callers yet; this is the seam for Phase 6. MikroTik adapter is a later phase.
+
+### Task 0.6 — Document verified endpoints — **S**
+- Write `.claude/rules/ruijie-cloud-api.md`: the verified cloud-eu endpoint set from the 0.1 spike (works/empty/unavailable per capability & device model), the module-level-env-capture gotcha (scripts must `source .env.local` before import), and that radio is eWeb-only. Add a Wrong-vs-Correct table per the `api-param-documentation.md` house style.
+
+---
+
+## 4. Global Constraints (apply to every task)
+
+- **Never** flip `RUIJIE_MOCK_MODE`; work against live `cloud-eu`.
+- Scripts importing `lib/ruijie/*`: **`set -a && source .env.local && set +a`** before `npx tsx` (auth.ts captures env at module load).
+- Preserve the **audit-log invariant**: any new mutating call → `ruijie_audit_log`. (Phase 0 adds no new mutations except metrics inserts, which are not user actions.)
+- Migrations applied **manually to the shared prod DB**; additive only; never drop/rename existing `ruijie_device_cache` columns.
+- `npm run type-check:memory` clean for touched files before commit; branch off `main`, push to `staging` first, PR to `main`.
+- Surgical changes only — do not refactor the working list/status/logs/reboot/tunnel code beyond wrapping it in the 0.5 adapter.
+
+---
+
+## 5. Verification Plan
+
+1. **Spike (0.1):** findings table produced and reviewed before any implementation.
+2. **CPU/mem (0.2):** re-run a read-only check against an online RAP2200(F) → cpu/mem non-null; screenshot the Overview tab on staging.
+3. **Persistence (0.4):** `select count(*), max(captured_at) from ruijie_device_metrics` before and after two sync cycles → count increased, timestamps fresh.
+4. **Log hygiene (0.3):** trigger a 404 path → confirm error log ≤500 chars.
+5. **Adapter (0.5):** `type-check:memory` clean; `RuijieAdapter.listDevices()` returns the same 25 devices as `getAllDevices()`.
+6. **Regression:** device list loads, a device reboots (test device only, with confirm), a tunnel launches — all still work on staging.
+7. **Docs (0.6):** `.claude/rules/ruijie-cloud-api.md` committed.
+
+---
+
+## 6. Open Decisions / Risks
+
+- **If the spike shows §2.6.6 CPU/mem returns empty/404 for RAP models on cloud-eu** → CPU/mem is genuinely eWeb-only; pivot 0.2 to "surface what IS available (clients, uptime, status) and mark CPU/mem/radio as eWeb-only in the UI." The spike is the decision point; don't pre-commit the fix.
+- **Traffic zeros** may be genuine (clinics are low-traffic) — confirm with the spike against a busier group (Newgen) before assuming a bug.
+- **Rate limits:** per-device metrics polling adds ~55 calls/sync; watch for Ruijie throttling (the debit/Zoho rate-limit lesson applies). If throttled, poll a subset or widen the interval.
+- **Metrics table growth:** 55 devices × 48 syncs/day ≈ 2,640 rows/day; 90-day retention ≈ 240k rows — trivial for Postgres, index on (sn, captured_at) covers the query.

--- a/docs/plans/2026-07-09-ra-report-reconciliation-spec.md
+++ b/docs/plans/2026-07-09-ra-report-reconciliation-spec.md
@@ -1,0 +1,113 @@
+# Spec — Revenue Assurance: Report Upload & Reconciliation Engine (v1: Cellular SIM)
+
+**Date:** 2026-07-09
+**Parent:** `docs/plans/2026-07-09-in-app-network-management-roadmap.md` (§6a Revenue Assurance)
+**Evidence:** `docs/plans/2026-07-09-revenue-assurance-map-coverage-audit.md`
+
+## 1. Why
+Consumer cellular customers (5G/LTE on MTN SIM+router, e.g. Ashwyn R449, Raymund R649) have **no pollable active-signal** — they sit behind MTN CGNAT, don't touch Interstellio, and have no mapped Reyee AP (static-IP polling rejected as uneconomic). The pragmatic active-signal is a **monthly SIM-management report** from the carrier, uploaded and reconciled against billing. Built as a **reusable framework**, this is the first slice of the Revenue Assurance module and delivers the unified mapping table the audit flagged as prerequisite.
+
+## 2. Locked decisions (2026-07-09)
+1. **Reusable RA framework** — upload → column-map → reconcile → exceptions → notify; cellular SIM is report type #1. Future report types (other carriers/providers) plug in.
+2. **Configurable recipient list** in settings (role label + email + WhatsApp number), not hard-coded, not RBAC-dependent.
+3. **Email + WhatsApp** notifications (Resend + existing WhatsApp template infra; WhatsApp needs an approved Meta template).
+
+## 3. Goal & success criteria
+Admin uploads the monthly SIM report → system reconciles it against active 5G/LTE services → produces a typed exception list → emails + WhatsApps the network manager, service lead, and executive a summary.
+
+**Done means:**
+1. An admin can upload a CSV/XLSX SIM report at `/admin/revenue-assurance` and see parsed row count + status.
+2. Reconciliation produces exceptions of each type (below) persisted and viewable in-app with an acknowledge/resolve action.
+3. On completion, the configured recipients receive an **email + WhatsApp** summary (period, #active-unbilled + R value, #billed-inactive, #unmatched, link).
+4. Ashwyn & Raymund resolve correctly once their SIM identifiers are mapped (or appear as `unmatched_service` until mapped).
+5. `npm run type-check:memory` clean for touched files; staging-first.
+
+## 4. Data model (additive migrations, applied per project convention)
+
+**Unified mapping table (high-leverage — resolves the audit's mapping-backfill prerequisite for ALL sources):**
+```sql
+create table service_network_identifiers (
+  id uuid primary key default gen_random_uuid(),
+  service_id uuid not null references customer_services(id) on delete cascade,
+  identifier_type text not null,   -- 'msisdn' | 'iccid' | 'interstellio_uuid' | 'ruijie_sn' | 'tarana_serial'
+  identifier_value text not null,
+  created_at timestamptz default now(),
+  unique (identifier_type, identifier_value)
+);
+```
+This one table backfills every mapping gap (5G MSISDN, Unjani Ruijie SN, Tarana serial, Interstellio UUID) — not just cellular.
+
+**Report engine tables:**
+```sql
+create table ra_report_uploads (
+  id uuid primary key default gen_random_uuid(),
+  report_type text not null,          -- 'mtn_sim_usage' (v1)
+  period_month date not null,         -- first of month
+  filename text, uploaded_by uuid,
+  row_count int, status text default 'parsing',  -- parsing|reconciled|failed
+  created_at timestamptz default now()
+);
+create table ra_report_rows (
+  id bigint generated always as identity primary key,
+  upload_id uuid references ra_report_uploads(id) on delete cascade,
+  external_id text,                   -- msisdn/iccid
+  sim_status text, usage_mb numeric, plan text,
+  raw jsonb
+);
+create table ra_exceptions (
+  id uuid primary key default gen_random_uuid(),
+  upload_id uuid references ra_report_uploads(id) on delete cascade,
+  report_type text, service_id uuid null references customer_services(id),
+  external_id text,
+  exception_type text not null,       -- see §5
+  severity text default 'medium',
+  amount numeric,                     -- R value at risk where applicable
+  detail jsonb,
+  resolved_at timestamptz null, resolved_by uuid null
+);
+create table ra_recipients (
+  id uuid primary key default gen_random_uuid(),
+  role_label text not null,           -- 'network_manager' | 'service_lead' | 'executive'
+  email text, whatsapp_number text, active boolean default true
+);
+```
+All RLS service-role only, matching project convention.
+
+## 5. Reconciliation rules (report_type = mtn_sim_usage)
+Match each report row (by `external_id` → `service_network_identifiers` where type in msisdn/iccid) to an active 5G/LTE `customer_services`:
+
+| Exception type | Condition | Meaning |
+|---|---|---|
+| `active_unbilled` | SIM active + usage>0, no active billed service matched | **Leakage** (priority; carries R value) |
+| `billed_inactive` | active 5G/LTE service, matched SIM suspended or usage=0 | dispute / churn |
+| `unmatched_sim` | report SIM not mapped to any service | mapping gap → drives backfill |
+| `unmatched_service` | active 5G/LTE service with no SIM in report | missing from carrier report / not provisioned |
+| `usage_anomaly` (optional) | usage far over/under plan | overage-bill / dormant |
+
+## 6. Tasks
+- **6.1** Migrations (§4) — apply manually to shared DB. **S**
+- **6.2** Report-type config: a small registry mapping file columns → normalized fields (`external_id`, `sim_status`, `usage_mb`, `plan`) with an `mtn_sim_usage` preset. Parser reuses **exceljs** (XLSX) + a light CSV path. **M**
+- **6.3** Upload API route (`POST /api/admin/revenue-assurance/uploads`) — admin-auth, store file meta, parse rows → `ra_report_rows`, set status. **M**
+- **6.4** Reconciliation service — apply §5 rules, write `ra_exceptions`. Pure/testable. **M**
+- **6.5** Notification — on `reconciled`, send summary to active `ra_recipients` via the existing `notification-router` (email channel + WhatsApp template). New email template `ra_reconciliation_summary`; new **approved** WhatsApp template. **M**
+- **6.6** Admin UI `/admin/revenue-assurance` — upload form, run history, exception table with acknowledge/resolve, recipient settings editor. **M**
+- **6.7** Seed `service_network_identifiers` for the known cellular customers (capture Ashwyn/Raymund MSISDN) + wire order-activation to populate it going forward (Phase 3 hook). **S**
+
+## 7. Dependencies / risks
+- **Sample MTN SIM report needed** to finalize the column mapping (build against a real export).
+- **WhatsApp template approval** (Meta, ~24h) — start early (cf `circletel_debit_order_notice` precedent).
+- **SIM identifier capture** — customer_services has no MSISDN today; `service_network_identifiers` + a backfill for the 2 known customers is required for them to reconcile.
+- Report is monthly/manual — this is **not** real-time monitoring (by design; real-time cellular needs carrier SIM-management API or TR-069, deferred until the base grows).
+
+## 8. Global constraints
+- Additive migrations, manual apply, service-role RLS; no destructive changes.
+- Reuse `lib/notifications/notification-router.ts` + `lib/integrations/whatsapp/*` — do not build new send paths.
+- `type-check:memory` clean; branch off main → staging → PR to main.
+- Recipients configurable (no hard-coded emails in code).
+
+## 9. Verification
+1. Upload a sample report on staging → row_count matches file.
+2. Seed one active_unbilled + one billed_inactive scenario → exceptions generated with correct type + R value.
+3. Recipients receive email + WhatsApp with correct counts + working in-app link.
+4. Acknowledge/resolve flips exception state and is audit-stamped.
+5. `service_network_identifiers` unique constraint prevents a SIM mapping to two services.

--- a/docs/plans/2026-07-09-ra-report-reconciliation-spec.md
+++ b/docs/plans/2026-07-09-ra-report-reconciliation-spec.md
@@ -4,6 +4,8 @@
 **Parent:** `docs/plans/2026-07-09-in-app-network-management-roadmap.md` (§6a Revenue Assurance)
 **Evidence:** `docs/plans/2026-07-09-revenue-assurance-map-coverage-audit.md`
 
+> **Whitelabel alignment (Seam 1 — Billing Engine):** Revenue Assurance is a **detect-only** layer — it produces `ra_exceptions`; *remediation* (advance-to-billing-ready, catch-up invoice, credit note) is executed by the billing engine / `CompliantBillingService`, never RA raw SQL. `ra_exceptions` emit to `platform_events`; `ra_recipients` route through the unified `notify()`. See `docs/superpowers/specs/2026-07-09-whitelabel-alignment-network-billing.md`.
+
 ## 1. Why
 Consumer cellular customers (5G/LTE on MTN SIM+router, e.g. Ashwyn R449, Raymund R649) have **no pollable active-signal** — they sit behind MTN CGNAT, don't touch Interstellio, and have no mapped Reyee AP (static-IP polling rejected as uneconomic). The pragmatic active-signal is a **monthly SIM-management report** from the carrier, uploaded and reconciled against billing. Built as a **reusable framework**, this is the first slice of the Revenue Assurance module and delivers the unified mapping table the audit flagged as prerequisite.
 

--- a/docs/plans/2026-07-09-revenue-assurance-map-coverage-audit.md
+++ b/docs/plans/2026-07-09-revenue-assurance-map-coverage-audit.md
@@ -1,0 +1,79 @@
+# Revenue Assurance — Map-Coverage Audit (2026-07-09)
+
+First reconciliation pass: every **active `customer_services`** row matched against its network active-signal (Ruijie AP online, Interstellio link) and billing freshness. Read-only, live prod DB.
+
+## Coverage summary (32 active services)
+
+| Category | Svcs | MRR | Online Ruijie | Interstellio | Any signal | **No signal** | Invoiced≥Jun |
+|---|---|---|---|---|---|---|---|
+| corporate (Unjani) | 19 | R8,550 | 10 | 0 | 10 | **5** | 16 |
+| fixed_wireless (Tarana) | 7 | R999 | 0 | 7 | 7 | 0 | 1 |
+| business_connectivity | 3 | R1,350 | 0 | 0 | 0 | **2** | 0 |
+| residential | 2 | R1,548 | 0 | 1 | 1 | **1** | 2 |
+| 5g | 1 | R449 | 0 | 0 | 0 | **1** | 1 |
+| **Total** | **32** | **~R12,896** | 10 | 8 | **18 (56%)** | **9 (28%)** | 20 |
+
+**Only 56% of active services have any verifiable network active-signal; 28% have none.**
+
+## Join model discovered
+- `corporate_sites.service_id → customer_services.id` (20/20 valid) — the Unjani/corporate path.
+- `ruijie_device_cache.corporate_site_id → corporate_sites.id` — Ruijie AP → site.
+- `customer_services.connection_id` = **Interstellio subscriber UUID** (Tarana/fixed_wireless path).
+- `corporate_sites.interstellio_subscriber_id` exists but is **0% populated** (dead link path).
+- **No Tarana device → service link** anywhere.
+
+## Findings
+
+### 1. The "6 unbilled Tarana services" = TEST DATA, not leakage ✅ caught
+The active-but-unbilled fixed_wireless rows are all **R0 test/junk records**: `Amoeba User`, `Test User` (Test Package), `ECHO Connection`, `Subscriber 2645064 / 3332867 / 35b741c8` (Standard Package, R0). They carry a real `connection_id` so they'd score as "active on Interstellio" and pollute every reconciliation. **Action: quarantine/delete.** Plus `Unjani Clinic - Training Demo` (known demo CT-2026-09999) in business_connectivity.
+→ Stripping junk, real active services ≈ **25**.
+
+### 2. Real structural gap — the 5G base has no active-signal linkage
+- **Ashwyn Watkins** — 5G 35 Mbps, **R449, invoiced 2 Jul**, no Interstellio (on MTN), no mapped Reyee AP.
+- **Raymund Watson** — 5G 60 Mbps, **R649, invoiced 2 Jul**, same.
+→ **R1,098/mo billed but currently unverifiable.** Per the topology they *should* have a Reyee AP; it's just not mapped. **Action: confirm + map their Reyee APs.**
+
+### 3. Unjani AP → service mapping is BROKEN (reverse check)
+**10 online APs are unlinked**; 8 are clearly clinics: `UNJANICLINICKAYAMANDI, UNJANIALEX2, UNJANICLINICUMSINGA, UNJANICLINICZAMDELA, UNJANICLINICBARCELONA, UNJANICLINICBARC2, UNJANICLINICDURBAN, UNJANICOSMO2` (2 are Newgen internal, legitimately not services). So clinics like Kayamandi/Alexandra/Umsinga/Zamdela show `online_aps=0` against their service **even though their AP is online** — the AP↔site↔service link is missing. They're billed, so not leakage, but **un-monitorable** until linked.
+→ **Action: link the 8 online clinic APs to their `corporate_sites`/service.**
+
+### 4. Billed but AP offline — investigate
+- **Unjani Clinic - Oukasie** — R450 invoiced, its AP is offline → genuine service-down-but-billed candidate (outage or churn). (Note: memory flags Oukasie as an approved-extension free clinic — reconcile.)
+
+### 5. Pipeline (not leakage)
+- **Unjani Clinic Delmas** — R450, never invoiced, onboarding `submitted` (not `billing_ready`) → correctly not billed yet.
+
+## What this means for Revenue Assurance
+The reconciliation engine is feasible and the join model is now known — but it is **gated by three data problems**, in priority order:
+1. **Data hygiene** — 6 test Interstellio subscribers + 1 demo clinic must be quarantined or every report shows false "active" rows.
+2. **Unjani AP→site→service mapping** — 8 online clinic APs unlinked; backfill the links.
+3. **5G/LTE Reyee AP mapping** — the entire non-Interstellio base needs its AP mapped, or it stays unverifiable (structural, per topology).
+4. Standardize on **one** Interstellio link (`connection_id` is populated; `corporate_sites.interstellio_subscriber_id` is dead — pick one).
+
+These four items ARE the "mapping backfill" prerequisite named in the roadmap §6a. Only after them is an automated active-but-unbilled / billed-but-inactive report trustworthy.
+
+---
+
+## Remediation applied — 2026-07-09 (Option 2)
+
+Built the unified mapping table and backfilled it (migration `20260709160000_create_service_network_identifiers.sql`, applied to prod):
+
+- **`service_network_identifiers`** created (service_id ↔ identifier_type/value; types msisdn/iccid/interstellio_uuid/ruijie_sn/tarana_serial).
+- **Linked 9 unlinked APs** to their verified sites (`ruijie_device_cache.corporate_site_id`): Alexandra, Barcelona (+BARC2), Kayamandi, Umsinga, Zamdela, Cosmo City (COSMO2), Oukasie, Durban.
+- **Backfilled 25 identifiers**: 23 `ruijie_sn` + 2 `interstellio_uuid` (real priced SkyFibre services; R0 test subscribers excluded).
+- **Quarantined 7 test/demo records** (reversible: `active=false`, `status=cancelled`): 6 R0 Interstellio test subs (already status=cancelled, active flag left true) + the R450 Training Demo clinic.
+
+**Coverage before → after:**
+
+| Metric | Before | After |
+|---|---|---|
+| Active services | 32 (incl. junk) | **25** (junk quarantined) |
+| Mapped to a network signal | 18 (56%) | **22 (88%)** |
+| Services with an online-AP signal | 10 | **16** |
+| Previously-broken clinics (Kayamandi/Alexandra/Umsinga/Zamdela) | 0 online-AP | **all 4 resolve** ✅ |
+
+**Residual (3 unmapped active services):**
+- **Ashwyn Watkins** (5G R449) & **Raymund Watson** (5G R649) — MSISDN capture blocked; no SIM number stored anywhere (needs the numbers from MTN). Belongs to the cellular report-reconciliation feature.
+- **Unjani Clinic Delmas** (R450) — onboarding `submitted`, no AP installed yet (pipeline, not leakage).
+
+**New reverse gap found:** **Unjani Clinic - Durban** has an **online AP but NO service record** (site `service_id` is null) — an active install that isn't set up for billing. Linked the AP to the Durban site; **needs a service created or confirmation it's not a paying customer.**

--- a/docs/superpowers/plans/2026-07-10-whitelabel-alignment-network-billing.md
+++ b/docs/superpowers/plans/2026-07-10-whitelabel-alignment-network-billing.md
@@ -1,0 +1,107 @@
+# Align session work (network mgmt + revenue assurance) with the whitelabel platform design
+
+## Context
+
+This session produced a large body of network-management + revenue-assurance + billing work (see `docs/plans/2026-07-09-*`, `docs/architecture/NETWORK_VISIBILITY_BRIDGES.md`, the `service_network_identifiers` table, and live billing changes for Soshanguve/Zamdela). In parallel, the whitelabel platform design (`docs/superpowers/specs/2026-07-09-whitelabel-platform-design.md`) landed its **Phase 0** (tenant config layer + feature registry + brand-literal CI ratchet, merged PR #608).
+
+The design's whole thesis is to convert a 254-page monolith's sprawl into **module boundaries = product architecture**, via a few seams. Our session's work lands squarely on two of those seams — **Integration Gateway (§5)** and **Billing Engine (§3)** — but was built in exactly the pre-seam style the design is trying to retire (bespoke clients reading `process.env`; raw-SQL writes to `customer_invoices`). 
+
+**The risk this plan addresses:** without alignment, our work *deepens the sprawl* the whitelabel design must later untangle (our catch-up invoices became a 153rd `customer_invoices` writer; our four network integrations added four more bespoke credential-in-env clients and per-provider sync-log tables). **The goal:** make this work conform to the seam boundaries so it becomes proof-of-concept *for* the seams rather than debt *against* them — without a speculative rebuild (the design forbids that; every step must pay for CircleTel now).
+
+## Current state (verified via exploration)
+
+| Whitelabel piece | State | Our work that touches it |
+|---|---|---|
+| `lib/tenant/` config accessor (`getTenantConfig()`) | ✅ built (branding/contacts; env-override; **no credential routing yet** — that's whitelabel Phase 2) | Network clients read `process.env` directly |
+| `lib/admin/feature-registry.ts` (maturity-aware nav) | ✅ built (no per-tenant flags yet — Phase 4) | Network + RA admin sections |
+| Brand-literal CI ratchet (`scripts/check-brand-literals.sh`, baseline **6182**) | ✅ built | `lib/interstellio/client.ts:62` default `'circletel.co.za'` |
+| **Integration Gateway** `lib/integrations/core/` (adapter contract, `integration_runs`, webhook intake) | ❌ **spec only** | Ruijie/Interstellio/Tarana/MikroTik = 4 bespoke clients + `*_sync_logs` tables |
+| **Billing Engine** `lib/billing/engine/` (single writer, state machine, `CollectionRail`) | ❌ **spec only** (152 scattered writers; `CompliantBillingService` is the closest thing) | RA catch-up invoices via raw SQL; billing_ready/verified flips |
+| `platform_events` + unified `notify()` | ❌ **spec only** (ad-hoc `lib/billing/debit-batch-alert.ts`) | RA reconciliation findings; billing mutations |
+| Instance-per-tenant physical isolation (no `tenant_id`) | ✅ the chosen model | `service_network_identifiers` (tenant-local — already correct) |
+
+## Alignment map: session work → seam
+
+- **Network bridges** (Ruijie, Interstellio, Tarana/TCS, MikroTik) → **Seam 3 Integration Gateway**.
+- **Revenue Assurance** (reconciliation, `service_network_identifiers`, RA report-upload spec) → **reads** Seam 3 (network signals) + **acts through** Seam 1 (billing).
+- **Billing actions** (invoice creation, pro-rata, debit alignment, VAT, billing_ready/verified) → **Seam 1 Billing Engine**.
+- **Docs** (roadmap, RA specs, tri-bridge runbook) → already follow the docs-in-DoD discipline (§8) ✅.
+
+## The plan
+
+### A. Guardrails to adopt now (stop deepening the sprawl) — **do immediately, cheap**
+These are principles applied to *new* code from here on, plus fixing the debts this session created:
+1. **No new raw-SQL writes to `customer_invoices`/payment tables.** Route through `CompliantBillingService` (`lib/billing/compliant-billing-service.ts`, has `generateInvoice()` + VAT + audit + PDF) until `lib/billing/engine/` exists — then it becomes the single writer. Our four catch-up invoices (INV-2026-00037…40) were raw-SQL; leave them (voidable) but **do not repeat the pattern**.
+2. **No new `process.env` credential reads in integration code.** New network/integration work resolves config through a single accessor (today `getTenantConfig()` for identity; a `getIntegrationCredentials(provider)` shape to be added in whitelabel Phase 2). Precedent to mirror: `lib/payments/payment-provider-settings-loader.ts` (NetCash creds already in a `payment_provider_settings` DB table).
+3. **No new bespoke `*_sync_logs` tables.** The next integration logs to the future `integration_runs`; until then reuse the existing `integration_cron_jobs` / `integration_activity_log` tables rather than minting a new per-provider table.
+4. **Every new API route declares auth context** (public/customer/admin-role/service) per §7 — the network/RA routes especially (device access + PII).
+
+### B. Integration Gateway conformance (network bridges) — **rides whitelabel Phase 3**
+5. **Make the network roadmap's "vendor-neutral `NetworkDeviceAdapter`" (Phase 0/6 of `docs/plans/2026-07-09-in-app-network-management-roadmap.md`) an *implementation of* the future `lib/integrations/core/` adapter contract** (`authenticate() / healthCheck() / capabilities`), not a parallel abstraction. Update the roadmap doc to state this dependency so we don't build two competing seams.
+6. **Nominate the network bridges as the first proof of the Integration Gateway.** Ruijie/Interstellio/Tarana/MikroTik are 4 real adapters with 4 different auth styles (OAuth, token, cookie-session, HMAC-proxy) — an ideal test that the `core` contract is general. Feed them into `app/admin/integrations` (health, last sync, re-auth) as they migrate.
+7. **Unify the 3 network sync-log tables** (`ruijie_sync_logs`, `tarana_sync_logs`, `mikrotik_sync_logs`) into `integration_runs` when Phase 3 builds it — a straight consolidation, and the dashboard's "last successful sync" then works for network too.
+8. **Feature-flag each network integration per tenant** (a tenant may have no Ruijie/Tarana) via the registry mechanism (Phase 4).
+
+### C. Billing Engine conformance (Revenue Assurance) — **rides whitelabel Phase 1**
+9. **Reframe Revenue Assurance as a read/detect layer that raises actions the billing engine executes** — never a direct billing writer. Update `docs/plans/2026-07-09-ra-report-reconciliation-spec.md`: the RA reconciliation produces `ra_exceptions`; *remediation* (advance-to-billing-ready, catch-up invoice, credit note) is performed by the billing engine / `CompliantBillingService`, not by RA SQL.
+10. **The billing engine is the correct home for the fixes this session surfaced:** the **VAT-exclusive treatment** (the R450→R517.50 generator bug), **pro-rata**, and the **NetCash action-date/line-limit guards** all belong in the engine's `CollectionRail` + invoice state machine (§3). Fold the VAT-bug fix into the Phase-1 billing-engine spec rather than a one-off patch.
+11. **`service_network_identifiers` becomes the join the billing engine + RA share** to answer "is this billed service actually live on the network." Keep it tenant-local (no `tenant_id` — correct for instance-per-tenant). Add `msisdn`/`iccid`/`mikrotik_serial` types as those sources land.
+
+### D. Tenant config, feature registry, brand ratchet — **small, now**
+12. **Register the Network-Management and Revenue-Assurance admin sections in `lib/admin/feature-registry.ts`** with maturity (`beta`/`internal` while in progress) so half-built screens are invisible to non-dev roles. Target workspaces: RA → **Finance**; Network → **Ops/Support**.
+13. **Don't increase the brand-literal count.** When touching `lib/interstellio/client.ts`, migrate the `'circletel.co.za'` default (line 62) to `getTenantConfig()` so the ratchet ticks *down*. Verify with `scripts/check-brand-literals.sh` before any push.
+
+### E. Observability baseline — **rides whitelabel Phase 0/1**
+14. **Revenue Assurance is the natural first consumer of `platform_events`**: leakage/exception detections and billing mutations (billing_ready flip, verified flip, invoice creation) write `(actor, entity, before/after, source)`. Our session did these via raw SQL + memory — the engine/RA should emit `platform_events` instead.
+15. **RA alerts + the RA report-reconciliation `ra_recipients`** route through the future unified `notify()` (generalizing `lib/billing/debit-batch-alert.ts`), not a second bespoke email path.
+
+### F. Immediate hygiene debts from this session (surface, don't silently carry)
+- The **generator VAT bug** (under-bills the whole Unjani base R67.50/mo) — schedule as a Phase-1 billing-engine item (item 10).
+- The **four raw-SQL catch-up invoices** — acceptable one-off; note in the billing-engine spec as a case the engine must be able to produce natively (pro-rata + catch-up).
+- The **11 legacy clinics mis-staged as "pending"** — a pipeline/data gap; belongs to the Ops workspace + billing-engine "active service" signal, not a quick flag fix.
+
+## Sequencing (ride the whitelabel phases — no speculative rebuild)
+
+| When | Action items | Whitelabel phase |
+|---|---|---|
+| **Now** (this/next session) | A (guardrails) + D (register sections, brand-literal migrate) + update the two roadmap/RA docs with the conformance notes (B5, C9) | Phase 0 hygiene |
+| **With billing-engine build** | C (RA as detect-layer; VAT/pro-rata/CollectionRail in engine; platform_events) + E | Phase 1 |
+| **With integration-gateway build** | B (network adapters conform to `core`; `integration_runs`; dashboard) | Phase 3 |
+| **With workspace rollout** | D feature-flags + workspace placement | Phase 4 |
+
+## Deliverables & placement (decided: cross-cutting spec + woven into phase plans)
+
+This alignment is **not a new phase**. It follows the design's spec-vs-plan convention: a durable companion **spec**, whose items are woven into each phase's plan as that phase is written.
+
+**Primary artifact — a new cross-cutting alignment spec:**
+- **`docs/superpowers/specs/2026-07-09-whitelabel-alignment-network-billing.md`** — the durable seam-map + guardrails (this plan, formalized). Companion to `2026-07-09-whitelabel-platform-design.md`, not a phase.
+- Add a one-line cross-reference to it in the umbrella design's §11 sequencing table (`docs/superpowers/specs/2026-07-09-whitelabel-platform-design.md`) so it's discoverable.
+
+**Woven into each phase's plan (when that phase is written):**
+- **Phase 0** `docs/superpowers/plans/2026-07-09-whitelabel-phase0-guardrails.md` — items **A + D**: register Network/RA sections, migrate the interstellio brand literal, adopt the no-new-raw-SQL / no-new-env-cred guardrails.
+- **Phase 1** (billing-engine plan, future) — items **C + E + F**: RA-as-detect-layer, VAT-exclusive fix, pro-rata + `CollectionRail` + NetCash guards, `platform_events`, `notify()`.
+- **Phase 3** (integration-gateway plan, future) — item **B**: network adapters implement `lib/integrations/core/`; `*_sync_logs`→`integration_runs`; dashboard.
+- **Phase 4** (workspace plan, future) — item **D** flags + workspace placement.
+
+**Conformance notes added to our own session docs (Now step):**
+- `docs/plans/2026-07-09-in-app-network-management-roadmap.md` — "conforms to Seam 3" note (B5–B8).
+- `docs/plans/2026-07-09-ra-report-reconciliation-spec.md` — "detect-only; remediate via billing engine" note (C9, E14–15).
+- `docs/architecture/NETWORK_VISIBILITY_BRIDGES.md` — brief seam-alignment note.
+
+**One code change in the Now step:**
+- `lib/admin/feature-registry.ts` — register Network-Management + Revenue-Assurance sections with maturity (`beta`/`internal`).
+
+## Verification
+
+- **Conformance is documented, not just intended:** the two `docs/plans/2026-07-09-*` files carry explicit "conforms to Seam 3 / Seam 1" sections; `git grep` for the new cross-references.
+- **No regression to the ratchet:** `bash scripts/check-brand-literals.sh` count ≤ 6182 (and lower if the interstellio literal is migrated).
+- **Registry:** `npm run test -- feature-registry` passes; Network/RA sections appear with correct maturity and are hidden for non-admin roles via `getVisibleSections`.
+- **Guardrail proof:** `git grep "from('customer_invoices')"` shows no *new* writer added after this plan; new integration code shows no new `process.env.<PROVIDER>_` credential read.
+- **End-state check (later phases):** once the seams exist, the network adapters resolve credentials via tenant config and log to `integration_runs`; RA emits `platform_events` and triggers billing-engine remediation with zero raw SQL.
+
+## Out of scope
+
+- Building `lib/integrations/core/` or `lib/billing/engine/` now — those are their own whitelabel phases with their own spec→plan cycles (the design mandates this).
+- Refactoring the existing 152 billing writers (whitelabel Phase 1 owns that).
+- Any `tenant_id`/shared-DB multi-tenant work (design explicitly rejects it for now).
+- Re-billing/collection changes for the catch-up invoices already created (finance owns the NetCash portal step).

--- a/docs/superpowers/specs/2026-07-09-whitelabel-alignment-network-billing.md
+++ b/docs/superpowers/specs/2026-07-09-whitelabel-alignment-network-billing.md
@@ -1,0 +1,96 @@
+# Whitelabel Alignment — Network Management & Revenue Assurance
+
+**Date:** 2026-07-09
+**Status:** Companion spec to `2026-07-09-whitelabel-platform-design.md` (cross-cutting; **not a phase**)
+**Author:** Jeffrey + Claude Code
+
+---
+
+## 0. Why this exists
+
+A large body of work landed alongside whitelabel Phase 0: in-app **network management** (Ruijie, Interstellio, Tarana/TCS, MikroTik bridges), a **Revenue Assurance** capability (`service_network_identifiers` + reconciliation), and live **billing** actions (catch-up invoices, `billing_ready`/mandate-verified fixes). See:
+
+- `docs/plans/2026-07-09-in-app-network-management-roadmap.md`
+- `docs/plans/2026-07-09-revenue-assurance-map-coverage-audit.md`
+- `docs/plans/2026-07-09-ra-report-reconciliation-spec.md`
+- `docs/architecture/NETWORK_VISIBILITY_BRIDGES.md`
+
+That work lands squarely on two whitelabel **seams** — **Integration Gateway (§5)** and **Billing Engine (§3)** — but was built in the pre-seam style the design is retiring: bespoke clients reading `process.env`, and raw-SQL writes to `customer_invoices`. Left unaligned it *deepens the sprawl* the design must later untangle (the catch-up invoices became one more of ~152 `customer_invoices` writers; the four network bridges added four bespoke credential-in-env clients + per-provider `*_sync_logs` tables).
+
+**Goal:** make this work conform to the seam boundaries so it becomes proof *for* the seams, not debt *against* them — with **no speculative rebuild** (the design forbids it; every step must pay for CircleTel now). This spec is the durable map; its items are woven into each phase's plan as that phase is written.
+
+## 1. Current state (verified 2026-07-09)
+
+| Whitelabel piece | State | Our work that touches it |
+|---|---|---|
+| `lib/tenant/` `getTenantConfig()` | ✅ built (branding/contacts; env-override; **no credential routing yet** — Phase 2) | Network clients read `process.env` directly |
+| `lib/admin/feature-registry.ts` | ✅ built (no per-tenant flags yet — Phase 4) | Network + RA admin sections unregistered |
+| Brand-literal ratchet (`scripts/check-brand-literals.sh`, baseline 6182) | ✅ built | `lib/interstellio/client.ts:62` default `'circletel.co.za'` |
+| **Integration Gateway** `lib/integrations/core/` | ❌ **spec only** | 4 bespoke clients + `ruijie/tarana/mikrotik_sync_logs` |
+| **Billing Engine** `lib/billing/engine/` | ❌ **spec only** (~152 scattered writers; `CompliantBillingService` closest) | RA catch-up invoices via raw SQL |
+| `platform_events` + unified `notify()` | ❌ **spec only** (ad-hoc `lib/billing/debit-batch-alert.ts`) | RA detections + billing mutations |
+| Instance-per-tenant (no `tenant_id`) | ✅ chosen model | `service_network_identifiers` (tenant-local — already correct) |
+
+## 2. Seam map
+
+- **Network bridges** (Ruijie, Interstellio, Tarana/TCS, MikroTik) → **Seam 3 Integration Gateway**.
+- **Revenue Assurance** → **reads** Seam 3 (network signals) + **acts through** Seam 1 (billing); never a direct billing writer.
+- **Billing actions** (invoice creation, pro-rata, debit alignment, VAT, `billing_ready`/verified) → **Seam 1 Billing Engine**.
+- **Docs** → already follow docs-in-DoD (§8). ✅
+
+## 3. Guardrails — adopt now (applies to all new code)
+
+1. **No new raw-SQL writes to `customer_invoices`/payment tables.** Route through `CompliantBillingService` (`lib/billing/compliant-billing-service.ts`) until `lib/billing/engine/` exists, then that becomes the single writer. The four catch-up invoices (INV-2026-00037…40) were raw-SQL — leave them (voidable), do not repeat.
+2. **No new `process.env` credential reads in integration code.** Resolve through one accessor (today `getTenantConfig()` for identity; a `getIntegrationCredentials(provider)` to be added in Phase 2). Mirror `lib/payments/payment-provider-settings-loader.ts` (NetCash creds already in a `payment_provider_settings` DB table).
+3. **No new bespoke `*_sync_logs` tables.** New integrations target the future `integration_runs`; until then reuse `integration_cron_jobs` / `integration_activity_log`.
+4. **Every new API route declares its auth context** (public / customer-session / admin-role / service) per §7 — network/RA routes especially (device access + PII).
+
+## 4. Conformance by seam (rides the phases; no rebuild now)
+
+### Seam 3 — Integration Gateway (whitelabel Phase 3)
+- The network roadmap's vendor-neutral **`NetworkDeviceAdapter`** is an *implementation of* the future `lib/integrations/core/` contract (`authenticate() / healthCheck() / capabilities`), not a parallel abstraction.
+- **The network bridges are the first proof of the gateway** — four real adapters, four auth styles (OAuth, token, cookie-session, HMAC-proxy) — an ideal generality test. They feed `app/admin/integrations` (health, last sync, re-auth).
+- Consolidate `ruijie/tarana/mikrotik_sync_logs` → `integration_runs` when Phase 3 builds it.
+- Feature-flag each network integration per tenant (Phase 4).
+
+### Seam 1 — Billing Engine (whitelabel Phase 1)
+- **Revenue Assurance is a read/detect layer**: it produces `ra_exceptions`; *remediation* (advance-to-billing-ready, catch-up invoice, credit note) is performed by the billing engine, never RA SQL.
+- The engine is the correct home for fixes this session surfaced: the **VAT-exclusive treatment** (the R450→R517.50 generator bug — see §5), **pro-rata**, and the **NetCash action-date / R1,500-line / R20,000-day guards** all belong in the engine's `CollectionRail` + invoice state machine.
+- `service_network_identifiers` is the shared join for "is this billed service actually live on the network." Tenant-local (no `tenant_id`). Add `msisdn`/`iccid`/`mikrotik_serial` types as sources land.
+
+### Observability (Phase 0/1)
+- **RA is the natural first consumer of `platform_events`**: detections + billing mutations (`billing_ready` flip, verified flip, invoice creation) write `(actor, entity, before/after, source)`.
+- RA alerts + the report-reconciliation `ra_recipients` route through the unified `notify()`, not a second bespoke email path.
+
+### Tenant config / registry / ratchet (now)
+- Register **Network-Management** (→ Ops/Support workspace) and **Revenue-Assurance** (→ Finance workspace) sections in `lib/admin/feature-registry.ts` with maturity (`beta`/`internal`).
+- When touching `lib/interstellio/client.ts`, migrate the `'circletel.co.za'` default to `getTenantConfig()` so the ratchet ticks **down**.
+
+## 5. Hygiene debts surfaced this session (carry forward, don't hide)
+
+- **Generator VAT bug** — treats `monthly_price` (ex-VAT) as VAT-inclusive, under-billing the Unjani base ~R67.50/mo (correct monthly R450→R517.50). → Phase-1 billing-engine item.
+- **Four raw-SQL catch-up invoices** — one-off; the engine must be able to produce this natively (pro-rata + catch-up) — capture as an engine test case.
+- **11 legacy clinics mis-staged "pending"** — billed but no onboarding submission; belongs to the Ops workspace + the engine's "active service" signal, not a flag fix.
+
+## 6. Weaving (where each item lands)
+
+| Phase / plan | Items |
+|---|---|
+| **Now** (Phase 0 hygiene) — `docs/superpowers/plans/2026-07-09-whitelabel-phase0-guardrails.md` | §3 guardrails; register Network/RA sections; migrate the interstellio literal |
+| **Phase 1** (billing-engine plan, future) | Seam 1 items + observability + §5 debts |
+| **Phase 3** (integration-gateway plan, future) | Seam 3 items |
+| **Phase 4** (workspace plan, future) | per-tenant flags + workspace placement |
+
+## 7. Verification
+
+- Conformance is documented: the two `docs/plans/2026-07-09-*` files carry "conforms to Seam 1 / Seam 3" notes; this spec is cross-referenced from the umbrella design §11.
+- `bash scripts/check-brand-literals.sh` count ≤ 6182 (lower once the interstellio literal migrates).
+- Guardrail proof over time: `git grep "from('customer_invoices')"` adds no new writer; new integration code adds no new `process.env.<PROVIDER>_` read.
+- End-state (later phases): network adapters resolve creds via tenant config and log to `integration_runs`; RA emits `platform_events` and triggers billing-engine remediation with zero raw SQL.
+
+## 8. Out of scope
+
+- Building `lib/integrations/core/` or `lib/billing/engine/` now (their own phases).
+- Refactoring the existing ~152 billing writers (Phase 1 owns it).
+- Any `tenant_id`/shared-DB work (design rejects it for now).
+- Re-billing the catch-up invoices already created (finance owns the NetCash portal step).

--- a/docs/superpowers/specs/2026-07-09-whitelabel-platform-design.md
+++ b/docs/superpowers/specs/2026-07-09-whitelabel-platform-design.md
@@ -301,6 +301,8 @@ Ordered by business value to CircleTel *now* — every phase pays for itself eve
 tenant ever signs. **Each phase gets its own spec → plan → implementation cycle**; this
 document is the umbrella, not one giant plan.
 
+> **Companion spec (cross-cutting, not a phase):** `docs/superpowers/specs/2026-07-09-whitelabel-alignment-network-billing.md` maps the 2026-07 network-management + revenue-assurance work onto Seam 3 (Integration Gateway) and Seam 1 (Billing Engine); its items are woven into the relevant phase plans.
+
 | Phase | Duration (est.) | Scope | Why this order |
 |---|---|---|---|
 | **0** | ~1–2 wks | Guardrails: `lib/tenant/` skeleton + config accessor, feature registry + generated nav, brand-literal CI gate, docs-in-DoD PR template, portable scheduler decision (§12), security quick wins (close criticals) | Cheap; stops the holes getting deeper; everything after builds on it |

--- a/supabase/migrations/20260709160000_create_service_network_identifiers.sql
+++ b/supabase/migrations/20260709160000_create_service_network_identifiers.sql
@@ -1,0 +1,21 @@
+-- Revenue Assurance: unified service ↔ network-identifier mapping
+-- One row per (identifier_type, identifier_value) → the customer_service it belongs to.
+-- Backfills the mapping-gap prerequisite for ALL active-signal sources (Ruijie AP SN,
+-- Interstellio subscriber UUID, Tarana serial, MTN SIM MSISDN/ICCID).
+-- Ref: docs/plans/2026-07-09-ra-report-reconciliation-spec.md §4
+
+create table if not exists service_network_identifiers (
+  id uuid primary key default gen_random_uuid(),
+  service_id uuid not null references customer_services(id) on delete cascade,
+  identifier_type text not null
+    check (identifier_type in ('msisdn','iccid','interstellio_uuid','ruijie_sn','tarana_serial')),
+  identifier_value text not null,
+  source text,                         -- how it was mapped: 'backfill','provisioning','manual'
+  created_at timestamptz not null default now(),
+  unique (identifier_type, identifier_value)
+);
+
+create index if not exists idx_sni_service on service_network_identifiers (service_id);
+
+-- Service-role only, matching ruijie_device_cache / RA convention
+alter table service_network_identifiers enable row level security;


### PR DESCRIPTION
## Summary

Planning docs for **in-app network management** + **Revenue Assurance**, plus the `service_network_identifiers` migration that unifies device/subscriber → `customer_services` mapping across all active-signal sources (Ruijie, Interstellio, Tarana, MTN SIM).

Docs-and-migration only — **no application code changes**.

## What's included

**Docs (`docs/plans/2026-07-09-*`):**
- **In-app network-management roadmap** — phases 0–6, two-layer NOC (hardware: Ruijie/MikroTik + subscriber/AAA: Interstellio)
- **Phase 0 foundation-fix spec** — Ruijie telemetry (implement documented CPU/mem endpoint), metrics persistence, vendor-neutral adapter
- **Revenue Assurance report-reconciliation engine spec** — reusable upload→map→reconcile→notify; cellular SIM as report type #1
- **Map-coverage audit** — reconciliation of active services vs network signals; mapping coverage **56% → 88%** after backfill

**Migration `20260709160000_create_service_network_identifiers.sql`:**
- Unified mapping table: `service_id ↔ identifier_type(msisdn/iccid/interstellio_uuid/ruijie_sn/tarana_serial)/value`, unique on (type, value), service-role RLS.

## ⚠️ Migration already applied to prod

Per project convention (Ruijie/RA migrations applied manually to the shared DB), this migration and its backfill were **already applied to production** during the mapping work — merging records it for history, it does **not** re-run. Live state today:
- Table created; **25 identifiers** backfilled (23 ruijie_sn + 2 interstellio_uuid)
- 9 orphaned Unjani APs linked to their sites; 4 previously-broken clinics now resolve
- 7 test/demo `customer_services` quarantined (reversible: `active=false`)

## Follow-ups (not in this PR)
- Capture MSISDNs for the 2 consumer 5G services (Ashwyn/Raymund) — blocked on SIM numbers from MTN
- Investigate **Unjani Durban**: online AP but no service record (active install not set up for billing)
- Build the RA reconciliation upload engine (spec included here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)