### PR TITLE
Promote: role-scoped admin workspaces (B1a + PR5 + PR2.5 + PR4) staging→main

### DIFF
--- a/__tests__/components/admin/layout/Sidebar.test.tsx
+++ b/__tests__/components/admin/layout/Sidebar.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * Runtime tests for the admin Sidebar workspace switcher (PR #613).
+ *
+ * The Sidebar renders role-scoped, workspace-grouped nav via getWorkspaceNav()
+ * and workspaceForPath() from the feature registry. These tests mount the REAL
+ * component and drive its interactions (switch workspace, expand accordion) to
+ * prove the wiring — not just re-test the registry selectors.
+ *
+ * Renderer: react-test-renderer. The repo's jest env is jest-environment-node
+ * (no jsdom), so RTL is unavailable; react-test-renderer runs the component with
+ * hooks + effects and lets us invoke handlers without a DOM.
+ *
+ * NOT covered here (no layout engine): visual position / clipping of the
+ * collapsed-rail switcher dropdown — that needs a real browser.
+ */
+import { describe, it, expect, jest } from '@jest/globals';
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import {
+  getWorkspaceNav,
+  hasChildren,
+  type WorkspaceId,
+} from '@/lib/admin/feature-registry';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---- environment shims (not the logic under test) ----
+// `mock`-prefixed so it is hoisting-safe inside the jest.mock factory.
+let mockPath = '/admin';
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPath,
+  useRouter: () => ({ push() {} }),
+}));
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...p }: any) => React.createElement('a', { href, ...p }, children),
+}));
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (p: any) =>
+    React.createElement('img', { alt: p.alt, src: typeof p.src === 'string' ? p.src : '' }),
+}));
+// Radix Tooltip pulls DOM APIs; the Sidebar's nav logic is what we test, so the
+// tooltip is stubbed to pass its children through (TooltipContent renders them
+// under a data-tooltip marker so the collapsed-rail label is still assertable).
+jest.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: any) => children,
+  Tooltip: ({ children }: any) => children,
+  TooltipTrigger: ({ children }: any) => children,
+  TooltipContent: ({ children }: any) =>
+    React.createElement('span', { 'data-tooltip': true }, children),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Sidebar } = require('@/components/admin/layout/Sidebar');
+
+// ---- helpers ----
+const text = (inst: any): string => {
+  const out: string[] = [];
+  const walk = (c: any) => {
+    if (c == null || c === false) return;
+    if (typeof c === 'string') { out.push(c); return; }
+    if (Array.isArray(c)) { c.forEach(walk); return; }
+    if (c.children) c.children.forEach(walk);
+  };
+  inst.children.forEach(walk);
+  return out.join('').trim();
+};
+
+function mount(role: string, isOpen = true, path = '/admin') {
+  mockPath = path;
+  let r: TestRenderer.ReactTestRenderer;
+  act(() => {
+    r = TestRenderer.create(
+      React.createElement(Sidebar, { isOpen, onToggle() {}, user: { role, full_name: 'Test User' } })
+    );
+  });
+  return r!.root;
+}
+
+const openSwitcher = (root: any) => {
+  const toggle = root.findByProps({ 'aria-label': 'Switch workspace' });
+  act(() => toggle.props.onClick());
+  return root.findAll((n: any) => n.props && n.props.role === 'menuitem');
+};
+
+const switcherLabels = (root: any): string[] => openSwitcher(root).map(text);
+
+const activeWorkspaceLabel = (root: any): string => {
+  const toggle = root.findByProps({ 'aria-label': 'Switch workspace' });
+  const span = toggle.findAll(
+    (n: any) =>
+      n.type === 'span' &&
+      /flex-1/.test(n.props.className || '') &&
+      /truncate/.test(n.props.className || '')
+  )[0];
+  return text(span);
+};
+
+const navTopLevelNames = (root: any): string[] => {
+  const nav = root.findByType('nav');
+  return nav
+    .findAll((n: any) => n.type === 'span' && /flex-1/.test(n.props.className || ''))
+    .map(text)
+    .filter(Boolean);
+};
+
+// =====================================================================
+describe('Sidebar workspace switcher', () => {
+  it('lists all 7 workspaces incl. Administration for elevated roles', () => {
+    for (const role of ['super_admin', 'product_manager'] as const) {
+      const labels = switcherLabels(mount(role));
+      expect(labels).toContain('Administration');
+      expect(labels).toContain('Executive');
+      expect(labels).toHaveLength(7);
+    }
+  });
+
+  it('hides Administration from editor & viewer but keeps the feature workspaces', () => {
+    for (const role of ['editor', 'viewer'] as const) {
+      const labels = switcherLabels(mount(role));
+      expect(labels).not.toContain('Administration');
+      expect(labels).toContain('Executive');
+      expect(labels.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('falls back to least privilege (viewer) for an unknown role', () => {
+    const labels = switcherLabels(mount('totally-not-a-role'));
+    expect(labels).not.toContain('Administration');
+    expect(labels).toContain('Executive');
+  });
+
+  it('swaps the nav to only the selected workspace’s items', () => {
+    const root = mount('super_admin', true, '/admin'); // starts on Executive
+    const before = navTopLevelNames(root);
+    const finance = openSwitcher(root).find((m: any) => text(m) === 'Finance');
+    expect(finance).toBeTruthy();
+    act(() => finance!.props.onClick());
+    const after = navTopLevelNames(root);
+    const expected = getWorkspaceNav({ role: 'super_admin' })
+      .find((w) => w.id === 'finance')!
+      .items.map((i) => i.name);
+    expect(after.sort()).toEqual([...expected].sort());
+    expect(after).not.toEqual(before);
+  });
+
+  it('opens the workspace matching the current route', () => {
+    const cases: Array<[string, string, string]> = [
+      ['/admin/quotes', 'super_admin', 'Sales & Marketing'],
+      ['/admin/contracts', 'super_admin', 'Ops & Onboarding'],
+      ['/admin/settings', 'super_admin', 'Administration'],
+    ];
+    for (const [path, role, label] of cases) {
+      expect(activeWorkspaceLabel(mount(role, true, path))).toBe(label);
+    }
+  });
+
+  it('falls back to the first accessible workspace for an unknown route (no crash)', () => {
+    expect(activeWorkspaceLabel(mount('viewer', true, '/admin/totally-unknown'))).toBe('Executive');
+  });
+
+  it('renders item tooltips on the collapsed rail', () => {
+    const root = mount('super_admin', false, '/admin');
+    const tooltips = root
+      .findAll((n: any) => n.props && n.props['data-tooltip'] === true)
+      .map(text)
+      .filter(Boolean);
+    expect(tooltips.length).toBeGreaterThan(0);
+  });
+
+  it('expands/collapses an accordion item and highlights the active child', () => {
+    // Discover a super_admin workspace + parent item with children.
+    let found: { ws: WorkspaceId; itemName: string; childHref: string } | null = null;
+    for (const w of getWorkspaceNav({ role: 'super_admin' })) {
+      for (const it of w.items) {
+        if (hasChildren(it)) {
+          found = { ws: w.id, itemName: it.name, childHref: it.children[0].href };
+          break;
+        }
+      }
+      if (found) break;
+    }
+    expect(found).toBeTruthy();
+
+    // (a) manual expand/collapse from a neutral route
+    const root = mount('super_admin', true, '/admin');
+    const wsLabel = getWorkspaceNav({ role: 'super_admin' }).find((w) => w.id === found!.ws)!.label;
+    const wsBtn = openSwitcher(root).find((m: any) => text(m) === wsLabel);
+    act(() => wsBtn!.props.onClick());
+
+    const childCount = () =>
+      root.findAll((n: any) => n.type === 'a' && n.props.href === found!.childHref).length;
+    expect(childCount()).toBe(0);
+    const parentBtn = root
+      .findAll((n: any) => n.type === 'button' && /w-full/.test(n.props.className || ''))
+      .find((b: any) => text(b).startsWith(found!.itemName));
+    expect(parentBtn).toBeTruthy();
+    act(() => parentBtn!.props.onClick());
+    expect(childCount()).toBeGreaterThan(0);
+    act(() => parentBtn!.props.onClick());
+    expect(childCount()).toBe(0);
+
+    // (b) auto-expand + active highlight when the route is a child href
+    const root2 = mount('super_admin', true, found!.childHref.split('?')[0]);
+    const activeAnchor = root2.findAll(
+      (n: any) => n.type === 'a' && n.props.href === found!.childHref
+    );
+    expect(activeAnchor.length).toBeGreaterThan(0);
+    expect(activeAnchor[0].props.className || '').toMatch(/bg-gray-100/);
+  });
+});

--- a/__tests__/components/admin/layout/Sidebar.test.tsx
+++ b/__tests__/components/admin/layout/Sidebar.test.tsx
@@ -209,4 +209,35 @@ describe('Sidebar workspace switcher', () => {
     expect(activeAnchor.length).toBeGreaterThan(0);
     expect(activeAnchor[0].props.className || '').toMatch(/bg-gray-100/);
   });
+
+  // ---- PR4: collapsed-rail child flyouts ----
+  const firstParent = () => {
+    for (const w of getWorkspaceNav({ role: 'super_admin' })) {
+      for (const it of w.items) if (hasChildren(it)) return { ws: w.id, item: it };
+    }
+    return null;
+  };
+
+  it('renders a child flyout (aria-haspopup) for a collapsed parent item', () => {
+    const found = firstParent();
+    expect(found).toBeTruthy();
+    const root = mount('super_admin', false, '/admin'); // collapsed rail
+    const wsLabel = getWorkspaceNav({ role: 'super_admin' }).find((w) => w.id === found!.ws)!.label;
+    const wsBtn = openSwitcher(root).find((m: any) => text(m) === wsLabel);
+    act(() => wsBtn!.props.onClick());
+    const triggers = root.findAll((n: any) => n.props && n.props['aria-haspopup'] === 'menu');
+    expect(triggers.length).toBeGreaterThan(0);
+  });
+
+  it('collapsed flyout exposes every child of the parent (reachable in the tree)', () => {
+    const found = firstParent();
+    const root = mount('super_admin', false, '/admin');
+    const wsLabel = getWorkspaceNav({ role: 'super_admin' }).find((w) => w.id === found!.ws)!.label;
+    const wsBtn = openSwitcher(root).find((m: any) => text(m) === wsLabel);
+    act(() => wsBtn!.props.onClick());
+    for (const child of (found!.item as any).children) {
+      const links = root.findAll((n: any) => n.type === 'a' && n.props.href === child.href);
+      expect(links.length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/__tests__/lib/admin/feature-registry.test.ts
+++ b/__tests__/lib/admin/feature-registry.test.ts
@@ -64,3 +64,58 @@ describe('getVisibleSections', () => {
     expect(getVisibleSections(onlyHidden, { isAdmin: true })).toEqual([]);
   });
 });
+
+import {
+  ITEM_MODULE,
+  ITEM_WORKSPACE,
+  WORKSPACES,
+  getWorkspaceNav,
+  workspaceForPath,
+} from '@/lib/admin/feature-registry';
+
+describe('module + workspace axes', () => {
+  const allItems = [...featureSections, ...bottomSections].flatMap((s) => s.items);
+
+  it('every top-level item has a workspace and a module tag', () => {
+    for (const item of allItems) {
+      expect(ITEM_WORKSPACE[item.name]).toBeDefined();
+      expect(ITEM_MODULE[item.name]).toBeDefined();
+    }
+  });
+
+  it('tag maps reference only real item names (no typos / stale keys)', () => {
+    const names = new Set(allItems.map((i) => i.name));
+    for (const k of Object.keys(ITEM_WORKSPACE)) expect(names.has(k)).toBe(true);
+    for (const k of Object.keys(ITEM_MODULE)) expect(names.has(k)).toBe(true);
+  });
+
+  it('WORKSPACES ids cover every workspace referenced by items', () => {
+    const wsIds = new Set(WORKSPACES.map((w) => w.id));
+    for (const ws of Object.values(ITEM_WORKSPACE)) expect(wsIds.has(ws)).toBe(true);
+  });
+
+  it('super_admin sees all workspaces incl. Administration', () => {
+    const ws = getWorkspaceNav({ role: 'super_admin' }).map((w) => w.id);
+    expect(ws).toContain('admin');
+    expect(ws).toContain('finance');
+  });
+
+  it('editor and viewer never see the Administration workspace', () => {
+    for (const role of ['editor', 'viewer'] as const) {
+      expect(getWorkspaceNav({ role }).map((w) => w.id)).not.toContain('admin');
+    }
+  });
+
+  it('module entitlement hides a disabled module’s items', () => {
+    const withoutBilling = getWorkspaceNav({ role: 'super_admin', modules: ['core'] });
+    const finance = withoutBilling.find((w) => w.id === 'finance');
+    expect(finance).toBeUndefined(); // Billing & Revenue + Payments are module "billing"
+  });
+
+  it('workspaceForPath resolves known routes', () => {
+    expect(workspaceForPath('/admin/quotes')).toBe('sales');
+    expect(workspaceForPath('/admin/billing/invoices')).toBe('finance');
+    expect(workspaceForPath('/admin/settings')).toBe('admin');
+    expect(workspaceForPath('/admin/nonexistent')).toBeNull();
+  });
+});

--- a/__tests__/lib/admin/feature-registry.test.ts
+++ b/__tests__/lib/admin/feature-registry.test.ts
@@ -119,3 +119,21 @@ describe('module + workspace axes', () => {
     expect(workspaceForPath('/admin/nonexistent')).toBeNull();
   });
 });
+
+describe('B1a role -> workspace mapping', () => {
+  it('viewer sees only read-oriented workspaces (executive, support)', () => {
+    const ws = getWorkspaceNav({ role: 'viewer' }).map((w) => w.id);
+    expect(ws.every((id) => id === 'executive' || id === 'support')).toBe(true);
+    expect(ws).toContain('support');
+  });
+  it('editor sees operational workspaces but not Administration', () => {
+    const ws = getWorkspaceNav({ role: 'editor' }).map((w) => w.id);
+    expect(ws).toEqual(expect.arrayContaining(['finance', 'sales', 'ops', 'platform']));
+    expect(ws).not.toContain('admin');
+  });
+  it('elevated roles see Administration', () => {
+    for (const role of ['super_admin', 'product_manager'] as const) {
+      expect(getWorkspaceNav({ role }).map((w) => w.id)).toContain('admin');
+    }
+  });
+});

--- a/__tests__/lib/admin/workspace-access.parity.test.ts
+++ b/__tests__/lib/admin/workspace-access.parity.test.ts
@@ -31,3 +31,24 @@ describe('workspace-access parity with feature-registry', () => {
     }
   });
 });
+
+import { ITEM_MODULE } from '@/lib/admin/feature-registry';
+import { ALL_MODULES, moduleForPathname } from '@/lib/admin/workspace-access';
+
+describe('module parity with feature-registry (PR2.5)', () => {
+  it('every nav href resolves to the module the registry assigns its item', () => {
+    const items = [...featureSections, ...bottomSections].flatMap((s) => s.items);
+    for (const item of items) {
+      const expected = ITEM_MODULE[item.name];
+      const hrefs = hasChildren(item) ? item.children.map((c) => c.href) : [item.href];
+      for (const href of hrefs) {
+        expect({ href, mod: moduleForPathname(href) }).toEqual({ href, mod: expected });
+      }
+    }
+  });
+
+  it('ALL_MODULES covers every module the registry references', () => {
+    const all = new Set(ALL_MODULES);
+    for (const m of Object.values(ITEM_MODULE)) expect(all.has(m)).toBe(true);
+  });
+});

--- a/__tests__/lib/admin/workspace-access.parity.test.ts
+++ b/__tests__/lib/admin/workspace-access.parity.test.ts
@@ -1,0 +1,33 @@
+import {
+  featureSections,
+  bottomSections,
+  ITEM_WORKSPACE,
+  WORKSPACES,
+  hasChildren,
+} from '@/lib/admin/feature-registry';
+import { WORKSPACE_ROLES, workspaceForPathname } from '@/lib/admin/workspace-access';
+
+/**
+ * Locks the edge-safe workspace-access module to the icon-laden feature-registry
+ * (which middleware can't import). If either drifts, these fail in CI.
+ */
+describe('workspace-access parity with feature-registry', () => {
+  it('WORKSPACE_ROLES matches WORKSPACES[].roles for every workspace', () => {
+    for (const w of WORKSPACES) {
+      const a = [...WORKSPACE_ROLES[w.id]].sort();
+      const b = [...w.roles].sort();
+      expect(a).toEqual(b);
+    }
+  });
+
+  it('every nav href resolves to the workspace the registry assigns its item', () => {
+    const items = [...featureSections, ...bottomSections].flatMap((s) => s.items);
+    for (const item of items) {
+      const expected = ITEM_WORKSPACE[item.name];
+      const hrefs = hasChildren(item) ? item.children.map((c) => c.href) : [item.href];
+      for (const href of hrefs) {
+        expect({ href, ws: workspaceForPathname(href) }).toEqual({ href, ws: expected });
+      }
+    }
+  });
+});

--- a/__tests__/lib/admin/workspace-access.test.ts
+++ b/__tests__/lib/admin/workspace-access.test.ts
@@ -49,3 +49,32 @@ describe('canAccessAdminPath (PR5 route guard)', () => {
     expect(canAccessAdminPath('viewer', '/admin/some-unmapped-route')).toBe(true);
   });
 });
