### PR TITLE
docs(ops): VPS devops checklist, execution plan, and agent rules

### DIFF
--- a/.claude/rules/vps-devops.md
+++ b/.claude/rules/vps-devops.md
@@ -1,0 +1,145 @@
+# VPS DevOps & Maintenance Rules
+
+**Trigger**: Deploying, debugging builds, Coolify/Docker, self-hosted runner, disk/RAM/load issues, VPS maintenance, CI workflow changes, “why is the server slow”, cron health on host  
+**Scope**: VPS 30 (`94.72.104.81`) — Coolify runtime + self-hosted GitHub Actions builds  
+**Canonical checklist**: `docs/deployment/VPS_DEVOPS_OPS_CHECKLIST.md`
+
+---
+
+## Architecture (do not reverse without explicit user approval)
+
+| Layer | Required choice |
+|-------|-----------------|
+| Production runtime | Coolify Docker on this VPS |
+| Heavy `next build` / image build | Self-hosted GHA runner on VPS (or future dedicated builder) |
+| Light PR checks | GitHub-hosted `ubuntu-latest` |
+| Staging full builds | Opt-in only (`deploy-staging` label) — never re-enable build-on-every-PR |
+| Primary build farm | **Not** Vercel Enhanced (cost + memory history) |
+
+**Build heap**: prod/staging deploy workflows use `NODE_OPTIONS='--max-old-space-size=12288'`.  
+**CPUs**: leave `BUILD_CPUS` unset for prod (effective `cpus:1`). Do not set `BUILD_CPUS=4` without a new benchmark — thrash was measured slower on this host.
+
+---
+
+## Performance SLOs (agents must respect)
+
+Before starting a full deploy or heavy local build on the VPS, check:
+
+| Check | Abort / escalate if |
+|-------|---------------------|
+| `df -h /` | Free &lt; 8 GB (deploy.yml fails hard near 4 GB) |
+| `free -h` available | &lt; 10 GB available and a deploy is required — free memory first |
+| Load average (1m) | &gt; 12 sustained — defer noncritical builds |
+| Existing self-hosted job | Another deploy/build already running — do not start a second full build |
+| Prod container | Unhealthy — fix runtime before new feature deploys |
+
+Target after cleanup for a deploy: **≥ 12–14 GB RAM available**, **≥ 10 GB disk free** (prefer ≥ 40 GB free steady-state).
+
+---
+
+## Hard rules (ALWAYS / NEVER)
+
+### ALWAYS
+
+1. **Prefer label-based container discovery** for prod:  
+   `docker ps --filter 'label=coolify.name=b7ukn3c76rd46dsl19oqq59e'`  
+   Coolify renames container suffixes — hardcoded full names break health checks.
+2. **One heavy CircleTel build at a time** on this VPS (prod image build, staging image build, or local `build:memory` — not in parallel).
+3. **Keep staging label-gated** when editing `staging-deployment.yml` / deploy-staging triggers.
+4. **Free or identify memory hogs before build**: orphan `next dev` / host `next-server` outside Docker, headless Chrome, multi‑GB IDE servers — not the healthy Coolify prod app.
+5. **Disk before image build**: if free &lt; 8 GB, prune safely (`docker image prune`, builder prune, journals) before retry.
+6. **After deploy**: wait for container **healthy**; show logs on failure; do not claim success without health evidence.
+7. **Primary git checkout**: keep `/home/circletel` on clean tracking `main`; feature work in worktrees (`git-tree-hygiene.md`).
+8. **paths-ignore awareness**: docs/md-only changes may not trigger `deploy.yml` — do not assume every push deploys.
+
+### NEVER
+
+1. **Never** move production builds back to Vercel as the default cost-saving “fix” without an explicit capacity/cost decision.
+2. **Never** pin light lint/type jobs to `self-hosted` without need — wastes the only fat runner.
+3. **Never** run `docker system prune -a` / `docker image prune -a` during an active deploy without confirming impact.
+4. **Never** kill Coolify `coolify-db`, `coolify-redis`, or proxy as “memory cleanup.”
+5. **Never** hardcode ephemeral Coolify container name suffixes in new scripts (use labels).
+6. **Never** set `BUILD_CPUS=4` on this host for prod workflow without re-measuring wall time + RAM.
+7. **Never** leave multi‑GB orphan Node/Next processes on the host overnight after agent sessions.
+8. **Never** use `git commit --no-verify` to skip secret scan when changing deploy secrets/scripts.
+
+---
+
+## Maintenance cadence (agents: suggest or run when asked “doctor” / ops)
+
+| Cadence | Minimum |
+|---------|---------|
+| Daily | `uptime`, `free -h`, `df -h /`, prod container healthy, runner up |
+| Weekly | Docker `system df` + light prune; runner job success; worktree count; cron log spot-check |
+| Monthly | Capacity review vs upgrade triggers in the ops checklist |
+
+Full commands: `docs/deployment/VPS_DEVOPS_OPS_CHECKLIST.md`.
+
+---
+
+## Safe cleanup order
+
+When freeing resources for a build:
+
+1. Orphan host `next dev` / non-Docker `next-server` (user.slice only)  
+2. Headless Chrome / chrome-devtools-mcp  
+3. Heavy optional IDE/agent helpers (only if policy allows; prefer ask for interactive tools)  
+4. `docker image prune -f` (dangling)  
+5. If still tight: `docker image prune -a -f` + `docker builder prune -a -f` **when no deploy running**  
+6. `journalctl --vacuum-size=100M`  
+7. Old `/tmp/buildx-cache`, Playwright caches if disk critical  
+
+Do **not** drop Coolify app/db/redis containers in this list.
+
+---
+
+## Workflow edit rules
+
+When changing `.github/workflows/deploy.yml` or `deploy-staging.yml`:
+
+- Keep disk preflight (≥ 4 GB fatal after cleanup; prefer acting at 8 GB).  
+- Keep memory free step intent (or improve it) — do not remove without replacement.  
+- Keep image commit verification if present.  
+- Keep health wait with **dynamic** container name resolution.  
+- Keep `concurrency` groups so prod deploys do not cancel each other carelessly (`cancel-in-progress: false` for prod).  
+- Document any runner label changes in `.github/workflows/README.md` + ops checklist.
+
+PR checks (`pr-checks.yml`) may stay non-blocking for historical type debt — do not “fix” by moving full `build:memory` onto self-hosted for every PR.
+
+---
+
+## Upgrade path (recommend only when triggered)
+
+Triggers (2+ weeks): deploy success &lt; 90% from contention; RAM &lt; 10 GB before builds often; load &gt; 10 sustained; deploy queue; disk thrash.
+
+1. **First choice**: dedicated builder VPS + same GHA workflows  
+2. **Alternative**: Coolify-native git build (simpler; same host unless builder split)  
+3. **Not preferred**: Vercel Enhanced as primary CI for this app  
+
+Do not implement upgrade without user approval (cost + infra change).
+
+---
+
+## Related files
+
+| Path | Role |
+|------|------|
+| `docs/deployment/VPS_DEVOPS_OPS_CHECKLIST.md` | Full checklist + execution plan |
+| `.github/workflows/deploy.yml` | Prod pipeline |
+| `.github/workflows/deploy-staging.yml` | Staging pipeline |
+| `.github/workflows/README.md` | CI overview |
+| `.claude/rules/git-tree-hygiene.md` | Checkout/worktrees |
+| `.claude/rules/vercel-deployment.md` | Vercel-specific (previews/legacy), not primary prod build |
+| `docs/architecture/CRON_SCHEDULE.md` | Crontab SoT |
+
+---
+
+## DO / DON’T summary
+
+| DO | DON’T |
+|----|--------|
+| Check disk/RAM/load before heavy builds | Start parallel full builds on one VPS |
+| Use Coolify labels for prod container | Hardcode Coolify name suffixes |
+| Keep staging opt-in | Auto-build staging every PR |
+| Prune Docker when free space Yellow/Red | Prune DB volumes or running prod stack |
+| Point ops work at the checklist | Invent a new deploy topology casually |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,9 +1,12 @@
 # CircleTel CI/CD Workflows
 
 CircleTel runs on **Coolify** (self-hosted, VPS 30 — 94.72.104.81, 24GB RAM).
