### PR TITLE
fix(billing): credit-note apply wrote to non-existent payment_reference column

### DIFF
--- a/lib/billing/compliant-billing-service.ts
+++ b/lib/billing/compliant-billing-service.ts
@@ -386,8 +386,7 @@ export class CompliantBillingService {
       .from('customer_invoices')
       .update({
         amount_paid: newAmountPaid,
-        status: newStatus,
-        payment_reference: `Credit Note: ${creditNote.credit_note_number}`
+        status: newStatus
       })
       .eq('id', originalInvoice.id);
 


### PR DESCRIPTION
## Problem

The credit-note **apply** path in `lib/billing/compliant-billing-service.ts` updated `customer_invoices` with a `payment_reference` column that **does not exist on that table**.

Verified against the live schema (`information_schema.columns`), `customer_invoices` has `amount_paid`, `paid_at`, `status`, `total_amount` — but **not** `payment_reference` (nor `payment_method`). PostgREST rejects the unknown column, so applying any credit note threw `Failed to update invoice`.

This is the exact defect surfaced during the **Kayamandi CT-2026-00022** June double-debit remediation (credit note CN-2026-00002 against INV-2026-00027). The one-off remediation script already landed on `main`; the underlying service bug did not.

## Fix

Remove the invalid `payment_reference` column from the invoice update in the CN-apply path. The credit note itself records the reference, so no data is lost on the invoice row.

```diff
       .update({
         amount_paid: newAmountPaid,
-        status: newStatus,
-        payment_reference: `Credit Note: ${creditNote.credit_note_number}`
+        status: newStatus
       })
```

## Verification

- Live-schema query confirms `customer_invoices` lacks `payment_reference`/`payment_method`.
- Pre-push scoped type-check passed (no type errors in changed files).

## ⚠️ Follow-up (separate, NOT in this PR)

`recordPayment()` in the same file writes **both** `payment_method` and `payment_reference` to `customer_invoices` (lines ~495–496) — a latent sibling bug that only hasn't surfaced because that method isn't on the live payment path. Its correct remediation (add the columns via migration vs. drop the writes) is a **design decision** and should be handled on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)