+
+describe('canAccessAdminPath module entitlement (PR2.5)', () => {
+  it('a disabled module denies its routes even for super_admin', () => {
+    const noBilling = ['core', 'crm', 'orders'] as const;
+    expect(canAccessAdminPath('super_admin', '/admin/billing', [...noBilling])).toBe(false);
+    expect(canAccessAdminPath('super_admin', '/admin/payments/transactions', [...noBilling])).toBe(false);
+    expect(canAccessAdminPath('super_admin', '/admin/finance/outstanding', [...noBilling])).toBe(false);
+  });
+
+  it('core routes stay reachable whenever core is enabled', () => {
+    for (const p of ['/admin', '/admin/dashboard', '/admin/settings', '/admin/users']) {
+      expect(canAccessAdminPath('super_admin', p, ['core'])).toBe(true);
+    }
+  });
+
+  it('enabled modules pass; role gating still applies on top', () => {
+    const mods = ['core', 'billing'] as const;
+    expect(canAccessAdminPath('editor', '/admin/billing', [...mods])).toBe(true);
+    expect(canAccessAdminPath('viewer', '/admin/billing', [...mods])).toBe(false); // role, not module
+  });
+
+  it('omitted modules = all on (pre-PR2.5 behaviour unchanged)', () => {
+    expect(canAccessAdminPath('super_admin', '/admin/billing')).toBe(true);
+  });
+
+  it('unmapped routes still fail open regardless of modules', () => {
+    expect(canAccessAdminPath('viewer', '/admin/some-unmapped-route', ['core'])).toBe(true);
+  });
+});

--- a/__tests__/lib/admin/workspace-access.test.ts
+++ b/__tests__/lib/admin/workspace-access.test.ts
@@ -1,0 +1,51 @@
+import { canAccessAdminPath, workspaceForPathname } from '@/lib/admin/workspace-access';
+
+describe('canAccessAdminPath (PR5 route guard)', () => {
+  it('viewer is blocked from operational + admin routes', () => {
+    for (const p of [
+      '/admin/billing', '/admin/quotes', '/admin/network/health',
+      '/admin/settings', '/admin/users', '/admin/orchestrator',
+    ]) {
+      expect(canAccessAdminPath('viewer', p)).toBe(false);
+    }
+  });
+
+  it('viewer reaches read-oriented routes', () => {
+    for (const p of ['/admin', '/admin/dashboard', '/admin/customers', '/admin/support/devices', '/admin/diagnostics']) {
+      expect(canAccessAdminPath('viewer', p)).toBe(true);
+    }
+  });
+
+  it('editor is blocked from Administration only', () => {
+    expect(canAccessAdminPath('editor', '/admin/settings')).toBe(false);
+    expect(canAccessAdminPath('editor', '/admin/users/roles')).toBe(false); // detail route
+    expect(canAccessAdminPath('editor', '/admin/orchestrator')).toBe(false);
+    expect(canAccessAdminPath('editor', '/admin/billing/invoices')).toBe(true);
+    expect(canAccessAdminPath('editor', '/admin/workflow')).toBe(true); // "Approvals" is ops, not admin
+  });
+
+  it('elevated roles reach everything mapped', () => {
+    for (const role of ['super_admin', 'product_manager'] as const) {
+      for (const p of ['/admin/settings', '/admin/billing', '/admin/network/health', '/admin/orchestrator']) {
+        expect(canAccessAdminPath(role, p)).toBe(true);
+      }
+    }
+  });
+
+  it('detail/query routes resolve to their parent workspace', () => {
+    expect(canAccessAdminPath('viewer', '/admin/quotes/123')).toBe(false);
+    expect(canAccessAdminPath('viewer', '/admin/billing?tab=x')).toBe(false);
+  });
+
+  it('longest-prefix: coverage/checker is sales, coverage/* is platform', () => {
+    expect(workspaceForPathname('/admin/coverage/checker')).toBe('sales');
+    expect(workspaceForPathname('/admin/coverage/maps')).toBe('platform');
+    // payments/settings (finance) must not be caught by /admin/settings (admin)
+    expect(workspaceForPathname('/admin/payments/settings')).toBe('finance');
+  });
+
+  it('unmapped admin routes fail open (returns null workspace)', () => {
+    expect(workspaceForPathname('/admin/some-unmapped-route')).toBeNull();
+    expect(canAccessAdminPath('viewer', '/admin/some-unmapped-route')).toBe(true);
+  });
+});

--- a/__tests__/lib/tenant/config.test.ts
+++ b/__tests__/lib/tenant/config.test.ts
@@ -33,3 +33,37 @@ describe('getTenantConfig', () => {
     expect(b.branding.companyName).toBe('CircleTel');
   });
 });
