### PR TITLE
feat(network): Remote Nodes dashboard, Sites view, wire Incidents into nav

### DIFF
--- a/app/admin/network/remote-nodes/[serial]/page.tsx
+++ b/app/admin/network/remote-nodes/[serial]/page.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+/**
+ * Tarana Remote Node (RN) dashboard — per-device detail.
+ *
+ * Reuses existing endpoints (no new backend):
+ *  - GET /api/admin/tarana/metrics/[serial]            → latest snapshot
+ *  - GET /api/admin/tarana/metrics/[serial]?from&to    → history window (charts)
+ */
+
+import { use, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  PiArrowsClockwiseBold,
+  PiCellSignalFullBold,
+  PiRulerBold,
+  PiUploadSimpleBold,
+  PiWarningBold,
+} from 'react-icons/pi';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  DetailPageHeader,
+  InfoRow,
+  SectionCard,
+  StatCard,
+  type StatusVariant,
+} from '@/components/admin/shared';
+
+interface RnMetric {
+  rn_serial_number: string;
+  bn_serial_number: string | null;
+  captured_at: string;
+  rssi_dbm: number | null;
+  sinr_db: number | null;
+  tx_power_dbm: number | null;
+  rx_power_dbm: number | null;
+  distance_m: number | null;
+  rf_distance_m: number | null;
+  rn_lat: number | null;
+  rn_lng: number | null;
+  rn_height_m: number | null;
+  bn_lat: number | null;
+  bn_lng: number | null;
+  bn_height_m: number | null;
+  link_status: string | null;
+}
+
+function linkVariant(status: string | null): StatusVariant {
+  if (!status) return 'neutral';
+  const s = status.toLowerCase();
+  if (s.includes('up') || s.includes('connect') || s.includes('active')) return 'success';
+  if (s.includes('down') || s.includes('disconnect') || s.includes('fail')) return 'error';
+  return 'neutral';
+}
+
+function fmt(value: number | null | undefined, unit: string, digits = 0): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  return `${value.toFixed(digits)} ${unit}`;
+}
+
+function coord(lat: number | null, lng: number | null): string {
+  if (lat == null || lng == null) return '—';
+  return `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+}
+
+export default function RemoteNodeDetailPage({
+  params,
+}: {
+  params: Promise<{ serial: string }>;
+}) {
+  const { serial: rawSerial } = use(params);
+  const serial = decodeURIComponent(rawSerial);
+
+  const [latest, setLatest] = useState<RnMetric | null>(null);
+  const [history, setHistory] = useState<RnMetric[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const to = new Date();
+      const from = new Date(to.getTime() - 7 * 24 * 60 * 60 * 1000);
+      const base = `/api/admin/tarana/metrics/${encodeURIComponent(serial)}`;
+
+      const [latestRes, historyRes] = await Promise.all([
+        fetch(base, { credentials: 'include' }),
+        fetch(`${base}?from=${from.toISOString()}&to=${to.toISOString()}`, {
+          credentials: 'include',
+        }),
+      ]);
+
+      if (!latestRes.ok) {
+        const body = await latestRes.json().catch(() => ({}));
+        throw new Error(body.error || 'Failed to load remote-node metrics');
+      }
+
+      const latestJson = await latestRes.json();
+      setLatest((latestJson.latest ?? null) as RnMetric | null);
+
+      if (historyRes.ok) {
+        const historyJson = await historyRes.json();
+        setHistory((historyJson.history ?? []) as RnMetric[]);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, [serial]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // History arrives newest-first; charts read left-to-right (oldest → newest).
+  const chartData = useMemo(
+    () =>
+      [...history].reverse().map((m) => ({
+        time: m.captured_at
+          ? new Date(m.captured_at).toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+            })
+          : '',
+        rssi: m.rssi_dbm,
+        tx: m.tx_power_dbm,
+      })),
+    [history]
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <DetailPageHeader
+        breadcrumbs={[
+          { label: 'Network' },
+          { label: 'Remote Nodes', href: '/admin/network/remote-nodes' },
+          { label: serial },
+        ]}
+        title={serial}
+        status={
+          latest?.link_status
+            ? { label: latest.link_status, variant: linkVariant(latest.link_status) }
+            : undefined
+        }
+        actions={
+          <Button onClick={fetchData} disabled={loading} variant="outline">
+            <PiArrowsClockwiseBold className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        }
+      />
+
+      <div className="max-w-7xl mx-auto p-6 space-y-6">
+        {error && (
+          <Alert className="border-red-200 bg-red-50">
+            <PiWarningBold className="h-4 w-4 text-red-600" />
+            <AlertDescription className="text-red-800">{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {loading && !latest ? (
+          <p className="text-sm text-gray-500 py-8 text-center">Loading remote node…</p>
+        ) : (
+          <>
+            {/* Latest snapshot */}
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+              <StatCard
+                label="RSSI (received)"
+                value={fmt(latest?.rssi_dbm ?? latest?.rx_power_dbm, 'dBm', 1)}
+                icon={<PiCellSignalFullBold className="h-5 w-5" />}
+              />
+              <StatCard
+                label="TX power"
+                value={fmt(latest?.tx_power_dbm, 'dBm', 1)}
+                icon={<PiUploadSimpleBold className="h-5 w-5" />}
+              />
+              <StatCard
+                label="RF distance"
+                value={fmt(latest?.rf_distance_m ?? latest?.distance_m, 'm')}
+                icon={<PiRulerBold className="h-5 w-5" />}
+              />
+              <StatCard
+                label="Connected BN"
+                value={latest?.bn_serial_number ?? '—'}
+              />
+            </div>
+
+            {/* Signal history */}
+            <SectionCard title="Signal history — last 7 days" icon={PiCellSignalFullBold}>
+              {chartData.length === 0 ? (
+                <p className="text-sm text-gray-500 py-10 text-center">
+                  No metric snapshots recorded in the last 7 days.
+                </p>
+              ) : (
+                <ResponsiveContainer width="100%" height={260}>
+                  <LineChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+                    <XAxis dataKey="time" tickLine={false} axisLine={false} minTickGap={24} />
+                    <YAxis
+                      tickLine={false}
+                      axisLine={false}
+                      width={48}
+                      tickFormatter={(v: number) => `${v} dBm`}
+                    />
+                    <Tooltip formatter={(v: number | string) => `${v} dBm`} />
+                    <Line
+                      type="monotone"
+                      dataKey="rssi"
+                      name="RSSI"
+                      stroke="var(--chart-1)"
+                      strokeWidth={2}
+                      dot={false}
+                      connectNulls
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="tx"
+                      name="TX power"
+                      stroke="var(--chart-2)"
+                      strokeWidth={2}
+                      dot={false}
+                      connectNulls
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              )}
+              <div className="flex items-center gap-4 mt-3 text-xs text-gray-500">
+                <span className="flex items-center gap-1.5">
+                  <span className="w-2.5 h-2.5 rounded-full" style={{ background: 'var(--chart-1)' }} />
+                  RSSI
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="w-2.5 h-2.5 rounded-full" style={{ background: 'var(--chart-2)' }} />
+                  TX power
+                </span>
+              </div>
+            </SectionCard>
+
+            {/* Device details */}
+            <SectionCard title="Link & location" icon={PiRulerBold}>
+              <div className="grid md:grid-cols-2 gap-x-8">
+                <div>
+                  <InfoRow label="RN serial" value={serial} />
+                  <InfoRow label="Connected BN" value={latest?.bn_serial_number ?? '—'} />
+                  <InfoRow label="Link status" value={latest?.link_status ?? '—'} />
+                  <InfoRow label="RF distance" value={fmt(latest?.rf_distance_m ?? latest?.distance_m, 'm')} />
+                </div>
+                <div>
+                  <InfoRow label="RN location" value={coord(latest?.rn_lat ?? null, latest?.rn_lng ?? null)} />
+                  <InfoRow label="RN height" value={fmt(latest?.rn_height_m, 'm', 1)} />
+                  <InfoRow label="BN location" value={coord(latest?.bn_lat ?? null, latest?.bn_lng ?? null)} />
+                  <InfoRow
+                    label="Last snapshot"
+                    value={latest?.captured_at ? new Date(latest.captured_at).toLocaleString() : '—'}
+                  />
+                </div>
+              </div>
+            </SectionCard>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/network/remote-nodes/page.tsx
+++ b/app/admin/network/remote-nodes/page.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+/**
+ * Tarana Remote Nodes (RN) — fleet view.
+ *
+ * Reuses existing endpoints (no new backend):
+ *  - GET /api/admin/tarana/device-counts  → RN connected/disconnected/new-installs/total
+ *  - GET /api/admin/tarana/metrics?limit=… → latest tarana_link_metrics rows (deduped per RN)
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  PiArrowsClockwiseBold,
+  PiBroadcastBold,
+  PiCellSignalFullBold,
+  PiCellSignalSlashBold,
+  PiPlusCircleBold,
+  PiRadioBold,
+  PiWarningBold,
+} from 'react-icons/pi';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { StatCard, StatusBadge, SectionCard, type StatusVariant } from '@/components/admin/shared';
+
+interface RnCounts {
+  connected: number;
+  disconnected: number;
+  spectrumUnassigned: number;
+  newInstalls30d: number;
+  total: number;
+}
+
+interface RnMetric {
+  rn_serial_number: string;
+  bn_serial_number: string | null;
+  captured_at: string;
+  rssi_dbm: number | null;
+  distance_m: number | null;
+  rf_distance_m: number | null;
+  link_status: string | null;
+}
+
+/** Map a Tarana RF link-state string to a semantic StatusBadge variant. */
+function linkVariant(status: string | null): StatusVariant {
+  if (!status) return 'neutral';
+  const s = status.toLowerCase();
+  if (s.includes('up') || s.includes('connect') || s.includes('active')) return 'success';
+  if (s.includes('down') || s.includes('disconnect') || s.includes('fail')) return 'error';
+  return 'neutral';
+}
+
+function fmt(value: number | null, unit: string, digits = 0): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  return `${value.toFixed(digits)} ${unit}`;
+}
+
+export default function RemoteNodesPage() {
+  const [counts, setCounts] = useState<RnCounts | null>(null);
+  const [metrics, setMetrics] = useState<RnMetric[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [countsRes, metricsRes] = await Promise.all([
+        fetch('/api/admin/tarana/device-counts', { credentials: 'include' }),
+        fetch('/api/admin/tarana/metrics?limit=500', { credentials: 'include' }),
+      ]);
+
+      // device-counts is optional (404 before first sync) — don't fail the page on it.
+      if (countsRes.ok) {
+        const countsJson = await countsRes.json();
+        if (countsJson?.success && countsJson.data?.rn) setCounts(countsJson.data.rn as RnCounts);
+      }
+
+      if (!metricsRes.ok) {
+        const body = await metricsRes.json().catch(() => ({}));
+        throw new Error(body.error || 'Failed to load remote-node metrics');
+      }
+      const metricsJson = await metricsRes.json();
+      setMetrics((metricsJson.metrics ?? []) as RnMetric[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Rows arrive ordered by captured_at desc → first per serial is the latest snapshot.
+  const latestPerRn = useMemo(() => {
+    const seen = new Map<string, RnMetric>();
+    for (const m of metrics) {
+      if (m.rn_serial_number && !seen.has(m.rn_serial_number)) seen.set(m.rn_serial_number, m);
+    }
+    return Array.from(seen.values());
+  }, [metrics]);
+
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return latestPerRn;
+    return latestPerRn.filter(
+      (r) =>
+        r.rn_serial_number.toLowerCase().includes(q) ||
+        (r.bn_serial_number ?? '').toLowerCase().includes(q)
+    );
+  }, [latestPerRn, search]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
+              <PiRadioBold className="h-8 w-8 text-orange-600" />
+              Remote Nodes
+            </h1>
+            <p className="text-gray-600 mt-1">
+              Tarana customer-premise radios (RNs) with the latest link telemetry.
+            </p>
+          </div>
+          <Button onClick={fetchData} disabled={loading} variant="outline">
+            <PiArrowsClockwiseBold className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </div>
+
+        {error && (
+          <Alert className="border-red-200 bg-red-50">
+            <PiWarningBold className="h-4 w-4 text-red-600" />
+            <AlertDescription className="text-red-800">{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Fleet counts (from device-counts rollup) */}
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <StatCard
+            label="Connected"
+            value={counts ? counts.connected.toLocaleString() : '—'}
+            icon={<PiCellSignalFullBold className="h-5 w-5" />}
+          />
+          <StatCard
+            label="Disconnected"
+            value={counts ? counts.disconnected.toLocaleString() : '—'}
+            icon={<PiCellSignalSlashBold className="h-5 w-5" />}
+          />
+          <StatCard
+            label="New Installs (30d)"
+            value={counts ? counts.newInstalls30d.toLocaleString() : '—'}
+            icon={<PiPlusCircleBold className="h-5 w-5" />}
+          />
+          <StatCard
+            label="Total RNs"
+            value={counts ? counts.total.toLocaleString() : latestPerRn.length.toLocaleString()}
+            icon={<PiBroadcastBold className="h-5 w-5" />}
+          />
+        </div>
+
+        {/* Directory */}
+        <SectionCard
+          title="Remote Node Directory"
+          icon={PiRadioBold}
+          action={
+            <Input
+              placeholder="Search serial or BN…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-56"
+            />
+          }
+        >
+          {loading && latestPerRn.length === 0 ? (
+            <p className="text-sm text-gray-500 py-8 text-center">Loading remote nodes…</p>
+          ) : rows.length === 0 ? (
+            <p className="text-sm text-gray-500 py-8 text-center">
+              No remote-node metrics yet. Trigger a Tarana metrics collection to populate this view.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[760px] text-sm">
+                <thead>
+                  <tr className="border-b text-left text-gray-500">
+                    <th className="px-3 py-2 font-medium">RN Serial</th>
+                    <th className="px-3 py-2 font-medium">Connected BN</th>
+                    <th className="px-3 py-2 font-medium">Link</th>
+                    <th className="px-3 py-2 font-medium">RSSI</th>
+                    <th className="px-3 py-2 font-medium">Distance</th>
+                    <th className="px-3 py-2 font-medium">Last seen</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r) => (
+                    <tr key={r.rn_serial_number} className="border-b last:border-0 hover:bg-gray-50">
+                      <td className="px-3 py-2">
+                        <Link
+                          href={`/admin/network/remote-nodes/${encodeURIComponent(r.rn_serial_number)}`}
+                          className="font-medium text-primary hover:underline font-mono text-[13px]"
+                        >
+                          {r.rn_serial_number}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 font-mono text-[13px] text-gray-600">
+                        {r.bn_serial_number ?? '—'}
+                      </td>
+                      <td className="px-3 py-2">
+                        <StatusBadge
+                          status={r.link_status ?? 'Unknown'}
+                          variant={linkVariant(r.link_status)}
+                        />
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">{fmt(r.rssi_dbm, 'dBm', 1)}</td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {fmt(r.rf_distance_m ?? r.distance_m, 'm')}
+                      </td>
+                      <td className="px-3 py-2 text-gray-500">
+                        {r.captured_at ? new Date(r.captured_at).toLocaleString() : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </SectionCard>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/network/sites/page.tsx
+++ b/app/admin/network/sites/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+/**
+ * Network Sites — physical Tarana sites, aggregated from base stations.
+ *
+ * Reuses the existing endpoint (no new backend):
+ *  - GET /api/admin/coverage/base-stations?pageSize=1000 → stations grouped by site_name
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  PiArrowsClockwiseBold,
+  PiBroadcastBold,
+  PiBuildingsBold,
+  PiMapPinBold,
+  PiPlugsConnectedBold,
+  PiWarningBold,
+} from 'react-icons/pi';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { StatCard, StatusBadge, SectionCard } from '@/components/admin/shared';
+
+interface BaseStation {
+  siteName: string;
+  market: string | null;
+  region: string | null;
+  activeConnections: number;
+  deviceStatus: number;
+}
+
+interface SiteRow {
+  siteName: string;
+  market: string;
+  region: string;
+  stationCount: number;
+  onlineCount: number;
+  totalConnections: number;
+}
+
+export default function NetworkSitesPage() {
+  const [stations, setStations] = useState<BaseStation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        '/api/admin/coverage/base-stations?pageSize=1000&sortBy=site_name&sortOrder=asc',
+        { credentials: 'include' }
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        throw new Error(json.error || 'Failed to load network sites');
+      }
+      setStations((json.data?.stations ?? []) as BaseStation[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const sites = useMemo<SiteRow[]>(() => {
+    const map = new Map<string, SiteRow>();
+    for (const s of stations) {
+      const key = s.siteName || 'Unknown';
+      const existing = map.get(key);
+      if (existing) {
+        existing.stationCount += 1;
+        existing.onlineCount += s.deviceStatus === 1 ? 1 : 0;
+        existing.totalConnections += s.activeConnections || 0;
+      } else {
+        map.set(key, {
+          siteName: key,
+          market: s.market || '—',
+          region: s.region || '—',
+          stationCount: 1,
+          onlineCount: s.deviceStatus === 1 ? 1 : 0,
+          totalConnections: s.activeConnections || 0,
+        });
+      }
+    }
+    return Array.from(map.values()).sort((a, b) => a.siteName.localeCompare(b.siteName));
+  }, [stations]);
+
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return sites;
+    return sites.filter(
+      (s) => s.siteName.toLowerCase().includes(q) || s.market.toLowerCase().includes(q)
+    );
+  }, [sites, search]);
+
+  const totals = useMemo(
+    () => ({
+      sites: sites.length,
+      stations: stations.length,
+      connections: sites.reduce((sum, s) => sum + s.totalConnections, 0),
+      markets: new Set(sites.map((s) => s.market)).size,
+    }),
+    [sites, stations]
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
+              <PiMapPinBold className="h-8 w-8 text-orange-600" />
+              Network Sites
+            </h1>
+            <p className="text-gray-600 mt-1">
+              Physical Tarana sites on the CircleTel network, with base-station coverage.
+            </p>
+          </div>
+          <Button onClick={fetchData} disabled={loading} variant="outline">
+            <PiArrowsClockwiseBold className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </div>
+
+        {error && (
+          <Alert className="border-red-200 bg-red-50">
+            <PiWarningBold className="h-4 w-4 text-red-600" />
+            <AlertDescription className="text-red-800">{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Totals */}
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <StatCard label="Sites" value={totals.sites.toLocaleString()} icon={<PiMapPinBold className="h-5 w-5" />} />
+          <StatCard label="Base Stations" value={totals.stations.toLocaleString()} icon={<PiBroadcastBold className="h-5 w-5" />} />
+          <StatCard label="Active Connections" value={totals.connections.toLocaleString()} icon={<PiPlugsConnectedBold className="h-5 w-5" />} />
+          <StatCard label="Markets" value={totals.markets.toLocaleString()} icon={<PiBuildingsBold className="h-5 w-5" />} />
+        </div>
+
+        {/* Directory */}
+        <SectionCard
+          title="Site Directory"
+          icon={PiMapPinBold}
+          action={
+            <Input
+              placeholder="Search site or market…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-56"
+            />
+          }
+        >
+          {loading && sites.length === 0 ? (
+            <p className="text-sm text-gray-500 py-8 text-center">Loading sites…</p>
+          ) : rows.length === 0 ? (
+            <p className="text-sm text-gray-500 py-8 text-center">
+              No sites found. Base-station data may not be synced yet.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[720px] text-sm">
+                <thead>
+                  <tr className="border-b text-left text-gray-500">
+                    <th className="px-3 py-2 font-medium">Site</th>
+                    <th className="px-3 py-2 font-medium">Market</th>
+                    <th className="px-3 py-2 font-medium">Region</th>
+                    <th className="px-3 py-2 font-medium">Base stations</th>
+                    <th className="px-3 py-2 font-medium">Connections</th>
+                    <th className="px-3 py-2 font-medium">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((s) => (
+                    <tr key={s.siteName} className="border-b last:border-0 hover:bg-gray-50">
+                      <td className="px-3 py-2 font-medium text-gray-900">{s.siteName}</td>
+                      <td className="px-3 py-2 text-gray-600">{s.market}</td>
+                      <td className="px-3 py-2 text-gray-600">{s.region}</td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {s.onlineCount}/{s.stationCount} online
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">{s.totalConnections.toLocaleString()}</td>
+                      <td className="px-3 py-2">
+                        <StatusBadge
+                          status={s.onlineCount === s.stationCount ? 'All online' : s.onlineCount === 0 ? 'Offline' : 'Degraded'}
+                          variant={s.onlineCount === s.stationCount ? 'success' : s.onlineCount === 0 ? 'error' : 'warning'}
+                        />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </SectionCard>
+      </div>
+    </div>
+  );
+}

--- a/lib/admin/feature-registry.ts
+++ b/lib/admin/feature-registry.ts
@@ -329,6 +329,9 @@ export const featureSections: NavSection[] = [
         icon: PiWifiHighBold,
         children: [
           { name: 'Devices', href: '/admin/network/devices', icon: PiWifiHighBold },
+          { name: 'Remote Nodes', href: '/admin/network/remote-nodes', icon: PiRadioBold },
+          { name: 'Sites', href: '/admin/network/sites', icon: PiMapPinBold },
+          { name: 'Incidents', href: '/admin/network/outages', icon: PiWarningCircleBold },
           { name: 'Health Monitor', href: '/admin/network/health', icon: PiPulseBold },
           { name: 'Analytics', href: '/admin/network/analytics', icon: PiChartBarBold },
           { name: 'Network Map', href: '/admin/network/map', icon: PiMapTrifoldBold },


### PR DESCRIPTION
## What this adds

Three items requested — **Remote Nodes dashboard**, **Sites**, and **Incidents** — built to match this repo's existing conventions (not transplanted from elsewhere).

### 1. Remote Nodes (RN) dashboard — net-new UI
- **`app/admin/network/remote-nodes/page.tsx`** — RN fleet list: connected / disconnected / new-installs / total stat cards + a directory table (serial, connected BN, link status, RSSI, distance, last seen) with search.
- **`app/admin/network/remote-nodes/[serial]/page.tsx`** — per-RN dashboard: latest RSSI / TX power / RF distance / connected BN, a **7-day signal history chart** (recharts), and a link & location detail panel.
- Built **entirely on existing endpoints** — `/api/admin/tarana/device-counts`, `/api/admin/tarana/metrics`, `/api/admin/tarana/metrics/[serial]`. **No new API routes, no schema changes, no new dependencies.**

### 2. Sites — net-new UI
- **`app/admin/network/sites/page.tsx`** — physical network sites aggregated from base stations (site, market, region, online/total stations, connections, status), reusing the existing `/api/admin/coverage/base-stations` endpoint. No new backend.

### 3. Incidents — nav wiring (no duplicate module)
- Your existing outage module (`app/admin/network/outages`, titled *"Incident Management"*, backed by `outage_incidents`) had **no sidebar entry**. Rather than build a second incidents module (which `CLAUDE.md` forbids), this **wires the existing pages into the nav as "Incidents"**, alongside new **Sites** and **Remote Nodes** entries, under *Network Management* in `lib/admin/feature-registry.ts`.

## Conventions followed
- `'use client'` pages using the `fetch('/api/...')` + `useState/useEffect` pattern (matches `devices`, `base-stations`, `outages`).
- Shared primitives only — `StatCard`, `StatusBadge` / `getStatusVariant`, `SectionCard`, `InfoRow`, `DetailPageHeader` (no new UI primitives, no invented color classes).
- `react-icons/pi` icons, `recharts` for charts, `use(params)` for React 19 route params.

## Verification
- ✅ `type-check:memory` is **clean on all new files** (the repo has ~243 pre-existing `tsc` errors elsewhere; none are mine, and `next.config.js` sets `ignoreBuildErrors: true` so builds don't gate on types anyway).
- ✅ Pre-push hook passed ("No type errors in the files you're pushing").
- ⚠️ `next lint` reports only style **warnings** (`max-lines-per-function`, `complexity`) — consistent with existing pages like `base-stations`.

## For the reviewer to validate
I don't have access to the live Supabase / Tarana TCS credentials, so I could not runtime-test against real data. Please confirm:
- The RN pages render with real `tarana_link_metrics` data (and that a metrics collection has run).
- Nav entries appear/authorize as expected.
- I **intentionally omitted an embedded Google map** on the RN detail page to avoid a hard dependency on the Maps API key in a first pass — coordinates are shown as fields. Happy to add a `@react-google-maps/api` map (matching `NetworkMap.tsx`) as a follow-up if wanted.

## Scope / safety
Additive: 3 new routes + 3 nav entries. No changes to existing pages, APIs, DB, or dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