-Builds run on a self-hosted GitHub Actions runner on that VPS; deploys are triggered via Coolify webhook.
+Heavy builds run on a **self-hosted GitHub Actions runner** on that VPS; the app runs in Coolify-managed containers.
 
 Migration completed: 2026-04-05. See `docs/architecture/archive/COOLIFY_MIGRATION_PLAN.md`.
+
+**Ops / performance (canonical):** [`docs/deployment/VPS_DEVOPS_OPS_CHECKLIST.md`](../../docs/deployment/VPS_DEVOPS_OPS_CHECKLIST.md)  
+**Agent rules:** [`.claude/rules/vps-devops.md`](../../.claude/rules/vps-devops.md)
 
 ---
 
@@ -11,17 +14,19 @@ Migration completed: 2026-04-05. See `docs/architecture/archive/COOLIFY_MIGRATIO
 
 ```
 PR opened/updated
-  └─ staging-deployment.yml  → push to staging branch → Coolify staging deploy
-  └─ pr-checks.yml           → Dockerfile validation, type-check, lint, build
+  └─ pr-checks.yml              → GitHub-hosted: Dockerfile validation, type-check, lint
+  └─ staging-deployment.yml     → only if label `deploy-staging` → force-push staging branch
+       └─ deploy-staging.yml    → self-hosted build → Coolify staging container
 
