### PR TITLE
fix(tarana): populate tarana_link_metrics — NQS envelope unwrap + KPI columns + Vercel cron

### DIFF
--- a/app/api/cron/tarana-metrics/route.ts
+++ b/app/api/cron/tarana-metrics/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Tarana Link Metrics Collection Cron Job
+ * GET/POST /api/cron/tarana-metrics
+ *
+ * Collects a snapshot of signal/link telemetry for all active Tarana RNs from
+ * the TCS Portal and stores rows in tarana_link_metrics. Runs on the Vercel
+ * cron mechanism (the equivalent Inngest cron does not self-fire in prod).
+ *
+ * Vercel Cron: every 15 minutes
+ * Protected by CRON_SECRET header.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withCronLogging, verifyCronSecret } from '@/lib/logging';
+import { collectLinkMetrics } from '@/lib/tarana/metrics-service';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120; // 2 minutes — one NQS call per active RN
+
+export async function GET(request: NextRequest) {
+  if (!verifyCronSecret(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const result = await withCronLogging('tarana-metrics', 'vercel_cron', async () => {
+      const collection = await collectLinkMetrics();
+      return {
+        records_processed: collection.collected,
+        records_failed: collection.errors.length,
+        records_skipped: collection.skipped,
+        execution_details: { errors: collection.errors.slice(0, 5) },
+      };
+    });
+
+    return NextResponse.json({
+      success: result.records_failed === 0,
+      message: `Tarana metrics collection ${result.records_failed > 0 ? 'partially ' : ''}completed`,
+      collected: result.records_processed,
+      skipped: result.records_skipped,
+      errors: result.records_failed,
+      duration_ms: result.durationMs,
+      logId: result.logId,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}
+
+// Also support POST for manual triggers
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/lib/tarana/client.ts
+++ b/lib/tarana/client.ts
@@ -210,9 +210,12 @@ export async function getAllRemoteNodes(): Promise<TaranaRadio[]> {
  */
 export async function getDeviceBySerial(serialNumber: string): Promise<TaranaDeviceState> {
   const raw = await taranaFetch<any>(`/api/nqs/v1/devices/${encodeURIComponent(serialNumber)}`);
+  // NQS v1 wraps the device payload in a `data` envelope (same as the bulk
+  // /operators/{op}/devices endpoint). Unwrap it, or every field reads undefined.
+  const d = raw && typeof raw === 'object' && raw.data ? raw.data : raw;
 
-  const carriers: TaranaDeviceState['carriers'] = Array.isArray(raw.carriers)
-    ? raw.carriers.map((c: any) => ({
+  const carriers: TaranaDeviceState['carriers'] = Array.isArray(d.carriers)
+    ? d.carriers.map((c: any) => ({
         id: c.id ?? 0,
         txPower: c.txPower ?? c['tx-power'] ?? undefined,
         rxPower: c.rxPower ?? c['rx-power'] ?? undefined,
@@ -221,22 +224,22 @@ export async function getDeviceBySerial(serialNumber: string): Promise<TaranaDev
     : [];
 
   return {
-    serialNumber: raw.serialNumber ?? serialNumber,
-    deviceType: raw.deviceType ?? raw.type ?? 'RN',
-    deviceId: raw.deviceId ?? undefined,
-    linkState: raw.linkState ?? raw['link-state'] ?? undefined,
-    losRange: typeof raw.losRange === 'number' ? raw.losRange : undefined,
-    sectorId: raw.sectorId ?? undefined,
-    band: raw.band ?? undefined,
+    serialNumber: d.serialNumber ?? serialNumber,
+    deviceType: d.deviceType ?? d.type ?? 'RN',
+    deviceId: d.deviceId ?? undefined,
+    linkState: d.linkState ?? d['link-state'] ?? undefined,
+    losRange: typeof d.losRange === 'number' ? d.losRange : undefined,
+    sectorId: d.sectorId ?? undefined,
+    band: d.band ?? undefined,
     carriers,
     installParams: {
-      latitude: raw.installParams?.latitude ?? raw.latitude ?? undefined,
-      longitude: raw.installParams?.longitude ?? raw.longitude ?? undefined,
-      height: raw.installParams?.height ?? raw.height ?? undefined,
-      azimuth: raw.installParams?.azimuth ?? raw.azimuth ?? undefined,
+      latitude: d.installParams?.latitude ?? d.latitude ?? undefined,
+      longitude: d.installParams?.longitude ?? d.longitude ?? undefined,
+      height: d.installParams?.height ?? d.installParams?.heightAgl ?? d.height ?? undefined,
+      azimuth: d.installParams?.azimuth ?? d.installParams?.antennaAzimuth ?? d.azimuth ?? undefined,
     },
-    ancestry: raw.ancestry ?? undefined,
-    raw,
+    ancestry: d.ancestry ?? undefined,
+    raw: d,
   };
 }
 

--- a/scripts/run-tarana-metrics-collection.ts
+++ b/scripts/run-tarana-metrics-collection.ts
@@ -1,0 +1,34 @@
+/**
+ * One-shot manual trigger for Tarana link-metrics collection.
+ *
+ * Runs collectLinkMetrics() directly (bypassing the Inngest event pipeline,
+ * which is dormant in this environment) and prints the result so we can
+ * verify tarana_link_metrics populates.
+ *
+ * Usage:
+ *   set -a && source /home/circletel/.env.local && set +a && npx tsx scripts/run-tarana-metrics-collection.ts
+ */
+
+import { collectLinkMetrics } from '@/lib/tarana/metrics-service';
+
+async function main() {
+  console.log('[run-collection] Starting Tarana link-metrics collection…');
+  const started = Date.now();
+
+  const result = await collectLinkMetrics();
+
+  console.log('[run-collection] Done in', Date.now() - started, 'ms');
+  console.log('[run-collection] collected:', result.collected);
+  console.log('[run-collection] skipped:', result.skipped);
+  console.log('[run-collection] errors:', result.errors.length);
+  if (result.errors.length > 0) {
+    for (const e of result.errors) console.log('   -', e);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('[run-collection] FAILED:', err instanceof Error ? err.message : err);
+    process.exit(1);
+  });

--- a/supabase/migrations/20260712230000_restore_tarana_link_metrics_kpi_columns.sql
+++ b/supabase/migrations/20260712230000_restore_tarana_link_metrics_kpi_columns.sql
@@ -1,0 +1,47 @@
+-- Restore TCS KPI columns on tarana_link_metrics + tarana_base_stations.
+--
+-- These were added by archived migration 20260401000001_add_kpi_columns_link_metrics.sql
+-- but were DROPPED by the 2026-05-23 baseline squash (20260523000000_baseline_squash.sql),
+-- leaving the live table missing rf_distance_m and 9 sibling KPI columns. The metrics
+-- collection (lib/tarana/metrics-service.ts) writes rf_distance_m, so every insert failed
+-- with: "Could not find the 'rf_distance_m' column of 'tarana_link_metrics'".
+--
+-- Idempotent (ADD COLUMN IF NOT EXISTS), additive, all nullable — safe to re-run.
+
+ALTER TABLE tarana_link_metrics
+  ADD COLUMN IF NOT EXISTS path_loss_db            NUMERIC(8,2)  DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS inr_carrier_0_db         NUMERIC(6,2)  DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS inr_carrier_1_db         NUMERIC(6,2)  DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS sensitivity_loss_0_db    NUMERIC(6,2)  DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS sensitivity_loss_1_db    NUMERIC(6,2)  DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS dl_per_pct               NUMERIC(5,2)  DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS ul_per_pct               NUMERIC(5,2)  DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS rf_distance_m            NUMERIC(10,2) DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS dl_peak_rate_mbps        NUMERIC(8,2)  DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS ul_peak_rate_mbps        NUMERIC(8,2)  DEFAULT NULL;
+
+COMMENT ON COLUMN tarana_link_metrics.path_loss_db          IS 'RF path loss in dB from TCS. More accurate than FSPL model for calibration.';
+COMMENT ON COLUMN tarana_link_metrics.inr_carrier_0_db      IS 'Interference-to-Noise Ratio carrier 0, dB. >10 dB indicates severe interference regardless of RSSI.';
+COMMENT ON COLUMN tarana_link_metrics.inr_carrier_1_db      IS 'Interference-to-Noise Ratio carrier 1, dB (dual-carrier deployments only).';
+COMMENT ON COLUMN tarana_link_metrics.sensitivity_loss_0_db IS 'Sensitivity loss carrier 0, dB. Indicates interference-induced receiver degradation.';
+COMMENT ON COLUMN tarana_link_metrics.sensitivity_loss_1_db IS 'Sensitivity loss carrier 1, dB.';
+COMMENT ON COLUMN tarana_link_metrics.dl_per_pct            IS 'Downlink Packet Error Rate, percent. High PER at good RSSI indicates interference.';
+COMMENT ON COLUMN tarana_link_metrics.ul_per_pct            IS 'Uplink Packet Error Rate, percent.';
+COMMENT ON COLUMN tarana_link_metrics.rf_distance_m         IS 'RF-measured distance in metres from TCS (more accurate than GPS haversine for link budget).';
+COMMENT ON COLUMN tarana_link_metrics.dl_peak_rate_mbps     IS 'Peak DL throughput rate observed in collection window, Mbps.';
+COMMENT ON COLUMN tarana_link_metrics.ul_peak_rate_mbps     IS 'Peak UL throughput rate observed in collection window, Mbps.';
+
+ALTER TABLE tarana_base_stations
+  ADD COLUMN IF NOT EXISTS network_profile_id   INTEGER DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS bandwidth_mhz        INTEGER DEFAULT NULL;
+
+COMMENT ON COLUMN tarana_base_stations.network_profile_id IS 'Tarana network profile: 1=4.5:1 DL:UL 15km, 2=4:1 30km, 5=2.67:1 15km, 6=1.75:1 15km. Affects tier eligibility.';
+COMMENT ON COLUMN tarana_base_stations.bandwidth_mhz      IS 'Operational RF bandwidth in MHz (20, 40, or 80). Affects max throughput capacity.';
+
+CREATE INDEX IF NOT EXISTS idx_tarana_link_metrics_path_loss
+  ON tarana_link_metrics (path_loss_db)
+  WHERE path_loss_db IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tarana_link_metrics_inr
+  ON tarana_link_metrics (inr_carrier_0_db)
+  WHERE inr_carrier_0_db IS NOT NULL;

--- a/vercel.json
+++ b/vercel.json
@@ -144,6 +144,10 @@
     "app/api/partners/feasibility/history/route.ts": {
       "maxDuration": 15,
       "memory": 256
+    },
+    "app/api/cron/tarana-metrics/route.ts": {
+      "maxDuration": 120,
+      "memory": 512
     }
   },
   "crons": [
@@ -237,6 +241,10 @@
     },
     {
       "path": "/api/cron/zoho-books-retry",
+      "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/cron/tarana-metrics",
       "schedule": "*/15 * * * *"
     }
   ]


### PR DESCRIPTION
## Problem

The Remote-Nodes / Sites pages in #616 read from `tarana_link_metrics`, but that table was **empty and could never populate** — two bugs blocked the collection end-to-end, so the RN pages only ever showed their empty state.

## Root causes fixed

**1. Schema drift (blocked every insert).** The live `tarana_link_metrics` table was missing `rf_distance_m` + 9 sibling KPI columns. They were added by archived migration `20260401000001_add_kpi_columns_link_metrics.sql` but **dropped by the 2026-05-23 baseline squash**, so `collectLinkMetrics()` failed with `Could not find the 'rf_distance_m' column of 'tarana_link_metrics'`.
→ Restored via idempotent, additive migration (`20260712230000_*`, all columns nullable). **Already applied to the live DB.**

**2. Response-envelope mismatch (all telemetry came back null).** `getDeviceBySerial` read `linkState`/`losRange`/`sectorId`/`carriers` at the top level, but NQS v1 wraps the payload under `data` (the sibling `getAllDevicesNqs` already unwraps it). Every field resolved to `undefined`.
→ `lib/tarana/client.ts` now unwraps `raw.data`.

## Verification

Ran a manual collection against the live TCS Portal after both fixes:

- **8 rows collected** (4 skipped: 2× TCS `403` not-on-our-operator, 2× placeholder serials that `404`).
- Real data now lands: **link status** (5 connected / 2 disconnected), **connected-BN serials**, **RF distance** (935 m–6090 m), **GPS coords**, **sector IDs**.
- **Known gap:** `rssi_dbm` / `tx_power_dbm` stay null — the NQS device-state `carriers[]` array is empty even for connected RNs, so signal strength needs a separate TCS KPI (TMQ) endpoint. Out of scope here.

So the RN fleet page now renders **5 of its 6 columns with real data** instead of the empty state.

## Keeping it populated

The 15-min Inngest cron doesn't self-fire in prod (dormant). Added **`/api/cron/tarana-metrics`** (Vercel cron, `*/15 * * * *`, `CRON_SECRET`-gated) matching the existing cron pattern, plus a `scripts/run-tarana-metrics-collection.ts` helper for manual/local runs.

> Note: `*/15` mirrors the original Inngest cadence. Each serverless invocation re-authenticates to TCS (in-process token cache doesn't survive between invocations) → ~96 TCS logins/day. If TCS rate-limits, dropping to `*/30` halves that.

## Test plan
- [x] `npm run type-check:memory` — clean for all changed files
- [x] Manual collection populates `tarana_link_metrics` with real telemetry
- [ ] Confirm `/admin/network/remote-nodes` renders the rows once #616 merges (pages live on that branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)