### PR TITLE
fix(billing): recordPayment wrote non-existent payment_method/payment_reference columns

### DIFF
--- a/lib/billing/compliant-billing-service.ts
+++ b/lib/billing/compliant-billing-service.ts
@@ -492,8 +492,8 @@ export class CompliantBillingService {
       .update({
         amount_paid: newAmountPaid,
         status: newStatus,
-        payment_method: paymentMethod,
-        payment_reference: paymentReference,
+        // NOTE: payment_method / payment_reference are NOT columns on
+        // customer_invoices — they are captured in the audit log below.
         paid_at: newStatus === 'paid' ? nowISO() : null
       })
       .eq('id', invoiceId);


### PR DESCRIPTION
## Problem

`CompliantBillingService.recordPayment()` updates `customer_invoices` with `payment_method` and `payment_reference` — **neither is a column on that table** (verified against the live schema: `customer_invoices` has `amount_paid`, `paid_at`, `status`, `total_amount`). PostgREST rejects the unknown columns, so any call throws `Failed to record payment`.

This is the **sibling defect** flagged in #611 (which fixed the credit-note-apply path).

## Why it hasn't surfaced

`CompliantBillingService.recordPayment` has **no callers** — confirmed across `app/`, `lib/`, `scripts/`. The live payment path records via the Zoho billing client's `recordPayment(payload)` (a different method/signature) and NetCash webhooks. So the bug is latent, not active.

## Fix — drop the invalid columns (not add them)

Because the method is uncalled, adding schema columns would be speculative. Consistent with #611, remove the two non-existent columns from the update. The payment metadata is **already captured in the audit log** (`logAudit('payment_recorded', … { payment_method, payment_reference })`), so nothing is lost. `paid_at` is a real column and is retained.

```diff
       .update({
         amount_paid: newAmountPaid,
         status: newStatus,
-        payment_method: paymentMethod,
-        payment_reference: paymentReference,
+        // NOTE: payment_method / payment_reference are NOT columns on
+        // customer_invoices — they are captured in the audit log below.
         paid_at: newStatus === 'paid' ? nowISO() : null
       })
```

## Verification

- Live-schema query confirms `customer_invoices` lacks `payment_method`/`payment_reference`.
- Caller search confirms `CompliantBillingService.recordPayment` is unused.
- Pre-push scoped type-check passed.

## Note

The method is currently dead code. This PR makes it correct-if-called; a separate cleanup could remove it entirely if it's confirmed obsolete. Left out of scope here to keep the change surgical.

Related: #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)