+
+import { ALL_MODULES } from '@/lib/admin/workspace-access';
+
+describe('getTenantConfig modules (PR2.5)', () => {
+  afterEach(() => {
+    resetTenantConfigForTests();
+    delete process.env.NEXT_PUBLIC_TENANT_MODULES;
+  });
+
+  it('defaults to all modules (CircleTel: everything on)', () => {
+    expect(getTenantConfig().modules).toEqual(ALL_MODULES);
+    expect(getTenantConfig().modules).toContain('core');
+  });
+
+  it('parses NEXT_PUBLIC_TENANT_MODULES and force-includes core', () => {
+    process.env.NEXT_PUBLIC_TENANT_MODULES = 'billing, crm ,orders';
+    const mods = getTenantConfig().modules;
+    expect(mods).toEqual(expect.arrayContaining(['billing', 'crm', 'orders', 'core']));
+    expect(mods).toHaveLength(4);
+  });
+
+  it('drops unknown module ids', () => {
+    process.env.NEXT_PUBLIC_TENANT_MODULES = 'billing,bogus,crm';
+    const mods = getTenantConfig().modules;
+    expect(mods).toEqual(expect.arrayContaining(['billing', 'crm', 'core']));
+    expect(mods).not.toContain('bogus');
+    expect(mods).toHaveLength(3);
+  });
+
+  it('blank env falls back to defaults', () => {
+    process.env.NEXT_PUBLIC_TENANT_MODULES = '  ';
+    expect(getTenantConfig().modules).toEqual(ALL_MODULES);
+  });
+});

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -86,8 +86,17 @@ function CollapsedFlyout({
   useEffect(() => {
     if (!open) return;
     const reposition = () => {
-      const r = btnRef.current?.getBoundingClientRect();
-      if (r) setCoords({ top: r.top, left: r.right });
+      const btn = btnRef.current;
+      if (!btn) return;
+      const r = btn.getBoundingClientRect();
+      // The panel is `position: fixed`, but the sidebar's `lg:translate-x-0`
+      // transform makes the SIDEBAR its containing block — so fixed coords are
+      // relative to the sidebar box, not the viewport. Subtract the sidebar
+      // origin so the panel tracks the trigger at any scroll position (verified:
+      // without this, bottom items in a scrolled long page fly off-screen).
+      const host = btn.closest('[data-testid="sidebar"]');
+      const h = host?.getBoundingClientRect();
+      setCoords({ top: r.top - (h?.top ?? 0), left: r.right - (h?.left ?? 0) });
     };
     reposition();
     window.addEventListener('scroll', reposition, true);

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -57,6 +57,78 @@ const WORKSPACE_ICON: Record<WorkspaceId, IconType> = {
   admin: PiGearBold,
 };
 
+/**
+ * Collapsed-rail (w-16) flyout for a parent item: hover/focus reveals its child
+ * links (PR4). Leaf items keep a name Tooltip; expanded rail uses the inline
+ * accordion. ponytail: CSS transition (not framer) matches the sidebar's motion
+ * vocabulary and `motion-reduce:` handles reduced-motion in one class — swap for
+ * motion.div + useReducedMotion() only if spring physics is wanted. The panel is
+ * `left-full pl-2`: contiguous with the icon (no hover dead-zone), pl-2 = the gap.
+ */
+function CollapsedFlyout({
+  item,
+  isActiveLink,
+}: {
+  item: NavItem;
+  isActiveLink: (href: string, end?: boolean) => boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  if (!hasChildren(item)) return null;
+  return (
+    <div
+      className="relative"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) setOpen(false);
+      }}
+    >
+      <button
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={item.name}
+        className="flex w-full items-center justify-center rounded-lg px-0 py-2.5 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
+      >
+        <item.icon className="h-5 w-5 flex-shrink-0" />
+      </button>
+
+      <div
+        role="menu"
+        className={cn(
+          'absolute left-full top-0 z-50 min-w-56 pl-2 transition duration-150 ease-out',
+          'motion-reduce:transition-none',
+          open
+            ? 'visible translate-x-0 opacity-100'
+            : 'pointer-events-none invisible -translate-x-1 opacity-0'
+        )}
+      >
+        <div className="rounded-lg border border-gray-200 bg-white p-1 shadow-lg">
+          <p className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
+            {item.name}
+          </p>
+          {item.children.map((child) => (
+            <Link
+              key={child.href}
+              href={child.href}
+              role="menuitem"
+              className={cn(
+                'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+                isActiveLink(child.href)
+                  ? 'bg-gray-100 text-gray-900 font-medium'
+                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+              )}
+            >
+              <child.icon className="h-4 w-4 flex-shrink-0" />
+              <span className="truncate">{child.name}</span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function Sidebar({ isOpen, onToggle, user }: SidebarProps) {
   const pathname = usePathname();
 
@@ -220,58 +292,44 @@ export function Sidebar({ isOpen, onToggle, user }: SidebarProps) {
           {items.map((item) => (
             <div key={item.name}>
               {hasChildren(item) ? (
-                <div className="space-y-1">
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        onClick={() => isOpen && toggleDropdown(item.name)}
-                        className={cn(
-                          'flex items-center w-full px-3 py-2.5 text-sm font-medium rounded-lg transition-all',
-                          'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                          isOpen && 'cursor-pointer',
-                          !isOpen && 'cursor-default'
-                        )}
-                      >
-                        <item.icon className="mr-3 h-5 w-5 flex-shrink-0" />
-                        {isOpen && (
-                          <>
-                            <span className="flex-1 text-left">{item.name}</span>
-                            {isExpanded(item.name) ? (
-                              <PiCaretDownBold className="h-4 w-4 transition-transform duration-200" />
-                            ) : (
-                              <PiCaretRightBold className="h-4 w-4 transition-transform duration-200" />
-                            )}
-                          </>
-                        )}
-                      </button>
-                    </TooltipTrigger>
-                    {!isOpen && (
-                      <TooltipContent side="right" className="font-medium">
-                        {item.name}
-                      </TooltipContent>
-                    )}
-                  </Tooltip>
+                !isOpen ? (
+                  <CollapsedFlyout item={item} isActiveLink={isActiveLink} />
+                ) : (
+                  <div className="space-y-1">
+                    <button
+                      onClick={() => toggleDropdown(item.name)}
+                      className="flex items-center w-full px-3 py-2.5 text-sm font-medium rounded-lg text-gray-600 hover:bg-gray-50 hover:text-gray-900 cursor-pointer transition-all"
+                    >
+                      <item.icon className="mr-3 h-5 w-5 flex-shrink-0" />
+                      <span className="flex-1 text-left">{item.name}</span>
+                      {isExpanded(item.name) ? (
+                        <PiCaretDownBold className="h-4 w-4 transition-transform duration-200" />
+                      ) : (
+                        <PiCaretRightBold className="h-4 w-4 transition-transform duration-200" />
+                      )}
+                    </button>
 
-                  {isOpen && isExpanded(item.name) && (
-                    <div className="ml-9 space-y-1 pl-4">
-                      {item.children.map((child) => (
-                        <Link
-                          key={child.href}
-                          href={child.href}
-                          className={cn(
-                            'flex items-center px-3 py-2 text-sm rounded-lg transition-all',
-                            isActiveLink(child.href)
-                              ? 'bg-gray-100 text-gray-900 font-medium'
-                              : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                          )}
-                        >
-                          <child.icon className="mr-2 h-4 w-4" />
-                          {child.name}
-                        </Link>
-                      ))}
-                    </div>
-                  )}
-                </div>
+                    {isExpanded(item.name) && (
+                      <div className="ml-9 space-y-1 pl-4">
+                        {item.children.map((child) => (
+                          <Link
+                            key={child.href}
+                            href={child.href}
+                            className={cn(
+                              'flex items-center px-3 py-2 text-sm rounded-lg transition-all',
+                              isActiveLink(child.href)
+                                ? 'bg-gray-100 text-gray-900 font-medium'
+                                : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                            )}
+                          >
+                            <child.icon className="mr-2 h-4 w-4" />
+                            {child.name}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
               ) : (
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -32,6 +32,7 @@ import {
   type WorkspaceId,
 } from '@/lib/admin/feature-registry';
 import type { AdminRole } from '@/lib/auth/constants';
+import { getTenantConfig } from '@/lib/tenant';
 
 interface User {
   full_name?: string;
@@ -66,7 +67,7 @@ export function Sidebar({ isOpen, onToggle, user }: SidebarProps) {
     : 'viewer';
 
   // Role-scoped, workspace-grouped nav (feature-registry, PR #613).
-  const workspaces = getWorkspaceNav({ role });
+  const workspaces = getWorkspaceNav({ role, modules: getTenantConfig().modules });
 
   const [activeWs, setActiveWs] = useState<WorkspaceId>(
     () => workspaceForPath(pathname) ?? workspaces[0]?.id ?? 'executive'

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -84,7 +84,7 @@ function CollapsedFlyout({
   const [coords, setCoords] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || typeof window === 'undefined') return;
     const reposition = () => {
       const btn = btnRef.current;
       if (!btn) return;
@@ -193,6 +193,29 @@ export function Sidebar({ isOpen, onToggle, user }: SidebarProps) {
   const ActiveIcon = active ? WORKSPACE_ICON[active.id] : PiTrendUpBold;
 
   const [switcherOpen, setSwitcherOpen] = useState(false);
+  // Collapsed switcher dropdown: same transform-occlusion fix as CollapsedFlyout —
+  // render `fixed` with coords relative to the sidebar box (its transform is the
+  // containing block), else the `left-full` panel is painted behind the content.
+  const switcherBtnRef = useRef<HTMLButtonElement>(null);
+  const [switcherCoords, setSwitcherCoords] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  useEffect(() => {
+    if (!switcherOpen || isOpen || typeof window === 'undefined') return; // only the collapsed rail needs fixed positioning
+    const reposition = () => {
+      const btn = switcherBtnRef.current;
+      if (!btn) return;
+      const r = btn.getBoundingClientRect();
+      const host = btn.closest('[data-testid="sidebar"]');
+      const h = host?.getBoundingClientRect();
+      setSwitcherCoords({ top: r.top - (h?.top ?? 0), left: r.right - (h?.left ?? 0) });
+    };
+    reposition();
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  }, [switcherOpen, isOpen]);
 
   // Auto-expand the dropdown that contains the active route.
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
@@ -267,6 +290,7 @@ export function Sidebar({ isOpen, onToggle, user }: SidebarProps) {
         {/* Workspace switcher */}
         <div className="relative border-b border-gray-200 px-2 py-2">
           <button
+            ref={switcherBtnRef}
             onClick={() => setSwitcherOpen((o) => !o)}
             aria-label="Switch workspace"
             aria-expanded={switcherOpen}
@@ -291,9 +315,10 @@ export function Sidebar({ isOpen, onToggle, user }: SidebarProps) {
               <div className="fixed inset-0 z-40" onClick={() => setSwitcherOpen(false)} aria-hidden />
               <div
                 className={cn(
-                  'absolute z-50 rounded-lg border border-gray-200 bg-white p-1 shadow-lg',
-                  isOpen ? 'inset-x-2 top-full mt-1' : 'left-full top-0 ml-2 w-56'
+                  'rounded-lg border border-gray-200 bg-white p-1 shadow-lg',
+                  isOpen ? 'absolute z-50 inset-x-2 top-full mt-1' : 'fixed z-[60] ml-2 w-56'
                 )}
+                style={!isOpen ? { top: switcherCoords.top, left: switcherCoords.left } : undefined}
                 role="menu"
               >
                 {workspaces.map((w) => {

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -1,10 +1,22 @@
 'use client';
-import { PiCaretDownBold, PiCaretLeftBold, PiCaretRightBold } from 'react-icons/pi';
+import {
+  PiCaretDownBold,
+  PiCaretLeftBold,
+  PiCaretRightBold,
+  PiCreditCardBold,
+  PiGearBold,
+  PiGlobeBold,
+  PiMegaphoneBold,
+  PiTrendUpBold,
+  PiUsersBold,
+  PiWrenchBold,
+} from 'react-icons/pi';
+import type { IconType } from 'react-icons';
 
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import {
   Tooltip,
@@ -13,13 +25,13 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import {
-  featureSections,
-  bottomSections,
-  getVisibleSections,
+  getWorkspaceNav,
+  workspaceForPath,
   hasChildren,
   type NavItem,
-  type NavSection,
+  type WorkspaceId,
 } from '@/lib/admin/feature-registry';
+import type { AdminRole } from '@/lib/auth/constants';
 
 interface User {
   full_name?: string;
@@ -32,53 +44,71 @@ interface SidebarProps {
   user: User;
 }
 
+const ADMIN_ROLES: AdminRole[] = ['super_admin', 'product_manager', 'editor', 'viewer'];
+
+const WORKSPACE_ICON: Record<WorkspaceId, IconType> = {
+  executive: PiTrendUpBold,
+  finance: PiCreditCardBold,
+  sales: PiMegaphoneBold,
+  ops: PiWrenchBold,
+  support: PiUsersBold,
+  platform: PiGlobeBold,
+  admin: PiGearBold,
+};
+
 export function Sidebar({ isOpen, onToggle, user }: SidebarProps) {
   const pathname = usePathname();
-  const isAdmin = user?.role === 'super_admin' || user?.role === 'product_manager';
 
-  // Get visible sections based on admin role
-  const visibleSections = getVisibleSections(featureSections, { isAdmin });
-  const visibleBottomSections = getVisibleSections(bottomSections, { isAdmin });
+  // Real admin roles are super_admin | product_manager | editor | viewer.
+  // Unknown/absent role falls back to least privilege.
+  const role: AdminRole = ADMIN_ROLES.includes(user?.role as AdminRole)
+    ? (user!.role as AdminRole)
+    : 'viewer';
 
-  // State to manage which dropdowns are expanded
-  const [expandedItems, setExpandedItems] = useState<string[]>(() => {
-    // Auto-expand dropdowns that contain the current active page
-    const expanded: string[] = [];
-    visibleSections.forEach((section) => {
-      section.items.forEach((item) => {
-        if (hasChildren(item)) {
-          const isCurrentlyActive = item.children.some((child) => pathname.startsWith(child.href));
-          if (isCurrentlyActive) {
-            expanded.push(item.name);
-          }
-        }
-      });
-    });
-    visibleBottomSections.forEach((section) => {
-      section.items.forEach((item) => {
-        if (hasChildren(item)) {
-          const isCurrentlyActive = item.children.some((child) => pathname.startsWith(child.href));
-          if (isCurrentlyActive) {
-            expanded.push(item.name);
-          }
-        }
-      });
-    });
-    return expanded;
-  });
+  // Role-scoped, workspace-grouped nav (feature-registry, PR #613).
+  const workspaces = getWorkspaceNav({ role });
+
+  const [activeWs, setActiveWs] = useState<WorkspaceId>(
+    () => workspaceForPath(pathname) ?? workspaces[0]?.id ?? 'executive'
+  );
+
+  // Follow the route into another (accessible) workspace on navigation.
+  useEffect(() => {
+    const w = workspaceForPath(pathname);
+    if (w && w !== activeWs && workspaces.some((x) => x.id === w)) setActiveWs(w);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  const active = workspaces.find((w) => w.id === activeWs) ?? workspaces[0];
+  const items: NavItem[] = active?.items ?? [];
+  const ActiveIcon = active ? WORKSPACE_ICON[active.id] : PiTrendUpBold;
+
+  const [switcherOpen, setSwitcherOpen] = useState(false);
+
+  // Auto-expand the dropdown that contains the active route.
+  const [expandedItems, setExpandedItems] = useState<string[]>([]);
+  useEffect(() => {
+    const expanded = items
+      .filter(
+        (i) =>
+          hasChildren(i) &&
+          i.children.some((c) => pathname.startsWith(c.href.split('?')[0]))
+      )
+      .map((i) => i.name);
+    if (expanded.length) {
+      setExpandedItems((prev) => Array.from(new Set([...prev, ...expanded])));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeWs, pathname]);
 
   const isActiveLink = (href: string, end?: boolean) => {
-    if (end) {
-      return pathname === href;
-    }
-    return pathname.startsWith(href);
+    const base = href.split('?')[0];
+    return end ? pathname === base : pathname.startsWith(base);
   };
 
   const toggleDropdown = (itemName: string) => {
-    setExpandedItems(prev =>
-      prev.includes(itemName)
-        ? prev.filter(name => name !== itemName)
-        : [...prev, itemName]
+    setExpandedItems((prev) =>
+      prev.includes(itemName) ? prev.filter((name) => name !== itemName) : [...prev, itemName]
     );
   };
 
@@ -89,139 +119,130 @@ export function Sidebar({ isOpen, onToggle, user }: SidebarProps) {
       <div
         className={cn(
           'fixed inset-y-0 left-0 z-50 flex flex-col bg-white border-r border-gray-200 transition-all duration-300',
-          // Mobile: Full overlay sidebar that slides in/out
           'lg:relative lg:z-auto',
-          isOpen
-            ? 'translate-x-0 w-64'
-            : '-translate-x-full lg:translate-x-0 lg:w-16',
-          // On desktop (lg+), sidebar is part of the layout
+          isOpen ? 'translate-x-0 w-64' : '-translate-x-full lg:translate-x-0 lg:w-16',
           'lg:flex lg:flex-shrink-0',
-          // Always hidden when printing
           'print:hidden'
         )}
         data-testid="sidebar"
       >
-      {/* Header */}
-      <div className="flex h-16 items-center justify-between px-4 border-b border-gray-200">
-        {isOpen && (
-          <div className="flex items-center space-x-2">
-            <div className="h-8 w-8 flex items-center justify-center">
-              <Image
-                src="/images/circletel-enclosed-logo.png"
-                alt="CircleTel Logo"
-                width={32}
-                height={32}
-                className="h-full w-full object-contain"
-              />
-            </div>
-            <span className="font-semibold text-gray-900">Admin Panel</span>
-          </div>
-        )}
-        <button
-          onClick={onToggle}
-          className="p-1.5 rounded-md hover:bg-gray-100 transition-colors"
-        >
-          <PiCaretLeftBold
-            className={cn(
-              'h-5 w-5 text-gray-500 transition-transform duration-200',
-              !isOpen && 'rotate-180'
-            )}
-          />
-        </button>
-      </div>
-
-      {/* Navigation */}
-      <nav className="flex-1 px-2 py-4 space-y-1 overflow-y-auto">
-        {visibleSections.map((section, sectionIndex) => (
-          <div key={section.label || 'main'}>
-            {/* Section Label */}
-            {section.label && isOpen && (
-              <div className={cn(
-                'px-3 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider',
-                sectionIndex > 0 && 'mt-4 pt-4 border-t border-gray-200'
-              )}>
-                {section.label}
+        {/* Header */}
+        <div className="flex h-16 items-center justify-between px-4 border-b border-gray-200">
+          {isOpen && (
+            <div className="flex items-center space-x-2">
+              <div className="h-8 w-8 flex items-center justify-center">
+                <Image
+                  src="/images/circletel-enclosed-logo.png"
+                  alt="CircleTel Logo"
+                  width={32}
+                  height={32}
+                  className="h-full w-full object-contain"
+                />
               </div>
-            )}
-            {section.label && !isOpen && sectionIndex > 0 && (
-              <div className="my-2 border-t border-gray-200" />
-            )}
+              <span className="font-semibold text-gray-900">Admin Panel</span>
+            </div>
+          )}
+          <button
+            onClick={onToggle}
+            className="p-1.5 rounded-md hover:bg-gray-100 transition-colors"
+          >
+            <PiCaretLeftBold
+              className={cn(
+                'h-5 w-5 text-gray-500 transition-transform duration-200',
+                !isOpen && 'rotate-180'
+              )}
+            />
+          </button>
+        </div>
 
-            {/* Section Items */}
-            {section.items.map((item) => (
-              <div key={item.name}>
-                {hasChildren(item) ? (
-                  <div className="space-y-1">
-                    {/* Dropdown Header - Clickable */}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          onClick={() => isOpen && toggleDropdown(item.name)}
-                          className={cn(
-                            'flex items-center w-full px-3 py-2.5 text-sm font-medium rounded-lg transition-all',
-                            'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                            isOpen && 'cursor-pointer',
-                            !isOpen && 'cursor-default'
-                          )}
-                        >
-                          <item.icon className="mr-3 h-5 w-5 flex-shrink-0" />
-                          {isOpen && (
-                            <>
-                              <span className="flex-1 text-left">{item.name}</span>
-                              {isExpanded(item.name) ? (
-                                <PiCaretDownBold className="h-4 w-4 transition-transform duration-200" />
-                              ) : (
-                                <PiCaretRightBold className="h-4 w-4 transition-transform duration-200" />
-                              )}
-                            </>
-                          )}
-                        </button>
-                      </TooltipTrigger>
-                      {!isOpen && (
-                        <TooltipContent side="right" className="font-medium">
-                          {item.name}
-                        </TooltipContent>
+        {/* Workspace switcher */}
+        <div className="relative border-b border-gray-200 px-2 py-2">
+          <button
+            onClick={() => setSwitcherOpen((o) => !o)}
+            aria-label="Switch workspace"
+            aria-expanded={switcherOpen}
+            className={cn(
+              'flex w-full items-center gap-2 rounded-lg py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50',
+              isOpen ? 'px-3' : 'justify-center px-0'
+            )}
+          >
+            <ActiveIcon className="h-5 w-5 flex-shrink-0 text-[#F5841E]" />
+            {isOpen && (
+              <>
+                <span className="flex-1 text-left truncate">{active?.label ?? 'Workspace'}</span>
+                <PiCaretDownBold
+                  className={cn('h-4 w-4 flex-shrink-0 text-gray-400 transition-transform', switcherOpen && 'rotate-180')}
+                />
+              </>
+            )}
+          </button>
+
+          {switcherOpen && (
+            <>
+              <div className="fixed inset-0 z-40" onClick={() => setSwitcherOpen(false)} aria-hidden />
+              <div
+                className={cn(
+                  'absolute z-50 rounded-lg border border-gray-200 bg-white p-1 shadow-lg',
+                  isOpen ? 'inset-x-2 top-full mt-1' : 'left-full top-0 ml-2 w-56'
+                )}
+                role="menu"
+              >
+                {workspaces.map((w) => {
+                  const Icon = WORKSPACE_ICON[w.id];
+                  return (
+                    <button
+                      key={w.id}
+                      role="menuitem"
+                      onClick={() => {
+                        setActiveWs(w.id);
+                        setSwitcherOpen(false);
+                      }}
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+                        w.id === active?.id
+                          ? 'bg-gray-100 text-gray-900 font-medium'
+                          : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
                       )}
-                    </Tooltip>
+                    >
+                      <Icon className="h-4 w-4 flex-shrink-0" />
+                      <span className="flex-1 text-left truncate">{w.label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
 
-                    {/* Dropdown Content */}
-                    {isOpen && isExpanded(item.name) && (
-                      <div className="ml-9 space-y-1 pl-4">
-                        {item.children.map((child) => (
-                          <Link
-                            key={child.href}
-                            href={child.href}
-                            className={cn(
-                              'flex items-center px-3 py-2 text-sm rounded-lg transition-all',
-                              isActiveLink(child.href)
-                                ? 'bg-gray-100 text-gray-900 font-medium'
-                                : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                            )}
-                          >
-                            <child.icon className="mr-2 h-4 w-4" />
-                            {child.name}
-                          </Link>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ) : (
+        {/* Navigation — active workspace's items */}
+        <nav className="flex-1 px-2 py-4 space-y-1 overflow-y-auto">
+          {items.map((item) => (
+            <div key={item.name}>
+              {hasChildren(item) ? (
+                <div className="space-y-1">
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Link
-                        href={item.href}
+                      <button
+                        onClick={() => isOpen && toggleDropdown(item.name)}
                         className={cn(
-                          'flex items-center px-3 py-2.5 text-sm font-medium rounded-lg transition-all',
-                          isActiveLink(item.href, item.end)
-                            ? 'bg-gray-100 text-gray-900 shadow-sm'
-                            : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                          'flex items-center w-full px-3 py-2.5 text-sm font-medium rounded-lg transition-all',
+                          'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
+                          isOpen && 'cursor-pointer',
+                          !isOpen && 'cursor-default'
                         )}
                       >
                         <item.icon className="mr-3 h-5 w-5 flex-shrink-0" />
                         {isOpen && (
-                          <span className="flex-1">{item.name}</span>
+                          <>
+                            <span className="flex-1 text-left">{item.name}</span>
+                            {isExpanded(item.name) ? (
+                              <PiCaretDownBold className="h-4 w-4 transition-transform duration-200" />
+                            ) : (
+                              <PiCaretRightBold className="h-4 w-4 transition-transform duration-200" />
+                            )}
+                          </>
                         )}
-                      </Link>
+                      </button>
                     </TooltipTrigger>
                     {!isOpen && (
                       <TooltipContent side="right" className="font-medium">
@@ -229,129 +250,71 @@ export function Sidebar({ isOpen, onToggle, user }: SidebarProps) {
                       </TooltipContent>
                     )}
                   </Tooltip>
-                )}
-              </div>
-            ))}
-          </div>
-        ))}
 
-        {/* Admin-only navigation */}
-        {visibleBottomSections.length > 0 && (
-          <>
-            <div className="pt-4 mt-4 border-t border-gray-200">
-              {isOpen && (
-                <div className="px-3 py-2 mb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
-                  Administration
-                </div>
-              )}
-              {visibleBottomSections.flatMap((section) => section.items).map((item) => (
-                <div key={item.name}>
-                  {hasChildren(item) ? (
-                    <div className="space-y-1">
-                      {/* Admin Dropdown Header - Clickable */}
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            onClick={() => isOpen && toggleDropdown(item.name)}
-                            className={cn(
-                              'flex items-center w-full px-3 py-2.5 text-sm font-medium rounded-lg transition-all',
-                              'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                              isOpen && 'cursor-pointer',
-                              !isOpen && 'cursor-default'
-                            )}
-                          >
-                            <item.icon className="mr-3 h-5 w-5 flex-shrink-0" />
-                            {isOpen && (
-                              <>
-                                <span className="flex-1 text-left">{item.name}</span>
-                                {isExpanded(item.name) ? (
-                                  <PiCaretDownBold className="h-4 w-4 transition-transform duration-200" />
-                                ) : (
-                                  <PiCaretRightBold className="h-4 w-4 transition-transform duration-200" />
-                                )}
-                              </>
-                            )}
-                          </button>
-                        </TooltipTrigger>
-                        {!isOpen && (
-                          <TooltipContent side="right" className="font-medium">
-                            {item.name}
-                          </TooltipContent>
-                        )}
-                      </Tooltip>
-
-                      {/* Admin Dropdown Content */}
-                      {isOpen && isExpanded(item.name) && (
-                        <div className="ml-9 space-y-1 pl-4">
-                          {item.children.map((child) => (
-                            <Link
-                              key={child.href}
-                              href={child.href}
-                              className={cn(
-                                'flex items-center px-3 py-2 text-sm rounded-lg transition-all',
-                                isActiveLink(child.href)
-                                  ? 'bg-gray-100 text-gray-900 font-medium'
-                                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                              )}
-                            >
-                              <child.icon className="mr-2 h-4 w-4" />
-                              {child.name}
-                            </Link>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  ) : (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
+                  {isOpen && isExpanded(item.name) && (
+                    <div className="ml-9 space-y-1 pl-4">
+                      {item.children.map((child) => (
                         <Link
-                          href={item.href!}
+                          key={child.href}
+                          href={child.href}
                           className={cn(
-                            'flex items-center px-3 py-2.5 text-sm font-medium rounded-lg transition-all',
-                            isActiveLink(item.href!)
-                              ? 'bg-gray-100 text-gray-900 shadow-sm'
+                            'flex items-center px-3 py-2 text-sm rounded-lg transition-all',
+                            isActiveLink(child.href)
+                              ? 'bg-gray-100 text-gray-900 font-medium'
                               : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
                           )}
                         >
-                          <item.icon className="mr-3 h-5 w-5 flex-shrink-0" />
-                          {isOpen && item.name}
+                          <child.icon className="mr-2 h-4 w-4" />
+                          {child.name}
                         </Link>
-                      </TooltipTrigger>
-                      {!isOpen && (
-                        <TooltipContent side="right" className="font-medium">
-                          {item.name}
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
+                      ))}
+                    </div>
                   )}
                 </div>
-              ))}
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Link
+                      href={item.href}
+                      className={cn(
+                        'flex items-center px-3 py-2.5 text-sm font-medium rounded-lg transition-all',
+                        isActiveLink(item.href, item.end)
+                          ? 'bg-gray-100 text-gray-900 shadow-sm'
+                          : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                      )}
+                    >
+                      <item.icon className="mr-3 h-5 w-5 flex-shrink-0" />
+                      {isOpen && <span className="flex-1">{item.name}</span>}
+                    </Link>
+                  </TooltipTrigger>
+                  {!isOpen && (
+                    <TooltipContent side="right" className="font-medium">
+                      {item.name}
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+              )}
             </div>
-          </>
-        )}
-      </nav>
+          ))}
+        </nav>
 
-      {/* User info */}
-      {isOpen && (
-        <div className="border-t border-gray-200 p-4">
-          <div className="flex items-center space-x-3">
-            <div className="h-8 w-8 bg-gray-300 rounded-full flex items-center justify-center">
-              <span className="text-sm font-medium text-gray-700">
-                {user?.full_name?.charAt(0) || 'U'}
-              </span>
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-gray-900 truncate">
-                {user?.full_name}
-              </p>
-              <p className="text-xs text-gray-500 truncate">
-                {user?.role?.replace('_', ' ')}
-              </p>
+        {/* User info */}
+        {isOpen && (
+          <div className="border-t border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="h-8 w-8 bg-gray-300 rounded-full flex items-center justify-center">
+                <span className="text-sm font-medium text-gray-700">
+                  {user?.full_name?.charAt(0) || 'U'}
+                </span>
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-900 truncate">{user?.full_name}</p>
+                <p className="text-xs text-gray-500 truncate">{user?.role?.replace('_', ' ')}</p>
+              </div>
             </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
     </TooltipProvider>
   );
 }

--- a/components/admin/layout/Sidebar.tsx
+++ b/components/admin/layout/Sidebar.tsx
@@ -16,7 +16,7 @@ import type { IconType } from 'react-icons';
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import {
   Tooltip,
@@ -62,8 +62,15 @@ const WORKSPACE_ICON: Record<WorkspaceId, IconType> = {
  * links (PR4). Leaf items keep a name Tooltip; expanded rail uses the inline
  * accordion. ponytail: CSS transition (not framer) matches the sidebar's motion
  * vocabulary and `motion-reduce:` handles reduced-motion in one class — swap for
- * motion.div + useReducedMotion() only if spring physics is wanted. The panel is
- * `left-full pl-2`: contiguous with the icon (no hover dead-zone), pl-2 = the gap.
+ * motion.div + useReducedMotion() only if spring physics is wanted.
+ *
+ * The panel is `position: fixed`, positioned from the trigger's
+ * getBoundingClientRect (spec §3 escalation). An `absolute left-full` panel is
+ * painted BEHIND the main content because the sidebar's `lg:translate-x-0`
+ * transform creates a stacking context the panel can't escape (verified live via
+ * elementFromPoint). `fixed` lifts it above content; it stays a DOM child of the
+ * wrapper so the hover-bridge (icon→panel without a dead-zone) still works, and
+ * it re-reads the rect on scroll/resize while open.
  */
 function CollapsedFlyout({
   item,
@@ -73,6 +80,24 @@ function CollapsedFlyout({
   isActiveLink: (href: string, end?: boolean) => boolean;
 }) {
   const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+
+  useEffect(() => {
+    if (!open) return;
+    const reposition = () => {
+      const r = btnRef.current?.getBoundingClientRect();
+      if (r) setCoords({ top: r.top, left: r.right });
+    };
+    reposition();
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  }, [open]);
+
   if (!hasChildren(item)) return null;
   return (
     <div
@@ -85,6 +110,7 @@ function CollapsedFlyout({
       }}
     >
       <button
+        ref={btnRef}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={item.name}
@@ -95,8 +121,9 @@ function CollapsedFlyout({
 
       <div
         role="menu"
+        style={{ position: 'fixed', top: coords.top, left: coords.left, zIndex: 60 }}
         className={cn(
-          'absolute left-full top-0 z-50 min-w-56 pl-2 transition duration-150 ease-out',
+          'min-w-56 pl-2 transition duration-150 ease-out',
           'motion-reduce:transition-none',
           open
             ? 'visible translate-x-0 opacity-100'

--- a/docs/2026-07-12-b1a-role-workspace-mapping.md
+++ b/docs/2026-07-12-b1a-role-workspace-mapping.md
@@ -1,0 +1,50 @@
+# B1a — Role-scoped admin workspaces
+
+**Date:** 2026-07-12
+**Scope:** Resolves porting-plan Blocker **B1** — map the 7 admin workspaces onto the
+existing 4 `AdminRole` values. **Data-only, no DB/auth change.**
+**Status:** shipped to `staging` for testing. NOT on `main`, NOT in production.
+
+## What changed
+
+`lib/admin/feature-registry.ts` — the `WORKSPACES` `roles:` values. The Sidebar
+(`components/admin/layout/Sidebar.tsx`, PR #613) already renders `getWorkspaceNav({role})`,
+which filters on `w.roles.includes(role)`, so this is **live on deploy**: editor/viewer
+see fewer workspaces the moment it ships.
+
+Three role tiers:
+
+| Const | Roles |
+|-------|-------|
+| `ELEVATED` | super_admin, product_manager |
+| `OPERATIONAL` | super_admin, product_manager, editor |
+| `ALL_ADMIN_ROLES` | super_admin, product_manager, editor, viewer |
+
+## Mapping table
+
+| Workspace | Roles | super_admin | product_manager | editor | viewer |
+|-----------|-------|:-:|:-:|:-:|:-:|
+| Executive | ALL | ✅ | ✅ | ✅ | ✅ |
+| Finance | OPERATIONAL | ✅ | ✅ | ✅ | — |
+| Sales & Marketing | OPERATIONAL | ✅ | ✅ | ✅ | — |
+| Ops & Onboarding | OPERATIONAL | ✅ | ✅ | ✅ | — |
+| Support | ALL | ✅ | ✅ | ✅ | ✅ |
+| Platform | OPERATIONAL | ✅ | ✅ | ✅ | — |
+| Administration | ELEVATED | ✅ | ✅ | — | — |
+| **Total** | | **7** | **7** | **6** | **2** |
+
+Rationale: `viewer` → read-oriented (Executive/Support); `editor` → operational feature
+workspaces; elevated → everything incl. Administration (parity with today's
+`getVisibleSections({ isAdmin })`).
+
+## Caveat — this is nav-hiding, NOT a security boundary
+
+Hiding a workspace only removes it from the sidebar. A `viewer` can still hand-type
+`/admin/settings` and reach the page until **server-side route guards (PR5)** land. This
+is expected at this stage. Do not treat B1a as access control.
+
+## Tests
+
+`__tests__/lib/admin/feature-registry.test.ts` — `describe('B1a role -> workspace mapping')`:
+viewer → {executive, support} only; editor → operational, no Administration; elevated →
+Administration present.

--- a/docs/2026-07-12-pr25-module-entitlement.md
+++ b/docs/2026-07-12-pr25-module-entitlement.md
@@ -1,0 +1,145 @@
+# PR2.5 — Module entitlement (the whitelabel sell-switch)
+
+**Date:** 2026-07-12
+**Target repo:** https://github.com/jdeweedata/circletel (branch off `origin/staging` @ `1053bb7f`)
+**Parent:** [porting-plan §3 PR2.5](./2026-07-11-role-scoped-admin-porting-plan.md) ·
+[catalog §3](./2026-07-11-modular-product-catalog.md) · builds on [PR5](./2026-07-12-pr5-server-route-guards.md)
+**Verified against:** the live `staging` ref (post-PR5). All file shapes below are real.
+
+---
+
+## 0. What exists / what's missing (evidenced)
+
+| Piece | State on staging |
+|---|---|
+| `getWorkspaceNav({role, modules})` | ✅ already module-aware (PR1 `a980da83`, tested) — but nothing passes `modules` |
+| `ITEM_MODULE` (item → ModuleId, 34 items) | ✅ in `lib/admin/feature-registry.ts` |
+| `lib/tenant/` (`getTenantConfig`, defaults, env overrides, 3 tests) | ✅ exists — **but `TenantConfig` = `{branding, contacts}` only. No `modules` field.** |
+| Server enforcement point | ✅ PR5's `canAccessAdminPath` in `middleware/admin-auth.ts` — workspace-only today |
+
+So PR2.5 = add the `modules` axis to tenant config, then thread it into the two consumers that
+already exist: the Sidebar (nav hiding) and the middleware guard (route rejection). Per the
+porting plan: *"disabling a module hides its sections and rejects its routes; CircleTel unchanged."*
+
+**No-op guarantee for CircleTel:** defaults enable all 15 modules; no env var set → behaviour
+byte-identical.
+
+---
+
+## 1. Design decisions
+
+1. **`ModuleId` stays in `feature-registry.ts`; consumers use `import type`** — type-only imports
+   are erased at compile, so tenant config and the edge middleware can share the type without
+   dragging the icon-laden registry into the edge bundle.
+2. **The canonical runtime module list lives in `lib/admin/workspace-access.ts`** (the pure,
+   edge-safe module): `ALL_MODULES` built from a `Record<ModuleId, true>` table — the compiler
+   errors if the registry's union gains/loses a member and the table isn't updated. `isModuleId()`
+   guards env parsing.
+3. **`'core'` can never be disabled.** Env parsing force-includes it. Dashboard (`/admin/dashboard`,
+   the PR5 deny-landing), Users, Settings, Notifications are `core` — disabling it would brick the
+   admin and re-open a redirect loop.
+4. **One deny path.** A module-denied route uses PR5's existing redirect
+   (`/admin/dashboard?denied=<workspace>`); no separate `denied=module:` branch. ponytail: add the
+   distinction only if a tenant support case ever needs it.
+5. **Fail-open for unmapped routes unchanged** (PR5 §2); parity tests extended to lock
+   route-prefix → module against `ITEM_MODULE`.
+
+---
+
+## 2. Changes (6 files modified, 0 new source files)
+
+### `lib/admin/workspace-access.ts`
+- `import type { ModuleId } from '@/lib/admin/feature-registry';` (erased — stays edge-safe).
+- `MODULE_IDS: Record<ModuleId, true>` → `ALL_MODULES`, `isModuleId()`.
+- Every `ADMIN_WORKSPACE_ROUTES` row gains `module: ModuleId` (derived from `ITEM_MODULE` via each
+  prefix's owning item — parity-tested, see §4). Notables: `/admin/finance/*` → `billing`
+  ("Billing & Revenue" children), `/admin/b2b/*` → `crm` ("B2B Customers" children),
+  `/admin/sales/feasibility` → `coverage` ("B2B Feasibility"), `/admin/workflow` → `compliance`
+  ("Approvals"), `/admin/zoho` → `integrations`, `/admin/support` → `crm`.
+- `moduleForPathname(pathname)` — same longest-prefix matcher; executive special case → `'core'`.
+- `canAccessAdminPath(role, pathname, modules?)` — role check as before **and**
+  `modules.includes(moduleForPathname(path))` when `modules` is passed. Omitted `modules` = all on.
+
+### `lib/tenant/types.ts`
+
+```ts
+import type { ModuleId } from '@/lib/admin/feature-registry';
+export interface TenantConfig {
+  branding: TenantBranding;
+  contacts: TenantContacts;
+  /** Sellable modules enabled for this tenant. 'core' is always present. */
+  modules: ModuleId[];
+}
+```
+
+### `lib/tenant/defaults.ts`
+`modules: ALL_MODULES` (import from workspace-access — pure). CircleTel = everything on.
+
+### `lib/tenant/config.ts`
+
+```ts
+modules: parseModules(process.env.NEXT_PUBLIC_TENANT_MODULES) ?? d.modules,
+```
+
+`parseModules`: comma-split, trim, keep `isModuleId` hits (warn + drop unknowns), force-include
+`'core'`, return null for unset/blank (→ defaults).
+
+### `middleware/admin-auth.ts`
+
+```ts
+import { getTenantConfig } from '@/lib/tenant';
+// in the PR5 guard:
+if (!canAccessAdminPath(role, pathname, getTenantConfig().modules)) { ...same redirect... }
+```
+
+(`lib/tenant` is pure data + type-only imports → edge-safe.)
+
+### `components/admin/layout/Sidebar.tsx`
+
+```ts
+const workspaces = getWorkspaceNav({ role, modules: getTenantConfig().modules });
+```
+
+---
+
+## 3. Env contract (per-tenant deployment)
+
+`NEXT_PUBLIC_TENANT_MODULES="billing,crm,orders,coverage"` — comma-separated ModuleIds.
+Unset → all modules (CircleTel). Unknown ids dropped with a console warning. `core` always added.
+NEXT_PUBLIC_ = baked at build per tenant instance (matches the existing tenant-config model).
+
+---
+
+## 4. Tests
+
+- **`__tests__/lib/tenant/config.test.ts`** (extend): defaults contain all modules incl. `core`;
+  env override parses; unknown ids dropped; `core` force-included; blank env → defaults.
+- **`__tests__/lib/admin/workspace-access.test.ts`** (extend): with `modules` lacking `billing`,
+  `/admin/billing` is denied **even for super_admin**; `core` routes (`/admin/dashboard`,
+  `/admin/settings`) allowed whenever `core` present; omitted `modules` → unchanged behaviour;
+  unmapped routes still fail open.
+- **`__tests__/lib/admin/workspace-access.parity.test.ts`** (extend): for every nav href, the
+  route table's `moduleForPathname(href)` === `ITEM_MODULE[owning item]`. Locks the third axis the
+  same way the workspace axis is locked.
+
+---
+
+## 5. Acceptance
+
+- All existing tests still green (24) + new module tests; type-check error set identical to parent;
+  build ✓.
+- **Staging (CircleTel, no env var): zero behaviour change** — same nav, same guard outcomes as PR5
+  verification (spot-check the PR5 matrix rows).
+- **Entitlement demo (unit-level):** the `getWorkspaceNav({modules:['core']})` test from PR1 plus
+  the new `canAccessAdminPath` module tests prove hide + reject. A live env-var demo requires a
+  rebuild with `NEXT_PUBLIC_TENANT_MODULES` set — optional; do NOT set it on the shared staging
+  deploy (it would disable modules for real staging users).
+
+---
+
+## 6. Out of scope
+
+- API-route module gating (same follow-up axis as PR5's `requirePermission` audit).
+- Module-aware marketing/site surfaces (tenant checkout, portal) — later phases.
+- DB-driven entitlements (env-var is the instance-per-tenant model today; a `tenant_modules` table
+  arrives with multi-tenant-per-instance, if ever).

--- a/docs/2026-07-12-pr4-collapsed-flyout.md
+++ b/docs/2026-07-12-pr4-collapsed-flyout.md
@@ -1,0 +1,103 @@
+# PR4 — Collapsed-rail flyout drawers (UX polish)
+
+**Date:** 2026-07-12
+**Target repo:** https://github.com/jdeweedata/circletel (branch off `origin/staging` @ `443d57a4`)
+**Parent:** [porting-plan §3 PR4](./2026-07-11-role-scoped-admin-porting-plan.md)
+**Verified against:** live `staging` ref (`Sidebar.tsx` post-#613/B1a/PR5/PR2.5).
+**Scope:** `components/admin/layout/Sidebar.tsx` only (+ its test). No data/role/guard changes.
+
+---
+
+## 0. The gap (evidenced)
+
+On the collapsed rail (`!isOpen`, `lg:w-16`), a parent nav item (one with children) rendered an
+icon button + a **name-only Tooltip**. Its children were gated on `isOpen && isExpanded(item.name)`,
+so **on the collapsed rail the child links never rendered** — a user had to expand the whole sidebar
+to reach e.g. Payments → Transactions. PR4 gives collapsed parents a hover/focus **flyout drawer**
+listing those children, so they're reachable without expanding. Leaf items keep their name tooltip.
+
+The workspace switcher already ships this pattern collapsed (`left-full top-0 ml-2 w-56` panel) — PR4
+applies the same visual language to per-item children.
+
+---
+
+## 1. Design decisions
+
+1. **New `CollapsedFlyout` subcomponent** in the same file; used only for `!isOpen && hasChildren`.
+   Expanded accordion and leaf tooltips are untouched.
+2. **Hover *and* focus-driven, local state** — matches the switcher's hand-rolled approach (no Radix
+   Popover dep). `onMouseEnter/Leave` + focus-within (`onFocus` / `onBlur` with `relatedTarget`
+   containment) so keyboard users get the same drawer.
+3. **CSS transition, not framer-motion** — the sidebar's motion vocabulary is Tailwind
+   `transition-*`; this file imports no framer. An opacity+translate CSS transition with
+   `motion-reduce:transition-none` covers reduced-motion in one class and adds zero imports.
+   `ponytail:` swap the wrapper for `motion.div` + `useReducedMotion()` if spring physics is wanted.
+4. **No dead-zone bridge** — the panel wrapper sits at `left-full` (contiguous with the icon) with
+   `pl-2` providing the visual gap, so moving the pointer icon→panel never crosses an unhovered gap.
+5. **Reuse the switcher's panel chrome** for consistency: `rounded-lg border border-gray-200 bg-white
+   p-1 shadow-lg`, `role="menu"`, child rows `role="menuitem"`, plus a small parent-name header (a
+   collapsed user has no other label for the group).
+
+---
+
+## 2. The change
+
+- **`Sidebar.tsx`:** new `CollapsedFlyout({ item, isActiveLink })` subcomponent (near
+  `WORKSPACE_ICON`). The `hasChildren` branch of the nav map routes `!isOpen` parents to it; the
+  `isOpen` accordion branch is behaviour-preserved with the now-dead collapsed guards removed
+  (`isOpen &&` conditions that were always true, and the collapsed-only `<Tooltip>` wrapper).
+- **`Sidebar.test.tsx`:** two new cases — a collapsed parent emits a flyout trigger
+  (`aria-haspopup="menu"`), and every child href is reachable in the tree.
+
+`Tooltip`/`TooltipTrigger`/`TooltipContent` imports stay — leaf items still use them collapsed.
+
+---
+
+## 3. Motion & accessibility
+
+- **Reduced motion:** `motion-reduce:transition-none` on the panel → instant show/hide.
+- **Keyboard:** icon button is tab-focusable (`aria-haspopup="menu"`, `aria-expanded`); focus opens
+  the panel; child `<Link>`s live inside the focus-within container, so tabbing through them keeps
+  it open; tabbing out (relatedTarget outside) closes it. No focus trap — it's a menu, not a modal.
+- **Scroll-clip risk:** the panel is `absolute` inside `<nav class="overflow-y-auto">`. A parent low
+  in a long workspace could clip against the scroll area. Verified live (§5). If it clips, the fix
+  is the switcher's escape hatch — render the panel `fixed` and position via `getBoundingClientRect`
+  on the trigger. Start `absolute`; escalate only if clipping is observed.
+
+---
+
+## 4. Tests — `__tests__/components/admin/layout/Sidebar.test.tsx`
+
+Env is jest-environment-node + react-test-renderer (no jsdom) — assert the **tree**, not hover.
+
+- **Add:** collapsed + a parent item → a node with `aria-haspopup: 'menu'` exists.
+- **Add:** collapsed flyout exposes every child href of the parent (reachable in the tree).
+- The existing collapsed-leaf tooltip test stays green (the default Executive workspace's Dashboard
+  is a leaf → still emits a tooltip); the accordion test (expanded) stays green.
+
+Interaction (hover open/close, keyboard traversal, scroll-clip, reduced-motion) is **live-verified**
+in §5 — node-env can't fire pointer/focus/scroll.
+
+---
+
+## 5. Acceptance
+
+Unit: updated Sidebar suite green (was 8; 10 after), no other suite touched; type-check error set
+identical to parent; build ✓.
+
+Live (staging, collapse via the `‹` toggle):
+- Hover/focus a collapsed parent icon → drawer slides in with child links + parent-name header.
+- Click a child → navigates; drawer's active child highlighted.
+- Keyboard: Tab to icon → drawer opens; Tab through children; Tab past → closes. No focus trap.
+- Parent near the bottom of a long workspace → drawer not clipped by the nav scroll area.
+- `prefers-reduced-motion` → drawer appears with no slide/fade.
+- Leaf items collapsed → still a plain name tooltip (unchanged).
+
+---
+
+## 6. Out of scope / notes
+
+- Expanded-sidebar accordion behaviour preserved (only dead collapsed-branch code removed).
+- No framer-motion introduced (CSS transition; §1.3 names the upgrade path).
+- Mobile (`< lg`) unaffected — the rail only collapses at `lg+`; on mobile the sidebar is a full
+  `w-64` overlay, so parents always use the accordion.

--- a/docs/2026-07-12-pr4-collapsed-flyout.md
+++ b/docs/2026-07-12-pr4-collapsed-flyout.md
@@ -64,10 +64,13 @@ applies the same visual language to per-item children.
   the panel can't escape, so it loses the paint order to the content column. Confirmed live via
   `document.elementFromPoint` (panel CSS-visible but not the hit-target). Raising the sidebar's
   z-index does **not** fix it (the occluder is in a different context). The fix is the spec's escape
-  hatch: render the panel **`position: fixed`**, positioned from the trigger's
-  `getBoundingClientRect` (top = rect.top, left = rect.right), `z-60`, re-read on scroll/resize while
-  open. It stays a DOM child of the wrapper so the hover-bridge is preserved. Re-verified live:
-  `hitInsidePanel: true`.
+  hatch: render the panel **`position: fixed`**, `z-60`, re-read on scroll/resize while open, kept a
+  DOM child of the wrapper so the hover-bridge **and** keyboard tab-order are preserved (a portal
+  would break both). Because the sidebar's transform makes it the containing block for the fixed
+  panel, coords are **relative to the sidebar box, not the viewport**:
+  `top = rect.top − sidebarRect.top`, `left = rect.right − sidebarRect.left`. Without the subtraction,
+  items low in a scrolled long page fly off-screen (`top` negative). Verified live at top and bottom
+  of a long workspace: `hitInsidePanel: true`, `withinViewport: true`.
 
 ---
 

--- a/docs/2026-07-12-pr4-collapsed-flyout.md
+++ b/docs/2026-07-12-pr4-collapsed-flyout.md
@@ -59,10 +59,15 @@ applies the same visual language to per-item children.
 - **Keyboard:** icon button is tab-focusable (`aria-haspopup="menu"`, `aria-expanded`); focus opens
   the panel; child `<Link>`s live inside the focus-within container, so tabbing through them keeps
   it open; tabbing out (relatedTarget outside) closes it. No focus trap — it's a menu, not a modal.
-- **Scroll-clip risk:** the panel is `absolute` inside `<nav class="overflow-y-auto">`. A parent low
-  in a long workspace could clip against the scroll area. Verified live (§5). If it clips, the fix
-  is the switcher's escape hatch — render the panel `fixed` and position via `getBoundingClientRect`
-  on the trigger. Start `absolute`; escalate only if clipping is observed.
+- **Stacking / clip — escalation APPLIED:** an `absolute left-full` panel is painted *behind* the
+  main content. The collapsed sidebar has `lg:translate-x-0` (a transform → stacking context) that
+  the panel can't escape, so it loses the paint order to the content column. Confirmed live via
+  `document.elementFromPoint` (panel CSS-visible but not the hit-target). Raising the sidebar's
+  z-index does **not** fix it (the occluder is in a different context). The fix is the spec's escape
+  hatch: render the panel **`position: fixed`**, positioned from the trigger's
+  `getBoundingClientRect` (top = rect.top, left = rect.right), `z-60`, re-read on scroll/resize while
+  open. It stays a DOM child of the wrapper so the hover-bridge is preserved. Re-verified live:
+  `hitInsidePanel: true`.
 
 ---
 

--- a/docs/2026-07-12-pr5-server-route-guards.md
+++ b/docs/2026-07-12-pr5-server-route-guards.md
@@ -1,0 +1,106 @@
+# PR5 — Server-side workspace route guards
+
+**Date:** 2026-07-12
+**Scope:** Enforce B1a's role→workspace mapping in middleware so a typed URL to a
+workspace the role can't enter is **rejected**, not just hidden in the nav.
+**Status:** shipped to `staging` and verified. NOT on `main`, NOT in production.
+**Depends on:** [B1a role-scoped workspaces](2026-07-12-b1a-role-workspace-mapping.md).
+
+## Why
+
+B1a scopes the **nav** by role (`getWorkspaceNav`), but that is nav-hiding only: a
+`viewer` could still hand-type `/admin/billing` and the page rendered (proven live).
+PR5 adds the server enforcement that makes the workspace boundary real.
+
+## What changed
+
+| File | Change |
+|------|--------|
+| `lib/admin/workspace-access.ts` | **NEW**, edge-safe. `WORKSPACE_ROLES` (mirrors `feature-registry` `WORKSPACES`), a route-prefix→workspace table, and `workspaceForPathname()` / `canAccessAdminPath()`. |
+| `middleware/admin-auth.ts` | After auth, reads `admin_users.role` and redirects denied requests to `/admin/dashboard?denied=<ws>`. |
+| `__tests__/lib/admin/workspace-access.test.ts` | Role × route matrix. |
+| `__tests__/lib/admin/workspace-access.parity.test.ts` | Parity lock: `workspace-access` ↔ `feature-registry`. |
+
+`feature-registry.ts` is untouched.
+
+### Why a second, edge-safe module (not import feature-registry)
+
+`middleware/admin-auth.ts` runs in the **edge runtime**. `feature-registry.ts` pulls
+`react-icons` and a JSX component, so it is not edge-importable. `workspace-access.ts`
+is kept pure (types + data + functions, no React). The two are kept in lockstep by the
+**parity test**, which fails CI if either the role sets or any route mapping drifts:
+
+1. `WORKSPACE_ROLES[ws]` must equal `WORKSPACES[].roles` for every workspace.
+2. Every real nav `href` in the registry must resolve (via `workspaceForPathname`) to
+   the workspace the registry assigns that item (`ITEM_WORKSPACE`).
+
+## Route resolution
+
+`ADMIN_WORKSPACE_ROUTES` maps URL prefixes to workspaces, matched **longest-prefix-first**
+(precomputed at module load). Two rules worth noting:
+
+- **Executive is special-cased**, not a prefix. Dashboard lives at `/admin` (and the
+  post-login `/admin/dashboard`); a `/admin` prefix would swallow every admin route.
+- **Longest-prefix disambiguation**, e.g. `/admin/coverage/checker` → `sales` beats
+  `/admin/coverage` → `platform`; `/admin/payments/settings` → `finance` is not caught
+  by `/admin/settings` → `admin`.
+
+## Enforcement flow (middleware)
+
+```
+authenticated?  ──no──▶ existing redirect to /admin/login
+      │yes
+read admin_users.role  (anon+cookie client, RLS applies)
+      │
+  no active row ──▶ redirect /admin/login?error=unauthorized
+      │
+canAccessAdminPath(role, path)?
+   yes ──▶ render
+   no  ──▶ redirect /admin/dashboard?denied=<workspace>
+```
+
+- **No redirect loop:** the deny target `/admin/dashboard` is the Executive workspace,
+  open to every admin role, so `canAccessAdminPath(anyRole, '/admin/dashboard')` is always
+  true — the landing never re-denies.
+- **One DB read per protected admin request** (`select role where email = … and is_active`).
+
+## Precondition — `admin_users` RLS self-select (verified present)
+
+The middleware reads the caller's role via the **anon+cookie** client, so RLS applies
+(`/api/admin/me` uses the service role and bypasses it). A self-select policy is required
+or every admin is bounced. On the shared project `agyjovdugmtopasyvlng` this **already
+exists** (two equivalent policies), so no migration was applied:
+
+```sql
+-- present as "Admin users can read admin_users" and "Users can view own admin record"
+create policy admin_users_self_select on public.admin_users
+  for select using (auth.uid() = id);
+```
+
+## Fail-open on unmapped routes (intentional)
+
+`canAccessAdminPath` returns `true` when a path resolves to no workspace. The sensitive
+prefixes (Administration, finance, etc.) are all mapped **and parity-tested**, so fail-open
+only affects routes not present in the registry. Tightening to default-deny (a catch-all
+row) is a deliberate follow-up **after a full admin-route audit** — not done here to avoid
+locking out unmapped-but-legitimate routes.
+
+## Verification (live on staging, typed URLs)
+
+One throwaway `admin_users` account, real login, role flipped per case, account deleted
+after (0 leftover rows). All 14 checks passed:
+
+| Role | `/admin/billing` | `/admin/settings` | `/admin/customers` | `/admin/dashboard` |
+|------|:---:|:---:|:---:|:---:|
+| viewer | redirect `denied=finance` | redirect `denied=admin` | render | render |
+| editor | render | redirect `denied=admin` | — | render |
+| super_admin | render | render | render | render |
+| product_manager | render | render | — | render |
+
+## Out of scope (follow-ups)
+
+- **API-route permission coverage** — a `requirePermission` audit of `/api/admin/*`
+  (route guards cover pages, not every API handler).
+- **Per-item write gating** — read/enter vs. mutate within a workspace.
+- **JWT `app_metadata.admin_role` claim** — removes the per-request DB read.
+- **Default-deny** — catch-all row after the route audit (see fail-open above).

--- a/lib/admin/feature-registry.ts
+++ b/lib/admin/feature-registry.ts
@@ -55,6 +55,7 @@ import {
   PiWrenchBold,
 } from 'react-icons/pi';
 import { RandSign } from '@/components/ui/icons/rand-sign';
+import type { AdminRole } from '@/lib/auth/constants';
 
 export type Maturity = 'stable' | 'beta' | 'internal' | 'hidden';
 
@@ -457,4 +458,172 @@ export function getVisibleSections(
     .filter((s) => (s.maturity ?? 'stable') !== 'hidden' && (s.maturity ?? 'stable') !== 'internal')
     .map((s) => ({ ...s, items: s.items.filter(itemVisible) }))
     .filter((s) => s.items.length > 0);
+}
+
+// ── Module + Workspace axes (whitelabel productization) ───────────
+// Additive: existing data/exports above are untouched. See
+// docs/2026-07-11-modular-product-catalog.md and the role-scoped-admin spec.
+
+/** Sellable module a section belongs to (the whitelabel product axis). */
+export type ModuleId =
+  | 'billing' | 'ra' | 'offers' | 'sales' | 'crm' | 'orders' | 'field'
+  | 'coverage' | 'network' | 'compliance' | 'portal' | 'checkout'
+  | 'workflows' | 'integrations' | 'core';
+
+/** Role-area a section renders in (the admin-console nav axis). */
+export type WorkspaceId =
+  | 'finance' | 'sales' | 'ops' | 'support' | 'executive' | 'platform' | 'admin';
+
+export interface WorkspaceMeta {
+  id: WorkspaceId;
+  label: string;
+  roles: AdminRole[]; // roles that may enter this workspace (porting-plan B1a)
+  order: number;
+}
+
+const ELEVATED: AdminRole[] = ['super_admin', 'product_manager'];
+const ALL_ADMIN_ROLES: AdminRole[] = ['super_admin', 'product_manager', 'editor', 'viewer'];
+
+// Parity with today's getVisibleSections({isAdmin}): everyone sees the feature
+// workspaces; only elevated roles see Administration. Persona-role refinement
+// (editor vs viewer) is a later decision (spec §5 / porting-plan B1).
+export const WORKSPACES: WorkspaceMeta[] = [
+  { id: 'executive', label: 'Executive',         roles: ALL_ADMIN_ROLES, order: 0 },
+  { id: 'finance',   label: 'Finance',           roles: ALL_ADMIN_ROLES, order: 1 },
+  { id: 'sales',     label: 'Sales & Marketing', roles: ALL_ADMIN_ROLES, order: 2 },
+  { id: 'ops',       label: 'Ops & Onboarding',  roles: ALL_ADMIN_ROLES, order: 3 },
+  { id: 'support',   label: 'Support',           roles: ALL_ADMIN_ROLES, order: 4 },
+  { id: 'platform',  label: 'Platform',          roles: ALL_ADMIN_ROLES, order: 5 },
+  { id: 'admin',     label: 'Administration',    roles: ELEVATED,        order: 6 },
+];
+
+/** Which workspace each top-level item renders in. Keyed by item.name (unique). */
+export const ITEM_WORKSPACE: Record<string, WorkspaceId> = {
+  Dashboard: 'executive',
+  'Billing & Revenue': 'finance',
+  Payments: 'finance',
+  Products: 'sales',
+  Quotes: 'sales',
+  Suppliers: 'sales',
+  'Sales Engine': 'sales',
+  'B2B Feasibility': 'sales',
+  'Coverage Checker': 'sales',
+  'CPQ Builder': 'sales',
+  Partners: 'sales',
+  'Competitor Analysis': 'sales',
+  Marketing: 'sales',
+  'CMS Management': 'sales',
+  Contracts: 'ops',
+  Orders: 'ops',
+  'Order Fulfillment': 'ops',
+  'Field Operations': 'ops',
+  'B2B Customers': 'ops',
+  'Corporate Clients': 'ops',
+  Approvals: 'ops',
+  'KYC Review': 'ops',
+  'KYB Compliance': 'ops',
+  'Document Reviews': 'ops',
+  Customers: 'support',
+  'Customer Devices': 'support',
+  Diagnostics: 'support',
+  Coverage: 'platform',
+  'Network Management': 'platform',
+  Notifications: 'platform',
+  Integrations: 'platform',
+  Orchestrator: 'admin',
+  Users: 'admin',
+  Settings: 'admin',
+};
+
+/** Which sellable module each top-level item belongs to. Keyed by item.name. */
+export const ITEM_MODULE: Record<string, ModuleId> = {
+  Dashboard: 'core',
+  'Billing & Revenue': 'billing',
+  Payments: 'billing',
+  Products: 'offers',
+  Quotes: 'offers',
+  Suppliers: 'offers',
+  'CPQ Builder': 'offers',
+  'Sales Engine': 'sales',
+  Partners: 'sales',
+  'Competitor Analysis': 'sales',
+  Marketing: 'sales',
+  'CMS Management': 'sales',
+  'B2B Feasibility': 'coverage',
+  'Coverage Checker': 'coverage',
+  Coverage: 'coverage',
+  'Network Management': 'network',
+  Contracts: 'orders',
+  Orders: 'orders',
+  'Order Fulfillment': 'orders',
+  'Field Operations': 'field',
+  Customers: 'crm',
+  'B2B Customers': 'crm',
+  'Corporate Clients': 'crm',
+  'Customer Devices': 'crm',
+  Diagnostics: 'crm',
+  Approvals: 'compliance',
+  'KYC Review': 'compliance',
+  'KYB Compliance': 'compliance',
+  'Document Reviews': 'compliance',
+  Notifications: 'core',
+  Integrations: 'integrations',
+  Orchestrator: 'workflows',
+  Users: 'core',
+  Settings: 'core',
+};
+
+export interface WorkspaceNav {
+  id: WorkspaceId;
+  label: string;
+  items: NavItem[];
+}
+
+const isElevated = (role: AdminRole) => ELEVATED.includes(role);
+
+// Mirrors getVisibleSections' item rule (hide internal/hidden; honour adminOnly).
+function moduleItemVisible(item: NavItem, role: AdminRole): boolean {
+  const m = item.maturity ?? 'stable';
+  if (m === 'hidden' || m === 'internal') return false;
+  if (item.adminOnly && !isElevated(role)) return false;
+  return true;
+}
+
+/**
+ * Role-scoped, module-gated nav grouped by workspace.
+ * @param modules enabled ModuleIds for the tenant; omit = all on (CircleTel #1).
+ *                This is the whitelabel per-module entitlement switch (Phase 2).
+ */
+export function getWorkspaceNav(opts: {
+  role: AdminRole;
+  modules?: ModuleId[];
+}): WorkspaceNav[] {
+  const { role, modules } = opts;
+  const allItems: NavItem[] = [...featureSections, ...bottomSections].flatMap((s) => s.items);
+  return WORKSPACES.filter((w) => w.roles.includes(role))
+    .sort((a, b) => a.order - b.order)
+    .map((w) => ({
+      id: w.id,
+      label: w.label,
+      items: allItems.filter(
+        (i) =>
+          ITEM_WORKSPACE[i.name] === w.id &&
+          moduleItemVisible(i, role) &&
+          (!modules || modules.includes(ITEM_MODULE[i.name] ?? 'core'))
+      ),
+    }))
+    .filter((w) => w.items.length > 0);
+}
+
+/** Which workspace owns a route (for deep-link / cross-workspace nav). */
+export function workspaceForPath(pathname: string): WorkspaceId | null {
+  const path = pathname.split('?')[0];
+  const allItems: NavItem[] = [...featureSections, ...bottomSections].flatMap((s) => s.items);
+  for (const item of allItems) {
+    const match = hasChildren(item)
+      ? item.children.some((c) => c.href.split('?')[0] === path)
+      : item.href.split('?')[0] === path;
+    if (match) return ITEM_WORKSPACE[item.name] ?? null;
+  }
+  return null;
 }

--- a/lib/admin/feature-registry.ts
+++ b/lib/admin/feature-registry.ts
@@ -482,18 +482,19 @@ export interface WorkspaceMeta {
 }
 
 const ELEVATED: AdminRole[] = ['super_admin', 'product_manager'];
+const OPERATIONAL: AdminRole[] = ['super_admin', 'product_manager', 'editor'];
 const ALL_ADMIN_ROLES: AdminRole[] = ['super_admin', 'product_manager', 'editor', 'viewer'];
 
-// Parity with today's getVisibleSections({isAdmin}): everyone sees the feature
-// workspaces; only elevated roles see Administration. Persona-role refinement
-// (editor vs viewer) is a later decision (spec §5 / porting-plan B1).
+// B1a: viewer -> read-oriented (Executive/Support); editor -> operational
+// feature workspaces; elevated -> all incl. Administration (parity with
+// today's getVisibleSections({isAdmin})).
 export const WORKSPACES: WorkspaceMeta[] = [
   { id: 'executive', label: 'Executive',         roles: ALL_ADMIN_ROLES, order: 0 },
-  { id: 'finance',   label: 'Finance',           roles: ALL_ADMIN_ROLES, order: 1 },
-  { id: 'sales',     label: 'Sales & Marketing', roles: ALL_ADMIN_ROLES, order: 2 },
-  { id: 'ops',       label: 'Ops & Onboarding',  roles: ALL_ADMIN_ROLES, order: 3 },
+  { id: 'finance',   label: 'Finance',           roles: OPERATIONAL,     order: 1 },
+  { id: 'sales',     label: 'Sales & Marketing', roles: OPERATIONAL,     order: 2 },
+  { id: 'ops',       label: 'Ops & Onboarding',  roles: OPERATIONAL,     order: 3 },
   { id: 'support',   label: 'Support',           roles: ALL_ADMIN_ROLES, order: 4 },
-  { id: 'platform',  label: 'Platform',          roles: ALL_ADMIN_ROLES, order: 5 },
+  { id: 'platform',  label: 'Platform',          roles: OPERATIONAL,     order: 5 },
   { id: 'admin',     label: 'Administration',    roles: ELEVATED,        order: 6 },
 ];
 

--- a/lib/admin/feature-registry.ts
+++ b/lib/admin/feature-registry.ts
@@ -592,7 +592,7 @@ function moduleItemVisible(item: NavItem, role: AdminRole): boolean {
 
 /**
  * Role-scoped, module-gated nav grouped by workspace.
- * @param modules enabled ModuleIds for the tenant; omit = all on (CircleTel #1).
+ * @param modules enabled ModuleIds for the tenant; omit = all on (tenant #1).
  *                This is the whitelabel per-module entitlement switch (Phase 2).
  */
 export function getWorkspaceNav(opts: {

--- a/lib/admin/workspace-access.ts
+++ b/lib/admin/workspace-access.ts
@@ -1,0 +1,107 @@
+/**
+ * Edge-safe workspace authorization for admin routes (PR5).
+ *
+ * Imported by middleware (edge runtime), so this MUST stay pure: no React, no
+ * icons, and NO import of feature-registry.ts (it pulls react-icons + a JSX
+ * component and is not edge-safe). WORKSPACE_ROLES mirrors feature-registry's
+ * WORKSPACES; a parity test locks the two together.
+ *
+ * See docs/2026-07-12-pr5-server-route-guards.md.
+ */
+import type { AdminRole } from '@/lib/auth/constants';
+
+export type WorkspaceId =
+  | 'executive' | 'finance' | 'sales' | 'ops' | 'support' | 'platform' | 'admin';
+
+const ELEVATED: AdminRole[] = ['super_admin', 'product_manager'];
+const OPERATIONAL: AdminRole[] = ['super_admin', 'product_manager', 'editor'];
+const READ_ALL: AdminRole[] = ['super_admin', 'product_manager', 'editor', 'viewer'];
+
+/** B1a mapping — must match feature-registry WORKSPACES (parity-tested). */
+export const WORKSPACE_ROLES: Record<WorkspaceId, AdminRole[]> = {
+  executive: READ_ALL,
+  finance: OPERATIONAL,
+  sales: OPERATIONAL,
+  ops: OPERATIONAL,
+  support: READ_ALL,
+  platform: OPERATIONAL,
+  admin: ELEVATED,
+};
+
+/**
+ * Route prefix -> owning workspace, derived from the registry's real hrefs.
+ * Matched longest-prefix-first. Executive (Dashboard lives at '/admin') is a
+ * special case in workspaceForPathname, not a prefix — a '/admin' prefix would
+ * swallow every admin route.
+ */
+export const ADMIN_WORKSPACE_ROUTES: ReadonlyArray<{ prefix: string; workspace: WorkspaceId }> = [
+  // finance
+  { prefix: '/admin/billing', workspace: 'finance' },
+  { prefix: '/admin/payments', workspace: 'finance' },
+  { prefix: '/admin/finance', workspace: 'finance' },
+  // sales (coverage/checker must beat platform's /admin/coverage — longest-first handles it)
+  { prefix: '/admin/coverage/checker', workspace: 'sales' },
+  { prefix: '/admin/sales-engine', workspace: 'sales' },
+  { prefix: '/admin/sales/feasibility', workspace: 'sales' },
+  { prefix: '/admin/competitor-analysis', workspace: 'sales' },
+  { prefix: '/admin/products', workspace: 'sales' },
+  { prefix: '/admin/quotes', workspace: 'sales' },
+  { prefix: '/admin/cpq', workspace: 'sales' },
+  { prefix: '/admin/partners', workspace: 'sales' },
+  { prefix: '/admin/marketing', workspace: 'sales' },
+  { prefix: '/admin/cms', workspace: 'sales' },
+  // ops
+  { prefix: '/admin/contracts', workspace: 'ops' },
+  { prefix: '/admin/orders', workspace: 'ops' },
+  { prefix: '/admin/fulfillment', workspace: 'ops' },
+  { prefix: '/admin/field-ops', workspace: 'ops' },
+  { prefix: '/admin/b2b-customers', workspace: 'ops' },
+  { prefix: '/admin/b2b', workspace: 'ops' },
+  { prefix: '/admin/unjani', workspace: 'ops' },
+  { prefix: '/admin/corporate', workspace: 'ops' },
+  { prefix: '/admin/compliance', workspace: 'ops' },
+  { prefix: '/admin/kyc', workspace: 'ops' },
+  { prefix: '/admin/workflow', workspace: 'ops' }, // "Approvals" item
+  // support
+  { prefix: '/admin/support', workspace: 'support' },
+  { prefix: '/admin/customers', workspace: 'support' },
+  { prefix: '/admin/diagnostics', workspace: 'support' },
+  // platform
+  { prefix: '/admin/coverage', workspace: 'platform' },
+  { prefix: '/admin/network', workspace: 'platform' },
+  { prefix: '/admin/notifications', workspace: 'platform' },
+  { prefix: '/admin/integrations', workspace: 'platform' },
+  { prefix: '/admin/zoho', workspace: 'platform' },
+  // admin (Administration) — the security-critical set
+  { prefix: '/admin/orchestrator', workspace: 'admin' },
+  { prefix: '/admin/users', workspace: 'admin' },
+  { prefix: '/admin/settings', workspace: 'admin' },
+];
+
+// Precompute longest-first once (module load).
+const ROUTES_BY_LEN = [...ADMIN_WORKSPACE_ROUTES].sort((a, b) => b.prefix.length - a.prefix.length);
+
+/** Owning workspace for a pathname, or null if not a registered admin route. */
+export function workspaceForPathname(pathname: string): WorkspaceId | null {
+  const path = pathname.split('?')[0];
+  // Executive: Dashboard lives at '/admin' (and the post-login '/admin/dashboard').
+  if (path === '/admin' || path === '/admin/dashboard' || path.startsWith('/admin/dashboard/')) {
+    return 'executive';
+  }
+  for (const r of ROUTES_BY_LEN) {
+    if (path === r.prefix || path.startsWith(r.prefix + '/')) return r.workspace;
+  }
+  return null;
+}
+
+/**
+ * Server authorization for an admin path.
+ * Unmapped admin routes fail OPEN (true) — the caller logs. Sensitive
+ * Administration/finance/etc. prefixes ARE mapped + parity-tested, so fail-open
+ * only affects routes not in the registry.
+ * ponytail: tighten to default-deny after a full admin-route audit (catch-all row).
+ */
+export function canAccessAdminPath(role: AdminRole, pathname: string): boolean {
+  const ws = workspaceForPathname(pathname);
+  return ws ? WORKSPACE_ROLES[ws].includes(role) : true;
+}

--- a/lib/admin/workspace-access.ts
+++ b/lib/admin/workspace-access.ts
@@ -1,17 +1,34 @@
 /**
- * Edge-safe workspace authorization for admin routes (PR5).
+ * Edge-safe workspace + module authorization for admin routes (PR5 + PR2.5).
  *
  * Imported by middleware (edge runtime), so this MUST stay pure: no React, no
- * icons, and NO import of feature-registry.ts (it pulls react-icons + a JSX
- * component and is not edge-safe). WORKSPACE_ROLES mirrors feature-registry's
- * WORKSPACES; a parity test locks the two together.
+ * icons, and no VALUE import of feature-registry.ts (it pulls react-icons + a
+ * JSX component and is not edge-safe). The `import type` below is erased at
+ * compile time, so the type is shared without a runtime dependency.
+ * WORKSPACE_ROLES mirrors feature-registry's WORKSPACES and each route's
+ * `module` mirrors ITEM_MODULE; parity tests lock all three together.
  *
- * See docs/2026-07-12-pr5-server-route-guards.md.
+ * See docs/2026-07-12-pr5-server-route-guards.md and
+ * docs/2026-07-12-pr25-module-entitlement.md.
  */
 import type { AdminRole } from '@/lib/auth/constants';
+import type { ModuleId } from '@/lib/admin/feature-registry';
 
 export type WorkspaceId =
   | 'executive' | 'finance' | 'sales' | 'ops' | 'support' | 'platform' | 'admin';
+
+// Canonical runtime module list. Record<ModuleId, true> makes the compiler
+// error here if the registry's ModuleId union ever gains/loses a member.
+const MODULE_IDS: Record<ModuleId, true> = {
+  billing: true, ra: true, offers: true, sales: true, crm: true, orders: true,
+  field: true, coverage: true, network: true, compliance: true, portal: true,
+  checkout: true, workflows: true, integrations: true, core: true,
+};
+export const ALL_MODULES = Object.keys(MODULE_IDS) as ModuleId[];
+
+export function isModuleId(v: string): v is ModuleId {
+  return v in MODULE_IDS;
+}
 
 const ELEVATED: AdminRole[] = ['super_admin', 'product_manager'];
 const OPERATIONAL: AdminRole[] = ['super_admin', 'product_manager', 'editor'];
@@ -29,79 +46,112 @@ export const WORKSPACE_ROLES: Record<WorkspaceId, AdminRole[]> = {
 };
 
 /**
- * Route prefix -> owning workspace, derived from the registry's real hrefs.
+ * Route prefix -> owning workspace + sellable module, derived from the
+ * registry's real hrefs (ITEM_WORKSPACE / ITEM_MODULE — parity-tested).
  * Matched longest-prefix-first. Executive (Dashboard lives at '/admin') is a
  * special case in workspaceForPathname, not a prefix — a '/admin' prefix would
  * swallow every admin route.
  */
-export const ADMIN_WORKSPACE_ROUTES: ReadonlyArray<{ prefix: string; workspace: WorkspaceId }> = [
+export const ADMIN_WORKSPACE_ROUTES: ReadonlyArray<{
+  prefix: string;
+  workspace: WorkspaceId;
+  module: ModuleId;
+}> = [
   // finance
-  { prefix: '/admin/billing', workspace: 'finance' },
-  { prefix: '/admin/payments', workspace: 'finance' },
-  { prefix: '/admin/finance', workspace: 'finance' },
+  { prefix: '/admin/billing', workspace: 'finance', module: 'billing' },
+  { prefix: '/admin/payments', workspace: 'finance', module: 'billing' },
+  { prefix: '/admin/finance', workspace: 'finance', module: 'billing' },
   // sales (coverage/checker must beat platform's /admin/coverage — longest-first handles it)
-  { prefix: '/admin/coverage/checker', workspace: 'sales' },
-  { prefix: '/admin/sales-engine', workspace: 'sales' },
-  { prefix: '/admin/sales/feasibility', workspace: 'sales' },
-  { prefix: '/admin/competitor-analysis', workspace: 'sales' },
-  { prefix: '/admin/products', workspace: 'sales' },
-  { prefix: '/admin/quotes', workspace: 'sales' },
-  { prefix: '/admin/cpq', workspace: 'sales' },
-  { prefix: '/admin/partners', workspace: 'sales' },
-  { prefix: '/admin/marketing', workspace: 'sales' },
-  { prefix: '/admin/cms', workspace: 'sales' },
+  { prefix: '/admin/coverage/checker', workspace: 'sales', module: 'coverage' },
+  { prefix: '/admin/sales-engine', workspace: 'sales', module: 'sales' },
+  { prefix: '/admin/sales/feasibility', workspace: 'sales', module: 'coverage' },
+  { prefix: '/admin/competitor-analysis', workspace: 'sales', module: 'sales' },
+  { prefix: '/admin/products', workspace: 'sales', module: 'offers' },
+  { prefix: '/admin/quotes', workspace: 'sales', module: 'offers' },
+  { prefix: '/admin/cpq', workspace: 'sales', module: 'offers' },
+  { prefix: '/admin/partners', workspace: 'sales', module: 'sales' },
+  { prefix: '/admin/marketing', workspace: 'sales', module: 'sales' },
+  { prefix: '/admin/cms', workspace: 'sales', module: 'sales' },
   // ops
-  { prefix: '/admin/contracts', workspace: 'ops' },
-  { prefix: '/admin/orders', workspace: 'ops' },
-  { prefix: '/admin/fulfillment', workspace: 'ops' },
-  { prefix: '/admin/field-ops', workspace: 'ops' },
-  { prefix: '/admin/b2b-customers', workspace: 'ops' },
-  { prefix: '/admin/b2b', workspace: 'ops' },
-  { prefix: '/admin/unjani', workspace: 'ops' },
-  { prefix: '/admin/corporate', workspace: 'ops' },
-  { prefix: '/admin/compliance', workspace: 'ops' },
-  { prefix: '/admin/kyc', workspace: 'ops' },
-  { prefix: '/admin/workflow', workspace: 'ops' }, // "Approvals" item
+  { prefix: '/admin/contracts', workspace: 'ops', module: 'orders' },
+  // "Installation Schedule" is a Field Operations child living under the orders
+  // URL namespace — longest-prefix wins so its module is 'field', not 'orders'.
+  { prefix: '/admin/orders/installations', workspace: 'ops', module: 'field' },
+  { prefix: '/admin/orders', workspace: 'ops', module: 'orders' },
+  { prefix: '/admin/fulfillment', workspace: 'ops', module: 'orders' },
+  { prefix: '/admin/field-ops', workspace: 'ops', module: 'field' },
+  { prefix: '/admin/b2b-customers', workspace: 'ops', module: 'crm' },
+  { prefix: '/admin/b2b', workspace: 'ops', module: 'crm' },
+  { prefix: '/admin/unjani', workspace: 'ops', module: 'crm' },
+  { prefix: '/admin/corporate', workspace: 'ops', module: 'crm' },
+  { prefix: '/admin/compliance', workspace: 'ops', module: 'compliance' },
+  { prefix: '/admin/kyc', workspace: 'ops', module: 'compliance' },
+  { prefix: '/admin/workflow', workspace: 'ops', module: 'compliance' }, // "Approvals" item
   // support
-  { prefix: '/admin/support', workspace: 'support' },
-  { prefix: '/admin/customers', workspace: 'support' },
-  { prefix: '/admin/diagnostics', workspace: 'support' },
+  { prefix: '/admin/support', workspace: 'support', module: 'crm' },
+  { prefix: '/admin/customers', workspace: 'support', module: 'crm' },
+  { prefix: '/admin/diagnostics', workspace: 'support', module: 'crm' },
   // platform
-  { prefix: '/admin/coverage', workspace: 'platform' },
-  { prefix: '/admin/network', workspace: 'platform' },
-  { prefix: '/admin/notifications', workspace: 'platform' },
-  { prefix: '/admin/integrations', workspace: 'platform' },
-  { prefix: '/admin/zoho', workspace: 'platform' },
+  { prefix: '/admin/coverage', workspace: 'platform', module: 'coverage' },
+  { prefix: '/admin/network', workspace: 'platform', module: 'network' },
+  { prefix: '/admin/notifications', workspace: 'platform', module: 'core' },
+  { prefix: '/admin/integrations', workspace: 'platform', module: 'integrations' },
+  { prefix: '/admin/zoho', workspace: 'platform', module: 'integrations' },
   // admin (Administration) — the security-critical set
-  { prefix: '/admin/orchestrator', workspace: 'admin' },
-  { prefix: '/admin/users', workspace: 'admin' },
-  { prefix: '/admin/settings', workspace: 'admin' },
+  { prefix: '/admin/orchestrator', workspace: 'admin', module: 'workflows' },
+  { prefix: '/admin/users', workspace: 'admin', module: 'core' },
+  { prefix: '/admin/settings', workspace: 'admin', module: 'core' },
 ];
 
 // Precompute longest-first once (module load).
 const ROUTES_BY_LEN = [...ADMIN_WORKSPACE_ROUTES].sort((a, b) => b.prefix.length - a.prefix.length);
 
-/** Owning workspace for a pathname, or null if not a registered admin route. */
-export function workspaceForPathname(pathname: string): WorkspaceId | null {
+function routeFor(pathname: string): (typeof ADMIN_WORKSPACE_ROUTES)[number] | null {
   const path = pathname.split('?')[0];
-  // Executive: Dashboard lives at '/admin' (and the post-login '/admin/dashboard').
-  if (path === '/admin' || path === '/admin/dashboard' || path.startsWith('/admin/dashboard/')) {
-    return 'executive';
-  }
   for (const r of ROUTES_BY_LEN) {
-    if (path === r.prefix || path.startsWith(r.prefix + '/')) return r.workspace;
+    if (path === r.prefix || path.startsWith(r.prefix + '/')) return r;
   }
   return null;
 }
 
+function isExecutivePath(pathname: string): boolean {
+  const path = pathname.split('?')[0];
+  // Executive: Dashboard lives at '/admin' (and the post-login '/admin/dashboard').
+  return path === '/admin' || path === '/admin/dashboard' || path.startsWith('/admin/dashboard/');
+}
+
+/** Owning workspace for a pathname, or null if not a registered admin route. */
+export function workspaceForPathname(pathname: string): WorkspaceId | null {
+  if (isExecutivePath(pathname)) return 'executive';
+  return routeFor(pathname)?.workspace ?? null;
+}
+
+/** Owning sellable module for a pathname, or null if not a registered admin route. */
+export function moduleForPathname(pathname: string): ModuleId | null {
+  if (isExecutivePath(pathname)) return 'core';
+  return routeFor(pathname)?.module ?? null;
+}
+
 /**
- * Server authorization for an admin path.
+ * Server authorization for an admin path: role must enter the workspace AND
+ * (when `modules` is passed) the tenant must have the route's module enabled.
+ * Omitted `modules` = all modules on (pre-PR2.5 behaviour).
  * Unmapped admin routes fail OPEN (true) — the caller logs. Sensitive
  * Administration/finance/etc. prefixes ARE mapped + parity-tested, so fail-open
  * only affects routes not in the registry.
  * ponytail: tighten to default-deny after a full admin-route audit (catch-all row).
  */
-export function canAccessAdminPath(role: AdminRole, pathname: string): boolean {
+export function canAccessAdminPath(
+  role: AdminRole,
+  pathname: string,
+  modules?: ModuleId[]
+): boolean {
   const ws = workspaceForPathname(pathname);
-  return ws ? WORKSPACE_ROLES[ws].includes(role) : true;
+  if (!ws) return true;
+  if (!WORKSPACE_ROLES[ws].includes(role)) return false;
+  if (modules) {
+    const m = moduleForPathname(pathname);
+    if (m && !modules.includes(m)) return false;
+  }
+  return true;
 }

--- a/lib/tenant/config.ts
+++ b/lib/tenant/config.ts
@@ -1,7 +1,31 @@
 import { CIRCLETEL_DEFAULTS } from './defaults';
+import { isModuleId } from '@/lib/admin/workspace-access';
+import type { ModuleId } from '@/lib/admin/feature-registry';
 import type { TenantConfig } from './types';
 
 let cached: TenantConfig | null = null;
+
+/**
+ * Parse NEXT_PUBLIC_TENANT_MODULES ("billing,crm,orders"). Unknown ids are
+ * dropped with a warning; 'core' is always force-included (Dashboard/Users/
+ * Settings and the guard's deny-landing live there — disabling it would brick
+ * the admin). Returns null for unset/blank -> caller falls back to defaults.
+ */
+function parseModules(raw: string | undefined): ModuleId[] | null {
+  if (!raw || !raw.trim()) return null;
+  const modules: ModuleId[] = [];
+  for (const part of raw.split(',')) {
+    const id = part.trim();
+    if (!id) continue;
+    if (isModuleId(id)) {
+      if (!modules.includes(id)) modules.push(id);
+    } else {
+      console.warn(`[tenant-config] Unknown module id in NEXT_PUBLIC_TENANT_MODULES: "${id}" (dropped)`);
+    }
+  }
+  if (!modules.includes('core')) modules.push('core');
+  return modules;
+}
 
 /**
  * Resolve the tenant's config: CircleTel defaults overridden by
@@ -32,6 +56,7 @@ export function getTenantConfig(): TenantConfig {
       },
     },
     contacts: { ...d.contacts },
+    modules: parseModules(process.env.NEXT_PUBLIC_TENANT_MODULES) ?? [...d.modules],
   };
   return cached;
 }

--- a/lib/tenant/defaults.ts
+++ b/lib/tenant/defaults.ts
@@ -1,3 +1,4 @@
+import { ALL_MODULES } from '@/lib/admin/workspace-access';
 import type { TenantConfig } from './types';
 
 /**
@@ -6,6 +7,8 @@ import type { TenantConfig } from './types';
  * (excluded from the brand-literal CI ratchet).
  */
 export const CIRCLETEL_DEFAULTS: TenantConfig = {
+  // Tenant #1 sells nothing to itself: every module on.
+  modules: ALL_MODULES,
   branding: {
     companyName: 'CircleTel',
     legalName: 'Circle Tel SA (Pty) Ltd',

--- a/lib/tenant/types.ts
+++ b/lib/tenant/types.ts
@@ -10,6 +10,8 @@
  * own values via NEXT_PUBLIC_TENANT_* env vars.
  */
 
+import type { ModuleId } from '@/lib/admin/feature-registry';
+
 export interface TenantAddress {
   name?: string;
   attention?: string;
@@ -58,6 +60,8 @@ export interface TenantBranding {
 }
 
 export interface TenantConfig {
+  /** Sellable modules enabled for this tenant ('core' is always present). */
+  modules: ModuleId[];
   branding: TenantBranding;
   contacts: TenantContacts;
 }

--- a/middleware/admin-auth.ts
+++ b/middleware/admin-auth.ts
@@ -9,6 +9,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import type { SupabaseClient, User } from '@supabase/supabase-js';
 import { canAccessAdminPath, workspaceForPathname } from '@/lib/admin/workspace-access';
 import type { AdminRole } from '@/lib/auth/constants';
+import { getTenantConfig } from '@/lib/tenant';
 
 // Note: Using console.log in middleware as @/lib/logging may not work in edge runtime
 
@@ -139,7 +140,7 @@ export async function handleAdminAuth(
   }
 
   const role = adminRow.role as AdminRole;
-  if (!canAccessAdminPath(role, pathname)) {
+  if (!canAccessAdminPath(role, pathname, getTenantConfig().modules)) {
     const ws = workspaceForPathname(pathname);
     console.warn('[admin-auth] workspace denied', { pathname, role, ws });
     const url = request.nextUrl.clone();

--- a/middleware/admin-auth.ts
+++ b/middleware/admin-auth.ts
@@ -7,6 +7,8 @@
 
 import { NextResponse, type NextRequest } from 'next/server';
 import type { SupabaseClient, User } from '@supabase/supabase-js';
+import { canAccessAdminPath, workspaceForPathname } from '@/lib/admin/workspace-access';
+import type { AdminRole } from '@/lib/auth/constants';
 
 // Note: Using console.log in middleware as @/lib/logging may not work in edge runtime
 
@@ -117,7 +119,34 @@ export async function handleAdminAuth(
     };
   }
 
-  // User is authenticated - let client-side verify admin_users table
-  // This avoids redirect loops and works with existing layout auth logic
+  // Authenticated. Authorize by workspace (PR5). Dashboard/Executive is open to
+  // every admin role, so it is always a safe, loop-free landing on denial.
+  // ponytail: one admin_users read per protected admin request. Upgrade path is a
+  // JWT app_metadata.admin_role claim (zero-DB); see docs/2026-07-12-pr5-server-route-guards.md.
+  const { data: adminRow } = await supabase
+    .from('admin_users')
+    .select('role')
+    .eq('email', user.email!)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (!adminRow) {
+    // Authenticated but not an active admin - send to login (parity with client).
+    const url = request.nextUrl.clone();
+    url.pathname = '/admin/login';
+    url.searchParams.set('error', 'unauthorized');
+    return { shouldRedirect: true, redirectResponse: NextResponse.redirect(url), user };
+  }
+
+  const role = adminRow.role as AdminRole;
+  if (!canAccessAdminPath(role, pathname)) {
+    const ws = workspaceForPathname(pathname);
+    console.warn('[admin-auth] workspace denied', { pathname, role, ws });
+    const url = request.nextUrl.clone();
+    url.pathname = '/admin/dashboard';
+    url.searchParams.set('denied', ws ?? 'unknown');
+    return { shouldRedirect: true, redirectResponse: NextResponse.redirect(url), user };
+  }
+
   return { shouldRedirect: false, user };
 }


### PR DESCRIPTION
Promotes the **role-scoped admin workspaces** stack from `staging` to `main`. Every change was applied, unit-gated, deployed to staging, and **verified live** (real browser, throwaway accounts torn down, 0 leftover rows). Staging is 10 commits ahead of `main`, 0 behind — a clean fast-forward superset.

> ⚠️ Merging this deploys to **production**. This PR supersedes PR #613 (its 3 commits — registry axes + Sidebar switcher + tests — are included below).

## What's included (in order)
| Commit | Change | Live-verified |
|--------|--------|---------------|
| `a980da83` | feature-registry: module + workspace + role axes | unit (15) |
| `3407a2fd` | Sidebar: role-scoped workspace switcher | ✅ |
| `16581f43` | runtime tests for the switcher | — |
| `094f1e9d` | **B1a**: map 7 workspaces onto 4 AdminRoles (editor/viewer scoping) | ✅ 7/7/6/2 per role |
| `1053bb7f` | **PR5**: server-side workspace route guards (middleware) | ✅ typed-URL redirect matrix 14/14 |
| `3af11de0` | PR5 spec doc | — |
| `443d57a4` | **PR2.5**: per-tenant module entitlement (whitelabel sell-switch) | ✅ no-op on CircleTel + entitlement demo |
| `15b251db` | **PR4**: collapsed-rail child flyouts | ✅ (see fixes) |
| `ebc9f980` | PR4 fix: flyout `position: fixed` (un-occlude) | ✅ |
| `b94b16c7` | PR4 fix: sidebar-relative coords (bottom-item positioning) | ✅ hover/keyboard/scroll/reduced-motion |

## Behavior
- **Nav is role-scoped**: super_admin/product_manager see all 7 workspaces incl. Administration; editor sees 6 (no Administration); viewer sees 2 (Executive, Support).
- **Routes are enforced server-side** (PR5): a role typing a URL for a workspace it can't enter is redirected to `/admin/dashboard?denied=<ws>` (no redirect loop; dashboard is Executive = all roles).
- **Modules are a per-tenant switch** (PR2.5): `NEXT_PUBLIC_TENANT_MODULES` hides a module's nav + rejects its routes. **CircleTel sets no env var → all 15 modules on → byte-identical behavior.** `core` is force-included.
- **Collapsed rail** (PR4): parent items reveal child links in a hover/focus flyout instead of a name-only tooltip.

## Precondition (already satisfied — no action needed)
PR5's middleware reads the caller's role via the anon+cookie client (RLS applies). The required `admin_users` self-select policy (`auth.uid() = id`) **already exists** on the shared Supabase — no migration in this PR.

## Notable engineering notes
- `lib/admin/workspace-access.ts` is edge-safe (type-only import of the icon-laden registry); **parity tests** lock its role/route/module tables to `feature-registry` so they can't drift.
- PR2.5's parity test caught a real registry drift (`/admin/orders/installations` → `field`), fixed in the route table.
- PR4's collapsed flyout hit a transform-occlusion + fixed-positioning containing-block gotcha; fixed with sidebar-relative `fixed` coords (a portal was rejected — it would break keyboard tab-order).

## Not in scope (tracked follow-ups)
API-route module/permission gating, per-item write gating, JWT `app_metadata.admin_role` claim (removes the per-request DB read), default-deny for unmapped admin routes, and the same `fixed`+offset fix for the collapsed **switcher** dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)