### PR TITLE
fix(zoho): Books-scoped OAuth + drop invalid custom fields

### DIFF
--- a/lib/integrations/zoho/books-api-client.ts
+++ b/lib/integrations/zoho/books-api-client.ts
@@ -108,11 +108,14 @@ export class ZohoBooksClient extends ZohoAPIClient {
   private readonly organizationId: string;
 
   constructor() {
+    // Zoho Books requires a Books-scoped OAuth token. Generic ZOHO_REFRESH_TOKEN
+    // is CRM-scoped and returns 401 code 57 on Books API calls.
+    // Prefer ZOHO_BOOKS_*; fall back to generic vars for local/dev compatibility.
     super({
-      clientId: process.env.ZOHO_CLIENT_ID!,
-      clientSecret: process.env.ZOHO_CLIENT_SECRET!,
-      refreshToken: process.env.ZOHO_REFRESH_TOKEN!,
-      region: (process.env.ZOHO_REGION as any) || 'US',
+      clientId: process.env.ZOHO_BOOKS_CLIENT_ID || process.env.ZOHO_CLIENT_ID!,
+      clientSecret: process.env.ZOHO_BOOKS_CLIENT_SECRET || process.env.ZOHO_CLIENT_SECRET!,
+      refreshToken: process.env.ZOHO_BOOKS_REFRESH_TOKEN || process.env.ZOHO_REFRESH_TOKEN!,
+      region: (process.env.ZOHO_BOOKS_REGION as any) || (process.env.ZOHO_REGION as any) || 'US',
     });
 
     // Zoho Books uses its own org ID (may differ from Billing org ID)

--- a/lib/integrations/zoho/books-sync-orchestrator.ts
+++ b/lib/integrations/zoho/books-sync-orchestrator.ts
@@ -202,10 +202,8 @@ export class ZohoBooksSyncOrchestrator {
                 country: customer.billing_address?.country || customer.address?.country || 'South Africa',
               }
             : undefined,
-          custom_fields: [
-            { label: 'CircleTel Customer ID', value: customer.id },
-            { label: 'Account Number', value: customer.account_number || '' },
-          ].filter(f => f.value),
+          // custom_fields omitted: labels must exist in the Books org or create
+          // returns 400 code 120129. Trace via email / zoho_books_contact_id instead.
         };
 
         // Upsert to Zoho Books
@@ -411,11 +409,9 @@ export class ZohoBooksSyncOrchestrator {
           line_items: lineItems,
           notes: invoice.notes || undefined,
           terms: invoice.terms || undefined,
-          custom_fields: [
-            { label: 'CircleTel Invoice ID', value: invoice.id },
-            { label: 'Invoice Type', value: invoice.invoice_type || '' },
-            { label: 'Service ID', value: invoice.service_id || '' },
-          ].filter(f => f.value),
+          // custom_fields omitted: 'CircleTel Invoice ID' etc. do not exist in the
+          // Books org (400 code 120129). Trace via matching invoice_number + DB
+          // zoho_books_invoice_id instead.
         };
 
         // Create invoice in Zoho Books


### PR DESCRIPTION
## Summary

- **Auth:** `ZohoBooksClient` now prefers `ZOHO_BOOKS_CLIENT_ID` / `SECRET` / `REFRESH_TOKEN` / `REGION`, with fallback to generic `ZOHO_*`. Fixes live 401 code 57 when the CRM refresh token is used against the Books API.
- **Custom fields:** Stop sending hard-coded Books `custom_fields` on contact upsert and invoice create. Labels such as `CircleTel Invoice ID` are not defined in the org and return 400 code 120129.
- **Out of scope (intentionally):** VAT treatment / `is_inclusive_tax`, tax_id helpers, invoice void/recreate, Supabase amount corrections. Those need a product-level VAT decision (ex-VAT Unjani vs incl-VAT consumer) before code or Books cleanup.

## Context

Diagnosed and partially fixed during a Books backfill session; WIP was rescued off primary into this branch. Larger tax-related WIP remains parked under `/tmp/zoho-wip-save` on the VPS and is **not** in this PR.

## Test plan

- [x] Diff limited to two files; no `is_inclusive_tax`
- [ ] With `ZOHO_BOOKS_REFRESH_TOKEN` set, Books read (e.g. getContact) succeeds via app client path
- [ ] Invoice create without custom_fields no longer returns 120129
- [ ] CRM integrations still use generic `ZOHO_REFRESH_TOKEN` (unchanged clients)
- [ ] Do **not** re-run bulk void/recreate of live Books invoices in this PR