-PR approved + 'automerge' label added
-  └─ auto-merge.yml          → squash merge to main
+PR approved + 'automerge' label
+  └─ auto-merge.yml             → squash merge to main
 
-Push to main
-  └─ deploy.yml              → build Docker image → push GHCR → trigger Coolify webhook
+Push to main (non-docs paths)
+  └─ deploy.yml                 → self-hosted: free RAM → disk guard → Turbopack build
+                                  → local Docker image → Coolify compose recreate → health wait
 
 Scheduled (every 6h)
-  └─ mtn-session.yml         → validate MTN session; refresh + redeploy if stale
+  └─ mtn-session.yml            → validate MTN session; refresh + redeploy if stale
 ```
 
 ---
@@ -34,12 +39,17 @@ Scheduled (every 6h)
 
 **Runner**: `self-hosted` (VPS 30 — 24GB RAM; GitHub-hosted ubuntu-latest OOMs on this 254-page app)
 
-**Steps**:
-1. Build Docker image with `NEXT_PUBLIC_*` secrets baked in as build args
-2. Push to `ghcr.io/jdeweedata/circletel:latest`
-3. Trigger Coolify deploy webhook → Coolify pulls the new image and restarts the container
+**Steps** (see `deploy.yml` for authoritative detail):
+1. Free host memory (orphan Next/Chrome) and enforce disk free space
+2. `npm ci` / tar-cached `node_modules` + restore `.next` cache
+3. `NODE_OPTIONS=--max-old-space-size=12288` Turbopack production build
+4. Build Docker image locally (`ghcr.io/jdeweedata/circletel:latest` + SHA tag)
+5. Coolify app directory: `docker compose up -d --force-recreate --no-build --pull never`
+6. Wait until container health is `healthy` (discover via `coolify.name` label)
 
-**Cache**: Local disk cache on VPS (`/tmp/buildx-cache`) — no network round-trip
+**Cache**: `/home/actions-runner/node_modules.tar`, `/home/actions-runner/.next-cache` on VPS
+
+**Host performance rules**: do not run parallel full builds; keep staging label-gated; see VPS devops checklist.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ All detailed patterns are in `.claude/rules/`:
 | `shared-memory.md` | Two-tier shared memory protocol — Hermes Agent + Claude Code handoffs |
 | `admin-shared-components.md` | StatusBadge/StatCard/SectionCard prop interfaces — verified signatures |
 | `vercel-deployment.md` | Manual deployment trigger API, monitoring, CircleTel project IDs |
+| `vps-devops.md` | VPS/Coolify/self-hosted runner SLOs, build hygiene, maintenance cadence |
 | `invoice-pdf-patterns.md` | VAT calc (excl-VAT multiply), fetch/blob download, print:hidden, jsPDF patterns |
 | `pre-push-hook.md` | Shared `.githooks/pre-push` — build-config + scoped type-check, escape hatches |
 | `icon-system.md` | Phosphor UI icons, Iconify brand logos, local hosting, licensing, and accessibility |

--- a/docs/deployment/VPS_DEVOPS_OPS_CHECKLIST.md
+++ b/docs/deployment/VPS_DEVOPS_OPS_CHECKLIST.md
@@ -1,0 +1,352 @@
+# VPS DevOps Ops Checklist & Execution Plan
+
+**Status**: Canonical  
+**Date**: 2026-07-21  
+**Host**: VPS 30 — `94.72.104.81` (24 GB RAM, 8 cores, ~193 GB disk)  
+**Runtime**: Coolify (prod + staging containers)  
+**CI build**: Self-hosted GitHub Actions runner on the same VPS  
+**Related**: `.claude/rules/vps-devops.md`, `.github/workflows/README.md`, `docs/architecture/CRON_SCHEDULE.md`
+
+---
+
+## Architecture decision (do not reverse lightly)
+
+| Layer | Choice | Why |
+|-------|--------|-----|
+| App runtime | Coolify on this VPS | Lowest hosting cost; full control |
+| Heavy `next build` | Self-hosted GHA (`runs-on: self-hosted`) | Needs ~12 GB heap; GitHub-hosted (~7 GB) OOMs; Vercel Enhanced builds cost too much |
+| Light CI (lint/type PR checks) | GitHub-hosted `ubuntu-latest` | Cheap; does not need 12 GB |
+| Staging deploys | Opt-in via `deploy-staging` PR label | Prevents 25–30 min builds on every PR |
+
+**Default recommendation**: keep this split. Upgrade path only when triggers fire (see [Upgrade triggers](#upgrade-triggers)).
+
+```
+PR opened
+  ├─ pr-checks.yml          → GitHub-hosted (light)
+  └─ staging-deployment.yml → label opt-in → push staging branch
+       └─ deploy-staging.yml → self-hosted build → Coolify staging
+
+Push to main (non-docs paths)
+  └─ deploy.yml             → self-hosted: free RAM → disk guard → build
+                               → local Docker image → Coolify recreate
+                               → health wait
+```
+
+---
+
+## 1. SLO targets (always optimal)
+
+Use these as the definition of “healthy enough to build and serve.”
+
+| Metric | Green | Yellow | Red (act now) |
+|--------|-------|--------|----------------|
+| Disk `/` free | ≥ 40 GB free (≤ ~80% used) | 15–40 GB free | **&lt; 8 GB free** (deploy.yml aborts at &lt; 4 GB after cleanup) |
+| Available RAM before build | ≥ 14 GB available | 10–14 GB | **&lt; 10 GB** after cleanup |
+| Load average (1m) vs 8 cores | &lt; 6 | 6–10 | **&gt; 12 sustained 5+ min** |
+| Swap used | &lt; 2 GB | 2–4 GB | **&gt; 4 GB** (memory pressure) |
+| Prod container health | `healthy` | restarting &lt; 2×/day | **unhealthy / crash loop** |
+| Staging container health | `healthy` when in use | stopped OK if unused | crash loop |
+| Deploy job duration (Turbopack) | ≤ 25 min | 25–40 min | **&gt; 50 min** or timeout (60) |
+| Deploy queue (jobs waiting on runner) | 0 | 1 | **≥ 2** or blocked &gt; 1 h |
+| Runner online | Online in GitHub | Idle &gt; 7 days (check) | Offline |
+
+---
+
+## 2. Daily checklist (5 minutes)
+
+Run on the VPS (SSH) or via agent with root/ops access.
+
+```bash
+# --- Host snapshot ---
+date -u
+uptime
+free -h
+df -h /
+systemctl --failed --no-pager
+
+# --- Coolify / app ---
+docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | head -20
+# Prod is Coolify-managed; name suffix changes — use labels:
+docker ps --filter 'label=coolify.name=b7ukn3c76rd46dsl19oqq59e' --format '{{.Names}} {{.Status}}'
+docker ps --filter 'name=circletel-staging' --format '{{.Names}} {{.Status}}'
+
+# --- Runner ---
+systemctl is-active actions.runner.jdeweedata-circletel.vps-runner.service 2>/dev/null \
+  || systemctl list-units --type=service --all | grep -i runner
+
+# --- Top consumers ---
+ps aux --sort=-%mem | head -8
+```
+
+**Pass criteria**
+- [ ] Disk free ≥ 15 GB (prefer ≥ 40 GB)
+- [ ] Available RAM ≥ 10 GB (prefer ≥ 14 GB when idle)
+- [ ] Prod container **healthy**
+- [ ] No unexpected `systemctl --failed` (ignore known benign `systemd-networkd-wait-online` unless networking is broken)
+- [ ] No orphan `next dev` / host-level `next-server` outside Docker eating multi‑GB RAM
+- [ ] Runner service active; no stuck multi-hour `node` build if no deploy is intentional
+
+**If Red**: do [Emergency procedures](#6-emergency-procedures) before starting another build.
+
+---
+
+## 3. Pre-deploy checklist (before merge to `main` or manual deploy)
+
+- [ ] **Primary checkout clean** or work is on a feature worktree (see `git-tree-hygiene`)
+- [ ] No active self-hosted job: GitHub → Actions → confirm runner idle
+- [ ] `free -h` available ≥ 12 GB; `df -h /` free ≥ 10 GB
+- [ ] Avoid concurrent heavy work: full `npm run build:memory`, multiple agents, Playwright browser farms, large Docker builds
+- [ ] Staging validated if UI/API risky (add `deploy-staging` label only when needed)
+- [ ] Secrets/env changes applied in Coolify **before** expecting runtime to pick them up
+- [ ] Paths that only touch `docs/**`, `*.md`, `.claude/**` etc. do **not** need a prod deploy (`deploy.yml` paths-ignore)
+
+**Do not** set `BUILD_CPUS=4` on this host for prod build — measured thrash (27–34 min) vs ~21 min at `cpus:1`; Turbopack is the speedup, not more cores.
+
+---
+
+## 4. Weekly checklist (15–25 minutes)
+
+### 4.1 Disk & Docker hygiene
+
+```bash
+df -h /
+docker system df
+# Safe: unused images/containers/networks (running containers kept)
+docker image prune -f
+docker container prune -f
+# Only if free < 25 GB and no deploy running:
+# docker image prune -a -f
+# docker builder prune -a -f
+
+# Runner / cache bulk (only if disk Yellow/Red)
+du -sh /home/actions-runner/node_modules.tar \
+       /home/actions-runner/.next-cache \
+       /tmp/buildx-cache 2>/dev/null
+journalctl --disk-usage
+# journalctl --vacuum-size=200M
+```
+
+- [ ] `docker system df` reviewed; reclaim dangling images if free &lt; 40 GB
+- [ ] Old runner `_diag` logs cleaned if large (`find /home/actions-runner/_diag/ -name '*.log' -mtime +7 -delete`)
+- [ ] Playwright/browser caches not multi‑GB on disk unless needed
+
+### 4.2 Runner & CI
+
+- [ ] GitHub → Settings → Actions → Runners: **Idle/Online**, labels correct
+- [ ] Last 5 `Build & Deploy` runs: success rate; duration trend
+- [ ] Staging deploys only when label used (no surprise 30 min jobs)
+- [ ] No workflow incorrectly set to `runs-on: self-hosted` for light work
+
+### 4.3 Application health
+
+- [ ] Prod homepage + one API smoke (auth not required path)
+- [ ] Coolify resource graphs: CPU/RAM for app containers not pegged 24/7
+- [ ] Cron log tail: `/var/log/circletel-cron.log` — integrations not all `down`
+- [ ] Payment sync backlog not growing unboundedly (known: stale pending count — track, don’t ignore)
+
+### 4.4 Git / tree (host checkout)
+
+- [ ] `/home/circletel` on clean `main` tracking `origin/main` (`git pull --ff-only` if behind)
+- [ ] Worktree count roughly ≤ 8 active topics; prune merged (see `git-tree-hygiene`)
+- [ ] No multi‑day untracked secrets or large artifacts on primary checkout
+
+### 4.5 Security / access
+
+- [ ] Runner only used for trusted CircleTel workflows (repo-scoped)
+- [ ] No long-lived credentials in world-readable files under `/tmp`
+- [ ] Coolify and Docker sockets not exposed publicly
+
+---
+
+## 5. Monthly checklist (30–45 minutes)
+
+- [ ] Review upgrade triggers below — still on single-box or need builder VPS?
+- [ ] Coolify, Docker, runner package updates (schedule maintenance window)
+- [ ] Node version on runner vs Dockerfile base (align when major changes)
+- [ ] GHCR / local image retention: keep last N prod tags; prune rest
+- [ ] Re-read `deploy.yml` / `deploy-staging.yml` for drift (heap, cpus, paths-ignore)
+- [ ] Confirm `CRON_SECRET` / `/root/.cron-env` still valid for crontab curls
+- [ ] Capacity: if load avg regularly &gt; 8 during business hours, plan dedicated builder
+
+---
+
+## 6. Emergency procedures
+
+### 6.1 Deploy failing: disk
+
+```bash
+df -h /
+# While NO critical deploy mid-write:
+docker image prune -a -f
+docker builder prune -a -f
+npm cache clean --force
+journalctl --vacuum-size=100M
+rm -rf /tmp/buildx-cache /tmp/com.google.Chrome.scoped_dir.* 2>/dev/null || true
+rm -rf /root/.cache/ms-playwright/ 2>/dev/null || true
+df -h /
+```
+
+Abort if still &lt; 4 GB free — free more (old worktrees, logs) before retry.
+
+### 6.2 Deploy failing: OOM / killed build
+
+```bash
+free -h
+# Prefer stop non-prod consumers first (agents, headless Chrome, host next dev)
+# Do NOT kill Coolify prod container unless necessary
+# Then re-run deploy workflow (workflow_dispatch or push)
+```
+
+Match `deploy.yml` “Free memory for build” spirit: orphan `next dev`, headless Chrome, heavy IDE servers — not the healthy prod container.
+
+### 6.3 Prod unhealthy after deploy
+
+```bash
+CONTAINER=$(docker ps --filter 'label=coolify.name=b7ukn3c76rd46dsl19oqq59e' --format '{{.Names}}' | head -1)
+docker logs --tail 100 "$CONTAINER"
+docker inspect --format='{{.State.Health.Status}}' "$CONTAINER"
+# Rollback: previous image tag if retained, or Coolify redeploy previous known-good
+```
+
+See also `docs/deployment/ROLLBACK_PROCEDURE.md` if present and current.
+
+### 6.4 Runner offline
+
+```bash
+systemctl status 'actions.runner.*' --no-pager
+# cd /home/actions-runner && sudo ./svc.sh status
+# journalctl -u 'actions.runner.*' -n 50 --no-pager
+```
+
+Re-register only with current GitHub runner token process; do not leave two runners double-consuming the host without intent.
+
+### 6.5 Load spike during agents + deploy
+
+1. Prefer **defer deploy** 15–30 min over killing prod.  
+2. Stop nonessential agent/browser processes.  
+3. One deploy at a time (prod concurrency group already `cancel-in-progress: false` — do not start staging build in parallel if RAM tight).
+
+---
+
+## 7. Workload rules (always)
+
+| Workload | Where | Notes |
+|----------|-------|--------|
+| `next build` (prod/staging images) | Self-hosted only | `NODE_OPTIONS=--max-old-space-size=12288` |
+| Lint / light type-check / small tests | GitHub-hosted | Do not pin to self-hosted |
+| Staging full build | Self-hosted + **label** `deploy-staging` | Never on every PR by default |
+| Prod runtime | Coolify Docker | Prefer label lookup over hardcoded container suffix |
+| Agent/dev servers on VPS | Allowed carefully | Stop before large deploys; no multi‑GB orphan `next dev` left overnight |
+| Vercel production builds | **Not** primary path | Vercel Enhanced cost/memory; Coolify is SoT for prod |
+
+**Hard constraints**
+1. Never run two full CircleTel production-class builds in parallel on this VPS.  
+2. Never force `BUILD_CPUS=4` for prod on this box without a re-benchmark.  
+3. Never delete running Coolify DB/redis containers during “cleanup.”  
+4. Never `docker system prune -a` blindly without checking free space need and running set.  
+5. Container names from Coolify **change suffix** — always filter by `coolify.name` label for prod.
+
+---
+
+## 8. Execution plan
+
+### Phase 0 — Baseline (day 0, ~30 min) ✅ decision already made
+
+| # | Task | Owner | Done when |
+|---|------|-------|-----------|
+| 0.1 | Confirm architecture: Coolify runtime + self-hosted build | Ops | This doc accepted |
+| 0.2 | Record baseline: `free -h`, `df -h`, last deploy duration, runner status | Ops | Numbers in weekly notes or handoff |
+| 0.3 | Link rule file for agents: `.claude/rules/vps-devops.md` | Agent | File exists |
+
+### Phase 1 — Operationalize checklists (week 1)
+
+| # | Task | Effort | Done when |
+|---|------|--------|-----------|
+| 1.1 | Run **Daily** checklist once and fix any Red items | 30–60 min | Green host |
+| 1.2 | Add calendar or cron reminder for **Weekly** (e.g. Mon 08:00 with git-hygiene) | 15 min | Reminder exists |
+| 1.3 | Ensure runner service enabled on boot | 10 min | `systemctl is-enabled` ok |
+| 1.4 | Document actual runner unit name in handoff if different from example | 5 min | Name recorded |
+| 1.5 | Verify staging remains **label-gated** | 10 min | No auto build every PR |
+| 1.6 | Align primary `/home/circletel` with `origin/main` | 10 min | `0/0` ahead/behind |
+
+### Phase 2 — Guardrails & automation (weeks 2–3)
+
+| # | Task | Effort | Done when |
+|---|------|--------|-----------|
+| 2.1 | Prefer runner labels `self-hosted` + `circletel-build` in workflows (optional hardening) | 30 min | Workflows updated + runner labeled |
+| 2.2 | Weekly disk prune script or documented one-liner in crontab (safe prune only) | 45 min | Free space stable week-over-week |
+| 2.3 | Alert path for failed deploy (GitHub email / Slack if available) | 30 min | Failures noticed &lt; 1 h |
+| 2.4 | Cap concurrent heavy agents during known deploy windows | process | Documented in this file + agent rule |
+| 2.5 | Confirm deploy.yml disk/memory preflight still matches reality | 20 min | No silent drift |
+
+### Phase 3 — Capacity decision (month 1–2, only if triggers hit)
+
+| # | Task | Effort | Done when |
+|---|------|--------|-----------|
+| 3.1 | Measure: deploy failures due to RAM/load, or queue time | ongoing | Data for 2–4 weeks |
+| 3.2 | If triggers met → provision **dedicated builder** (8+ vCPU, 32 GB) OR Coolify-native build trial | 1–2 days | Builds off prod host or simplified pipeline |
+| 3.3 | If not met → stay single-box; re-evaluate next quarter | 0 | Decision logged |
+
+### Phase 4 — Continuous improvement (ongoing)
+
+| # | Task | Notes |
+|---|------|--------|
+| 4.1 | Keep Turbopack prod build unless regression | Revert path: plain `npm run build` in deploy.yml |
+| 4.2 | Reduce app build cost long-term | Route split, less admin in same bundle — product/eng |
+| 4.3 | Integration/cron health (5 healthy / 3 down pattern) | Separate from build host but affects “ops green” |
+
+---
+
+## Upgrade triggers
+
+Move off “build on prod VPS” only when **any** of these hold for 2+ weeks:
+
+1. Deploy success rate &lt; 90% due to host resource contention  
+2. Available RAM before build often &lt; 10 GB despite cleanup  
+3. Sustained load &gt; 10 during business hours with agents + Coolify  
+4. Deploy queue regularly ≥ 1 job waiting &gt; 30 min  
+5. Disk free repeatedly &lt; 15 GB despite weekly prune  
+
+**Preferred upgrade**: dedicated build VPS (keep GHA workflows, change `runs-on` / runner registration).  
+**Alternative**: Coolify-native git builds (simpler GHA, same host contention unless builder separated).  
+**Avoid**: Vercel Enhanced as primary build farm for cost reasons.
+
+---
+
+## Quick command card
+
+```bash
+# Health one-liner
+echo "=== $(date -u) ===" && uptime && free -h | sed -n '1,2p' && df -h / | tail -1 && \
+  docker ps --filter 'label=coolify.name=b7ukn3c76rd46dsl19oqq59e' --format 'prod: {{.Names}} {{.Status}}' && \
+  docker ps --filter 'name=circletel-staging' --format 'staging: {{.Names}} {{.Status}}'
+
+# Safe light prune
+docker image prune -f && docker container prune -f
+
+# Aggressive prune (no deploy running; free space critical)
+docker image prune -a -f && docker builder prune -a -f && journalctl --vacuum-size=100M
+
+# Prod logs
+C=$(docker ps --filter 'label=coolify.name=b7ukn3c76rd46dsl19oqq59e' --format '{{.Names}}' | head -1)
+docker logs --tail 80 "$C"
+```
+
+---
+
+## References
+
+| Doc / path | Purpose |
+|------------|---------|
+| `.github/workflows/deploy.yml` | Prod build + deploy (memory free, disk guard, Turbopack, Coolify) |
+| `.github/workflows/deploy-staging.yml` | Staging build |
+| `.github/workflows/staging-deployment.yml` | Label-gated staging branch push |
+| `.github/workflows/README.md` | Pipeline overview |
+| `.claude/rules/vps-devops.md` | Agent-enforced DevOps rules |
+| `.claude/rules/git-tree-hygiene.md` | Primary checkout + worktrees |
+| `docs/architecture/CRON_SCHEDULE.md` | Crontab as scheduler of record |
+| `docs/deployment/ROLLBACK_PROCEDURE.md` | Rollback if still accurate |
+
+---
+
+**Version**: 1.0 · **Updated**: 2026-07-21


### PR DESCRIPTION
## Summary

- Add canonical VPS ops checklist and phased execution plan for Coolify + self-hosted GitHub Actions builds (`docs/deployment/VPS_DEVOPS_OPS_CHECKLIST.md`).
- Add agent-enforced DevOps rules (SLOs, ALWAYS/NEVER, safe cleanup, workflow edit constraints) in `.claude/rules/vps-devops.md`.
- Link the rule from `CLAUDE.md` and correct/refresh `.github/workflows/README.md` (label-gated staging, local Docker + Coolify recreate path).

## Context

Recommendation for current setup: keep self-hosted builds on the VPS with Coolify runtime; optimize ops and disk/RAM hygiene; only split to a dedicated builder if upgrade triggers hit.

## Test plan

- [ ] Skim checklist SLOs and daily/weekly sections for accuracy vs VPS 30
- [ ] Confirm workflow README matches `deploy.yml` / staging label behavior
- [ ] No application code changes — docs/rules only