### PR TITLE
feat(network): Omada-style Health/Devices/Analytics with live Ruijie metrics

### DIFF
--- a/__tests__/lib/network/analytics-aggregates.test.ts
+++ b/__tests__/lib/network/analytics-aggregates.test.ts
@@ -1,0 +1,100 @@
+import {
+  aggregateSsidActivity,
+  computeGroupTrafficCards,
+  computeRadioUtilSummary,
+} from '@/lib/network/analytics-aggregates';
+
+describe('computeGroupTrafficCards', () => {
+  it('sums rollups per group and sorts by total bytes', () => {
+    const cards = computeGroupTrafficCards([
+      {
+        group_id: 'a',
+        group_name: 'Unjani',
+        total_rx_bytes: 100,
+        total_tx_bytes: 50,
+        captured_at: '2026-07-25T10:00:00Z',
+      },
+      {
+        group_id: 'a',
+        group_name: 'Unjani',
+        total_rx_bytes: 200,
+        total_tx_bytes: 25,
+        captured_at: '2026-07-25T11:00:00Z',
+      },
+      {
+        group_id: 'b',
+        group_name: 'Newgen',
+        total_rx_bytes: 10,
+        total_tx_bytes: 5,
+        captured_at: '2026-07-25T11:00:00Z',
+      },
+    ]);
+    expect(cards).toHaveLength(2);
+    expect(cards[0].groupName).toBe('Unjani');
+    expect(cards[0].totalBytes).toBe(375);
+    expect(cards[0].sampleCount).toBe(2);
+    expect(cards[1].groupName).toBe('Newgen');
+  });
+});
+
+describe('computeRadioUtilSummary', () => {
+  it('returns null averages when util is missing (no fake dBm)', () => {
+    const summary = computeRadioUtilSummary([
+      {
+        sn: '1',
+        device_name: 'AP1',
+        status: 'online',
+        radio_2g_utilization: null,
+        radio_5g_utilization: null,
+      },
+    ]);
+    expect(summary.avg2g).toBeNull();
+    expect(summary.avg5g).toBeNull();
+    expect(summary.avgBlended).toBeNull();
+    expect(summary.devicesWithRadio).toBe(0);
+  });
+
+  it('averages 2g/5g and lists channels when present', () => {
+    const summary = computeRadioUtilSummary([
+      {
+        sn: '1',
+        device_name: 'AP1',
+        status: 'online',
+        radio_2g_utilization: 20,
+        radio_5g_utilization: 40,
+        radio_2g_channel: 6,
+        radio_5g_channel: 36,
+      },
+      {
+        sn: '2',
+        device_name: 'AP2',
+        status: 'online',
+        radio_2g_utilization: 10,
+        radio_5g_utilization: null,
+        radio_2g_channel: 11,
+      },
+    ]);
+    expect(summary.avg2g).toBe(15);
+    expect(summary.avg5g).toBe(40);
+    expect(summary.devicesWithRadio).toBe(2);
+    expect(summary.channels2g).toEqual([6, 11]);
+    expect(summary.channels5g).toEqual([36]);
+  });
+});
+
+describe('aggregateSsidActivity', () => {
+  it('counts clients per SSID and skips blanks', () => {
+    expect(
+      aggregateSsidActivity([
+        { ssid: 'Clinic' },
+        { ssid: 'Clinic' },
+        { ssid: 'Guest' },
+        { ssid: '' },
+        { ssid: null },
+      ])
+    ).toEqual([
+      { ssid: 'Clinic', clients: 2 },
+      { ssid: 'Guest', clients: 1 },
+    ]);
+  });
+});

--- a/__tests__/lib/network/performance-aggregates.test.ts
+++ b/__tests__/lib/network/performance-aggregates.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Network performance aggregate helpers (System Health dashboard)
+ */
+
+import {
+  avgOrNull,
+  buildDailyUptimeSeries,
+  bpsToMbps,
+  classifyDeviceRole,
+  computeFleetOverview,
+  computeNetworkInventory,
+  computeResourceAverages,
+  percentDelta,
+  roundPercent,
+} from '@/lib/network/performance-aggregates';
+
+describe('roundPercent', () => {
+  it('rounds to two decimal places', () => {
+    expect(roundPercent(99.985)).toBe(99.99);
+    expect(roundPercent(0)).toBe(0);
+  });
+});
+
+describe('percentDelta', () => {
+  it('returns change vs previous', () => {
+    expect(percentDelta(98, 96)).toBeCloseTo(2.083, 2);
+  });
+
+  it('returns null when previous is zero', () => {
+    expect(percentDelta(50, 0)).toBeNull();
+  });
+});
+
+describe('bpsToMbps', () => {
+  it('converts bits per second to Mbps', () => {
+    expect(bpsToMbps(842_000_000)).toBeCloseTo(842, 1);
+  });
+});
+
+describe('avgOrNull', () => {
+  it('averages numbers and ignores nulls', () => {
+    expect(avgOrNull([10, null, 20, undefined])).toBe(15);
+  });
+
+  it('returns null for empty', () => {
+    expect(avgOrNull([])).toBeNull();
+    expect(avgOrNull([null, undefined])).toBeNull();
+  });
+});
+
+describe('computeResourceAverages', () => {
+  it('averages CPU, memory, and blended radio utilization', () => {
+    const result = computeResourceAverages([
+      { cpu_usage: 60, memory_usage: 40, radio_2g_utilization: 20, radio_5g_utilization: 40 },
+      { cpu_usage: 80, memory_usage: 60, radio_2g_utilization: 30, radio_5g_utilization: 50 },
+    ]);
+
+    expect(result.avgCpu).toBe(70);
+    expect(result.avgMemory).toBe(50);
+    expect(result.avgRadio).toBe(35);
+  });
+});
+
+describe('computeFleetOverview', () => {
+  it('builds System Health KPIs from device + snapshot inputs', () => {
+    const overview = computeFleetOverview({
+      devices: [
+        { sn: 'a', status: 'online', online_clients: 10, cpu_usage: 50, memory_usage: 40, radio_2g_utilization: 10, radio_5g_utilization: 20 },
+        { sn: 'b', status: 'online', online_clients: 5, cpu_usage: 70, memory_usage: 60, radio_2g_utilization: 30, radio_5g_utilization: 40 },
+        { sn: 'c', status: 'offline', online_clients: 0, cpu_usage: null, memory_usage: null, radio_2g_utilization: null, radio_5g_utilization: null },
+      ],
+      healthBySn: {
+        a: { health_score: 95, anomaly_count: 0 },
+        b: { health_score: 72, anomaly_count: 1 },
+        c: { health_score: 20, anomaly_count: 2 },
+      },
+      priorOnlineRate: 66.67,
+    });
+
+    expect(overview.totalDevices).toBe(3);
+    expect(overview.onlineDevices).toBe(2);
+    expect(overview.uptimePercent).toBeCloseTo(66.67, 1);
+    expect(overview.healthyDevices).toBe(1);
+    expect(overview.warningDevices).toBe(1);
+    expect(overview.criticalDevices).toBe(1);
+    expect(overview.offlineDevices).toBe(1);
+    expect(overview.successRatePercent).toBeCloseTo(33.33, 1); // healthy / total
+    expect(overview.responseConsistencyPercent).toBeCloseTo(66.67, 1); // score >= 50
+    expect(overview.totalClients).toBe(15);
+    expect(overview.resources.avgCpu).toBe(60);
+    expect(overview.uptimeDeltaVsPrior).toBeCloseTo(0, 1);
+  });
+});
+
+describe('buildDailyUptimeSeries', () => {
+  it('computes daily online rates for last N days', () => {
+    const series = buildDailyUptimeSeries({
+      days: 3,
+      now: new Date('2026-07-25T12:00:00Z'),
+      snapshots: [
+        { device_sn: 'a', status: 'online', captured_at: '2026-07-25T10:00:00Z' },
+        { device_sn: 'b', status: 'offline', captured_at: '2026-07-25T10:00:00Z' },
+        { device_sn: 'a', status: 'online', captured_at: '2026-07-24T10:00:00Z' },
+        { device_sn: 'b', status: 'online', captured_at: '2026-07-24T10:00:00Z' },
+        { device_sn: 'a', status: 'offline', captured_at: '2026-07-23T10:00:00Z' },
+      ],
+      deviceCount: 2,
+    });
+
+    expect(series).toHaveLength(3);
+    expect(series[0].date).toBe('2026-07-23');
+    expect(series[0].uptimePercent).toBe(0); // only offline snapshot that day for a; b missing → treat by samples
+    expect(series[1].uptimePercent).toBe(100);
+    expect(series[2].uptimePercent).toBe(50);
+  });
+});
+
+describe('classifyDeviceRole', () => {
+  it('detects gateway, switch, and AP from model/name', () => {
+    expect(classifyDeviceRole('TL-ER7206', 'Edge')).toBe('gateway');
+    expect(classifyDeviceRole('TL-SG2210MP', 'Core Switch')).toBe('switch');
+    expect(classifyDeviceRole('RAP2260', 'Lobby AP')).toBe('ap');
+    expect(classifyDeviceRole(null, 'OPERATIONSAP')).toBe('ap');
+  });
+});
+
+describe('computeNetworkInventory', () => {
+  it('counts roles and picks edge device', () => {
+    const inv = computeNetworkInventory([
+      {
+        sn: 'g1',
+        device_name: 'Edge',
+        model: 'ER7206',
+        status: 'online',
+        online_clients: 2,
+      },
+      {
+        sn: 's1',
+        device_name: 'Core Switch',
+        model: 'SG2210',
+        status: 'offline',
+        online_clients: 0,
+      },
+      {
+        sn: 'a1',
+        device_name: 'Lobby',
+        model: 'RAP2260',
+        status: 'online',
+        online_clients: 5,
+      },
+    ]);
+
+    expect(inv.gateway).toBe(1);
+    expect(inv.ap).toBe(1);
+    expect(inv.switchTotal).toBe(1);
+    expect(inv.switchOnline).toBe(0);
+    expect(inv.client).toBe(7);
+    expect(inv.guest).toBeNull();
+    expect(inv.edgeDevice?.sn).toBe('g1');
+  });
+});

--- a/__tests__/lib/ruijie/active-window.test.ts
+++ b/__tests__/lib/ruijie/active-window.test.ts
@@ -1,0 +1,60 @@
+import {
+  filterActiveDevices,
+  isDeviceActiveInWindow,
+} from '@/lib/ruijie/active-window';
+
+const NOW = Date.parse('2026-07-25T18:00:00.000Z');
+
+describe('isDeviceActiveInWindow', () => {
+  it('keeps currently online devices even without last_seen', () => {
+    expect(
+      isDeviceActiveInWindow({ sn: 'a', status: 'online', last_seen_at: null }, NOW)
+    ).toBe(true);
+  });
+
+  it('keeps offline devices seen within 14 days', () => {
+    expect(
+      isDeviceActiveInWindow(
+        {
+          sn: 'b',
+          status: 'offline',
+          last_seen_at: '2026-07-20T12:00:00.000Z',
+        },
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('drops offline devices older than 14 days', () => {
+    expect(
+      isDeviceActiveInWindow(
+        {
+          sn: 'c',
+          status: 'offline',
+          last_seen_at: '2026-07-01T12:00:00.000Z',
+        },
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it('drops offline devices with no last_seen', () => {
+    expect(
+      isDeviceActiveInWindow({ sn: 'd', status: 'offline', last_seen_at: null }, NOW)
+    ).toBe(false);
+  });
+});
+
+describe('filterActiveDevices', () => {
+  it('filters the fleet to the active window', () => {
+    const devices = [
+      { sn: 'on', status: 'online', last_seen_at: null },
+      { sn: 'recent', status: 'offline', last_seen_at: '2026-07-15T00:00:00.000Z' },
+      { sn: 'stale', status: 'offline', last_seen_at: '2026-06-01T00:00:00.000Z' },
+    ];
+    expect(filterActiveDevices(devices, NOW).map((d) => d.sn)).toEqual([
+      'on',
+      'recent',
+    ]);
+  });
+});

--- a/__tests__/lib/ruijie/performance-metrics.test.ts
+++ b/__tests__/lib/ruijie/performance-metrics.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Ruijie performance metric mappers (Tier 1 — current_performance + STA util)
+ */
+
+import {
+  aggregateStaMetricsForDevice,
+  buildHourlyFlowRequest,
+  mapCurrentPerformance,
+  pickFlowDeviceSn,
+  type StaUserRaw,
+} from '@/lib/ruijie/performance-metrics';
+
+describe('mapCurrentPerformance', () => {
+  it('maps cpuRate and memoryRate from current_performance payload', () => {
+    expect(
+      mapCurrentPerformance({
+        cpuRate: 30,
+        memoryRate: 63,
+        memoryFree: 114336,
+        flashRate: 67,
+        processNum: 179,
+      })
+    ).toEqual({
+      cpu_usage: 30,
+      memory_usage: 63,
+    });
+  });
+
+  it('returns nulls when rates are missing', () => {
+    expect(mapCurrentPerformance({})).toEqual({
+      cpu_usage: null,
+      memory_usage: null,
+    });
+  });
+});
+
+describe('aggregateStaMetricsForDevice', () => {
+  const stas: StaUserRaw[] = [
+    {
+      sn: 'AP-1',
+      mac: 'aa',
+      band: '2.4G',
+      channel: '6',
+      utilization: 40,
+      rssi: '-50',
+    },
+    {
+      sn: 'AP-1',
+      mac: 'bb',
+      band: '5G',
+      channel: '36',
+      utilization: 20,
+      rssi: '-55',
+    },
+    {
+      sn: 'AP-1',
+      mac: 'cc',
+      band: '5G',
+      channel: '36',
+      utilization: 30,
+      rssi: '-60',
+    },
+    {
+      sn: 'AP-2',
+      mac: 'dd',
+      band: '5G',
+      channel: '44',
+      utilization: 90,
+      rssi: '-40',
+    },
+  ];
+
+  it('counts clients and averages utilization by band for one AP', () => {
+    expect(aggregateStaMetricsForDevice(stas, 'AP-1')).toEqual({
+      online_clients: 3,
+      radio_2g_channel: 6,
+      radio_5g_channel: 36,
+      radio_2g_utilization: 40,
+      radio_5g_utilization: 25,
+    });
+  });
+
+  it('returns zeros/nulls when AP has no stations', () => {
+    expect(aggregateStaMetricsForDevice(stas, 'AP-MISSING')).toEqual({
+      online_clients: 0,
+      radio_2g_channel: null,
+      radio_5g_channel: null,
+      radio_2g_utilization: null,
+      radio_5g_utilization: null,
+    });
+  });
+});
+
+describe('buildHourlyFlowRequest', () => {
+  it('builds sn + startDate + endDate window (docs 2.6.2)', () => {
+    const end = 1_700_000_000_000;
+    const body = buildHourlyFlowRequest({ sn: 'EG-1', hours: 24, endMs: end });
+    expect(body).toEqual({
+      sn: 'EG-1',
+      startDate: end - 24 * 60 * 60 * 1000,
+      endDate: end,
+    });
+  });
+});
+
+describe('pickFlowDeviceSn', () => {
+  it('prefers online gateway/EG models', () => {
+    expect(
+      pickFlowDeviceSn([
+        { sn: 'AP-1', status: 'online', model: 'RAP2200' },
+        { sn: 'EG-9', status: 'online', model: 'EG2100' },
+        { sn: 'AP-2', status: 'offline', model: 'RAP2200' },
+      ])
+    ).toBe('EG-9');
+  });
+
+  it('falls back to first online device', () => {
+    expect(
+      pickFlowDeviceSn([
+        { sn: 'AP-1', status: 'offline', model: 'RAP2200' },
+        { sn: 'AP-2', status: 'online', model: 'RAP2200' },
+      ])
+    ).toBe('AP-2');
+  });
+});

--- a/app/admin/network/analytics/page.tsx
+++ b/app/admin/network/analytics/page.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
 import {
   PiArrowsClockwiseBold,
-  PiChartLineBold,
   PiArrowDownBold,
   PiArrowUpBold,
   PiClockBold,
   PiWifiHighBold,
   PiLightningBold,
   PiDatabaseBold,
+  PiBroadcastBold,
 } from 'react-icons/pi';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
@@ -20,11 +22,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { TrafficChart, AppFlowChart, formatBytes, formatBps } from '@/components/admin/network/TrafficChart';
-
-// =============================================================================
-// TYPES
-// =============================================================================
+import { TrafficChart, formatBytes, formatBps } from '@/components/admin/network/TrafficChart';
+import {
+  MetricCard,
+  BandwidthChart,
+  TopApplicationsCard,
+  AppCategoryBreakdown,
+  GroupTrafficCards,
+  SsidActivityCards,
+  RadioUtilSummaryCard,
+} from '@/components/admin/network/performance';
+import type { GroupTrafficCard, RadioUtilSummary, SsidActivityCard } from '@/lib/network/analytics-aggregates';
 
 interface TrafficDataPoint {
   timestamp: number;
@@ -34,6 +42,8 @@ interface TrafficDataPoint {
   rxPkts: number;
   txPkts: number;
   buildingId: number;
+  avgRxMbps?: number;
+  avgTxMbps?: number;
 }
 
 interface TrafficSummary {
@@ -44,6 +54,8 @@ interface TrafficSummary {
   avgTxRate: number;
   peakRxBytes: number;
   peakTxBytes: number;
+  avgRxMbps?: number;
+  avgTxMbps?: number;
   dataPoints: TrafficDataPoint[];
 }
 
@@ -55,22 +67,18 @@ interface AppFlowData {
   upDownFlow: number;
 }
 
-interface TrafficApiResponse {
-  groupId: string;
+interface AnalyticsApiResponse {
+  groups: Array<{ id: string; name: string }>;
+  groupId: string | null;
   hours: number;
+  source: 'supabase' | 'live';
   traffic: TrafficSummary;
   appFlow?: AppFlowData[];
+  groupTraffic?: GroupTrafficCard[];
+  ssidActivity?: SsidActivityCard[];
+  radio?: RadioUtilSummary;
   fetchedAt: string;
 }
-
-interface NetworkGroup {
-  id: number;
-  name: string;
-}
-
-// =============================================================================
-// HELPERS
-// =============================================================================
 
 function formatDuration(hours: number): string {
   if (hours < 24) return `${hours} hour${hours > 1 ? 's' : ''}`;
@@ -78,154 +86,137 @@ function formatDuration(hours: number): string {
   return `${days} day${days > 1 ? 's' : ''}`;
 }
 
-// =============================================================================
-// COMPONENT
-// =============================================================================
+const emptyRadio: RadioUtilSummary = {
+  avg2g: null,
+  avg5g: null,
+  avgBlended: null,
+  devicesWithRadio: 0,
+  totalDevices: 0,
+  channels2g: [],
+  channels5g: [],
+  byDevice: [],
+};
 
 export default function NetworkAnalyticsPage() {
-  const [data, setData] = useState<TrafficApiResponse | null>(null);
-  const [groups, setGroups] = useState<NetworkGroup[]>([]);
+  const [data, setData] = useState<AnalyticsApiResponse | null>(null);
+  const [groups, setGroups] = useState<Array<{ id: string; name: string }>>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>('');
   const [selectedHours, setSelectedHours] = useState<string>('24');
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [preferLive, setPreferLive] = useState(false);
 
-  // Fetch available groups
-  const fetchGroups = useCallback(async () => {
-    try {
-      const response = await fetch('/api/ruijie/devices', {
-        credentials: 'include',
-      });
-      if (!response.ok) return;
+  const fetchTrafficData = useCallback(
+    async (isRefresh = false, live = preferLive) => {
+      if (isRefresh) setRefreshing(true);
+      else setLoading(true);
 
-      const result = await response.json();
-      const devices = result.devices || [];
+      try {
+        const params = new URLSearchParams({
+          hours: selectedHours,
+          includeApps: 'true',
+        });
+        if (selectedGroupId) params.set('groupId', selectedGroupId);
+        if (live) params.set('live', 'true');
 
-      // Extract unique groups from devices
-      const groupMap = new Map<number, string>();
-      for (const device of devices) {
-        if (device.group_id && device.group_name) {
-          groupMap.set(parseInt(device.group_id, 10), device.group_name);
+        const response = await fetch(`/api/admin/network/analytics?${params}`, {
+          credentials: 'include',
+        });
+
+        if (!response.ok) throw new Error('Failed to fetch analytics');
+
+        const result: AnalyticsApiResponse = await response.json();
+        setData(result);
+        if (result.groups?.length) {
+          setGroups(result.groups);
+          if (!selectedGroupId && result.groupId) {
+            setSelectedGroupId(result.groupId);
+          }
         }
+        setError(null);
+      } catch (err) {
+        setError('Failed to load traffic analytics');
+        console.error(err);
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
       }
+    },
+    [selectedGroupId, selectedHours, preferLive]
+  );
 
-      const groupList = Array.from(groupMap.entries()).map(([id, name]) => ({
-        id,
-        name,
-      }));
-
-      setGroups(groupList);
-
-      // Select first group if none selected
-      if (groupList.length > 0 && !selectedGroupId) {
-        setSelectedGroupId(String(groupList[0].id));
-      }
-    } catch (err) {
-      console.error('Failed to fetch groups:', err);
-    }
-  }, [selectedGroupId]);
-
-  // Fetch traffic data
-  const fetchTrafficData = useCallback(async (isRefresh = false) => {
-    if (!selectedGroupId) {
-      setLoading(false);
-      return;
-    }
-
-    if (isRefresh) setRefreshing(true);
-    else setLoading(true);
-
-    try {
-      const params = new URLSearchParams({
-        groupId: selectedGroupId,
-        hours: selectedHours,
-        includeApps: 'true',
-      });
-
-      const response = await fetch(`/api/ruijie/traffic?${params}`, {
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch traffic data');
-      }
-
-      const result: TrafficApiResponse = await response.json();
-      setData(result);
-      setError(null);
-    } catch (err) {
-      setError('Failed to load traffic data');
-      console.error(err);
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  }, [selectedGroupId, selectedHours]);
-
-  // Initial load
   useEffect(() => {
-    fetchGroups();
-  }, [fetchGroups]);
+    fetchTrafficData();
+  }, [fetchTrafficData]);
 
-  // Fetch data when group or time range changes
   useEffect(() => {
-    if (selectedGroupId) {
-      fetchTrafficData();
-    }
-  }, [selectedGroupId, selectedHours, fetchTrafficData]);
-
-  // Auto-refresh every 5 minutes
-  useEffect(() => {
-    if (!selectedGroupId) return;
     const interval = setInterval(() => fetchTrafficData(true), 5 * 60 * 1000);
     return () => clearInterval(interval);
-  }, [selectedGroupId, fetchTrafficData]);
+  }, [fetchTrafficData]);
 
-  const selectedGroup = groups.find(g => String(g.id) === selectedGroupId);
+  const selectedGroup = groups.find((g) => g.id === selectedGroupId);
+
+  const bandwidthSeries =
+    data?.traffic.dataPoints.map((p) => ({
+      captured_at: p.timeString,
+      avgRxMbps: p.avgRxMbps ?? 0,
+      avgTxMbps: p.avgTxMbps ?? 0,
+      avgThroughputMbps: (p.avgRxMbps ?? 0) + (p.avgTxMbps ?? 0),
+    })) ?? [];
 
   if (loading && !data) {
     return (
       <div className="space-y-6">
-        <div className="h-8 w-48 bg-gray-100 rounded animate-pulse" />
+        <div className="h-8 w-56 bg-slate-100 rounded animate-pulse" />
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-28 bg-gray-100 rounded-lg animate-pulse" />
+            <div key={i} className="h-28 bg-slate-100 rounded-xl animate-pulse" />
           ))}
         </div>
-        <div className="h-[400px] bg-gray-100 rounded-lg animate-pulse" />
+        <div className="h-[350px] bg-slate-100 rounded-xl animate-pulse" />
       </div>
     );
   }
 
+  const appFlow = data?.appFlow ?? [];
+  const groupTraffic = data?.groupTraffic ?? [];
+  const ssidActivity = data?.ssidActivity ?? [];
+  const radio = data?.radio ?? emptyRadio;
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+    <div className="space-y-6 -mx-1">
+      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Bandwidth Analytics</h1>
-          <p className="text-gray-500 mt-1">
-            Network traffic monitoring and application usage
+          <p className="text-xs text-slate-400 mb-1">Activity / Infrastructure / Analytics</p>
+          <h1 className="text-2xl font-semibold text-slate-900 tracking-tight">
+            Network Analytics
+          </h1>
+          <p className="text-slate-500 mt-1 text-sm">
+            Group-scoped Ruijie throughput · app-flow · radio util from cache
           </p>
         </div>
-        <div className="flex items-center gap-3">
-          {/* Group Selector */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/admin/network/health">System Health</Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/admin/network/devices">Devices</Link>
+          </Button>
           <Select value={selectedGroupId} onValueChange={setSelectedGroupId}>
-            <SelectTrigger className="w-[200px]">
+            <SelectTrigger className="w-[200px] rounded-lg border-slate-200">
               <SelectValue placeholder="Select network group" />
             </SelectTrigger>
             <SelectContent>
               {groups.map((group) => (
-                <SelectItem key={group.id} value={String(group.id)}>
+                <SelectItem key={group.id} value={group.id}>
                   {group.name}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
-
-          {/* Time Range Selector */}
           <Select value={selectedHours} onValueChange={setSelectedHours}>
-            <SelectTrigger className="w-[130px]">
+            <SelectTrigger className="w-[140px] rounded-lg border-slate-200">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -236,235 +227,146 @@ export default function NetworkAnalyticsPage() {
               <SelectItem value="168">Last 7 days</SelectItem>
             </SelectContent>
           </Select>
-
-          {/* Refresh Button */}
+          <Button
+            variant={preferLive ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => {
+              const next = !preferLive;
+              setPreferLive(next);
+              fetchTrafficData(true, next);
+            }}
+          >
+            <PiBroadcastBold className="w-4 h-4 mr-2" />
+            {preferLive ? 'Live' : 'Cached'}
+          </Button>
           <Button
             variant="outline"
             size="sm"
             onClick={() => fetchTrafficData(true)}
-            disabled={refreshing || !selectedGroupId}
+            disabled={refreshing}
           >
-            <PiArrowsClockwiseBold
-              className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`}
-            />
+            <PiArrowsClockwiseBold className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
             Refresh
           </Button>
         </div>
       </div>
 
-      {/* Error State */}
-      {error && (
-        <Card className="border-red-200 bg-red-50">
+      {error ? (
+        <Card className="border-red-200 bg-red-50 rounded-xl">
           <CardContent className="py-4">
             <p className="text-red-700">{error}</p>
           </CardContent>
         </Card>
-      )}
+      ) : null}
 
-      {/* No Group Selected */}
-      {!selectedGroupId && groups.length === 0 && (
-        <Card>
+      {!selectedGroupId && groups.length === 0 ? (
+        <Card className="rounded-xl border-slate-200">
           <CardContent className="py-12 text-center">
-            <PiWifiHighBold className="w-12 h-12 mx-auto mb-4 text-gray-400" />
-            <p className="text-gray-600">No network groups found</p>
-            <p className="text-sm text-gray-500 mt-1">
-              Sync devices first to view traffic analytics
+            <PiWifiHighBold className="w-12 h-12 mx-auto mb-4 text-slate-300" />
+            <p className="text-slate-600">No network groups found</p>
+            <p className="text-sm text-slate-500 mt-1">
+              Sync Ruijie devices first to view traffic analytics
             </p>
           </CardContent>
         </Card>
-      )}
+      ) : null}
 
-      {/* Data Display */}
-      {data && (
+      {data ? (
         <>
-          {/* Summary Stats */}
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="outline"
+              className={
+                data.source === 'live'
+                  ? 'border-blue-200 bg-blue-50 text-blue-700'
+                  : 'border-slate-200 bg-slate-50 text-slate-600'
+              }
+            >
+              Source: {data.source === 'live' ? 'Ruijie live' : 'Supabase rollups'}
+            </Badge>
+            <span className="text-xs text-slate-400">
+              {selectedGroup?.name || 'Network'} · {formatDuration(parseInt(selectedHours, 10))}
+            </span>
+          </div>
+
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm text-gray-500">Total Download</p>
-                    <p className="text-2xl font-bold text-emerald-600">
-                      {formatBytes(data.traffic.totalRxBytes)}
-                    </p>
-                    <p className="text-xs text-gray-400 mt-1">
-                      Avg: {formatBps(data.traffic.avgRxRate)}
-                    </p>
-                  </div>
-                  <div className="p-3 bg-emerald-100 rounded-full">
-                    <PiArrowDownBold className="w-6 h-6 text-emerald-600" />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+            <MetricCard
+              title="Total Download"
+              value={formatBytes(data.traffic.totalRxBytes)}
+              subtitle={`Avg ${formatBps(data.traffic.avgRxRate)}`}
+            >
+              <PiArrowDownBold className="w-5 h-5 text-emerald-600" />
+            </MetricCard>
+            <MetricCard
+              title="Total Upload"
+              value={formatBytes(data.traffic.totalTxBytes)}
+              subtitle={`Avg ${formatBps(data.traffic.avgTxRate)}`}
+            >
+              <PiArrowUpBold className="w-5 h-5 text-blue-600" />
+            </MetricCard>
+            <MetricCard
+              title="Peak Download / window"
+              value={formatBytes(data.traffic.peakRxBytes)}
+              subtitle={formatDuration(parseInt(selectedHours, 10))}
+            >
+              <PiLightningBold className="w-5 h-5 text-amber-600" />
+            </MetricCard>
+            <MetricCard
+              title="Total Traffic"
+              value={formatBytes(data.traffic.totalBytes)}
+              subtitle={`${data.traffic.dataPoints.length} data points`}
+            >
+              <PiDatabaseBold className="w-5 h-5 text-slate-500" />
+            </MetricCard>
+          </div>
 
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm text-gray-500">Total Upload</p>
-                    <p className="text-2xl font-bold text-blue-600">
-                      {formatBytes(data.traffic.totalTxBytes)}
-                    </p>
-                    <p className="text-xs text-gray-400 mt-1">
-                      Avg: {formatBps(data.traffic.avgTxRate)}
-                    </p>
-                  </div>
-                  <div className="p-3 bg-blue-100 rounded-full">
-                    <PiArrowUpBold className="w-6 h-6 text-blue-600" />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+          <GroupTrafficCards
+            groups={groupTraffic}
+            selectedGroupId={selectedGroupId}
+            onSelectGroup={setSelectedGroupId}
+          />
 
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm text-gray-500">Peak Download/hr</p>
-                    <p className="text-2xl font-bold text-gray-900">
-                      {formatBytes(data.traffic.peakRxBytes)}
-                    </p>
-                    <p className="text-xs text-gray-400 mt-1">
-                      In {formatDuration(parseInt(selectedHours))}
-                    </p>
-                  </div>
-                  <div className="p-3 bg-orange-100 rounded-full">
-                    <PiLightningBold className="w-6 h-6 text-orange-600" />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+            <div className="xl:col-span-2">
+              <TrafficChart
+                dataPoints={data.traffic.dataPoints}
+                title={`Traffic — ${selectedGroup?.name || 'Network'}`}
+                height={350}
+              />
+            </div>
+            <BandwidthChart
+              data={bandwidthSeries}
+              title="Throughput (Mbps)"
+              subtitle="From rollup avg rates"
+              height={300}
+            />
+          </div>
 
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm text-gray-500">Total Traffic</p>
-                    <p className="text-2xl font-bold text-gray-900">
-                      {formatBytes(data.traffic.totalBytes)}
-                    </p>
-                    <p className="text-xs text-gray-400 mt-1">
-                      {data.traffic.dataPoints.length} data points
-                    </p>
-                  </div>
-                  <div className="p-3 bg-gray-100 rounded-full">
-                    <PiDatabaseBold className="w-6 h-6 text-gray-600" />
-                  </div>
-                </div>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <TopApplicationsCard data={appFlow} maxItems={10} />
+            <Card className="rounded-xl border-slate-200/80 shadow-sm border bg-white">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base font-semibold text-slate-900">
+                  Traffic by Category
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <AppCategoryBreakdown data={appFlow} />
               </CardContent>
             </Card>
           </div>
 
-          {/* Traffic Chart */}
-          <TrafficChart
-            dataPoints={data.traffic.dataPoints}
-            title={`Traffic - ${selectedGroup?.name || 'Network'} (${formatDuration(parseInt(selectedHours))})`}
-            height={350}
-          />
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <SsidActivityCards ssids={ssidActivity} />
+            <RadioUtilSummaryCard radio={radio} />
+          </div>
 
-          {/* App Flow Chart */}
-          {data.appFlow && data.appFlow.length > 0 && (
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <AppFlowChart
-                data={data.appFlow}
-                title="Top Applications by Traffic"
-                maxItems={10}
-              />
-
-              {/* App Categories Summary */}
-              <Card>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-lg">Traffic by Category</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <CategoryBreakdown data={data.appFlow} />
-                </CardContent>
-              </Card>
-            </div>
-          )}
-
-          {/* Last Updated */}
-          <div className="flex items-center justify-end gap-2 text-sm text-gray-500">
+          <div className="flex items-center justify-end gap-2 text-sm text-slate-500">
             <PiClockBold className="w-4 h-4" />
             Last updated: {new Date(data.fetchedAt).toLocaleString('en-ZA')}
           </div>
         </>
-      )}
-    </div>
-  );
-}
-
-// =============================================================================
-// CATEGORY BREAKDOWN COMPONENT
-// =============================================================================
-
-interface CategoryBreakdownProps {
-  data: AppFlowData[];
-}
-
-function CategoryBreakdown({ data }: CategoryBreakdownProps) {
-  // Group by category
-  const categories = data.reduce((acc, app) => {
-    const cat = app.appGroupName || 'Other';
-    if (!acc[cat]) {
-      acc[cat] = { total: 0, apps: 0 };
-    }
-    acc[cat].total += app.upDownFlow;
-    acc[cat].apps += 1;
-    return acc;
-  }, {} as Record<string, { total: number; apps: number }>);
-
-  const sortedCategories = Object.entries(categories)
-    .sort(([, a], [, b]) => b.total - a.total);
-
-  const totalTraffic = data.reduce((sum, app) => sum + app.upDownFlow, 0);
-
-  const categoryColors: Record<string, string> = {
-    Streaming: 'bg-purple-500',
-    Social: 'bg-blue-500',
-    Work: 'bg-green-500',
-    Gaming: 'bg-red-500',
-    Other: 'bg-gray-500',
-  };
-
-  return (
-    <div className="space-y-4">
-      {sortedCategories.map(([category, stats]) => {
-        const percentage = totalTraffic > 0
-          ? (stats.total / totalTraffic) * 100
-          : 0;
-
-        return (
-          <div key={category}>
-            <div className="flex items-center justify-between mb-1">
-              <div className="flex items-center gap-2">
-                <div
-                  className={`w-3 h-3 rounded-full ${categoryColors[category] || 'bg-gray-400'}`}
-                />
-                <span className="font-medium text-sm text-gray-900">
-                  {category}
-                </span>
-                <span className="text-xs text-gray-500">
-                  ({stats.apps} app{stats.apps > 1 ? 's' : ''})
-                </span>
-              </div>
-              <div className="flex items-center gap-2 text-sm">
-                <span className="font-medium">{formatBytes(stats.total)}</span>
-                <span className="text-gray-400 w-12 text-right">
-                  {percentage.toFixed(0)}%
-                </span>
-              </div>
-            </div>
-            <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
-              <div
-                className={`h-full ${categoryColors[category] || 'bg-gray-400'} rounded-full transition-all`}
-                style={{ width: `${percentage}%` }}
-              />
-            </div>
-          </div>
-        );
-      })}
+      ) : null}
     </div>
   );
 }

--- a/app/admin/network/devices/page.tsx
+++ b/app/admin/network/devices/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import { PiArrowsClockwiseBold, PiWarningBold } from 'react-icons/pi';
+import Link from 'next/link';
+import { PiArrowsClockwiseBold, PiWarningBold, PiWarningCircleBold } from 'react-icons/pi';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -16,11 +17,16 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import {
-  DeviceStatCards,
   DeviceFilters,
   DeviceTable,
   DeviceCard,
 } from '@/components/admin/network';
+import {
+  MetricCard,
+  NetworkOverviewTiles,
+  type NetworkInventory,
+} from '@/components/admin/network/performance';
+import { computeNetworkInventory } from '@/lib/network/performance-aggregates';
 
 interface RuijieDevice {
   sn: string;
@@ -29,6 +35,8 @@ interface RuijieDevice {
   group_name: string | null;
   management_ip: string | null;
   online_clients: number;
+  cpu_usage?: number | null;
+  memory_usage?: number | null;
   status: string;
   config_status: string | null;
   synced_at: string;
@@ -68,53 +76,52 @@ export default function RuijieDevicesPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Filters from URL
   const [search, setSearch] = useState(searchParams.get('search') || '');
   const [statusFilter, setStatusFilter] = useState(searchParams.get('status') || '');
   const [groupFilter, setGroupFilter] = useState(searchParams.get('group') || '');
   const [modelFilter, setModelFilter] = useState(searchParams.get('model') || '');
 
-  // Reboot dialog
   const [rebootDevice, setRebootDevice] = useState<RuijieDevice | null>(null);
   const [rebooting, setRebooting] = useState(false);
 
-  // Tunnel count
-  const [tunnelCount, setTunnelCount] = useState(0);
+  const [tunnelCount] = useState(0);
   const TUNNEL_LIMIT = 10;
 
-  const fetchDevices = useCallback(async (isRefresh = false) => {
-    if (isRefresh) setRefreshing(true);
-    try {
-      const params = new URLSearchParams();
-      if (search) params.set('search', search);
-      if (statusFilter) params.set('status', statusFilter);
-      if (groupFilter) params.set('group', groupFilter);
-      if (modelFilter) params.set('model', modelFilter);
+  const fetchDevices = useCallback(
+    async (isRefresh = false) => {
+      if (isRefresh) setRefreshing(true);
+      try {
+        const params = new URLSearchParams();
+        if (search) params.set('search', search);
+        if (statusFilter) params.set('status', statusFilter);
+        if (groupFilter) params.set('group', groupFilter);
+        if (modelFilter) params.set('model', modelFilter);
 
-      const response = await fetch(`/api/ruijie/devices?${params.toString()}`, {
-        credentials: 'include',
-      });
-      if (!response.ok) throw new Error('Failed to fetch devices');
+        const response = await fetch(`/api/ruijie/devices?${params.toString()}`, {
+          credentials: 'include',
+        });
+        if (!response.ok) throw new Error('Failed to fetch devices');
 
-      const result = await response.json();
-      setData(result);
-      setError(null);
-    } catch (err) {
-      setError('Failed to load devices');
-      console.error(err);
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  }, [search, statusFilter, groupFilter, modelFilter]);
+        const result = await response.json();
+        setData(result);
+        setError(null);
+      } catch (err) {
+        setError('Failed to load devices');
+        console.error(err);
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [search, statusFilter, groupFilter, modelFilter]
+  );
 
   useEffect(() => {
     fetchDevices();
-    const interval = setInterval(() => fetchDevices(), 30000); // Refresh every 30s
+    const interval = setInterval(() => fetchDevices(), 30000);
     return () => clearInterval(interval);
   }, [fetchDevices]);
 
-  // Update URL when filters change
   useEffect(() => {
     const params = new URLSearchParams();
     if (search) params.set('search', search);
@@ -130,8 +137,7 @@ export default function RuijieDevicesPage() {
     setRefreshing(true);
     try {
       await fetch('/api/ruijie/sync', { method: 'POST', credentials: 'include' });
-      // Wait a moment for sync to start, then fetch fresh data
-      await new Promise(r => setTimeout(r, 2000));
+      await new Promise((r) => setTimeout(r, 2000));
       await fetchDevices(true);
     } catch (err) {
       console.error('Failed to trigger sync:', err);
@@ -146,7 +152,7 @@ export default function RuijieDevicesPage() {
     try {
       const response = await fetch(`/api/ruijie/reboot/${rebootDevice.sn}`, {
         method: 'POST',
-        credentials: 'include'
+        credentials: 'include',
       });
       if (!response.ok) throw new Error('Reboot failed');
       setRebootDevice(null);
@@ -160,8 +166,20 @@ export default function RuijieDevicesPage() {
   const handleExportCSV = () => {
     if (!data?.devices) return;
 
-    const headers = ['Device Name', 'Model', 'SN', 'Group', 'Status', 'Config Status', 'Mgmt IP', 'Clients', 'Last Synced'];
-    const rows = data.devices.map(d => [
+    const headers = [
+      'Device Name',
+      'Model',
+      'SN',
+      'Group',
+      'Status',
+      'Config Status',
+      'Mgmt IP',
+      'CPU %',
+      'Mem %',
+      'Clients',
+      'Last Synced',
+    ];
+    const rows = data.devices.map((d) => [
       d.device_name,
       d.model || '',
       d.sn,
@@ -169,11 +187,13 @@ export default function RuijieDevicesPage() {
       d.status,
       d.config_status || '',
       d.management_ip || '',
+      d.cpu_usage == null ? '' : String(Math.round(d.cpu_usage)),
+      d.memory_usage == null ? '' : String(Math.round(d.memory_usage)),
       d.online_clients.toString(),
       d.synced_at,
     ]);
 
-    const csv = [headers.join(','), ...rows.map(r => r.join(','))].join('\n');
+    const csv = [headers.join(','), ...rows.map((r) => r.join(','))].join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -182,53 +202,93 @@ export default function RuijieDevicesPage() {
     a.click();
   };
 
-  // Check if data is stale (> 15 mins)
-  const isStale = data?.lastSynced &&
-    (Date.now() - new Date(data.lastSynced).getTime()) > 15 * 60 * 1000;
+  const isStale =
+    data?.lastSynced &&
+    Date.now() - new Date(data.lastSynced).getTime() > 15 * 60 * 1000;
+
+  const inventory: NetworkInventory = useMemo(() => {
+    const devices = data?.devices || [];
+    const computed = computeNetworkInventory(devices);
+    return {
+      gateway: computed.gateway,
+      ap: computed.ap,
+      switch: { online: computed.switchOnline, total: computed.switchTotal },
+      client: computed.client,
+      guest: computed.guest,
+    };
+  }, [data?.devices]);
 
   if (loading) {
     return (
       <div className="space-y-6">
-        {/* Skeleton stat cards */}
-        <div className="grid grid-cols-2 xl:grid-cols-4 gap-4">
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-28 bg-gray-100 rounded-lg animate-pulse" />
+        <div className="h-8 w-56 bg-slate-100 rounded animate-pulse" />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-48 bg-slate-100 rounded-xl animate-pulse" />
           ))}
         </div>
-        {/* Skeleton filter bar */}
-        <div className="h-16 bg-gray-100 rounded-lg animate-pulse" />
-        {/* Skeleton table */}
-        <div className="h-64 bg-gray-100 rounded-lg animate-pulse" />
+        <div className="h-64 bg-slate-100 rounded-xl animate-pulse" />
       </div>
     );
   }
 
-  const onlineCount = data?.devices.filter((d) => d.status === 'online').length || 0;
-  const offlineCount = data?.devices.filter((d) => d.status === 'offline').length || 0;
-  const isMockData = data?.devices.every((d) => d.mock_data) && (data?.devices.length || 0) > 0;
+  if (error && !data) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[400px] gap-4">
+        <PiWarningCircleBold className="w-12 h-12 text-red-500" />
+        <p className="text-slate-600">{error}</p>
+        <Button onClick={() => fetchDevices()}>Retry</Button>
+      </div>
+    );
+  }
+
+  const devices = data?.devices || [];
+  const onlineCount = devices.filter((d) => d.status === 'online').length;
+  const offlineCount = devices.filter((d) => d.status === 'offline').length;
+  const totalClients = devices.reduce((sum, d) => sum + (d.online_clients || 0), 0);
+  const withCpu = devices.filter((d) => d.cpu_usage != null).length;
+  const isMockData = devices.length > 0 && devices.every((d) => d.mock_data);
+  const onlinePercent =
+    devices.length > 0 ? Math.round((onlineCount / devices.length) * 100) : 0;
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+    <div className="space-y-6 -mx-1">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Network Devices</h1>
-          <p className="text-gray-500 mt-1">
-            Ruijie Cloud managed devices
+          <p className="text-xs text-slate-400 mb-1">Activity / Infrastructure / Devices</p>
+          <h1 className="text-2xl font-semibold text-slate-900 tracking-tight">Devices</h1>
+          <p className="text-slate-500 mt-1 text-sm">
+            Ruijie Cloud managed fleet · {data?.total || 0} devices · {totalClients} clients
             {data?.lastSynced && (
-              <span className="ml-2 text-sm">
-                • Last synced {formatRelativeTime(data.lastSynced)}
-              </span>
+              <span> · Last synced {formatRelativeTime(data.lastSynced)}</span>
             )}
           </p>
         </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/admin/network/health">System Health</Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/admin/network/analytics">Open Analytics</Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={refreshing}
+          >
+            <PiArrowsClockwiseBold
+              className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`}
+            />
+            Refresh
+          </Button>
+        </div>
       </div>
 
-      {/* Mock Data Banner */}
       {isMockData && (
-        <Card className="border-purple-200 bg-purple-50">
+        <Card className="border border-purple-200/80 bg-purple-50/80 shadow-sm rounded-xl">
           <CardContent className="py-3">
-            <div className="flex items-center gap-2 text-purple-800">
+            <div className="flex items-center gap-2 text-purple-800 text-sm">
               <span className="w-2 h-2 rounded-full bg-purple-500" />
               <span className="font-medium">
                 Displaying mock data — Connect Ruijie API for live data
@@ -238,15 +298,15 @@ export default function RuijieDevicesPage() {
         </Card>
       )}
 
-      {/* Stale Warning */}
       {isStale && (
-        <Card className="border-2 border-yellow-200 bg-yellow-50">
+        <Card className="border border-amber-200/80 bg-amber-50/80 shadow-sm rounded-xl">
           <CardContent className="py-3">
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
-                <PiWarningBold className="w-5 h-5 text-yellow-600" />
-                <span className="text-yellow-800 font-medium">
-                  Device data may be outdated — last synced {formatRelativeTime(data?.lastSynced || '')}
+                <PiWarningBold className="w-5 h-5 text-amber-600" />
+                <span className="text-amber-800 text-sm font-medium">
+                  Device data may be outdated — last synced{' '}
+                  {formatRelativeTime(data?.lastSynced || '')}
                 </span>
               </div>
               <Button
@@ -254,7 +314,7 @@ export default function RuijieDevicesPage() {
                 size="sm"
                 onClick={handleRefresh}
                 disabled={refreshing}
-                className="border-yellow-300 text-yellow-700 hover:bg-yellow-100"
+                className="border-amber-300 text-amber-800 hover:bg-amber-100"
               >
                 Refresh Now
               </Button>
@@ -263,18 +323,23 @@ export default function RuijieDevicesPage() {
         </Card>
       )}
 
-      {/* Stat Cards */}
-      <DeviceStatCards
-        total={data?.total || 0}
-        online={onlineCount}
-        offline={offlineCount}
-        activeTunnels={tunnelCount}
-        tunnelLimit={TUNNEL_LIMIT}
-        activeFilter={statusFilter}
-        onFilterChange={setStatusFilter}
-      />
+      <div className="grid grid-cols-1 xl:grid-cols-[1fr_280px_280px] gap-4">
+        <NetworkOverviewTiles inventory={inventory} />
+        <MetricCard
+          title="Online Devices"
+          value={`${onlineCount}`}
+          subtitle={`${onlinePercent}% of visible fleet`}
+          delta={`${offlineCount} offline`}
+          deltaPositive={offlineCount === 0}
+        />
+        <MetricCard
+          title="Telemetry Coverage"
+          value={`${withCpu}`}
+          subtitle="Devices with live CPU/mem"
+          delta={`${totalClients} clients online`}
+        />
+      </div>
 
-      {/* Filters */}
       <DeviceFilters
         search={search}
         onSearchChange={setSearch}
@@ -286,22 +351,19 @@ export default function RuijieDevicesPage() {
         onModelChange={setModelFilter}
         groups={data?.filters.groups || []}
         models={data?.filters.models || []}
-        onRefresh={handleRefresh}
         onExport={handleExportCSV}
-        refreshing={refreshing}
       />
 
-      {/* Device List - Table on desktop, Cards on mobile */}
       <div className="hidden md:block">
         <DeviceTable
-          devices={data?.devices || []}
+          devices={devices}
           tunnelLimitReached={tunnelCount >= TUNNEL_LIMIT}
           onReboot={setRebootDevice}
           formatRelativeTime={formatRelativeTime}
         />
       </div>
       <div className="md:hidden space-y-3">
-        {data?.devices.map((device) => (
+        {devices.map((device) => (
           <DeviceCard
             key={device.sn}
             device={device}
@@ -310,22 +372,24 @@ export default function RuijieDevicesPage() {
             formatRelativeTime={formatRelativeTime}
           />
         ))}
-        {data?.devices.length === 0 && (
-          <Card>
-            <CardContent className="py-8 text-center text-gray-500">
+        {devices.length === 0 && (
+          <Card className="border border-slate-200/80 shadow-sm rounded-xl">
+            <CardContent className="py-8 text-center text-slate-400">
               No devices found
             </CardContent>
           </Card>
         )}
       </div>
 
-      {/* Footer */}
-      <div className="flex items-center justify-between text-sm text-gray-500">
-        <span>Showing {data?.devices.length || 0} of {data?.total || 0} devices</span>
-        <span>Active tunnels: {tunnelCount}/{TUNNEL_LIMIT}</span>
+      <div className="flex items-center justify-between text-xs text-slate-500">
+        <span>
+          Showing {devices.length} of {data?.total || 0} devices
+        </span>
+        <span>
+          Active tunnels: {tunnelCount}/{TUNNEL_LIMIT}
+        </span>
       </div>
 
-      {/* Reboot Confirmation Dialog */}
       <AlertDialog open={!!rebootDevice} onOpenChange={() => setRebootDevice(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/app/admin/network/health/page.tsx
+++ b/app/admin/network/health/page.tsx
@@ -1,43 +1,62 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
 import {
   PiArrowsClockwiseBold,
-  PiHeartbeatBold,
-  PiWarningBold,
-  PiCheckCircleBold,
-  PiXCircleBold,
-  PiCaretRightBold,
-  PiClockBold,
-  PiWifiHighBold,
-  PiTrendUpBold,
-  PiTrendDownBold,
+  PiCpuBold,
+  PiMemoryBold,
+  PiBroadcastBold,
   PiWarningCircleBold,
-  PiUsersBold,
 } from 'react-icons/pi';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import Link from 'next/link';
+import {
+  MetricCard,
+  DotMatrixChart,
+  SegmentedBar,
+  ResourceUsageList,
+  BandwidthChart,
+  DevicesMonitorTable,
+  NetworkOverviewTiles,
+  PendingAlertsCard,
+  EdgeDeviceCard,
+  type NetworkInventory,
+  type EdgeDeviceInfo,
+} from '@/components/admin/network/performance';
 
-// =============================================================================
-// TYPES
-// =============================================================================
-
-interface NetworkHealthOverview {
+type HealthOverview = {
   overallScore: number;
   totalDevices: number;
   healthyDevices: number;
   warningDevices: number;
   criticalDevices: number;
   offlineDevices: number;
+  onlineDevices: number;
   totalClients: number;
   anomaliesLast24h: number;
-}
+  uptimePercent: number;
+  uptimeDeltaVsPrior: number | null;
+  successRatePercent: number;
+  failedSharePercent: number;
+  responseConsistencyPercent: number;
+  resources: {
+    avgCpu: number | null;
+    avgMemory: number | null;
+    avgRadio: number | null;
+    updatedAt: string | null;
+  };
+  bandwidth: {
+    avgThroughputMbps: number | null;
+    avgRxMbps: number | null;
+    avgTxMbps: number | null;
+    deltaPercent: number | null;
+  };
+};
 
-interface DeviceHealthSummary {
+type DeviceRow = {
   sn: string;
   device_name: string;
+  model?: string | null;
   group_name: string | null;
   customer_name: string | null;
   status: string;
@@ -46,9 +65,11 @@ interface DeviceHealthSummary {
   anomaly_count: number;
   last_anomaly_type: string | null;
   last_anomaly_at: string | null;
-}
+  synced_at?: string | null;
+  last_seen_at?: string | null;
+};
 
-interface HealthAlert {
+type HealthAlert = {
   id: string;
   device_sn: string;
   device_name?: string;
@@ -58,72 +79,37 @@ interface HealthAlert {
   message: string;
   acknowledged: boolean;
   created_at: string;
-}
+};
 
-interface HealthDashboardData {
-  overview: NetworkHealthOverview;
-  devicesByHealth: DeviceHealthSummary[];
+type HealthDashboardData = {
+  overview: HealthOverview;
+  inventory?: NetworkInventory;
+  edgeDevice?: EdgeDeviceInfo | null;
+  uptimeSeries: Array<{ date: string; uptimePercent: number; sampleCount: number }>;
+  bandwidthSeries: Array<{
+    captured_at: string;
+    avgRxMbps: number;
+    avgTxMbps: number;
+    avgThroughputMbps: number;
+  }>;
+  devicesByHealth: DeviceRow[];
   unacknowledgedAlerts: HealthAlert[];
-  recentAnomalies: DeviceHealthSummary[];
+  recentAnomalies: DeviceRow[];
+};
+
+function formatDelta(delta: number | null, suffix = ''): string | null {
+  if (delta == null) return null;
+  const sign = delta > 0 ? '+' : '';
+  return `${sign}${delta.toFixed(2)}%${suffix}`;
 }
 
-// =============================================================================
-// HELPERS
-// =============================================================================
-
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-
-  if (diffMins < 1) return 'Just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  const diffHours = Math.floor(diffMins / 60);
-  if (diffHours < 24) return `${diffHours}h ago`;
-  const diffDays = Math.floor(diffHours / 24);
-  return `${diffDays}d ago`;
+function formatRelative(iso: string | null): string {
+  if (!iso) return '—';
+  const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min ago`;
+  return `${Math.floor(mins / 60)}h ago`;
 }
-
-function getHealthColor(score: number): string {
-  if (score >= 80) return 'text-green-600 bg-green-50 border-green-200';
-  if (score >= 50) return 'text-yellow-600 bg-yellow-50 border-yellow-200';
-  return 'text-red-600 bg-red-50 border-red-200';
-}
-
-function getHealthLabel(score: number): string {
-  if (score >= 80) return 'Healthy';
-  if (score >= 50) return 'Warning';
-  return 'Critical';
-}
-
-function getSeverityColor(severity: string): string {
-  switch (severity) {
-    case 'critical':
-      return 'bg-red-100 text-red-800 border-red-300';
-    case 'warning':
-      return 'bg-yellow-100 text-yellow-800 border-yellow-300';
-    default:
-      return 'bg-blue-100 text-blue-800 border-blue-300';
-  }
-}
-
-function getAnomalyIcon(type: string | null) {
-  switch (type) {
-    case 'client_spike':
-      return <PiTrendUpBold className="w-4 h-4 text-orange-500" />;
-    case 'client_drop':
-      return <PiTrendDownBold className="w-4 h-4 text-red-500" />;
-    case 'offline_flap':
-      return <PiWarningCircleBold className="w-4 h-4 text-red-500" />;
-    default:
-      return <PiWarningBold className="w-4 h-4 text-yellow-500" />;
-  }
-}
-
-// =============================================================================
-// COMPONENT
-// =============================================================================
 
 export default function NetworkHealthPage() {
   const [data, setData] = useState<HealthDashboardData | null>(null);
@@ -135,13 +121,9 @@ export default function NetworkHealthPage() {
   const fetchData = useCallback(async (isRefresh = false) => {
     if (isRefresh) setRefreshing(true);
     try {
-      const response = await fetch('/api/admin/network/health', {
-        credentials: 'include',
-      });
+      const response = await fetch('/api/admin/network/health', { credentials: 'include' });
       if (!response.ok) throw new Error('Failed to fetch health data');
-
-      const result = await response.json();
-      setData(result);
+      setData(await response.json());
       setError(null);
     } catch (err) {
       setError('Failed to load health data');
@@ -154,7 +136,7 @@ export default function NetworkHealthPage() {
 
   useEffect(() => {
     fetchData();
-    const interval = setInterval(() => fetchData(), 60000); // Refresh every minute
+    const interval = setInterval(() => fetchData(), 60000);
     return () => clearInterval(interval);
   }, [fetchData]);
 
@@ -177,13 +159,16 @@ export default function NetworkHealthPage() {
   if (loading) {
     return (
       <div className="space-y-6">
-        <div className="h-8 w-48 bg-gray-100 rounded animate-pulse" />
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-28 bg-gray-100 rounded-lg animate-pulse" />
+        <div className="h-8 w-56 bg-slate-100 rounded animate-pulse" />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-48 bg-slate-100 rounded-xl animate-pulse" />
           ))}
         </div>
-        <div className="h-64 bg-gray-100 rounded-lg animate-pulse" />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="h-56 bg-slate-100 rounded-xl animate-pulse" />
+          <div className="h-56 bg-slate-100 rounded-xl animate-pulse" />
+        </div>
       </div>
     );
   }
@@ -192,395 +177,176 @@ export default function NetworkHealthPage() {
     return (
       <div className="flex flex-col items-center justify-center min-h-[400px] gap-4">
         <PiWarningCircleBold className="w-12 h-12 text-red-500" />
-        <p className="text-gray-600">{error || 'No data available'}</p>
+        <p className="text-slate-600">{error || 'No data available'}</p>
         <Button onClick={() => fetchData()}>Retry</Button>
       </div>
     );
   }
 
-  const { overview, devicesByHealth, unacknowledgedAlerts, recentAnomalies } = data;
+  const {
+    overview,
+    uptimeSeries,
+    bandwidthSeries,
+    devicesByHealth,
+    unacknowledgedAlerts,
+    inventory,
+    edgeDevice,
+  } = data;
+  const uptimeDelta = formatDelta(overview.uptimeDeltaVsPrior, ' vs prior 24h');
+  const throughputDelta = formatDelta(overview.bandwidth.deltaPercent, ' from last sample');
+  const inventorySafe: NetworkInventory = inventory ?? {
+    gateway: 0,
+    ap: overview.totalDevices,
+    switch: { online: 0, total: 0 },
+    client: overview.totalClients,
+    guest: null,
+  };
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+    <div className="space-y-6 -mx-1">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Network Health</h1>
-          <p className="text-gray-500 mt-1">
-            Proactive device monitoring and anomaly detection
+          <p className="text-xs text-slate-400 mb-1">Activity / Infrastructure / System Health</p>
+          <h1 className="text-2xl font-semibold text-slate-900 tracking-tight">System Health</h1>
+          <p className="text-slate-500 mt-1 text-sm">
+            Aggregate Ruijie Wi-Fi performance from Supabase · {overview.totalDevices} devices ·{' '}
+            {overview.totalClients} clients online
           </p>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => fetchData(true)}
-          disabled={refreshing}
-        >
-          <PiArrowsClockwiseBold
-            className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`}
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/admin/network/analytics">Open Analytics</Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fetchData(true)}
+            disabled={refreshing}
+          >
+            <PiArrowsClockwiseBold className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {/* Omada-inspired overview row */}
+      <div className="grid grid-cols-1 xl:grid-cols-[320px_1fr] gap-4">
+        <div className="space-y-4">
+          <EdgeDeviceCard device={edgeDevice ?? null} />
+          <PendingAlertsCard
+            alerts={unacknowledgedAlerts}
+            acknowledging={acknowledging}
+            onAcknowledge={handleAcknowledge}
           />
-          Refresh
-        </Button>
+        </div>
+        <NetworkOverviewTiles inventory={inventorySafe} />
       </div>
 
-      {/* Overall Health Score Banner */}
-      <Card
-        className={`border-2 ${
-          overview.overallScore >= 80
-            ? 'border-green-200 bg-green-50'
-            : overview.overallScore >= 50
-              ? 'border-yellow-200 bg-yellow-50'
-              : 'border-red-200 bg-red-50'
-        }`}
-      >
-        <CardContent className="py-6">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <div
-                className={`p-4 rounded-full ${
-                  overview.overallScore >= 80
-                    ? 'bg-green-100'
-                    : overview.overallScore >= 50
-                      ? 'bg-yellow-100'
-                      : 'bg-red-100'
-                }`}
-              >
-                <PiHeartbeatBold
-                  className={`w-8 h-8 ${
-                    overview.overallScore >= 80
-                      ? 'text-green-600'
-                      : overview.overallScore >= 50
-                        ? 'text-yellow-600'
-                        : 'text-red-600'
-                  }`}
-                />
-              </div>
-              <div>
-                <p className="text-sm text-gray-600">Overall Network Health</p>
-                <p
-                  className={`text-4xl font-bold ${
-                    overview.overallScore >= 80
-                      ? 'text-green-700'
-                      : overview.overallScore >= 50
-                        ? 'text-yellow-700'
-                        : 'text-red-700'
-                  }`}
-                >
-                  {overview.overallScore}%
-                </p>
-              </div>
-            </div>
-            <div className="text-right">
-              <p className="text-sm text-gray-600">
-                {overview.anomaliesLast24h} anomalies in last 24h
-              </p>
-              <p className="text-sm text-gray-500">
-                {overview.totalClients.toLocaleString()} connected clients
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Top KPI row */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <MetricCard
+          title="Service Availability"
+          value={`${overview.uptimePercent.toFixed(2)}%`}
+          subtitle="Overall Uptime"
+          delta={uptimeDelta}
+          deltaPositive={
+            overview.uptimeDeltaVsPrior == null ? null : overview.uptimeDeltaVsPrior >= 0
+          }
+        >
+          <DotMatrixChart values={uptimeSeries.map((d) => d.uptimePercent)} />
+        </MetricCard>
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-gray-500">Total Devices</p>
-                <p className="text-2xl font-bold text-gray-900">
-                  {overview.totalDevices}
-                </p>
-              </div>
-              <div className="p-3 bg-blue-100 rounded-full">
-                <PiWifiHighBold className="w-6 h-6 text-blue-600" />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        <MetricCard
+          title="Request Success Rate"
+          value={`${overview.successRatePercent.toFixed(2)}%`}
+          subtitle="Avg. healthy device share"
+          delta={`${overview.healthyDevices} healthy · ${overview.warningDevices + overview.criticalDevices + overview.offlineDevices} degraded`}
+        >
+          <SegmentedBar
+            successPercent={overview.successRatePercent}
+            failedPercent={overview.failedSharePercent}
+            successLabel="Healthy devices"
+            failedLabel="Degraded / offline"
+          />
+        </MetricCard>
 
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-gray-500">Healthy</p>
-                <p className="text-2xl font-bold text-green-600">
-                  {overview.healthyDevices}
-                </p>
-              </div>
-              <div className="p-3 bg-green-100 rounded-full">
-                <PiCheckCircleBold className="w-6 h-6 text-green-600" />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-gray-500">Warning</p>
-                <p className="text-2xl font-bold text-yellow-600">
-                  {overview.warningDevices}
-                </p>
-              </div>
-              <div className="p-3 bg-yellow-100 rounded-full">
-                <PiWarningBold className="w-6 h-6 text-yellow-600" />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-gray-500">Critical</p>
-                <p className="text-2xl font-bold text-red-600">
-                  {overview.criticalDevices}
-                </p>
-              </div>
-              <div className="p-3 bg-red-100 rounded-full">
-                <PiXCircleBold className="w-6 h-6 text-red-600" />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-gray-500">Offline</p>
-                <p className="text-2xl font-bold text-gray-600">
-                  {overview.offlineDevices}
-                </p>
-              </div>
-              <div className="p-3 bg-gray-100 rounded-full">
-                <PiWifiHighBold className="w-6 h-6 text-gray-400" />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        <MetricCard
+          title="Response Stability"
+          value={`${overview.responseConsistencyPercent.toFixed(2)}%`}
+          subtitle={
+            overview.responseConsistencyPercent >= 80
+              ? 'Stable within normal threshold'
+              : 'Below consistency threshold'
+          }
+        >
+          <BandwidthChart
+            data={bandwidthSeries}
+            bare
+            variant="area"
+            height={120}
+          />
+        </MetricCard>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Unacknowledged Alerts */}
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-lg flex items-center gap-2">
-                <PiWarningBold className="w-5 h-5 text-red-500" />
-                Active Alerts
-                {unacknowledgedAlerts.length > 0 && (
-                  <Badge variant="destructive" className="ml-2">
-                    {unacknowledgedAlerts.length}
-                  </Badge>
-                )}
-              </CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {unacknowledgedAlerts.length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
-                <PiCheckCircleBold className="w-8 h-8 mx-auto mb-2 text-green-500" />
-                <p>No active alerts</p>
-              </div>
-            ) : (
-              <div className="space-y-3 max-h-[400px] overflow-y-auto">
-                {unacknowledgedAlerts.slice(0, 10).map((alert) => (
-                  <div
-                    key={alert.id}
-                    className="flex items-start justify-between p-3 rounded-lg border"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <Badge
-                          variant="outline"
-                          className={getSeverityColor(alert.severity)}
-                        >
-                          {alert.severity}
-                        </Badge>
-                        <span className="text-xs text-gray-500">
-                          {formatRelativeTime(alert.created_at)}
-                        </span>
-                      </div>
-                      <p className="font-medium text-gray-900 truncate">
-                        {alert.device_name || alert.device_sn}
-                      </p>
-                      <p className="text-sm text-gray-600">{alert.message}</p>
-                      {alert.customer_name && (
-                        <p className="text-xs text-gray-500 mt-1">
-                          Customer: {alert.customer_name}
-                        </p>
-                      )}
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleAcknowledge(alert.id)}
-                      disabled={acknowledging === alert.id}
-                      className="ml-2 shrink-0"
-                    >
-                      {acknowledging === alert.id ? 'Ack...' : 'Ack'}
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+      {/* Middle row */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <ResourceUsageList
+          title="Resource Usage"
+          subtitle={`Average resource utilization ${
+            overview.resources.avgCpu == null
+              ? '—'
+              : (
+                  ((overview.resources.avgCpu || 0) +
+                    (overview.resources.avgMemory || 0) +
+                    (overview.resources.avgRadio || 0)) /
+                  3
+                ).toFixed(1)
+          }% · Updated ${formatRelative(overview.resources.updatedAt)}`}
+          rows={[
+            {
+              key: 'cpu',
+              label: 'CPU',
+              value: overview.resources.avgCpu,
+              icon: <PiCpuBold className="w-4 h-4" />,
+            },
+            {
+              key: 'radio',
+              label: 'Radio util',
+              value: overview.resources.avgRadio,
+              icon: <PiBroadcastBold className="w-4 h-4" />,
+            },
+            {
+              key: 'memory',
+              label: 'Memory',
+              value: overview.resources.avgMemory,
+              icon: <PiMemoryBold className="w-4 h-4" />,
+            },
+          ]}
+        />
 
-        {/* Recent Anomalies */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-lg flex items-center gap-2">
-              <PiTrendDownBold className="w-5 h-5" />
-              Recent Anomalies
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {recentAnomalies.length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
-                <PiCheckCircleBold className="w-8 h-8 mx-auto mb-2 text-green-500" />
-                <p>No recent anomalies detected</p>
-              </div>
-            ) : (
-              <div className="space-y-3 max-h-[400px] overflow-y-auto">
-                {recentAnomalies.map((device) => (
-                  <Link
-                    key={device.sn}
-                    href={`/admin/network/devices/${device.sn}`}
-                    className="block"
-                  >
-                    <div className="flex items-center justify-between p-3 rounded-lg border hover:bg-gray-50 transition-colors">
-                      <div className="flex items-center gap-3">
-                        {getAnomalyIcon(device.last_anomaly_type)}
-                        <div>
-                          <p className="font-medium text-gray-900">
-                            {device.device_name}
-                          </p>
-                          <p className="text-xs text-gray-500">
-                            {device.customer_name || device.group_name || 'Unknown'}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <Badge
-                          variant="outline"
-                          className={getHealthColor(device.health_score)}
-                        >
-                          {device.health_score}%
-                        </Badge>
-                        {device.last_anomaly_at && (
-                          <p className="text-xs text-gray-500 mt-1">
-                            {formatRelativeTime(device.last_anomaly_at)}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <div className="space-y-3">
+          <MetricCard
+            title="Network Bandwidth"
+            value={
+              overview.bandwidth.avgThroughputMbps == null
+                ? '—'
+                : `${overview.bandwidth.avgThroughputMbps.toFixed(0)} Mbps`
+            }
+            subtitle="Average Throughput"
+            delta={throughputDelta}
+            deltaPositive={
+              overview.bandwidth.deltaPercent == null
+                ? null
+                : overview.bandwidth.deltaPercent >= 0
+            }
+            className="h-full"
+          >
+            <BandwidthChart data={bandwidthSeries} bare height={160} />
+          </MetricCard>
+        </div>
       </div>
 
-      {/* Devices by Health Score */}
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg flex items-center gap-2">
-              <PiHeartbeatBold className="w-5 h-5" />
-              Device Health Rankings
-            </CardTitle>
-            <Link href="/admin/network/devices">
-              <Button variant="ghost" size="sm">
-                View All <PiCaretRightBold className="w-4 h-4 ml-1" />
-              </Button>
-            </Link>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {devicesByHealth.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
-              <PiHeartbeatBold className="w-8 h-8 mx-auto mb-2 opacity-50" />
-              <p>No health data available yet</p>
-              <p className="text-sm mt-1">Health snapshots will appear after the next sync</p>
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-b text-left text-sm text-gray-500">
-                    <th className="pb-3 font-medium">Device</th>
-                    <th className="pb-3 font-medium">Customer/Group</th>
-                    <th className="pb-3 font-medium">Status</th>
-                    <th className="pb-3 font-medium">Clients</th>
-                    <th className="pb-3 font-medium">Health</th>
-                    <th className="pb-3 font-medium">Anomalies (24h)</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {devicesByHealth.slice(0, 20).map((device) => (
-                    <tr key={device.sn} className="text-sm">
-                      <td className="py-3">
-                        <Link
-                          href={`/admin/network/devices/${device.sn}`}
-                          className="text-circleTel-orange hover:underline font-medium"
-                        >
-                          {device.device_name}
-                        </Link>
-                      </td>
-                      <td className="py-3 text-gray-600">
-                        {device.customer_name || device.group_name || '--'}
-                      </td>
-                      <td className="py-3">
-                        <Badge
-                          variant="outline"
-                          className={
-                            device.status === 'online'
-                              ? 'bg-green-50 text-green-700 border-green-200'
-                              : 'bg-gray-50 text-gray-700 border-gray-200'
-                          }
-                        >
-                          {device.status}
-                        </Badge>
-                      </td>
-                      <td className="py-3">
-                        <div className="flex items-center gap-1">
-                          <PiUsersBold className="w-4 h-4 text-gray-400" />
-                          {device.online_clients}
-                        </div>
-                      </td>
-                      <td className="py-3">
-                        <Badge
-                          variant="outline"
-                          className={getHealthColor(device.health_score)}
-                        >
-                          {device.health_score}% - {getHealthLabel(device.health_score)}
-                        </Badge>
-                      </td>
-                      <td className="py-3">
-                        {device.anomaly_count > 0 ? (
-                          <span className="flex items-center gap-1">
-                            {getAnomalyIcon(device.last_anomaly_type)}
-                            <span className="text-gray-600">{device.anomaly_count}</span>
-                          </span>
-                        ) : (
-                          <span className="text-gray-400">--</span>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <DevicesMonitorTable rows={devicesByHealth} />
     </div>
   );
 }

--- a/app/api/admin/network/analytics/route.ts
+++ b/app/api/admin/network/analytics/route.ts
@@ -1,0 +1,229 @@
+/**
+ * Network Analytics API (Supabase-backed + live Ruijie)
+ *
+ * GET /api/admin/network/analytics
+ * Query: groupId (optional), hours (default 24, max 168), live=true, includeApps
+ *
+ * Returns rollup throughput, app-flow, group traffic cards, SSID STA activity,
+ * and radio util from device cache (honest empty when missing).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import {
+  getNetworkTraffic,
+  getAppFlow,
+  getGroupStaUsers,
+  pickFlowDeviceSn,
+} from '@/lib/ruijie/client';
+import { bpsToMbps, roundPercent } from '@/lib/network/performance-aggregates';
+import {
+  aggregateSsidActivity,
+  computeGroupTrafficCards,
+  computeRadioUtilSummary,
+} from '@/lib/network/analytics-aggregates';
+
+export const dynamic = 'force-dynamic';
+
+const emptyTraffic = {
+  totalRxBytes: 0,
+  totalTxBytes: 0,
+  totalBytes: 0,
+  avgRxRate: 0,
+  avgTxRate: 0,
+  peakRxBytes: 0,
+  peakTxBytes: 0,
+  avgRxMbps: 0,
+  avgTxMbps: 0,
+  dataPoints: [] as unknown[],
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) {
+      return authResult.response;
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const groupId = searchParams.get('groupId');
+    const hours = Math.min(parseInt(searchParams.get('hours') || '24', 10), 168);
+    const live = searchParams.get('live') === 'true';
+    const includeApps = searchParams.get('includeApps') !== 'false';
+
+    const supabase = await createClient();
+    const since = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
+    const { data: deviceGroups } = await supabase
+      .from('ruijie_device_cache')
+      .select(
+        'group_id, group_name, sn, device_name, status, model, radio_2g_utilization, radio_5g_utilization, radio_2g_channel, radio_5g_channel'
+      )
+      .not('group_id', 'is', null);
+
+    const groupMap = new Map<string, string>();
+    for (const row of deviceGroups || []) {
+      if (row.group_id && !groupMap.has(row.group_id)) {
+        groupMap.set(row.group_id, row.group_name || row.group_id);
+      }
+    }
+    const groups = Array.from(groupMap.entries()).map(([id, name]) => ({ id, name }));
+    const effectiveGroupId = groupId || groups[0]?.id || null;
+
+    // Group traffic cards from all rollups in window
+    const { data: allRollups } = await supabase
+      .from('ruijie_traffic_rollups')
+      .select(
+        'group_id, group_name, total_rx_bytes, total_tx_bytes, captured_at'
+      )
+      .gte('captured_at', since);
+
+    const groupTraffic = computeGroupTrafficCards(allRollups || []);
+
+    const groupDevices = (deviceGroups || []).filter(
+      (d) => d.group_id === effectiveGroupId
+    );
+    const radio = computeRadioUtilSummary(
+      groupDevices.map((d) => ({
+        sn: d.sn,
+        device_name: d.device_name,
+        status: d.status,
+        radio_2g_utilization: d.radio_2g_utilization,
+        radio_5g_utilization: d.radio_5g_utilization,
+        radio_2g_channel: d.radio_2g_channel,
+        radio_5g_channel: d.radio_5g_channel,
+      }))
+    );
+
+    let ssidActivity: ReturnType<typeof aggregateSsidActivity> = [];
+    if (effectiveGroupId) {
+      try {
+        const stas = await getGroupStaUsers(effectiveGroupId);
+        ssidActivity = aggregateSsidActivity(stas);
+      } catch {
+        ssidActivity = [];
+      }
+    }
+
+    if (!effectiveGroupId) {
+      return NextResponse.json({
+        groups,
+        groupId: null,
+        hours,
+        source: 'supabase',
+        traffic: emptyTraffic,
+        appFlow: [],
+        groupTraffic,
+        ssidActivity: [],
+        radio,
+        fetchedAt: new Date().toISOString(),
+      });
+    }
+
+    let appFlow: Awaited<ReturnType<typeof getAppFlow>> = [];
+    if (includeApps) {
+      try {
+        appFlow = await getAppFlow(effectiveGroupId);
+      } catch {
+        appFlow = [];
+      }
+    }
+
+    if (live) {
+      const flowSn = pickFlowDeviceSn(
+        groupDevices.map((d) => ({ sn: d.sn, status: d.status, model: d.model }))
+      );
+      if (!flowSn) {
+        return NextResponse.json(
+          { error: 'No device available in group for live flow API' },
+          { status: 404 }
+        );
+      }
+
+      const trafficSummary = await getNetworkTraffic({ sn: flowSn, hours });
+
+      return NextResponse.json({
+        groups,
+        groupId: effectiveGroupId,
+        flowSn,
+        hours,
+        source: 'live',
+        traffic: {
+          ...trafficSummary,
+          avgRxMbps: roundPercent(bpsToMbps(trafficSummary.avgRxRate)),
+          avgTxMbps: roundPercent(bpsToMbps(trafficSummary.avgTxRate)),
+        },
+        appFlow,
+        groupTraffic,
+        ssidActivity,
+        radio,
+        fetchedAt: new Date().toISOString(),
+      });
+    }
+
+    const { data: rollups, error } = await supabase
+      .from('ruijie_traffic_rollups')
+      .select(
+        'group_id, group_name, captured_at, hours_window, total_rx_bytes, total_tx_bytes, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, raw_summary'
+      )
+      .eq('group_id', effectiveGroupId)
+      .gte('captured_at', since)
+      .order('captured_at', { ascending: true });
+
+    if (error) {
+      console.error('[AnalyticsAPI] Failed to fetch rollups:', error);
+      return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 });
+    }
+
+    const dataPoints = (rollups || []).map((row) => ({
+      timestamp: new Date(row.captured_at).getTime(),
+      timeString: row.captured_at,
+      rxBytes: Number(row.total_rx_bytes) || 0,
+      txBytes: Number(row.total_tx_bytes) || 0,
+      rxPkts: 0,
+      txPkts: 0,
+      buildingId: 0,
+      avgRxMbps: roundPercent(bpsToMbps(row.avg_rx_bps || 0)),
+      avgTxMbps: roundPercent(bpsToMbps(row.avg_tx_bps || 0)),
+    }));
+
+    const totalRxBytes = dataPoints.reduce((s, p) => s + p.rxBytes, 0);
+    const totalTxBytes = dataPoints.reduce((s, p) => s + p.txBytes, 0);
+    const avgRxRate =
+      rollups && rollups.length > 0
+        ? rollups.reduce((s, r) => s + (r.avg_rx_bps || 0), 0) / rollups.length
+        : 0;
+    const avgTxRate =
+      rollups && rollups.length > 0
+        ? rollups.reduce((s, r) => s + (r.avg_tx_bps || 0), 0) / rollups.length
+        : 0;
+
+    return NextResponse.json({
+      groups,
+      groupId: effectiveGroupId,
+      hours,
+      source: 'supabase',
+      traffic: {
+        totalRxBytes,
+        totalTxBytes,
+        totalBytes: totalRxBytes + totalTxBytes,
+        avgRxRate,
+        avgTxRate,
+        peakRxBytes: Math.max(0, ...dataPoints.map((p) => p.rxBytes), 0),
+        peakTxBytes: Math.max(0, ...dataPoints.map((p) => p.txBytes), 0),
+        avgRxMbps: roundPercent(bpsToMbps(avgRxRate)),
+        avgTxMbps: roundPercent(bpsToMbps(avgTxRate)),
+        dataPoints,
+      },
+      appFlow,
+      groupTraffic,
+      ssidActivity,
+      radio,
+      fetchedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('[AnalyticsAPI] Unexpected error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/admin/network/health/route.ts
+++ b/app/api/admin/network/health/route.ts
@@ -2,12 +2,20 @@
  * Network Health Dashboard API
  *
  * GET /api/admin/network/health
- * Returns aggregated health data for the network health dashboard
+ * System Health aggregate payload for WiFi (Ruijie) fleet.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import {
+  bpsToMbps,
+  buildDailyUptimeSeries,
+  classifyDeviceRole,
+  computeFleetOverview,
+  computeNetworkInventory,
+  roundPercent,
+} from '@/lib/network/performance-aggregates';
 
 export async function GET(request: NextRequest) {
   try {
@@ -19,11 +27,14 @@ export async function GET(request: NextRequest) {
     const supabase = await createClient();
     const now = new Date();
     const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+    const fortyEightHoursAgo = new Date(now.getTime() - 48 * 60 * 60 * 1000).toISOString();
+    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
 
-    // Get all devices with latest health data
     const { data: devices, error: devicesError } = await supabase
       .from('ruijie_device_cache')
-      .select('sn, device_name, group_name, customer_name, status, online_clients')
+      .select(
+        'sn, device_name, model, group_name, customer_name, status, online_clients, cpu_usage, memory_usage, radio_2g_utilization, radio_5g_utilization, management_ip, wan_ip, synced_at, last_seen_at'
+      )
       .order('device_name');
 
     if (devicesError) {
@@ -31,18 +42,16 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch devices' }, { status: 500 });
     }
 
-    // Get latest health snapshot for each device
     const { data: latestSnapshots, error: snapshotsError } = await supabase
       .from('device_health_snapshots')
-      .select('device_sn, health_score, anomaly_detected, anomaly_type, captured_at')
-      .gte('captured_at', twentyFourHoursAgo)
+      .select('device_sn, health_score, anomaly_detected, anomaly_type, status, captured_at')
+      .gte('captured_at', thirtyDaysAgo)
       .order('captured_at', { ascending: false });
 
     if (snapshotsError) {
       console.error('[HealthAPI] Failed to fetch snapshots:', snapshotsError);
     }
 
-    // Group snapshots by device and get latest + anomaly count
     const deviceHealthMap: Record<
       string,
       {
@@ -53,7 +62,12 @@ export async function GET(request: NextRequest) {
       }
     > = {};
 
-    for (const snapshot of latestSnapshots || []) {
+    const snapshots24h = (latestSnapshots || []).filter((s) => s.captured_at >= twentyFourHoursAgo);
+    const snapshotsPriorDay = (latestSnapshots || []).filter(
+      (s) => s.captured_at >= fortyEightHoursAgo && s.captured_at < twentyFourHoursAgo
+    );
+
+    for (const snapshot of snapshots24h) {
       if (!deviceHealthMap[snapshot.device_sn]) {
         deviceHealthMap[snapshot.device_sn] = {
           health_score: snapshot.health_score,
@@ -72,7 +86,31 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Get unacknowledged alerts
+    let priorOnline = 0;
+    let priorTotal = 0;
+    for (const snap of snapshotsPriorDay) {
+      priorTotal += 1;
+      if (snap.status === 'online') priorOnline += 1;
+    }
+    const priorOnlineRate =
+      priorTotal > 0 ? roundPercent((priorOnline / priorTotal) * 100) : null;
+
+    const fleetDevices = (devices || []).map((d) => ({
+      sn: d.sn,
+      status: d.status,
+      online_clients: d.online_clients || 0,
+      cpu_usage: d.cpu_usage,
+      memory_usage: d.memory_usage,
+      radio_2g_utilization: d.radio_2g_utilization,
+      radio_5g_utilization: d.radio_5g_utilization,
+    }));
+
+    const overviewBase = computeFleetOverview({
+      devices: fleetDevices,
+      healthBySn: deviceHealthMap,
+      priorOnlineRate,
+    });
+
     const { data: alerts, error: alertsError } = await supabase
       .from('network_health_alerts')
       .select('id, device_sn, alert_type, severity, message, acknowledged, created_at')
@@ -84,7 +122,6 @@ export async function GET(request: NextRequest) {
       console.error('[HealthAPI] Failed to fetch alerts:', alertsError);
     }
 
-    // Enrich alerts with device names
     const enrichedAlerts = (alerts || []).map((alert) => {
       const device = devices?.find((d) => d.sn === alert.device_sn);
       return {
@@ -94,53 +131,33 @@ export async function GET(request: NextRequest) {
       };
     });
 
-    // Calculate overview stats
-    const totalDevices = devices?.length || 0;
-    const offlineDevices = devices?.filter((d) => d.status === 'offline').length || 0;
-    const totalClients = devices?.reduce((sum, d) => sum + (d.online_clients || 0), 0) || 0;
-
-    let healthyDevices = 0;
-    let warningDevices = 0;
-    let criticalDevices = 0;
-    let totalHealthScore = 0;
-    let devicesWithHealth = 0;
-
-    // Build devices by health list
     const devicesByHealth = (devices || []).map((device) => {
       const healthData = deviceHealthMap[device.sn] || {
-        health_score: device.status === 'online' ? 100 : 80,
+        health_score: device.status === 'online' ? 100 : 40,
         anomaly_count: 0,
         last_anomaly_type: null,
         last_anomaly_at: null,
       };
 
-      const healthScore = healthData.health_score;
-
-      if (healthScore >= 80) healthyDevices++;
-      else if (healthScore >= 50) warningDevices++;
-      else criticalDevices++;
-
-      totalHealthScore += healthScore;
-      devicesWithHealth++;
-
       return {
         sn: device.sn,
         device_name: device.device_name,
+        model: device.model,
         group_name: device.group_name,
         customer_name: device.customer_name,
         status: device.status,
         online_clients: device.online_clients,
-        health_score: healthScore,
+        health_score: healthData.health_score,
         anomaly_count: healthData.anomaly_count,
         last_anomaly_type: healthData.last_anomaly_type,
         last_anomaly_at: healthData.last_anomaly_at,
+        synced_at: device.synced_at,
+        last_seen_at: device.last_seen_at,
       };
     });
 
-    // Sort by health score (lowest first to highlight issues)
     devicesByHealth.sort((a, b) => a.health_score - b.health_score);
 
-    // Get devices with recent anomalies
     const recentAnomalies = devicesByHealth
       .filter((d) => d.anomaly_count > 0)
       .sort((a, b) => {
@@ -150,26 +167,152 @@ export async function GET(request: NextRequest) {
       })
       .slice(0, 10);
 
-    // Calculate anomalies in last 24h
-    const anomaliesLast24h = Object.values(deviceHealthMap).reduce(
-      (sum, d) => sum + d.anomaly_count,
-      0
+    const uptimeSeries = buildDailyUptimeSeries({
+      days: 30,
+      now,
+      snapshots: (latestSnapshots || []).map((s) => ({
+        device_sn: s.device_sn,
+        status: s.status,
+        captured_at: s.captured_at,
+      })),
+      deviceCount: overviewBase.totalDevices,
+    });
+
+    const { data: trafficRows, error: trafficError } = await supabase
+      .from('ruijie_traffic_rollups')
+      .select(
+        'group_id, group_name, captured_at, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, total_rx_bytes, total_tx_bytes'
+      )
+      .gte('captured_at', twentyFourHoursAgo)
+      .order('captured_at', { ascending: true });
+
+    if (trafficError) {
+      console.error('[HealthAPI] Failed to fetch traffic rollups:', trafficError);
+    }
+
+    // Aggregate all groups per timestamp for fleet bandwidth series
+    const bandwidthByTs = new Map<
+      string,
+      { rx: number; tx: number; count: number }
+    >();
+    for (const row of trafficRows || []) {
+      const key = row.captured_at;
+      const existing = bandwidthByTs.get(key) || { rx: 0, tx: 0, count: 0 };
+      existing.rx += row.avg_rx_bps || 0;
+      existing.tx += row.avg_tx_bps || 0;
+      existing.count += 1;
+      bandwidthByTs.set(key, existing);
+    }
+
+    const bandwidthSeries = Array.from(bandwidthByTs.entries()).map(([captured_at, v]) => ({
+      captured_at,
+      avgRxMbps: roundPercent(bpsToMbps(v.rx)),
+      avgTxMbps: roundPercent(bpsToMbps(v.tx)),
+      avgThroughputMbps: roundPercent(bpsToMbps(v.rx + v.tx)),
+    }));
+
+    const latestBandwidth = bandwidthSeries[bandwidthSeries.length - 1] || null;
+    const priorBandwidth =
+      bandwidthSeries.length > 1 ? bandwidthSeries[bandwidthSeries.length - 2] : null;
+    const throughputDelta =
+      latestBandwidth && priorBandwidth && priorBandwidth.avgThroughputMbps > 0
+        ? roundPercent(
+            ((latestBandwidth.avgThroughputMbps - priorBandwidth.avgThroughputMbps) /
+              priorBandwidth.avgThroughputMbps) *
+              100
+          )
+        : null;
+
+    const failedShare = roundPercent(
+      100 - overviewBase.successRatePercent
     );
 
-    const overallScore =
-      devicesWithHealth > 0 ? Math.round(totalHealthScore / devicesWithHealth) : 100;
+    const inventory = computeNetworkInventory(
+      (devices || []).map((d) => ({
+        sn: d.sn,
+        device_name: d.device_name,
+        model: d.model,
+        status: d.status,
+        online_clients: d.online_clients || 0,
+        cpu_usage: d.cpu_usage,
+        memory_usage: d.memory_usage,
+        radio_2g_utilization: d.radio_2g_utilization,
+        radio_5g_utilization: d.radio_5g_utilization,
+        management_ip: d.management_ip,
+        wan_ip: d.wan_ip,
+        synced_at: d.synced_at,
+      }))
+    );
+
+    const edge = inventory.edgeDevice;
+    const edgeDevice = edge
+      ? {
+          sn: edge.sn,
+          device_name: edge.device_name,
+          model: edge.model ?? null,
+          status: edge.status,
+          role: classifyDeviceRole(edge.model, edge.device_name),
+          online_clients: edge.online_clients,
+          cpu_usage: edge.cpu_usage ?? null,
+          memory_usage: edge.memory_usage ?? null,
+          radio_2g_utilization: edge.radio_2g_utilization ?? null,
+          radio_5g_utilization: edge.radio_5g_utilization ?? null,
+          management_ip: edge.management_ip ?? null,
+          wan_ip: edge.wan_ip ?? null,
+          synced_at: edge.synced_at ?? null,
+        }
+      : null;
 
     return NextResponse.json({
       overview: {
-        overallScore,
-        totalDevices,
-        healthyDevices,
-        warningDevices,
-        criticalDevices,
-        offlineDevices,
-        totalClients,
-        anomaliesLast24h,
+        overallScore: overviewBase.overallScore,
+        totalDevices: overviewBase.totalDevices,
+        healthyDevices: overviewBase.healthyDevices,
+        warningDevices: overviewBase.warningDevices,
+        criticalDevices: overviewBase.criticalDevices,
+        offlineDevices: overviewBase.offlineDevices,
+        onlineDevices: overviewBase.onlineDevices,
+        totalClients: overviewBase.totalClients,
+        anomaliesLast24h: overviewBase.anomaliesLast24h,
+        uptimePercent: overviewBase.uptimePercent,
+        uptimeDeltaVsPrior: overviewBase.uptimeDeltaVsPrior,
+        successRatePercent: overviewBase.successRatePercent,
+        failedSharePercent: failedShare,
+        responseConsistencyPercent: overviewBase.responseConsistencyPercent,
+        resources: {
+          avgCpu: overviewBase.resources.avgCpu == null ? null : roundPercent(overviewBase.resources.avgCpu),
+          avgMemory:
+            overviewBase.resources.avgMemory == null
+              ? null
+              : roundPercent(overviewBase.resources.avgMemory),
+          avgRadio:
+            overviewBase.resources.avgRadio == null
+              ? null
+              : roundPercent(overviewBase.resources.avgRadio),
+          updatedAt:
+            devices?.reduce<string | null>((latest, d) => {
+              if (!d.synced_at) return latest;
+              if (!latest || d.synced_at > latest) return d.synced_at;
+              return latest;
+            }, null) ?? null,
+        },
+        bandwidth: {
+          avgThroughputMbps: latestBandwidth?.avgThroughputMbps ?? null,
+          avgRxMbps: latestBandwidth?.avgRxMbps ?? null,
+          avgTxMbps: latestBandwidth?.avgTxMbps ?? null,
+          deltaPercent: throughputDelta,
+        },
       },
+      inventory: {
+        gateway: inventory.gateway,
+        ap: inventory.ap,
+        switch: { online: inventory.switchOnline, total: inventory.switchTotal },
+        client: inventory.client,
+        guest: inventory.guest,
+      },
+      edgeDevice,
+      uptimeSeries,
+      bandwidthSeries,
       devicesByHealth,
       unacknowledgedAlerts: enrichedAlerts,
       recentAnomalies,

--- a/app/api/ruijie/traffic/route.ts
+++ b/app/api/ruijie/traffic/route.ts
@@ -10,7 +10,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClientWithSession, createClient } from '@/lib/supabase/server';
-import { getNetworkTraffic, getAppFlow } from '@/lib/ruijie/client';
+import { getNetworkTraffic, getAppFlow, pickFlowDeviceSn } from '@/lib/ruijie/client';
 import { apiLogger } from '@/lib/logging/logger';
 
 export const dynamic = 'force-dynamic';
@@ -51,14 +51,28 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
     }
 
-    // Fetch traffic data
+    const { data: devices } = await supabaseAdmin
+      .from('ruijie_device_cache')
+      .select('sn, status, model')
+      .eq('group_id', groupId);
+
+    const flowSn = pickFlowDeviceSn(devices || []);
+    if (!flowSn) {
+      return NextResponse.json(
+        { error: 'No device available in group for flow API (requires sn)' },
+        { status: 404 }
+      );
+    }
+
+    // Fetch traffic data (API 2.6.2 requires device sn)
     const [trafficSummary, appFlow] = await Promise.all([
-      getNetworkTraffic(groupId, hours),
+      getNetworkTraffic({ sn: flowSn, hours }),
       includeApps ? getAppFlow(groupId) : Promise.resolve([]),
     ]);
 
     return NextResponse.json({
       groupId,
+      flowSn,
       hours,
       traffic: trafficSummary,
       appFlow: includeApps ? appFlow : undefined,

--- a/components/admin/network/DeviceCard.tsx
+++ b/components/admin/network/DeviceCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { PiWifiHighBold, PiWifiSlashBold } from 'react-icons/pi';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
@@ -12,10 +13,17 @@ interface RuijieDevice {
   group_name: string | null;
   management_ip: string | null;
   online_clients: number;
+  cpu_usage?: number | null;
+  memory_usage?: number | null;
   status: string;
   config_status: string | null;
   synced_at: string;
   mock_data: boolean;
+}
+
+function formatPct(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return `${Math.round(value)}%`;
 }
 
 interface DeviceCardProps {
@@ -37,25 +45,31 @@ export function DeviceCard({
   return (
     <div
       className={cn(
-        'p-4 rounded-lg border bg-white',
-        !isOnline && 'bg-red-50/50 border-red-200'
+        'p-4 rounded-xl border border-slate-200/80 bg-white shadow-sm',
+        !isOnline && 'bg-red-50/40 border-red-200'
       )}
     >
       <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
+        <Link
+          href={`/admin/network/devices/${device.sn}`}
+          className="flex items-center gap-2 min-w-0 hover:text-blue-600"
+        >
           <StatusIcon
             className={cn(
               'h-5 w-5 flex-shrink-0',
-              isOnline ? 'text-green-600' : 'text-red-600'
+              isOnline ? 'text-blue-500' : 'text-red-500'
             )}
           />
-          <span className="font-medium truncate">{device.device_name}</span>
+          <span className="font-medium truncate text-slate-900">{device.device_name}</span>
           {device.mock_data && (
-            <Badge variant="outline" className="text-xs bg-purple-50 text-purple-600 border-purple-200 flex-shrink-0">
+            <Badge
+              variant="outline"
+              className="text-xs bg-purple-50 text-purple-600 border-purple-200 flex-shrink-0"
+            >
               MOCK
             </Badge>
           )}
-        </div>
+        </Link>
         <DeviceActionsMenu
           sn={device.sn}
           deviceName={device.device_name}
@@ -64,11 +78,12 @@ export function DeviceCard({
           onReboot={() => onReboot(device)}
         />
       </div>
-      <div className="mt-2 text-sm text-gray-600">
-        {device.model || 'Unknown'} • {device.group_name || 'No group'}
+      <div className="mt-2 text-sm text-slate-500">
+        {device.model || 'Unknown'} · {device.group_name || 'No group'}
       </div>
-      <div className="mt-1 text-sm text-gray-500">
-        {device.online_clients} clients • Synced {formatRelativeTime(device.synced_at)}
+      <div className="mt-1 text-sm text-slate-500">
+        CPU {formatPct(device.cpu_usage)} · Mem {formatPct(device.memory_usage)} ·{' '}
+        {device.online_clients} clients · Synced {formatRelativeTime(device.synced_at)}
       </div>
     </div>
   );

--- a/components/admin/network/DeviceFilters.tsx
+++ b/components/admin/network/DeviceFilters.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import {
-  PiArrowsClockwiseBold,
   PiDownloadBold,
   PiFunnelBold,
   PiMagnifyingGlassBold,
@@ -24,7 +23,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
-import { cn } from '@/lib/utils';
 
 interface DeviceFiltersProps {
   search: string;
@@ -37,9 +35,7 @@ interface DeviceFiltersProps {
   onModelChange: (value: string) => void;
   groups: string[];
   models: string[];
-  onRefresh: () => void;
   onExport: () => void;
-  refreshing: boolean;
 }
 
 export function DeviceFilters({
@@ -53,9 +49,7 @@ export function DeviceFilters({
   onModelChange,
   groups,
   models,
-  onRefresh,
   onExport,
-  refreshing,
 }: DeviceFiltersProps) {
   const [filtersOpen, setFiltersOpen] = useState(false);
 
@@ -69,22 +63,20 @@ export function DeviceFilters({
   };
 
   return (
-    <Card>
+    <Card className="border border-slate-200/80 shadow-sm rounded-xl bg-white">
       <CardContent className="pt-4 pb-4">
         <Collapsible open={filtersOpen} onOpenChange={setFiltersOpen}>
           <div className="flex flex-wrap items-center gap-3">
-            {/* Search */}
             <div className="relative flex-1 min-w-[200px]">
-              <PiMagnifyingGlassBold className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <PiMagnifyingGlassBold className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
               <Input
                 placeholder="Search by SN, name, or IP..."
                 value={search}
                 onChange={(e) => onSearchChange(e.target.value)}
-                className="pl-9"
+                className="pl-9 border-slate-200"
               />
             </div>
 
-            {/* Filters toggle */}
             <CollapsibleTrigger asChild>
               <Button variant="outline" size="sm">
                 <PiFunnelBold className="h-4 w-4 mr-2" />
@@ -97,27 +89,16 @@ export function DeviceFilters({
               </Button>
             </CollapsibleTrigger>
 
-            {/* Actions */}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onRefresh}
-              disabled={refreshing}
-            >
-              <PiArrowsClockwiseBold className={cn('h-4 w-4 mr-2', refreshing && 'animate-spin')} />
-              Refresh
-            </Button>
             <Button variant="outline" size="sm" onClick={onExport}>
               <PiDownloadBold className="h-4 w-4 mr-2" />
               Export
             </Button>
           </div>
 
-          {/* Active filter chips */}
           {hasFilters && (
             <div className="flex flex-wrap items-center gap-2 mt-3">
               {statusFilter && (
-                <Badge variant="secondary" className="gap-1">
+                <Badge variant="secondary" className="gap-1 bg-slate-100 text-slate-700">
                   Status: {statusFilter}
                   <button onClick={() => onStatusChange('')} className="ml-1 hover:text-red-500">
                     <PiXBold className="h-3 w-3" />
@@ -125,7 +106,7 @@ export function DeviceFilters({
                 </Badge>
               )}
               {groupFilter && (
-                <Badge variant="secondary" className="gap-1">
+                <Badge variant="secondary" className="gap-1 bg-slate-100 text-slate-700">
                   Group: {groupFilter}
                   <button onClick={() => onGroupChange('')} className="ml-1 hover:text-red-500">
                     <PiXBold className="h-3 w-3" />
@@ -133,7 +114,7 @@ export function DeviceFilters({
                 </Badge>
               )}
               {modelFilter && (
-                <Badge variant="secondary" className="gap-1">
+                <Badge variant="secondary" className="gap-1 bg-slate-100 text-slate-700">
                   Model: {modelFilter}
                   <button onClick={() => onModelChange('')} className="ml-1 hover:text-red-500">
                     <PiXBold className="h-3 w-3" />
@@ -143,12 +124,14 @@ export function DeviceFilters({
             </div>
           )}
 
-          {/* Expanded filters */}
           <CollapsibleContent>
-            <div className="flex flex-wrap items-end gap-4 mt-4 pt-4 border-t">
+            <div className="flex flex-wrap items-end gap-4 mt-4 pt-4 border-t border-slate-100">
               <div className="w-40">
-                <label className="text-sm font-medium text-gray-700 mb-1 block">Status</label>
-                <Select value={statusFilter || 'all'} onValueChange={(v) => onStatusChange(v === 'all' ? '' : v)}>
+                <label className="text-xs font-medium text-slate-500 mb-1 block">Status</label>
+                <Select
+                  value={statusFilter || 'all'}
+                  onValueChange={(v) => onStatusChange(v === 'all' ? '' : v)}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="All" />
                   </SelectTrigger>
@@ -160,29 +143,39 @@ export function DeviceFilters({
                 </Select>
               </div>
               <div className="w-48">
-                <label className="text-sm font-medium text-gray-700 mb-1 block">Group</label>
-                <Select value={groupFilter || 'all'} onValueChange={(v) => onGroupChange(v === 'all' ? '' : v)}>
+                <label className="text-xs font-medium text-slate-500 mb-1 block">Group</label>
+                <Select
+                  value={groupFilter || 'all'}
+                  onValueChange={(v) => onGroupChange(v === 'all' ? '' : v)}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="All Groups" />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">All Groups</SelectItem>
                     {groups.map((g) => (
-                      <SelectItem key={g} value={g}>{g}</SelectItem>
+                      <SelectItem key={g} value={g}>
+                        {g}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
               </div>
               <div className="w-48">
-                <label className="text-sm font-medium text-gray-700 mb-1 block">Model</label>
-                <Select value={modelFilter || 'all'} onValueChange={(v) => onModelChange(v === 'all' ? '' : v)}>
+                <label className="text-xs font-medium text-slate-500 mb-1 block">Model</label>
+                <Select
+                  value={modelFilter || 'all'}
+                  onValueChange={(v) => onModelChange(v === 'all' ? '' : v)}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="All Models" />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">All Models</SelectItem>
                     {models.map((m) => (
-                      <SelectItem key={m} value={m}>{m}</SelectItem>
+                      <SelectItem key={m} value={m}>
+                        {m}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>

--- a/components/admin/network/DeviceTable.tsx
+++ b/components/admin/network/DeviceTable.tsx
@@ -1,17 +1,11 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent } from '@/components/ui/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
+import { PiWifiHighBold } from 'react-icons/pi';
 import { DeviceActionsMenu } from './DeviceActionsMenu';
 
 interface RuijieDevice {
@@ -21,10 +15,36 @@ interface RuijieDevice {
   group_name: string | null;
   management_ip: string | null;
   online_clients: number;
+  cpu_usage?: number | null;
+  memory_usage?: number | null;
   status: string;
   config_status: string | null;
   synced_at: string;
   mock_data: boolean;
+}
+
+function formatPct(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return `${Math.round(value)}%`;
+}
+
+function statusBadge(status: string): { label: string; className: string } {
+  if (status === 'online') {
+    return {
+      label: 'Online',
+      className: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    };
+  }
+  if (status === 'offline') {
+    return {
+      label: 'Offline',
+      className: 'bg-red-50 text-red-700 border-red-200',
+    };
+  }
+  return {
+    label: status || 'Unknown',
+    className: 'bg-slate-50 text-slate-600 border-slate-200',
+  };
 }
 
 interface DeviceTableProps {
@@ -42,94 +62,121 @@ export function DeviceTable({
 }: DeviceTableProps) {
   const router = useRouter();
 
-  const handleRowClick = (sn: string) => {
-    router.push(`/admin/network/devices/${sn}`);
-  };
-
   return (
-    <Card>
+    <Card className="border border-slate-200/80 shadow-sm rounded-xl bg-white">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-semibold text-slate-900">
+          Devices Monitoring
+        </CardTitle>
+        <p className="text-xs text-slate-500">
+          Ruijie Wi-Fi fleet from Supabase cache · CPU / memory from live sync
+        </p>
+      </CardHeader>
       <CardContent className="p-0">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-16">Status</TableHead>
-              <TableHead>Device</TableHead>
-              <TableHead className="hidden md:table-cell">Model</TableHead>
-              <TableHead className="hidden lg:table-cell">Group</TableHead>
-              <TableHead className="hidden lg:table-cell">IP</TableHead>
-              <TableHead className="text-center w-20">Clients</TableHead>
-              <TableHead className="hidden sm:table-cell w-24">Synced</TableHead>
-              <TableHead className="w-12"></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {devices.map((device) => {
-              const isOnline = device.status === 'online';
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-slate-100 text-left text-xs uppercase tracking-wide text-slate-400">
+                <th className="px-4 py-3 font-medium">Device</th>
+                <th className="px-4 py-3 font-medium hidden md:table-cell">Model</th>
+                <th className="px-4 py-3 font-medium hidden lg:table-cell">Group</th>
+                <th className="px-4 py-3 font-medium hidden lg:table-cell">IP</th>
+                <th className="px-4 py-3 font-medium text-center">CPU</th>
+                <th className="px-4 py-3 font-medium text-center">Mem</th>
+                <th className="px-4 py-3 font-medium text-center">Clients</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium hidden sm:table-cell">Synced</th>
+                <th className="px-4 py-3 font-medium w-12" />
+              </tr>
+            </thead>
+            <tbody>
+              {devices.length === 0 ? (
+                <tr>
+                  <td colSpan={10} className="px-4 py-10 text-center text-slate-400">
+                    No devices found
+                  </td>
+                </tr>
+              ) : (
+                devices.map((device) => {
+                  const isOnline = device.status === 'online';
+                  const status = statusBadge(device.status);
 
-              return (
-                <TableRow
-                  key={device.sn}
-                  className={cn(
-                    'cursor-pointer',
-                    !isOnline && 'bg-red-50/50'
-                  )}
-                  onClick={() => handleRowClick(device.sn)}
-                >
-                  <TableCell onClick={(e) => e.stopPropagation()}>
-                    <div
+                  return (
+                    <tr
+                      key={device.sn}
                       className={cn(
-                        'w-3 h-3 rounded-full',
-                        isOnline ? 'bg-green-500' : 'bg-red-500'
+                        'border-b border-slate-50 hover:bg-slate-50/80 cursor-pointer',
+                        !isOnline && 'bg-red-50/30'
                       )}
-                      title={isOnline ? 'Online' : 'Offline'}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium">{device.device_name}</span>
-                      {device.mock_data && (
-                        <Badge variant="outline" className="text-xs bg-purple-50 text-purple-600 border-purple-200">
-                          MOCK
+                      onClick={() => router.push(`/admin/network/devices/${device.sn}`)}
+                    >
+                      <td className="px-4 py-3">
+                        <Link
+                          href={`/admin/network/devices/${device.sn}`}
+                          className="inline-flex items-center gap-2 font-medium text-slate-900 hover:text-blue-600"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <PiWifiHighBold
+                            className={cn(
+                              'w-4 h-4',
+                              isOnline ? 'text-blue-500' : 'text-slate-400'
+                            )}
+                          />
+                          <span className="truncate max-w-[180px]">{device.device_name}</span>
+                          {device.mock_data && (
+                            <Badge
+                              variant="outline"
+                              className="text-[10px] bg-purple-50 text-purple-600 border-purple-200"
+                            >
+                              MOCK
+                            </Badge>
+                          )}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3 text-slate-600 hidden md:table-cell">
+                        {device.model || '—'}
+                      </td>
+                      <td className="px-4 py-3 text-slate-600 hidden lg:table-cell">
+                        {device.group_name || '—'}
+                      </td>
+                      <td className="px-4 py-3 hidden lg:table-cell">
+                        <code className="text-xs text-slate-500">
+                          {device.management_ip || '—'}
+                        </code>
+                      </td>
+                      <td className="px-4 py-3 text-center tabular-nums text-slate-700">
+                        {formatPct(device.cpu_usage)}
+                      </td>
+                      <td className="px-4 py-3 text-center tabular-nums text-slate-700">
+                        {formatPct(device.memory_usage)}
+                      </td>
+                      <td className="px-4 py-3 text-center font-medium tabular-nums text-slate-900">
+                        {device.online_clients}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge variant="outline" className={cn('font-medium', status.className)}>
+                          {status.label}
                         </Badge>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell text-gray-600">
-                    {device.model || '-'}
-                  </TableCell>
-                  <TableCell className="hidden lg:table-cell text-gray-600">
-                    {device.group_name || '-'}
-                  </TableCell>
-                  <TableCell className="hidden lg:table-cell">
-                    <code className="text-xs text-gray-600">{device.management_ip || '-'}</code>
-                  </TableCell>
-                  <TableCell className="text-center font-medium">
-                    {device.online_clients}
-                  </TableCell>
-                  <TableCell className="hidden sm:table-cell text-gray-500 text-sm">
-                    {formatRelativeTime(device.synced_at)}
-                  </TableCell>
-                  <TableCell onClick={(e) => e.stopPropagation()}>
-                    <DeviceActionsMenu
-                      sn={device.sn}
-                      deviceName={device.device_name}
-                      isOnline={isOnline}
-                      tunnelLimitReached={tunnelLimitReached}
-                      onReboot={() => onReboot(device)}
-                    />
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-            {devices.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={8} className="text-center py-8 text-gray-500">
-                  No devices found
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
+                      </td>
+                      <td className="px-4 py-3 text-slate-500 hidden sm:table-cell">
+                        {formatRelativeTime(device.synced_at)}
+                      </td>
+                      <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                        <DeviceActionsMenu
+                          sn={device.sn}
+                          deviceName={device.device_name}
+                          isOnline={isOnline}
+                          tunnelLimitReached={tunnelLimitReached}
+                          onReboot={() => onReboot(device)}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
       </CardContent>
     </Card>
   );

--- a/components/admin/network/performance/AnalyticsEmptyState.tsx
+++ b/components/admin/network/performance/AnalyticsEmptyState.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+type AnalyticsEmptyStateProps = {
+  title: string;
+  description: string;
+  icon?: ReactNode;
+  className?: string;
+};
+
+export function AnalyticsEmptyState({
+  title,
+  description,
+  icon,
+  className,
+}: AnalyticsEmptyStateProps) {
+  return (
+    <Card
+      className={cn(
+        'border border-slate-200/80 shadow-sm rounded-xl bg-white h-full',
+        className
+      )}
+    >
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold text-slate-900">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center justify-center py-10 text-center">
+        {icon ? <div className="mb-3 text-slate-300">{icon}</div> : null}
+        <p className="text-sm text-slate-600">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/performance/BandwidthChart.tsx
+++ b/components/admin/network/performance/BandwidthChart.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+type BandwidthPoint = {
+  captured_at: string;
+  avgRxMbps: number;
+  avgTxMbps: number;
+  avgThroughputMbps?: number;
+};
+
+type BandwidthChartProps = {
+  data: BandwidthPoint[];
+  title?: string;
+  subtitle?: string;
+  className?: string;
+  height?: number;
+  variant?: 'dual-line' | 'area';
+  bare?: boolean;
+};
+
+function formatTick(iso: string) {
+  const d = new Date(iso);
+  return d.toLocaleTimeString('en-ZA', { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+export function BandwidthChart({
+  data,
+  title = 'Network Bandwidth',
+  subtitle,
+  className,
+  height = 180,
+  variant = 'dual-line',
+  bare = false,
+}: BandwidthChartProps) {
+  const chartData = data.map((d) => ({
+    ...d,
+    label: formatTick(d.captured_at),
+  }));
+
+  const chart =
+    chartData.length === 0 ? (
+      <div
+        className="flex items-center justify-center text-sm text-slate-400"
+        style={{ height }}
+      >
+        No bandwidth rollups yet — will populate after the next Ruijie sync.
+      </div>
+    ) : (
+      <ResponsiveContainer width="100%" height={height}>
+        {variant === 'area' ? (
+          <AreaChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" vertical />
+            <XAxis dataKey="label" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false} width={40} />
+            <Tooltip
+              contentStyle={{ borderRadius: 8, borderColor: '#e2e8f0', fontSize: 12 }}
+              formatter={(value: number) => [`${Number(value).toFixed(2)} Mbps`, '']}
+            />
+            <Area
+              type="monotone"
+              dataKey="avgThroughputMbps"
+              stroke="#2563eb"
+              fill="#93c5fd"
+              fillOpacity={0.45}
+              name="Throughput"
+            />
+          </AreaChart>
+        ) : (
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" vertical />
+            <XAxis dataKey="label" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false} width={40} />
+            <Tooltip
+              contentStyle={{ borderRadius: 8, borderColor: '#e2e8f0', fontSize: 12 }}
+              formatter={(value: number, name: string) => [`${Number(value).toFixed(2)} Mbps`, name]}
+            />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Line type="monotone" dataKey="avgRxMbps" stroke="#2563eb" strokeWidth={2} dot={false} name="Download" />
+            <Line type="monotone" dataKey="avgTxMbps" stroke="#f59e0b" strokeWidth={2} dot={false} name="Upload" />
+          </LineChart>
+        )}
+      </ResponsiveContainer>
+    );
+
+  if (bare) {
+    return <div className={className}>{chart}</div>;
+  }
+
+  return (
+    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-slate-500">{title}</CardTitle>
+        {subtitle ? <p className="text-xs text-slate-400">{subtitle}</p> : null}
+      </CardHeader>
+      <CardContent>{chart}</CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/performance/DevicesMonitorTable.tsx
+++ b/components/admin/network/performance/DevicesMonitorTable.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { PiWifiHighBold, PiCaretLeftBold, PiCaretRightBold } from 'react-icons/pi';
+
+export type DeviceMonitorRow = {
+  sn: string;
+  device_name: string;
+  model?: string | null;
+  group_name: string | null;
+  customer_name: string | null;
+  status: string;
+  health_score: number;
+  synced_at?: string | null;
+  last_seen_at?: string | null;
+};
+
+type DevicesMonitorTableProps = {
+  rows: DeviceMonitorRow[];
+  className?: string;
+};
+
+function statusLabel(row: DeviceMonitorRow): { label: string; className: string } {
+  if (row.status === 'offline' || row.health_score < 50) {
+    return { label: row.status === 'offline' ? 'Offline' : 'Critical', className: 'bg-red-50 text-red-700 border-red-200' };
+  }
+  if (row.health_score < 80) {
+    return { label: 'In Progress', className: 'bg-amber-50 text-amber-700 border-amber-200' };
+  }
+  return { label: 'Healthy', className: 'bg-emerald-50 text-emerald-700 border-emerald-200' };
+}
+
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const diffMins = Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const h = Math.floor(diffMins / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+export function DevicesMonitorTable({ rows, className }: DevicesMonitorTableProps) {
+  const [pageSize, setPageSize] = useState(10);
+  const [page, setPage] = useState(0);
+
+  const pageCount = Math.max(1, Math.ceil(rows.length / pageSize));
+  const safePage = Math.min(page, pageCount - 1);
+  const slice = useMemo(() => {
+    const start = safePage * pageSize;
+    return rows.slice(start, start + pageSize);
+  }, [rows, safePage, pageSize]);
+
+  const from = rows.length === 0 ? 0 : safePage * pageSize + 1;
+  const to = Math.min(rows.length, (safePage + 1) * pageSize);
+
+  return (
+    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-semibold text-slate-900">Devices Monitoring</CardTitle>
+        <p className="text-xs text-slate-500">Ruijie Wi-Fi fleet status from Supabase cache</p>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-slate-100 text-left text-xs uppercase tracking-wide text-slate-400">
+                <th className="px-4 py-3 font-medium">Service</th>
+                <th className="px-4 py-3 font-medium">Environment</th>
+                <th className="px-4 py-3 font-medium">Category</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Last Checked</th>
+                <th className="px-4 py-3 font-medium">Owner</th>
+              </tr>
+            </thead>
+            <tbody>
+              {slice.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-10 text-center text-slate-400">
+                    No devices in cache yet.
+                  </td>
+                </tr>
+              ) : (
+                slice.map((row) => {
+                  const status = statusLabel(row);
+                  return (
+                    <tr key={row.sn} className="border-b border-slate-50 hover:bg-slate-50/80">
+                      <td className="px-4 py-3">
+                        <Link
+                          href={`/admin/network/devices/${row.sn}`}
+                          className="inline-flex items-center gap-2 font-medium text-slate-900 hover:text-blue-600"
+                        >
+                          <PiWifiHighBold className="w-4 h-4 text-blue-500" />
+                          <span className="truncate max-w-[180px]">{row.device_name}</span>
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3 text-slate-600">{row.group_name || '—'}</td>
+                      <td className="px-4 py-3 text-slate-600">{row.model || 'AP'}</td>
+                      <td className="px-4 py-3">
+                        <Badge variant="outline" className={cn('font-medium', status.className)}>
+                          {status.label}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3 text-slate-500">
+                        {formatRelative(row.synced_at || row.last_seen_at)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="inline-flex items-center gap-2">
+                          <span className="w-6 h-6 rounded-full bg-slate-200 text-[10px] font-semibold text-slate-600 inline-flex items-center justify-center">
+                            {(row.customer_name || 'CT').slice(0, 2).toUpperCase()}
+                          </span>
+                          <span className="text-slate-700 truncate max-w-[140px]">
+                            {row.customer_name || 'Unassigned'}
+                          </span>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 px-4 py-3 border-t border-slate-100">
+          <p className="text-xs text-slate-500">
+            Showing {from}-{to} of {rows.length} entries
+          </p>
+          <div className="flex items-center gap-2">
+            <Select
+              value={String(pageSize)}
+              onValueChange={(v) => {
+                setPageSize(Number(v));
+                setPage(0);
+              }}
+            >
+              <SelectTrigger className="h-8 w-[100px] text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="10">Show 10</SelectItem>
+                <SelectItem value="25">Show 25</SelectItem>
+                <SelectItem value="50">Show 50</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8"
+              disabled={safePage <= 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+            >
+              <PiCaretLeftBold className="w-4 h-4" />
+            </Button>
+            <span className="text-xs text-slate-500 tabular-nums">
+              {safePage + 1} / {pageCount}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8"
+              disabled={safePage >= pageCount - 1}
+              onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+            >
+              <PiCaretRightBold className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/performance/DotMatrixChart.tsx
+++ b/components/admin/network/performance/DotMatrixChart.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+type DotMatrixChartProps = {
+  values: number[];
+  label?: string;
+  className?: string;
+};
+
+/** 30-day uptime as a blue intensity grid (mockup-style). */
+export function DotMatrixChart({ values, label = 'Last 30 Days', className }: DotMatrixChartProps) {
+  const cols = 15;
+  const rows = Math.max(1, Math.ceil(values.length / cols));
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      <div
+        className="grid gap-1"
+        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+        aria-label={label}
+      >
+        {Array.from({ length: rows * cols }).map((_, i) => {
+          const v = values[i];
+          const intensity =
+            v == null ? 0 : Math.min(1, Math.max(0.15, v / 100));
+          return (
+            <div
+              key={i}
+              title={v == null ? undefined : `${v.toFixed(1)}%`}
+              className={cn(
+                'aspect-square rounded-[2px]',
+                v == null ? 'bg-slate-100' : 'bg-blue-600'
+              )}
+              style={v == null ? undefined : { opacity: intensity }}
+            />
+          );
+        })}
+      </div>
+      <p className="text-[11px] text-slate-400">{label}</p>
+    </div>
+  );
+}

--- a/components/admin/network/performance/EdgeDeviceCard.tsx
+++ b/components/admin/network/performance/EdgeDeviceCard.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import { PiCpuBold, PiMemoryBold, PiBroadcastBold } from 'react-icons/pi';
+import {
+  NetworkOverviewIcon,
+  type NetworkOverviewIconName,
+} from '@/components/icons/NetworkOverviewIcon';
+
+export type EdgeDeviceInfo = {
+  sn: string;
+  device_name: string;
+  model: string | null;
+  status: string;
+  role: string;
+  online_clients: number;
+  cpu_usage: number | null;
+  memory_usage: number | null;
+  radio_2g_utilization: number | null;
+  radio_5g_utilization: number | null;
+  management_ip: string | null;
+  wan_ip: string | null;
+  synced_at: string | null;
+};
+
+type EdgeDeviceCardProps = {
+  device: EdgeDeviceInfo | null;
+  className?: string;
+};
+
+function avgRadio(a: number | null, b: number | null): number | null {
+  const vals = [a, b].filter((v): v is number => typeof v === 'number');
+  if (!vals.length) return null;
+  return vals.reduce((s, v) => s + v, 0) / vals.length;
+}
+
+export function EdgeDeviceCard({ device, className }: EdgeDeviceCardProps) {
+  if (!device) {
+    return (
+      <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-medium text-slate-800">Primary device</CardTitle>
+        </CardHeader>
+        <CardContent className="py-10 text-center text-sm text-slate-400">No Data</CardContent>
+      </Card>
+    );
+  }
+
+  const online = device.status === 'online';
+  const radio = avgRadio(device.radio_2g_utilization, device.radio_5g_utilization);
+  const roleIconName: NetworkOverviewIconName =
+    device.role === 'gateway'
+      ? 'gateway'
+      : device.role === 'switch'
+        ? 'switch'
+        : 'ap';
+
+  return (
+    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+      <CardHeader className="pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <CardTitle className="text-base font-medium text-slate-800 truncate">
+              <Link href={`/admin/network/devices/${device.sn}`} className="hover:text-blue-600">
+                {device.device_name}
+              </Link>
+            </CardTitle>
+            <p className="text-xs text-slate-500 mt-1 truncate">
+              {device.model || 'Unknown model'} · {device.sn}
+            </p>
+          </div>
+          <Badge
+            variant="outline"
+            className={
+              online
+                ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+                : 'bg-red-50 text-red-700 border-red-200'
+            }
+          >
+            {online ? 'CONNECTED' : 'OFFLINE'}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-2 text-xs text-slate-500">
+          <NetworkOverviewIcon name={roleIconName} size={18} title={device.role} />
+          <span className="capitalize">{device.role === 'unknown' ? 'device' : device.role}</span>
+          {(device.wan_ip || device.management_ip) && (
+            <span className="tabular-nums">· {device.wan_ip || device.management_ip}</span>
+          )}
+          <span>· {device.online_clients} clients</span>
+        </div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <div className="rounded-lg bg-slate-50 p-2.5">
+            <div className="text-[11px] text-slate-500 inline-flex items-center gap-1">
+              <PiCpuBold className="w-3.5 h-3.5" /> CPU
+            </div>
+            <div className="text-lg font-semibold tabular-nums mt-0.5">
+              {device.cpu_usage == null ? '—' : `${Math.round(device.cpu_usage)}%`}
+            </div>
+          </div>
+          <div className="rounded-lg bg-slate-50 p-2.5">
+            <div className="text-[11px] text-slate-500 inline-flex items-center gap-1">
+              <PiMemoryBold className="w-3.5 h-3.5" /> Memory
+            </div>
+            <div className="text-lg font-semibold tabular-nums mt-0.5">
+              {device.memory_usage == null ? '—' : `${Math.round(device.memory_usage)}%`}
+            </div>
+          </div>
+          <div className="rounded-lg bg-slate-50 p-2.5">
+            <div className="text-[11px] text-slate-500 inline-flex items-center gap-1">
+              <PiBroadcastBold className="w-3.5 h-3.5" /> Radio
+            </div>
+            <div className="text-lg font-semibold tabular-nums mt-0.5">
+              {radio == null ? '—' : `${Math.round(radio)}%`}
+            </div>
+          </div>
+        </div>
+        <p className="text-[11px] text-slate-400">
+          Port map unavailable from Ruijie API — shown when supported.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/performance/GroupTrafficCards.tsx
+++ b/components/admin/network/performance/GroupTrafficCards.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { PiBroadcastBold, PiWifiHighBold } from 'react-icons/pi';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatBytes } from '@/components/admin/network/TrafficChart';
+import { cn } from '@/lib/utils';
+import type { GroupTrafficCard } from '@/lib/network/analytics-aggregates';
+import type { SsidActivityCard } from '@/lib/network/analytics-aggregates';
+import { AnalyticsEmptyState } from './AnalyticsEmptyState';
+
+type GroupTrafficCardsProps = {
+  groups: GroupTrafficCard[];
+  selectedGroupId?: string | null;
+  onSelectGroup?: (groupId: string) => void;
+  className?: string;
+};
+
+export function GroupTrafficCards({
+  groups,
+  selectedGroupId,
+  onSelectGroup,
+  className,
+}: GroupTrafficCardsProps) {
+  if (!groups.length) {
+    return (
+      <AnalyticsEmptyState
+        title="Group Traffic"
+        description="No group traffic rollups in this window yet. Run a Ruijie sync to populate throughput."
+        icon={<PiBroadcastBold className="w-10 h-10" />}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <Card
+      className={cn(
+        'border border-slate-200/80 shadow-sm rounded-xl bg-white',
+        className
+      )}
+    >
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold text-slate-900">Group Traffic</CardTitle>
+        <p className="text-xs text-slate-500">
+          Summed Ruijie rollups in the selected time window
+        </p>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+        {groups.map((g) => {
+          const active = g.groupId === selectedGroupId;
+          return (
+            <button
+              key={g.groupId}
+              type="button"
+              onClick={() => onSelectGroup?.(g.groupId)}
+              className={cn(
+                'text-left rounded-xl border p-3 transition-colors',
+                active
+                  ? 'border-blue-300 bg-blue-50/60'
+                  : 'border-slate-100 bg-slate-50/50 hover:border-slate-200'
+              )}
+            >
+              <p className="text-sm font-medium text-slate-900 truncate">{g.groupName}</p>
+              <p className="text-xl font-semibold tabular-nums text-slate-900 mt-1">
+                {formatBytes(g.totalBytes)}
+              </p>
+              <p className="text-xs text-slate-500 mt-1">
+                ↓ {formatBytes(g.totalRxBytes)} · ↑ {formatBytes(g.totalTxBytes)} ·{' '}
+                {g.sampleCount} samples
+              </p>
+            </button>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+type SsidActivityCardsProps = {
+  ssids: SsidActivityCard[];
+  className?: string;
+};
+
+export function SsidActivityCards({ ssids, className }: SsidActivityCardsProps) {
+  if (!ssids.length) {
+    return (
+      <AnalyticsEmptyState
+        title="SSID Activity"
+        description="No live STA associations with SSID names for this group. Ruijie does not expose SSID byte traffic here."
+        icon={<PiWifiHighBold className="w-10 h-10" />}
+        className={className}
+      />
+    );
+  }
+
+  const maxClients = Math.max(...ssids.map((s) => s.clients), 1);
+
+  return (
+    <Card
+      className={cn(
+        'border border-slate-200/80 shadow-sm rounded-xl bg-white',
+        className
+      )}
+    >
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold text-slate-900">SSID Activity</CardTitle>
+        <p className="text-xs text-slate-500">
+          Live client counts by SSID (STA API — not byte traffic)
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {ssids.map((row) => {
+          const pct = (row.clients / maxClients) * 100;
+          return (
+            <div key={row.ssid}>
+              <div className="flex items-center justify-between text-sm mb-1">
+                <span className="font-medium text-slate-900 truncate">{row.ssid}</span>
+                <span className="tabular-nums text-slate-600">
+                  {row.clients} client{row.clients === 1 ? '' : 's'}
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-slate-100 overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-emerald-500"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/performance/MetricCard.tsx
+++ b/components/admin/network/performance/MetricCard.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+type MetricCardProps = {
+  title: string;
+  value: string;
+  subtitle?: string;
+  delta?: string | null;
+  deltaPositive?: boolean | null;
+  children?: ReactNode;
+  className?: string;
+};
+
+export function MetricCard({
+  title,
+  value,
+  subtitle,
+  delta,
+  deltaPositive,
+  children,
+  className,
+}: MetricCardProps) {
+  return (
+    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+      <CardHeader className="pb-2 space-y-0">
+        <CardTitle className="text-sm font-medium text-slate-500">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <p className="text-3xl font-semibold tracking-tight text-slate-900">{value}</p>
+          {subtitle ? <p className="text-xs text-slate-500 mt-1">{subtitle}</p> : null}
+          {delta ? (
+            <p
+              className={cn(
+                'text-xs mt-1 font-medium',
+                deltaPositive === true && 'text-blue-600',
+                deltaPositive === false && 'text-amber-600',
+                deltaPositive == null && 'text-slate-500'
+              )}
+            >
+              {delta}
+            </p>
+          ) : null}
+        </div>
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/performance/NetworkOverviewTiles.tsx
+++ b/components/admin/network/performance/NetworkOverviewTiles.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import {
+  NetworkOverviewIcon,
+  type NetworkOverviewIconName,
+} from '@/components/icons/NetworkOverviewIcon';
+
+export type NetworkInventory = {
+  gateway: number;
+  ap: number;
+  switch: { online: number; total: number };
+  client: number;
+  guest: number | null;
+};
+
+type NetworkOverviewTilesProps = {
+  inventory: NetworkInventory;
+  className?: string;
+};
+
+const tiles: Array<{
+  key: NetworkOverviewIconName;
+  label: string;
+}> = [
+  { key: 'gateway', label: 'Gateway' },
+  { key: 'ap', label: 'AP' },
+  { key: 'switch', label: 'Switch' },
+  { key: 'client', label: 'Client' },
+  { key: 'guest', label: 'Guest' },
+];
+
+export function NetworkOverviewTiles({ inventory, className }: NetworkOverviewTilesProps) {
+  const values: Record<NetworkOverviewIconName, ReactNode> = {
+    gateway: inventory.gateway,
+    ap: inventory.ap,
+    switch: (
+      <>
+        <span className="text-emerald-700">{inventory.switch.online}</span>
+        <span className="text-slate-400 text-base font-medium">/{inventory.switch.total}</span>
+      </>
+    ),
+    client: inventory.client,
+    guest: inventory.guest == null ? '—' : inventory.guest,
+  };
+
+  return (
+    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-medium text-slate-800">Network Overview</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap justify-between gap-2">
+          {tiles.map((tile) => (
+            <div key={tile.key} className="flex-1 min-w-[72px] text-center px-1 py-1">
+              <div className="mx-auto mb-2 grid place-items-center h-10">
+                <NetworkOverviewIcon name={tile.key} size={tile.key === 'client' ? 36 : 32} title={tile.label} />
+              </div>
+              <div className="text-xs text-slate-500">{tile.label}</div>
+              <div className="text-2xl font-semibold text-slate-900 mt-0.5 tabular-nums">
+                {values[tile.key]}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/performance/PendingAlertsCard.tsx
+++ b/components/admin/network/performance/PendingAlertsCard.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import { PiCheckCircleBold, PiWarningBold } from 'react-icons/pi';
+import Link from 'next/link';
+
+export type PendingAlertItem = {
+  id: string;
+  device_sn: string;
+  device_name?: string;
+  customer_name?: string;
+  alert_type: string;
+  severity: string;
+  message: string;
+  created_at: string;
+};
+
+type PendingAlertsCardProps = {
+  alerts: PendingAlertItem[];
+  acknowledging?: string | null;
+  onAcknowledge?: (id: string) => void;
+  className?: string;
+};
+
+function formatRelative(iso: string): string {
+  const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const h = Math.floor(mins / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+export function PendingAlertsCard({
+  alerts,
+  acknowledging,
+  onAcknowledge,
+  className,
+}: PendingAlertsCardProps) {
+  return (
+    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+      <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-base font-medium text-slate-800 inline-flex items-center gap-2">
+          Pending Alerts
+          {alerts.length > 0 ? (
+            <Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100 border-0">
+              {alerts.length}
+            </Badge>
+          ) : null}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {alerts.length === 0 ? (
+          <div className="py-8 text-center text-sm text-slate-400">
+            <PiWarningBold className="w-8 h-8 mx-auto mb-2 text-slate-300" />
+            No Data
+          </div>
+        ) : (
+          <ul className="divide-y divide-slate-100">
+            {alerts.slice(0, 6).map((alert) => (
+              <li key={alert.id} className="py-3 flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm text-slate-900 truncate">
+                    <Link
+                      href={`/admin/network/devices/${alert.device_sn}`}
+                      className="font-medium hover:text-blue-600"
+                    >
+                      {alert.device_name || alert.device_sn}
+                    </Link>
+                    <span className="text-slate-500"> · {alert.message}</span>
+                  </p>
+                  <p className="text-xs text-slate-400 mt-0.5">
+                    {formatRelative(alert.created_at)}
+                    {alert.customer_name ? ` · ${alert.customer_name}` : ''}
+                  </p>
+                </div>
+                {onAcknowledge ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="shrink-0 h-8"
+                    disabled={acknowledging === alert.id}
+                    onClick={() => onAcknowledge(alert.id)}
+                  >
+                    <PiCheckCircleBold className="w-4 h-4 mr-1" />
+                    Ack
+                  </Button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/performance/RadioUtilSummaryCard.tsx
+++ b/components/admin/network/performance/RadioUtilSummaryCard.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import Link from 'next/link';
+import { PiBroadcastBold } from 'react-icons/pi';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { RadioUtilSummary } from '@/lib/network/analytics-aggregates';
+import { AnalyticsEmptyState } from './AnalyticsEmptyState';
+import { ResourceUsageList } from './ResourceUsageList';
+
+type RadioUtilSummaryCardProps = {
+  radio: RadioUtilSummary;
+  className?: string;
+};
+
+export function RadioUtilSummaryCard({ radio, className }: RadioUtilSummaryCardProps) {
+  if (radio.devicesWithRadio === 0) {
+    return (
+      <AnalyticsEmptyState
+        title="Channel / Radio Util"
+        description="No radio utilization in device cache for this group. Ruijie does not provide spectrum density (dBm) here — sync live metrics first."
+        icon={<PiBroadcastBold className="w-10 h-10" />}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      <ResourceUsageList
+        title="Radio Utilization"
+        subtitle={`${radio.devicesWithRadio}/${radio.totalDevices} devices with util · from cache (not fake dBm density)`}
+        rows={[
+          {
+            key: '2g',
+            label: '2.4 GHz util',
+            value: radio.avg2g,
+            icon: <PiBroadcastBold className="w-4 h-4" />,
+          },
+          {
+            key: '5g',
+            label: '5 GHz util',
+            value: radio.avg5g,
+            icon: <PiBroadcastBold className="w-4 h-4" />,
+          },
+          {
+            key: 'blend',
+            label: 'Blended util',
+            value: radio.avgBlended,
+            icon: <PiBroadcastBold className="w-4 h-4" />,
+          },
+        ]}
+      />
+
+      <Card className="border border-slate-200/80 shadow-sm rounded-xl bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-slate-500">Channels in use</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div>
+            <p className="text-xs text-slate-400 mb-1.5">2.4 GHz</p>
+            <div className="flex flex-wrap gap-1.5">
+              {radio.channels2g.length ? (
+                radio.channels2g.map((ch) => (
+                  <Badge key={`2g-${ch}`} variant="outline" className="tabular-nums">
+                    Ch {ch}
+                  </Badge>
+                ))
+              ) : (
+                <span className="text-sm text-slate-400">—</span>
+              )}
+            </div>
+          </div>
+          <div>
+            <p className="text-xs text-slate-400 mb-1.5">5 GHz</p>
+            <div className="flex flex-wrap gap-1.5">
+              {radio.channels5g.length ? (
+                radio.channels5g.map((ch) => (
+                  <Badge key={`5g-${ch}`} variant="outline" className="tabular-nums">
+                    Ch {ch}
+                  </Badge>
+                ))
+              ) : (
+                <span className="text-sm text-slate-400">—</span>
+              )}
+            </div>
+          </div>
+
+          {radio.byDevice.length > 0 ? (
+            <div className="pt-2 border-t border-slate-100">
+              <p className="text-xs text-slate-400 mb-2">Highest util devices</p>
+              <ul className="space-y-1.5">
+                {radio.byDevice.slice(0, 5).map((d) => (
+                  <li key={d.sn} className="flex items-center justify-between text-sm gap-2">
+                    <Link
+                      href={`/admin/network/devices/${d.sn}`}
+                      className="truncate text-slate-800 hover:text-blue-600"
+                    >
+                      {d.device_name}
+                    </Link>
+                    <span className="tabular-nums text-slate-500 shrink-0">
+                      {d.radio_2g_utilization == null ? '—' : `${Math.round(d.radio_2g_utilization)}%`}{' '}
+                      /{' '}
+                      {d.radio_5g_utilization == null ? '—' : `${Math.round(d.radio_5g_utilization)}%`}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/admin/network/performance/ResourceUsageList.tsx
+++ b/components/admin/network/performance/ResourceUsageList.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+type ResourceRow = {
+  key: string;
+  label: string;
+  value: number | null;
+  icon: ReactNode;
+};
+
+type ResourceUsageListProps = {
+  title?: string;
+  subtitle?: string;
+  rows: ResourceRow[];
+  className?: string;
+};
+
+function statusFor(value: number | null): { label: string; bar: string; text: string } {
+  if (value == null) return { label: '—', bar: 'bg-slate-200', text: 'text-slate-400' };
+  if (value >= 80) return { label: 'High', bar: 'bg-red-500', text: 'text-red-600' };
+  if (value >= 65) return { label: 'Elevated', bar: 'bg-amber-400', text: 'text-amber-600' };
+  return { label: 'Normal', bar: 'bg-blue-600', text: 'text-blue-600' };
+}
+
+export function ResourceUsageList({
+  title = 'Resource Usage',
+  subtitle,
+  rows,
+  className,
+}: ResourceUsageListProps) {
+  return (
+    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-slate-500">{title}</CardTitle>
+        {subtitle ? <p className="text-xs text-slate-400">{subtitle}</p> : null}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {rows.map((row) => {
+          const status = statusFor(row.value);
+          const width = row.value == null ? 0 : Math.min(100, Math.max(0, row.value));
+          return (
+            <div key={row.key} className="space-y-1.5">
+              <div className="flex items-center justify-between gap-2 text-sm">
+                <span className="inline-flex items-center gap-2 text-slate-700 font-medium">
+                  <span className="text-slate-400">{row.icon}</span>
+                  {row.label}
+                </span>
+                <span className="tabular-nums text-slate-900 font-semibold">
+                  {row.value == null ? '—' : `${row.value.toFixed(0)}%`}
+                  <span className={cn('ml-2 text-xs font-medium', status.text)}>{status.label}</span>
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-slate-100 overflow-hidden">
+                <div className={cn('h-full rounded-full transition-all', status.bar)} style={{ width: `${width}%` }} />
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/performance/SegmentedBar.tsx
+++ b/components/admin/network/performance/SegmentedBar.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+type SegmentedBarProps = {
+  successPercent: number;
+  failedPercent: number;
+  successLabel?: string;
+  failedLabel?: string;
+  className?: string;
+};
+
+export function SegmentedBar({
+  successPercent,
+  failedPercent,
+  successLabel = 'Successful',
+  failedLabel = 'Failed / degraded',
+  className,
+}: SegmentedBarProps) {
+  const success = Math.max(0, Math.min(100, successPercent));
+  const failed = Math.max(0, Math.min(100 - success, failedPercent));
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      <p className="text-[11px] font-medium text-slate-500 uppercase tracking-wide">
+        Live Traffic Distribution
+      </p>
+      <div className="h-3 w-full rounded-full overflow-hidden flex bg-slate-100">
+        <div className="h-full bg-blue-600 transition-all" style={{ width: `${success}%` }} />
+        <div className="h-full bg-amber-400 transition-all" style={{ width: `${failed}%` }} />
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-600">
+        <span className="inline-flex items-center gap-1.5">
+          <span className="w-2 h-2 rounded-full bg-blue-600" />
+          {successLabel} ({success.toFixed(1)}%)
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="w-2 h-2 rounded-full bg-amber-400" />
+          {failedLabel} ({failed.toFixed(1)}%)
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/network/performance/TopApplicationsCard.tsx
+++ b/components/admin/network/performance/TopApplicationsCard.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { PiAppWindowBold } from 'react-icons/pi';
+import { AppFlowChart, formatBytes } from '@/components/admin/network/TrafficChart';
+import { AnalyticsEmptyState } from './AnalyticsEmptyState';
+
+export type AppFlowItem = {
+  appGroupName: string;
+  appName: string;
+  downFlow: number;
+  upFlow: number;
+  upDownFlow: number;
+};
+
+type TopApplicationsCardProps = {
+  data: AppFlowItem[];
+  maxItems?: number;
+};
+
+export function TopApplicationsCard({ data, maxItems = 10 }: TopApplicationsCardProps) {
+  if (!data.length) {
+    return (
+      <AnalyticsEmptyState
+        title="Top Applications"
+        description="No application flow data from Ruijie for this group (EG app-flow unavailable or empty)."
+        icon={<PiAppWindowBold className="w-10 h-10" />}
+      />
+    );
+  }
+
+  return <AppFlowChart data={data} title="Top Applications by Traffic" maxItems={maxItems} />;
+}
+
+export function AppCategoryBreakdown({ data }: { data: AppFlowItem[] }) {
+  if (!data.length) {
+    return (
+      <div className="flex flex-col items-center justify-center py-10 text-center">
+        <PiAppWindowBold className="w-10 h-10 text-slate-300 mb-3" />
+        <p className="text-sm text-slate-600">
+          Categories appear when Ruijie returns app-flow groups for this network.
+        </p>
+      </div>
+    );
+  }
+
+  const categories = data.reduce(
+    (acc, app) => {
+      const cat = app.appGroupName || 'Other';
+      if (!acc[cat]) acc[cat] = { total: 0, apps: 0 };
+      acc[cat].total += app.upDownFlow;
+      acc[cat].apps += 1;
+      return acc;
+    },
+    {} as Record<string, { total: number; apps: number }>
+  );
+
+  const sorted = Object.entries(categories).sort(([, a], [, b]) => b.total - a.total);
+  const totalTraffic = data.reduce((sum, app) => sum + app.upDownFlow, 0);
+  const colors: Record<string, string> = {
+    Streaming: 'bg-violet-500',
+    Social: 'bg-blue-500',
+    Work: 'bg-emerald-500',
+    Gaming: 'bg-red-500',
+    Other: 'bg-slate-500',
+  };
+
+  return (
+    <div className="space-y-4">
+      {sorted.map(([category, stats]) => {
+        const percentage = totalTraffic > 0 ? (stats.total / totalTraffic) * 100 : 0;
+        return (
+          <div key={category}>
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center gap-2">
+                <div className={`w-3 h-3 rounded-full ${colors[category] || 'bg-slate-400'}`} />
+                <span className="font-medium text-sm text-slate-900">{category}</span>
+                <span className="text-xs text-slate-500">
+                  ({stats.apps} app{stats.apps > 1 ? 's' : ''})
+                </span>
+              </div>
+              <div className="flex items-center gap-2 text-sm">
+                <span className="font-medium">{formatBytes(stats.total)}</span>
+                <span className="text-slate-400 w-12 text-right">{percentage.toFixed(0)}%</span>
+              </div>
+            </div>
+            <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
+              <div
+                className={`h-full ${colors[category] || 'bg-slate-400'} rounded-full`}
+                style={{ width: `${percentage}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/admin/network/performance/index.ts
+++ b/components/admin/network/performance/index.ts
@@ -1,0 +1,18 @@
+export { MetricCard } from './MetricCard';
+export { DotMatrixChart } from './DotMatrixChart';
+export { SegmentedBar } from './SegmentedBar';
+export { ResourceUsageList } from './ResourceUsageList';
+export { BandwidthChart } from './BandwidthChart';
+export { DevicesMonitorTable } from './DevicesMonitorTable';
+export type { DeviceMonitorRow } from './DevicesMonitorTable';
+export { NetworkOverviewTiles } from './NetworkOverviewTiles';
+export type { NetworkInventory } from './NetworkOverviewTiles';
+export { PendingAlertsCard } from './PendingAlertsCard';
+export type { PendingAlertItem } from './PendingAlertsCard';
+export { EdgeDeviceCard } from './EdgeDeviceCard';
+export type { EdgeDeviceInfo } from './EdgeDeviceCard';
+export { AnalyticsEmptyState } from './AnalyticsEmptyState';
+export { TopApplicationsCard, AppCategoryBreakdown } from './TopApplicationsCard';
+export type { AppFlowItem } from './TopApplicationsCard';
+export { GroupTrafficCards, SsidActivityCards } from './GroupTrafficCards';
+export { RadioUtilSummaryCard } from './RadioUtilSummaryCard';

--- a/components/icons/NetworkOverviewIcon.tsx
+++ b/components/icons/NetworkOverviewIcon.tsx
@@ -1,0 +1,166 @@
+/**
+ * Network Overview device icons
+ *
+ * Ported from `/home/omada-clone` Omada SVG sprite (`omada-icons.svg`):
+ * dashboard-gateway-light, dashboard-ap-light, dashboard-switch-light,
+ * clients-light, dashboard-guest-light.
+ *
+ * Outline strokes use currentColor; accent fills keep Omada brand green (#00A870).
+ * Source: TP-Link Omada-style clone assets on this VPS (UI recreation).
+ */
+
+import { cn } from '@/lib/utils';
+
+export type NetworkOverviewIconName =
+  | 'gateway'
+  | 'ap'
+  | 'switch'
+  | 'client'
+  | 'guest';
+
+type NetworkOverviewIconProps = {
+  name: NetworkOverviewIconName;
+  className?: string;
+  size?: number;
+  title?: string;
+};
+
+const ACCENT = '#00A870';
+
+export function NetworkOverviewIcon({
+  name,
+  className,
+  size = 32,
+  title,
+}: NetworkOverviewIconProps) {
+  const common = {
+    xmlns: 'http://www.w3.org/2000/svg',
+    width: size,
+    height: size,
+    className: cn('inline-block shrink-0 text-slate-800', className),
+    'aria-hidden': title ? undefined : true,
+    role: title ? 'img' : undefined,
+  } as const;
+
+  switch (name) {
+    case 'gateway':
+      return (
+        <svg {...common} viewBox="0 0 32 32">
+          {title ? <title>{title}</title> : null}
+          <path
+            d="M5.564 15.207c0-.342.276-.619.618-.619h19.636c.342 0 .618.277.618.619v6.37H5.564v-6.37ZM5.83 14.573 8.12 9.63h15.76l2.29 4.943H5.83Z"
+            stroke="currentColor"
+            strokeWidth=".945"
+            fill="none"
+          />
+          <path d="M8 17.454h1.455v1.455H8v-1.454ZM10.91 17.454h4.363v1.455h-4.364v-1.454Z" fill={ACCENT} />
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M20.874 16.582h1.163v1.163h-1.163zm-2.038 0H20v1.164h-1.164zm5.237 0h-1.164v1.163h1.164zM18.836 18.327H20v1.164h-1.164zm2.038 0h1.163v1.164h-1.163zm3.199 0h-1.164v1.164h1.164z"
+            fill={ACCENT}
+          />
+        </svg>
+      );
+    case 'ap':
+      return (
+        <svg {...common} viewBox="0 0 33 32">
+          {title ? <title>{title}</title> : null}
+          <rect
+            x="7.685"
+            y="7.018"
+            width="17.964"
+            height="17.964"
+            rx="8.982"
+            stroke="currentColor"
+            strokeWidth=".945"
+            fill="none"
+          />
+          <path
+            d="M16.666 19.638c2.008 0 3.637-1.716 3.637-3.637s-1.629-3.637-3.637-3.637c-1.006 0-1.916.43-2.575 1.101l.9.998a2.273 2.273 0 1 1-.55 2.002l-1.302.396c.046.177.104.348.175.515l1.029-.315-.927.534c.092.181.198.355.318.52l.668-.386-.562.524c.668.831 1.685 1.385 2.826 1.385Z"
+            fill={ACCENT}
+          />
+        </svg>
+      );
+    case 'switch':
+      return (
+        <svg {...common} viewBox="0 0 33 32">
+          {title ? <title>{title}</title> : null}
+          <path
+            d="M6.397 15.207c0-.342.277-.619.618-.619h19.636c.342 0 .619.277.619.619v6.37H6.397v-6.37Z"
+            stroke="currentColor"
+            strokeWidth=".945"
+            fill="none"
+          />
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M20.148 17.423h-1.47v1.47h1.47v-1.47Zm-2.573 0h-1.469v1.47h1.47v-1.47Zm3.674 0h1.469v1.47h-1.47v-1.47Zm4.035 0h-1.469v1.47h1.47v-1.47Z"
+            fill={ACCENT}
+          />
+          <path d="M8.833 17.423h4.379v1.47H8.833v-1.47Z" fill={ACCENT} />
+          <path
+            d="m6.664 14.573 2.29-4.943h15.76l2.289 4.943H6.664Z"
+            stroke="currentColor"
+            strokeWidth=".945"
+            fill="none"
+          />
+        </svg>
+      );
+    case 'client':
+      return (
+        <svg {...common} viewBox="0 0 44 44">
+          {title ? <title>{title}</title> : null}
+          <path
+            d="M26.479 11.819H10.555v13.818h21.927V23.85M7.817 29.47a.707.707 0 0 0 .576 1.12h26.25c.576 0 .91-.65.576-1.12l-2.738-3.832H10.555l-2.738 3.833Z"
+            stroke="currentColor"
+            strokeWidth="1.3"
+            fill="none"
+          />
+          <path
+            d="M7.725 32.662c0 .057.047.104.104.104h27.378a.103.103 0 0 0 .103-.104v-2.074H7.725v2.074ZM27.892 10.65h6.331v11.674h-6.331V10.65ZM29.531 20.357h3.053"
+            stroke="currentColor"
+            strokeWidth="1.3"
+            fill="none"
+          />
+          <path fill={ACCENT} d="M13.723 15.069h6.868v2.092h-6.868z" />
+        </svg>
+      );
+    case 'guest':
+      return (
+        <svg {...common} viewBox="0 0 33 32">
+          {title ? <title>{title}</title> : null}
+          <circle
+            cx="13.061"
+            cy="11.273"
+            r="3.527"
+            stroke="currentColor"
+            strokeWidth=".945"
+            fill="none"
+          />
+          <path
+            d="M20.21 23.527H5.91c.233-3.955 3.364-7.054 7.15-7.054 3.787 0 6.918 3.1 7.15 7.054Z"
+            stroke="currentColor"
+            strokeWidth=".945"
+            fill="none"
+          />
+          <circle
+            cx="21.424"
+            cy="14.274"
+            r="2.073"
+            stroke="currentColor"
+            strokeWidth=".945"
+            fill="none"
+          />
+          <path
+            d="M16.333 23.49h10.182a5.09 5.09 0 0 0-5.091-5.09 5.07 5.07 0 0 0-3.182 1.114"
+            stroke="currentColor"
+            strokeWidth=".945"
+            fill="none"
+          />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}

--- a/docs/plans/2026-07-25-omada-network-ui-phase1-health.md
+++ b/docs/plans/2026-07-25-omada-network-ui-phase1-health.md
@@ -1,0 +1,27 @@
+# Omada-inspired Network UI — Phase 1 (System Health)
+
+**Date:** 2026-07-25  
+**Status:** Approved for implementation  
+**Branch:** `cursor/network-performance-dashboard`
+
+## Decisions
+- Port Omada patterns into CircleTel React (not Vue embed, not pixel-perfect Omada skin)
+- Phase order: Health → Devices → Analytics
+- Data: real Ruijie/Supabase only; Omada-style empty states when fields missing
+- Phase 1 scope: enhance `/admin/network/health` only
+
+## Phase 1 deliverables
+1. **Network Overview tiles** — Gateway / AP / Switch (online/total) / Client / Guest from `ruijie_device_cache` (+ model heuristics)
+2. **Pending Alerts card** — restyle existing `unacknowledgedAlerts` to Omada-like list
+3. **Edge / primary device card** — best-effort gateway or highest-client online device; CPU/mem/radio; no fake port map if unsupported
+4. Keep existing System Health KPI row, resource bars, bandwidth, devices table
+
+## Out of Phase 1
+- Devices page chips/drawer
+- Analytics SSID/app/density widgets
+- Topology
+
+## Success
+- Health page shows overview tiles + alerts + edge card with live cache data
+- Missing roles/metrics show empty/— not mock numbers
+- Aggregate unit tests for inventory classification

--- a/docs/plans/2026-07-25-omada-network-ui-phase3-analytics.md
+++ b/docs/plans/2026-07-25-omada-network-ui-phase3-analytics.md
@@ -1,0 +1,18 @@
+# Omada-inspired Network UI — Phase 3 (Analytics)
+
+**Date:** 2026-07-25  
+**Status:** Implemented  
+**Route:** `/admin/network/analytics`
+
+## Scope
+- Keep rollup throughput KPIs + Cached/Live toggle
+- Top applications via Ruijie `flow/app` — empty state when none
+- Group traffic cards from `ruijie_traffic_rollups` when present
+- SSID activity from live STA client counts (not invented byte traffic)
+- Channel/radio util from `ruijie_device_cache` — empty if missing; no fake dBm density
+
+## Key files
+- `app/api/admin/network/analytics/route.ts`
+- `app/admin/network/analytics/page.tsx`
+- `lib/network/analytics-aggregates.ts`
+- `components/admin/network/performance/{TopApplicationsCard,GroupTrafficCards,RadioUtilSummaryCard,AnalyticsEmptyState}.tsx`

--- a/lib/admin/feature-registry.ts
+++ b/lib/admin/feature-registry.ts
@@ -330,7 +330,7 @@ export const featureSections: NavSection[] = [
         icon: PiWifiHighBold,
         children: [
           { name: 'Devices', href: '/admin/network/devices', icon: PiWifiHighBold },
-          { name: 'Health Monitor', href: '/admin/network/health', icon: PiPulseBold },
+          { name: 'System Health', href: '/admin/network/health', icon: PiPulseBold },
           { name: 'Analytics', href: '/admin/network/analytics', icon: PiChartBarBold },
           { name: 'Network Map', href: '/admin/network/map', icon: PiMapTrifoldBold },
         ],

--- a/lib/inngest/functions/ruijie-sync.ts
+++ b/lib/inngest/functions/ruijie-sync.ts
@@ -13,7 +13,11 @@
 import { inngest } from '../client';
 import {
   getAllDevices,
+  enrichDevicesWithLiveMetrics,
   upsertDevices,
+  pruneDevicesNotInSet,
+  filterActiveDevices,
+  RUIJIE_ACTIVE_WINDOW_DAYS,
   createSyncLog,
   logSyncRun,
   seedMockData,
@@ -93,22 +97,63 @@ export const ruijieSyncFunction = inngest.createFunction(
       return result;
     });
 
-    // Step 4: Upsert devices
+    // Step 3b: Keep only online or last_seen within 14 days
+    const activeDevices = await step.run('filter-active-window', async () => {
+      const filtered = filterActiveDevices(
+        devices as unknown as RuijieDevice[]
+      );
+      console.log(
+        `[RuijieSync] Active window ${RUIJIE_ACTIVE_WINDOW_DAYS}d: ` +
+          `${filtered.length}/${(devices as unknown as RuijieDevice[]).length} kept`
+      );
+      return filtered;
+    });
+
+    // Step 4: Enrich with current_performance + STA util/clients (Tier 1)
+    const enrichedDevices = await step.run('enrich-live-metrics', async () => {
+      console.log('[RuijieSync] Enriching CPU/mem + STA metrics...');
+      const result = await enrichDevicesWithLiveMetrics(
+        activeDevices as unknown as RuijieDevice[]
+      );
+      const withCpu = result.filter((d) => d.cpu_usage != null).length;
+      const withClients = result.reduce((s, d) => s + (d.online_clients || 0), 0);
+      console.log(
+        `[RuijieSync] Metrics: ${withCpu} devices with CPU, ${withClients} total STA clients`
+      );
+      return result;
+    });
+
+    // Step 5: Upsert devices
     const syncResult = await step.run('upsert-devices', async () => {
       console.log('[RuijieSync] Upserting devices to cache...');
       // Cast needed because Inngest's JsonifyObject type wrapper differs from RuijieDevice
-      const result = await upsertDevices(devices as unknown as RuijieDevice[], isMockMode());
+      const result = await upsertDevices(
+        enrichedDevices as unknown as RuijieDevice[],
+        isMockMode()
+      );
       console.log(`[RuijieSync] Upserted: ${result.added} added, ${result.updated} updated`);
       return result;
     });
 
-    // Step 5: Update sync log
+    // Step 5b: Remove cache rows outside the active window
+    const pruneResult = await step.run('prune-inactive-devices', async () => {
+      const keepSns = (enrichedDevices as unknown as RuijieDevice[]).map((d) => d.sn);
+      const result = await pruneDevicesNotInSet(keepSns);
+      if (result.deleted > 0) {
+        console.log(
+          `[RuijieSync] Pruned ${result.deleted} inactive devices: ${result.deletedSns.join(', ')}`
+        );
+      }
+      return result;
+    });
+
+    // Step 6: Update sync log
     const duration = Date.now() - startTime;
     await step.run('update-sync-log', async () => {
       await logSyncRun(
         {
           ...syncResult,
-          devicesFetched: devices.length,
+          devicesFetched: (activeDevices as unknown as RuijieDevice[]).length,
           durationMs: duration,
         },
         triggeredBy,
@@ -118,15 +163,16 @@ export const ruijieSyncFunction = inngest.createFunction(
       console.log(`[RuijieSync] Updated sync log ${syncLogId}`);
     });
 
-    // Step 6: Send completion event
+    // Step 7: Send completion event
     await step.run('send-completion-event', async () => {
       await inngest.send({
         name: 'ruijie/sync.completed',
         data: {
           sync_log_id: syncLogId,
-          devices_fetched: devices.length,
+          devices_fetched: (activeDevices as unknown as RuijieDevice[]).length,
           added: syncResult.added,
           updated: syncResult.updated,
+          pruned: pruneResult.deleted,
           errors: syncResult.errors.length,
           duration_ms: duration,
         },
@@ -136,9 +182,10 @@ export const ruijieSyncFunction = inngest.createFunction(
     return {
       success: syncResult.errors.length === 0,
       syncLogId,
-      devicesFetched: devices.length,
+      devicesFetched: (activeDevices as unknown as RuijieDevice[]).length,
       added: syncResult.added,
       updated: syncResult.updated,
+      pruned: pruneResult.deleted,
       errors: syncResult.errors.length,
       duration,
     };

--- a/lib/inngest/functions/ruijie-traffic-rollup.ts
+++ b/lib/inngest/functions/ruijie-traffic-rollup.ts
@@ -1,0 +1,139 @@
+/**
+ * Ruijie Traffic Rollup
+ *
+ * After each device sync, fetch hourly flow per group (via a representative
+ * device SN — API V2.0.3 §2.6.2) and persist rollups for Health / Analytics.
+ *
+ * Trigger: ruijie/sync.completed
+ */
+
+import { inngest } from '../client';
+import { createClient } from '@/lib/supabase/server';
+import { getNetworkTraffic, pickFlowDeviceSn } from '@/lib/ruijie/client';
+
+const HOURS_WINDOW = 24;
+const RETENTION_DAYS = 14;
+const GROUP_DELAY_MS = 400;
+
+type GroupRow = {
+  group_id: string;
+  group_name: string | null;
+};
+
+export const ruijieTrafficRollupFunction = inngest.createFunction(
+  {
+    id: 'ruijie-traffic-rollup',
+    name: 'Ruijie Traffic Rollup',
+    retries: 2,
+  },
+  { event: 'ruijie/sync.completed' },
+  async ({ step }) => {
+    const groups = await step.run('fetch-groups', async () => {
+      const supabase = await createClient();
+      const { data, error } = await supabase
+        .from('ruijie_device_cache')
+        .select('group_id, group_name')
+        .not('group_id', 'is', null);
+
+      if (error) {
+        console.error('[TrafficRollup] Failed to fetch groups:', error);
+        return [] as GroupRow[];
+      }
+
+      const map = new Map<string, string | null>();
+      for (const row of data || []) {
+        if (!row.group_id) continue;
+        if (!map.has(row.group_id)) {
+          map.set(row.group_id, row.group_name);
+        }
+      }
+
+      return Array.from(map.entries()).map(([group_id, group_name]) => ({
+        group_id,
+        group_name,
+      }));
+    });
+
+    if (groups.length === 0) {
+      return { groupsProcessed: 0, rowsInserted: 0 };
+    }
+
+    // Bucket to the hour so retries/upserts coalesce within the same window
+    const hourBucket = new Date();
+    hourBucket.setUTCMinutes(0, 0, 0);
+    const capturedAt = hourBucket.toISOString();
+
+    const rowsInserted = await step.run('rollup-groups', async () => {
+      const supabase = await createClient();
+      let inserted = 0;
+
+      for (const group of groups) {
+        try {
+          const { data: devices } = await supabase
+            .from('ruijie_device_cache')
+            .select('sn, status, model')
+            .eq('group_id', group.group_id);
+
+          const flowSn = pickFlowDeviceSn(devices || []);
+          if (!flowSn) {
+            console.warn(`[TrafficRollup] No device SN for group ${group.group_id}`);
+            continue;
+          }
+
+          const traffic = await getNetworkTraffic({ sn: flowSn, hours: HOURS_WINDOW });
+          const hoursSeconds = Math.max(HOURS_WINDOW, 1) * 3600;
+          const peakRxBps = (traffic.peakRxBytes * 8) / hoursSeconds;
+          const peakTxBps = (traffic.peakTxBytes * 8) / hoursSeconds;
+
+          const { error } = await supabase.from('ruijie_traffic_rollups').upsert(
+            {
+              group_id: group.group_id,
+              group_name: group.group_name,
+              captured_at: capturedAt,
+              hours_window: HOURS_WINDOW,
+              total_rx_bytes: Math.round(traffic.totalRxBytes),
+              total_tx_bytes: Math.round(traffic.totalTxBytes),
+              avg_rx_bps: traffic.avgRxRate,
+              avg_tx_bps: traffic.avgTxRate,
+              peak_rx_bps: peakRxBps,
+              peak_tx_bps: peakTxBps,
+              raw_summary: {
+                totalBytes: traffic.totalBytes,
+                dataPointCount: traffic.dataPoints.length,
+                flowSn,
+              },
+            },
+            { onConflict: 'group_id,captured_at,hours_window' }
+          );
+
+          if (error) {
+            console.error(`[TrafficRollup] Upsert failed for ${group.group_id}:`, error);
+          } else {
+            inserted += 1;
+          }
+        } catch (err) {
+          console.error(`[TrafficRollup] Group ${group.group_id} failed:`, err);
+        }
+
+        await new Promise((r) => setTimeout(r, GROUP_DELAY_MS));
+      }
+
+      return inserted;
+    });
+
+    await step.run('prune-old-rollups', async () => {
+      const supabase = await createClient();
+      const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+      const { error } = await supabase
+        .from('ruijie_traffic_rollups')
+        .delete()
+        .lt('captured_at', cutoff);
+
+      if (error) {
+        console.error('[TrafficRollup] Prune failed:', error);
+      }
+    });
+
+    return { groupsProcessed: groups.length, rowsInserted };
+  }
+);

--- a/lib/inngest/index.ts
+++ b/lib/inngest/index.ts
@@ -83,6 +83,10 @@ export {
 } from './functions/ruijie-health-monitor';
 
 export {
+  ruijieTrafficRollupFunction,
+} from './functions/ruijie-traffic-rollup';
+
+export {
   mikrotikSyncFunction,
   mikrotikSyncCompletedFunction,
 } from './functions/mikrotik-sync';
@@ -228,6 +232,10 @@ import {
 } from './functions/ruijie-health-monitor';
 
 import {
+  ruijieTrafficRollupFunction,
+} from './functions/ruijie-traffic-rollup';
+
+import {
   mikrotikSyncFunction,
   mikrotikSyncCompletedFunction,
 } from './functions/mikrotik-sync';
@@ -344,6 +352,8 @@ export const functions = [
   ruijieOfflineAlertsFunction,
   // Ruijie health monitoring
   ruijieHealthMonitorFunction,
+  // Ruijie traffic rollups for System Health / Analytics
+  ruijieTrafficRollupFunction,
   // MikroTik router sync
   mikrotikSyncFunction,
   mikrotikSyncCompletedFunction,

--- a/lib/network/analytics-aggregates.ts
+++ b/lib/network/analytics-aggregates.ts
@@ -1,0 +1,184 @@
+/**
+ * Pure helpers for Network Analytics (Phase 3).
+ * No I/O — unit-tested aggregates for group traffic, radio util, SSID activity.
+ */
+
+import { avgOrNull, roundPercent } from './performance-aggregates';
+
+export type GroupRollupRow = {
+  group_id: string;
+  group_name: string | null;
+  total_rx_bytes: number | null;
+  total_tx_bytes: number | null;
+  captured_at: string;
+};
+
+export type GroupTrafficCard = {
+  groupId: string;
+  groupName: string;
+  totalRxBytes: number;
+  totalTxBytes: number;
+  totalBytes: number;
+  sampleCount: number;
+  lastCapturedAt: string | null;
+};
+
+export type RadioDeviceRow = {
+  sn: string;
+  device_name: string;
+  status: string;
+  radio_2g_utilization: number | null;
+  radio_5g_utilization: number | null;
+  radio_2g_channel?: number | null;
+  radio_5g_channel?: number | null;
+};
+
+export type RadioUtilSummary = {
+  avg2g: number | null;
+  avg5g: number | null;
+  avgBlended: number | null;
+  devicesWithRadio: number;
+  totalDevices: number;
+  channels2g: number[];
+  channels5g: number[];
+  byDevice: Array<{
+    sn: string;
+    device_name: string;
+    status: string;
+    radio_2g_utilization: number | null;
+    radio_5g_utilization: number | null;
+  }>;
+};
+
+export type SsidStaRow = {
+  ssid?: string | null;
+};
+
+export type SsidActivityCard = {
+  ssid: string;
+  clients: number;
+};
+
+/**
+ * Sum rollup traffic per group within the selected window.
+ * Only returns groups that have at least one rollup row.
+ */
+export function computeGroupTrafficCards(rows: GroupRollupRow[]): GroupTrafficCard[] {
+  const byGroup = new Map<
+    string,
+    {
+      groupName: string;
+      rx: number;
+      tx: number;
+      samples: number;
+      lastCapturedAt: string | null;
+    }
+  >();
+
+  for (const row of rows) {
+    if (!row.group_id) continue;
+    const prev = byGroup.get(row.group_id) || {
+      groupName: row.group_name || row.group_id,
+      rx: 0,
+      tx: 0,
+      samples: 0,
+      lastCapturedAt: null as string | null,
+    };
+    prev.rx += Number(row.total_rx_bytes) || 0;
+    prev.tx += Number(row.total_tx_bytes) || 0;
+    prev.samples += 1;
+    if (row.group_name) prev.groupName = row.group_name;
+    if (
+      !prev.lastCapturedAt ||
+      new Date(row.captured_at).getTime() > new Date(prev.lastCapturedAt).getTime()
+    ) {
+      prev.lastCapturedAt = row.captured_at;
+    }
+    byGroup.set(row.group_id, prev);
+  }
+
+  return Array.from(byGroup.entries())
+    .map(([groupId, v]) => ({
+      groupId,
+      groupName: v.groupName,
+      totalRxBytes: v.rx,
+      totalTxBytes: v.tx,
+      totalBytes: v.rx + v.tx,
+      sampleCount: v.samples,
+      lastCapturedAt: v.lastCapturedAt,
+    }))
+    .filter((c) => c.totalBytes > 0 || c.sampleCount > 0)
+    .sort((a, b) => b.totalBytes - a.totalBytes);
+}
+
+/**
+ * Radio / channel util from device cache only.
+ * Returns null averages when no device has util metrics (empty UI, no fake dBm).
+ */
+export function computeRadioUtilSummary(devices: RadioDeviceRow[]): RadioUtilSummary {
+  const withRadio = devices.filter(
+    (d) => d.radio_2g_utilization != null || d.radio_5g_utilization != null
+  );
+  const channels2g = [
+    ...new Set(
+      devices
+        .map((d) => d.radio_2g_channel)
+        .filter((c): c is number => typeof c === 'number' && !Number.isNaN(c))
+    ),
+  ].sort((a, b) => a - b);
+  const channels5g = [
+    ...new Set(
+      devices
+        .map((d) => d.radio_5g_channel)
+        .filter((c): c is number => typeof c === 'number' && !Number.isNaN(c))
+    ),
+  ].sort((a, b) => a - b);
+
+  const avg2g = avgOrNull(devices.map((d) => d.radio_2g_utilization));
+  const avg5g = avgOrNull(devices.map((d) => d.radio_5g_utilization));
+  const blended = devices.map((d) =>
+    avgOrNull([d.radio_2g_utilization, d.radio_5g_utilization])
+  );
+
+  return {
+    avg2g: avg2g == null ? null : roundPercent(avg2g),
+    avg5g: avg5g == null ? null : roundPercent(avg5g),
+    avgBlended: (() => {
+      const v = avgOrNull(blended);
+      return v == null ? null : roundPercent(v);
+    })(),
+    devicesWithRadio: withRadio.length,
+    totalDevices: devices.length,
+    channels2g,
+    channels5g,
+    byDevice: withRadio
+      .map((d) => ({
+        sn: d.sn,
+        device_name: d.device_name,
+        status: d.status,
+        radio_2g_utilization: d.radio_2g_utilization,
+        radio_5g_utilization: d.radio_5g_utilization,
+      }))
+      .sort((a, b) => {
+        const aMax = Math.max(a.radio_2g_utilization ?? 0, a.radio_5g_utilization ?? 0);
+        const bMax = Math.max(b.radio_2g_utilization ?? 0, b.radio_5g_utilization ?? 0);
+        return bMax - aMax;
+      }),
+  };
+}
+
+/**
+ * Client counts by SSID from live STA rows (not byte traffic).
+ * Empty when Ruijie STA has no SSID associations.
+ */
+export function aggregateSsidActivity(stas: SsidStaRow[]): SsidActivityCard[] {
+  const counts = new Map<string, number>();
+  for (const sta of stas) {
+    const ssid = (sta.ssid || '').trim();
+    if (!ssid) continue;
+    counts.set(ssid, (counts.get(ssid) || 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([ssid, clients]) => ({ ssid, clients }))
+    .sort((a, b) => b.clients - a.clients || a.ssid.localeCompare(b.ssid));
+}

--- a/lib/network/performance-aggregates.ts
+++ b/lib/network/performance-aggregates.ts
@@ -1,0 +1,277 @@
+/**
+ * Pure helpers for Network System Health / Analytics aggregates.
+ * Kept free of I/O so unit tests can lock KPI math.
+ */
+
+export type DeviceResourceRow = {
+  cpu_usage: number | null;
+  memory_usage: number | null;
+  radio_2g_utilization: number | null;
+  radio_5g_utilization: number | null;
+};
+
+export type FleetDeviceInput = DeviceResourceRow & {
+  sn: string;
+  status: string;
+  online_clients: number;
+};
+
+export type DeviceHealthInput = {
+  health_score: number;
+  anomaly_count: number;
+};
+
+export type UptimeSnapshotPoint = {
+  device_sn: string;
+  status: string | null;
+  captured_at: string;
+};
+
+export type DailyUptimePoint = {
+  date: string;
+  uptimePercent: number;
+  sampleCount: number;
+};
+
+export function roundPercent(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function percentDelta(current: number, previous: number): number | null {
+  if (previous === 0) return null;
+  return roundPercent(((current - previous) / previous) * 100);
+}
+
+export function bpsToMbps(bps: number): number {
+  return bps / 1_000_000;
+}
+
+export function avgOrNull(
+  values: Array<number | null | undefined>
+): number | null {
+  const nums = values.filter((v): v is number => typeof v === 'number' && !Number.isNaN(v));
+  if (nums.length === 0) return null;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+function blendedRadio(
+  radio2g: number | null | undefined,
+  radio5g: number | null | undefined
+): number | null {
+  return avgOrNull([radio2g, radio5g]);
+}
+
+export function computeResourceAverages(rows: DeviceResourceRow[]): {
+  avgCpu: number | null;
+  avgMemory: number | null;
+  avgRadio: number | null;
+} {
+  return {
+    avgCpu: avgOrNull(rows.map((r) => r.cpu_usage)),
+    avgMemory: avgOrNull(rows.map((r) => r.memory_usage)),
+    avgRadio: avgOrNull(rows.map((r) => blendedRadio(r.radio_2g_utilization, r.radio_5g_utilization))),
+  };
+}
+
+export function computeFleetOverview(input: {
+  devices: FleetDeviceInput[];
+  healthBySn: Record<string, DeviceHealthInput>;
+  priorOnlineRate?: number | null;
+  consistencyThreshold?: number;
+}): {
+  totalDevices: number;
+  onlineDevices: number;
+  offlineDevices: number;
+  healthyDevices: number;
+  warningDevices: number;
+  criticalDevices: number;
+  totalClients: number;
+  uptimePercent: number;
+  successRatePercent: number;
+  responseConsistencyPercent: number;
+  uptimeDeltaVsPrior: number | null;
+  anomaliesLast24h: number;
+  overallScore: number;
+  resources: ReturnType<typeof computeResourceAverages>;
+} {
+  const threshold = input.consistencyThreshold ?? 50;
+  const totalDevices = input.devices.length;
+  const onlineDevices = input.devices.filter((d) => d.status === 'online').length;
+  const offlineDevices = input.devices.filter((d) => d.status === 'offline').length;
+  const totalClients = input.devices.reduce((sum, d) => sum + (d.online_clients || 0), 0);
+
+  let healthyDevices = 0;
+  let warningDevices = 0;
+  let criticalDevices = 0;
+  let totalHealthScore = 0;
+  let consistent = 0;
+  let anomaliesLast24h = 0;
+
+  for (const device of input.devices) {
+    const health = input.healthBySn[device.sn] ?? {
+      health_score: device.status === 'online' ? 100 : 40,
+      anomaly_count: 0,
+    };
+    const score = health.health_score;
+    totalHealthScore += score;
+    anomaliesLast24h += health.anomaly_count;
+
+    if (score >= 80) healthyDevices++;
+    else if (score >= 50) warningDevices++;
+    else criticalDevices++;
+
+    if (score >= threshold) consistent++;
+  }
+
+  const uptimePercent = totalDevices > 0 ? roundPercent((onlineDevices / totalDevices) * 100) : 100;
+  const successRatePercent =
+    totalDevices > 0 ? roundPercent((healthyDevices / totalDevices) * 100) : 100;
+  const responseConsistencyPercent =
+    totalDevices > 0 ? roundPercent((consistent / totalDevices) * 100) : 100;
+  const overallScore =
+    totalDevices > 0 ? Math.round(totalHealthScore / totalDevices) : 100;
+
+  return {
+    totalDevices,
+    onlineDevices,
+    offlineDevices,
+    healthyDevices,
+    warningDevices,
+    criticalDevices,
+    totalClients,
+    uptimePercent,
+    successRatePercent,
+    responseConsistencyPercent,
+    uptimeDeltaVsPrior:
+      input.priorOnlineRate == null ? null : percentDelta(uptimePercent, input.priorOnlineRate),
+    anomaliesLast24h,
+    overallScore,
+    resources: computeResourceAverages(input.devices),
+  };
+}
+
+/**
+ * Daily uptime = online samples / all samples that day (fleet-wide).
+ * Days with no samples return 0% with sampleCount 0.
+ */
+export function buildDailyUptimeSeries(input: {
+  days: number;
+  now: Date;
+  snapshots: UptimeSnapshotPoint[];
+  deviceCount: number;
+}): DailyUptimePoint[] {
+  const dayKeys: string[] = [];
+  for (let i = input.days - 1; i >= 0; i--) {
+    const d = new Date(input.now);
+    d.setUTCHours(0, 0, 0, 0);
+    d.setUTCDate(d.getUTCDate() - i);
+    dayKeys.push(d.toISOString().slice(0, 10));
+  }
+
+  const byDay: Record<string, { online: number; total: number }> = {};
+  for (const key of dayKeys) {
+    byDay[key] = { online: 0, total: 0 };
+  }
+
+  for (const snap of input.snapshots) {
+    const key = snap.captured_at.slice(0, 10);
+    if (!byDay[key]) continue;
+    byDay[key].total += 1;
+    if (snap.status === 'online') byDay[key].online += 1;
+  }
+
+  return dayKeys.map((date) => {
+    const bucket = byDay[date];
+    const uptimePercent =
+      bucket.total > 0 ? roundPercent((bucket.online / bucket.total) * 100) : 0;
+    return { date, uptimePercent, sampleCount: bucket.total };
+  });
+}
+
+export type DeviceRole = 'gateway' | 'switch' | 'ap' | 'unknown';
+
+export type InventoryDeviceInput = {
+  sn: string;
+  device_name: string;
+  model: string | null | undefined;
+  status: string;
+  online_clients: number;
+  cpu_usage?: number | null;
+  memory_usage?: number | null;
+  radio_2g_utilization?: number | null;
+  radio_5g_utilization?: number | null;
+  management_ip?: string | null;
+  wan_ip?: string | null;
+  synced_at?: string | null;
+};
+
+/**
+ * Classify Ruijie/Omada-like hardware from model + name heuristics.
+ * Defaults unknown Wi-Fi APs to `ap` when model is empty but name suggests AP.
+ */
+export function classifyDeviceRole(
+  model: string | null | undefined,
+  deviceName: string | null | undefined
+): DeviceRole {
+  const hay = `${model || ''} ${deviceName || ''}`.toLowerCase();
+  if (/gateway|router|\ber\d|\beg\d|er7206|er605|tl-er|tl-r/.test(hay)) return 'gateway';
+  if (/switch|\bsg\d|tl-sg|tl-sl|core.?switch|access.?switch/.test(hay)) return 'switch';
+  if (/\bap\b|eap|rap|access.?point|wifi|wi-fi|reyee/.test(hay)) return 'ap';
+  // Ruijie fleet is predominantly APs when model unknown
+  if (!model && deviceName) return 'ap';
+  return 'unknown';
+}
+
+export function computeNetworkInventory(devices: InventoryDeviceInput[]): {
+  gateway: number;
+  ap: number;
+  switchOnline: number;
+  switchTotal: number;
+  client: number;
+  guest: number | null;
+  edgeDevice: InventoryDeviceInput | null;
+} {
+  let gateway = 0;
+  let ap = 0;
+  let switchOnline = 0;
+  let switchTotal = 0;
+  let client = 0;
+
+  const gateways: InventoryDeviceInput[] = [];
+  const onlineDevices: InventoryDeviceInput[] = [];
+
+  for (const device of devices) {
+    const role = classifyDeviceRole(device.model, device.device_name);
+    client += device.online_clients || 0;
+    if (device.status === 'online') onlineDevices.push(device);
+
+    if (role === 'gateway') {
+      gateway += 1;
+      gateways.push(device);
+    } else if (role === 'switch') {
+      switchTotal += 1;
+      if (device.status === 'online') switchOnline += 1;
+    } else if (role === 'ap' || role === 'unknown') {
+      ap += 1;
+    }
+  }
+
+  // Prefer online gateway; else busiest online device
+  let edgeDevice: InventoryDeviceInput | null =
+    gateways.find((g) => g.status === 'online') || gateways[0] || null;
+  if (!edgeDevice && onlineDevices.length > 0) {
+    edgeDevice = [...onlineDevices].sort(
+      (a, b) => (b.online_clients || 0) - (a.online_clients || 0)
+    )[0];
+  }
+
+  return {
+    gateway,
+    ap,
+    switchOnline,
+    switchTotal,
+    client,
+    guest: null, // Ruijie cache has no guest split yet
+    edgeDevice,
+  };
+}

--- a/lib/ruijie/active-window.ts
+++ b/lib/ruijie/active-window.ts
@@ -1,0 +1,37 @@
+/**
+ * Ruijie fleet retention: only devices active within a sliding window
+ * (currently online, or lastOnline / last_seen_at within N days).
+ */
+
+export const RUIJIE_ACTIVE_WINDOW_DAYS = 14;
+
+export type ActiveWindowDevice = {
+  sn: string;
+  status: string;
+  last_seen_at?: string | null;
+};
+
+/**
+ * True if the device is online now, or was last seen within `windowDays`.
+ * Offline devices with missing/invalid last_seen are inactive.
+ */
+export function isDeviceActiveInWindow(
+  device: ActiveWindowDevice,
+  nowMs: number = Date.now(),
+  windowDays: number = RUIJIE_ACTIVE_WINDOW_DAYS
+): boolean {
+  if (device.status === 'online') return true;
+  if (!device.last_seen_at) return false;
+  const seen = new Date(device.last_seen_at).getTime();
+  if (Number.isNaN(seen)) return false;
+  const cutoff = nowMs - windowDays * 24 * 60 * 60 * 1000;
+  return seen >= cutoff;
+}
+
+export function filterActiveDevices<T extends ActiveWindowDevice>(
+  devices: T[],
+  nowMs: number = Date.now(),
+  windowDays: number = RUIJIE_ACTIVE_WINDOW_DAYS
+): T[] {
+  return devices.filter((d) => isDeviceActiveInWindow(d, nowMs, windowDays));
+}

--- a/lib/ruijie/client.ts
+++ b/lib/ruijie/client.ts
@@ -10,9 +10,29 @@
 import { getAccessToken } from './auth';
 import { getMockDevices, getMockDevice, createMockTunnel } from './mock';
 import { RuijieDevice, RuijieTunnel } from './types';
+import {
+  aggregateStaMetricsForDevice,
+  buildHourlyFlowRequest,
+  mapCurrentPerformance,
+  pickFlowDeviceSn,
+  type StaUserRaw,
+} from './performance-metrics';
 
 const RUIJIE_BASE_URL = process.env.RUIJIE_BASE_URL || 'https://cloud.ruijienetworks.com/service/api';
 const MOCK_MODE = process.env.RUIJIE_MOCK_MODE === 'true';
+
+/**
+ * Logbiz (STA / performance / flow) is hosted at cloud root, NOT under /service/api.
+ * Example: https://cloud-eu.ruijienetworks.com/logbizagent/logbiz/api/...
+ * Override with RUIJIE_LOG_BIZ_BASE if Ruijie documents a separate logbiz host.
+ */
+function getLogbizBaseUrl(): string {
+  if (process.env.RUIJIE_LOG_BIZ_BASE) {
+    return process.env.RUIJIE_LOG_BIZ_BASE.replace(/\/$/, '');
+  }
+  const host = RUIJIE_BASE_URL.replace(/\/service\/api\/?$/, '');
+  return `${host}/logbizagent/logbiz/api`;
+}
 
 // =============================================================================
 // API FETCH HELPER
@@ -24,12 +44,13 @@ const MOCK_MODE = process.env.RUIJIE_MOCK_MODE === 'true';
  */
 async function ruijieFetch<T>(
   endpoint: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
+  baseUrl: string = RUIJIE_BASE_URL
 ): Promise<T> {
   const token = await getAccessToken();
 
   // Ruijie API uses query param for auth, not header
-  const url = new URL(`${RUIJIE_BASE_URL}${endpoint}`);
+  const url = new URL(`${baseUrl}${endpoint}`);
   url.searchParams.set('access_token', token);
 
   const response = await fetch(url.toString(), {
@@ -47,6 +68,14 @@ async function ruijieFetch<T>(
   }
 
   return response.json();
+}
+
+/** Authenticated fetch against the logbiz agent (CPU/mem, STA, flow). */
+async function ruijieLogbizFetch<T>(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<T> {
+  return ruijieFetch<T>(endpoint, options, getLogbizBaseUrl());
 }
 
 // =============================================================================
@@ -284,21 +313,25 @@ export async function getDevice(sn: string): Promise<RuijieDevice> {
 
 /**
  * Online STA (station/client) response from Ruijie Cloud
- * Endpoint: /logbizagent/logbiz/api/sta/sta_users
+ * Endpoint: /logbizagent/logbiz/api/sta/sta_users (API V2.0.3 §2.5.1)
  */
 interface StaUsersResponse {
   code: number;
   msg?: string;
-  list?: Array<{
-    mac: string;
-    userIp: string;
-    ssid: string;
-    rssi: string;
-    band: string;
-    channel: string;
-    sn: string; // AP serial number
-  }>;
+  list?: StaUserRaw[];
   count?: number;
+}
+
+interface CurrentPerformanceResponse {
+  code: number;
+  msg?: string;
+  data?: {
+    cpuRate?: number;
+    memoryRate?: number;
+    memoryFree?: number;
+    flashRate?: number;
+    processNum?: number;
+  };
 }
 
 export interface DeviceMetrics {
@@ -312,45 +345,7 @@ export interface DeviceMetrics {
   radio_5g_utilization: number | null;
 }
 
-/**
- * Get device metrics (client count from STA API)
- *
- * NOTE: Ruijie Cloud API limitations:
- * - CPU/memory metrics are only available at network level, not per-device
- * - Uptime is not exposed via API
- * - Radio channel/utilization requires eWeb tunnel access
- * - Only online_clients can be derived from the STA (station) API
- *
- * Per-device performance data requires direct eWeb tunnel access.
- */
-export async function getDeviceMetrics(sn: string, groupId?: string): Promise<DeviceMetrics> {
-  const metrics = getEmptyMetrics();
-
-  // Get online client count from STA API
-  if (groupId) {
-    try {
-      const response = await ruijieFetch<StaUsersResponse>(
-        '/logbizagent/logbiz/api/sta/sta_users',
-        {
-          method: 'POST',
-          body: JSON.stringify({
-            groupId: parseInt(groupId, 10),
-            pageIndex: 0,
-          }),
-        }
-      );
-
-      if (response.code === 0 && response.list) {
-        // Count clients connected to this specific AP
-        metrics.online_clients = response.list.filter(sta => sta.sn === sn).length;
-      }
-    } catch (error) {
-      console.error(`[Ruijie] Failed to fetch STA list for ${sn}:`, error);
-    }
-  }
-
-  return metrics;
-}
+const METRICS_DELAY_MS = 250;
 
 function getEmptyMetrics(): DeviceMetrics {
   return {
@@ -363,6 +358,132 @@ function getEmptyMetrics(): DeviceMetrics {
     radio_2g_utilization: null,
     radio_5g_utilization: null,
   };
+}
+
+/**
+ * GET /logbizagent/logbiz/api/sys/current_performance (API V2.0.3 §2.6.6)
+ */
+export async function getDeviceCurrentPerformance(
+  sn: string
+): Promise<{ cpu_usage: number | null; memory_usage: number | null }> {
+  if (MOCK_MODE) {
+    const mock = getMockDevice(sn);
+    return {
+      cpu_usage: mock.cpu_usage ?? null,
+      memory_usage: mock.memory_usage ?? null,
+    };
+  }
+
+  try {
+    const params = new URLSearchParams({ sn });
+    const response = await ruijieLogbizFetch<CurrentPerformanceResponse>(
+      `/sys/current_performance?${params}`
+    );
+    if (response.code !== 0) {
+      console.error(`[Ruijie] current_performance failed for ${sn}:`, response.msg);
+      return { cpu_usage: null, memory_usage: null };
+    }
+    return mapCurrentPerformance(response.data);
+  } catch (error) {
+    console.error(`[Ruijie] current_performance error for ${sn}:`, error);
+    return { cpu_usage: null, memory_usage: null };
+  }
+}
+
+/**
+ * Fetch STA list for a network group (current online users).
+ */
+export async function getGroupStaUsers(groupId: string): Promise<StaUserRaw[]> {
+  if (MOCK_MODE) {
+    return [];
+  }
+
+  try {
+    const response = await ruijieLogbizFetch<StaUsersResponse>(
+      '/sta/sta_users',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          groupId: parseInt(groupId, 10),
+          pageIndex: 0,
+          pageSize: 1000,
+          staType: 'currentUser',
+        }),
+      }
+    );
+    if (response.code !== 0 || !response.list) {
+      return [];
+    }
+    return response.list;
+  } catch (error) {
+    console.error(`[Ruijie] Failed to fetch STA list for group ${groupId}:`, error);
+    return [];
+  }
+}
+
+/**
+ * Live device metrics: current_performance (CPU/mem) + STA util/clients.
+ * Uptime is still not exposed by Cloud JSON APIs.
+ */
+export async function getDeviceMetrics(sn: string, groupId?: string): Promise<DeviceMetrics> {
+  const metrics = getEmptyMetrics();
+
+  const perf = await getDeviceCurrentPerformance(sn);
+  metrics.cpu_usage = perf.cpu_usage;
+  metrics.memory_usage = perf.memory_usage;
+
+  if (groupId) {
+    const stas = await getGroupStaUsers(groupId);
+    const staMetrics = aggregateStaMetricsForDevice(stas, sn);
+    Object.assign(metrics, staMetrics);
+  }
+
+  return metrics;
+}
+
+/**
+ * Enrich a device list with live CPU/mem + STA metrics (for sync).
+ * One STA fetch per group; current_performance per online device (rate-limited).
+ */
+export async function enrichDevicesWithLiveMetrics(
+  devices: RuijieDevice[]
+): Promise<RuijieDevice[]> {
+  if (MOCK_MODE || devices.length === 0) {
+    return devices;
+  }
+
+  const byGroup = new Map<string, StaUserRaw[]>();
+  const groupIds = [
+    ...new Set(devices.map((d) => d.group_id).filter((id): id is string => Boolean(id))),
+  ];
+
+  for (const groupId of groupIds) {
+    byGroup.set(groupId, await getGroupStaUsers(groupId));
+    await new Promise((r) => setTimeout(r, METRICS_DELAY_MS));
+  }
+
+  const enriched: RuijieDevice[] = [];
+  for (const device of devices) {
+    const next: RuijieDevice = { ...device };
+    const stas = device.group_id ? byGroup.get(device.group_id) || [] : [];
+    const staMetrics = aggregateStaMetricsForDevice(stas, device.sn);
+    next.online_clients = staMetrics.online_clients;
+    next.radio_2g_channel = staMetrics.radio_2g_channel ?? undefined;
+    next.radio_5g_channel = staMetrics.radio_5g_channel ?? undefined;
+    next.radio_2g_utilization = staMetrics.radio_2g_utilization ?? undefined;
+    next.radio_5g_utilization = staMetrics.radio_5g_utilization ?? undefined;
+
+    if (device.status === 'online') {
+      const perf = await getDeviceCurrentPerformance(device.sn);
+      next.cpu_usage = perf.cpu_usage ?? undefined;
+      next.memory_usage = perf.memory_usage ?? undefined;
+      await new Promise((r) => setTimeout(r, METRICS_DELAY_MS));
+    }
+
+    enriched.push(next);
+  }
+
+  return enriched;
 }
 
 // =============================================================================
@@ -381,6 +502,9 @@ export interface RuijieClient {
   channel: number;
   sn: string; // AP serial number this client is connected to
   signalQuality: 'excellent' | 'good' | 'fair' | 'poor';
+  utilization: number | null;
+  uplinkRate: number | null;
+  downlinkRate: number | null;
 }
 
 /**
@@ -408,7 +532,6 @@ function getSignalQuality(rssi: number): 'excellent' | 'good' | 'fair' | 'poor' 
  */
 export async function getDeviceClients(sn: string, groupId: string): Promise<RuijieClient[]> {
   if (MOCK_MODE) {
-    // Return mock clients for testing
     return [
       {
         mac: '00:1A:2B:3C:4D:5E',
@@ -419,6 +542,9 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
         channel: 36,
         sn,
         signalQuality: 'excellent',
+        utilization: 22,
+        uplinkRate: 40_000_000,
+        downlinkRate: 120_000_000,
       },
       {
         mac: '00:1A:2B:3C:4D:5F',
@@ -429,6 +555,9 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
         channel: 36,
         sn,
         signalQuality: 'good',
+        utilization: 28,
+        uplinkRate: 20_000_000,
+        downlinkRate: 80_000_000,
       },
       {
         mac: 'AA:BB:CC:DD:EE:FF',
@@ -439,40 +568,44 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
         channel: 6,
         sn,
         signalQuality: 'fair',
+        utilization: 45,
+        uplinkRate: 5_000_000,
+        downlinkRate: 15_000_000,
       },
     ];
   }
 
   try {
-    const response = await ruijieFetch<StaUsersResponse>(
-      '/logbizagent/logbiz/api/sta/sta_users',
-      {
-        method: 'POST',
-        body: JSON.stringify({
-          groupId: parseInt(groupId, 10),
-          pageIndex: 0,
-        }),
-      }
-    );
-
-    if (response.code !== 0 || !response.list) {
-      return [];
-    }
-
-    // Filter clients connected to this specific AP and transform
-    return response.list
-      .filter(sta => sta.sn === sn)
-      .map(sta => {
-        const rssi = parseInt(sta.rssi, 10) || -80;
+    const list = await getGroupStaUsers(groupId);
+    return list
+      .filter((sta) => sta.sn === sn)
+      .map((sta) => {
+        const rssi =
+          typeof sta.rssi === 'number'
+            ? sta.rssi
+            : parseInt(String(sta.rssi ?? ''), 10) || -80;
+        const channel =
+          typeof sta.channel === 'number'
+            ? sta.channel
+            : parseInt(String(sta.channel ?? ''), 10) || 0;
+        const utilization =
+          typeof sta.utilization === 'number'
+            ? sta.utilization
+            : Number.isFinite(parseFloat(String(sta.utilization ?? '')))
+              ? parseFloat(String(sta.utilization))
+              : null;
         return {
-          mac: sta.mac,
-          userIp: sta.userIp,
-          ssid: sta.ssid,
+          mac: sta.mac || '',
+          userIp: sta.userIp || '',
+          ssid: sta.ssid || '',
           rssi,
-          band: sta.band,
-          channel: parseInt(sta.channel, 10) || 0,
-          sn: sta.sn,
+          band: sta.band || '',
+          channel,
+          sn: sta.sn || sn,
           signalQuality: getSignalQuality(rssi),
+          utilization,
+          uplinkRate: typeof sta.uplinkRate === 'number' ? sta.uplinkRate : null,
+          downlinkRate: typeof sta.downlinkRate === 'number' ? sta.downlinkRate : null,
         };
       });
   } catch (error) {
@@ -780,39 +913,48 @@ function generateMockAppFlowData(): AppFlowData[] {
 }
 
 /**
- * Get network-wide traffic data (hourly)
+ * Get hourly flow trend (API V2.0.3 §2.6.2 — Reyee EG flow).
+ * Docs require sn + startDate + endDate (not groupId).
  *
- * @param groupId - Network group ID
- * @param hours - Number of hours of data to fetch (default 24)
- * @returns Traffic summary with data points
+ * @param snOrOpts - Device serial, or { sn, hours }
+ * @param hours - Window length when first arg is sn (default 24)
  */
-export async function getNetworkTraffic(groupId: string, hours: number = 24): Promise<TrafficSummary> {
+export async function getNetworkTraffic(
+  snOrOpts: string | { sn: string; hours?: number },
+  hours: number = 24
+): Promise<TrafficSummary> {
+  const sn = typeof snOrOpts === 'string' ? snOrOpts : snOrOpts.sn;
+  const windowHours = typeof snOrOpts === 'string' ? hours : (snOrOpts.hours ?? 24);
+
   if (MOCK_MODE) {
-    const dataPoints = generateMockTrafficData(hours);
+    const dataPoints = generateMockTrafficData(windowHours);
     return calculateTrafficSummary(dataPoints);
   }
 
+  if (!sn) {
+    console.error('[Ruijie] getNetworkTraffic requires device sn (API 2.6.2)');
+    return getEmptyTrafficSummary();
+  }
+
   try {
-    const response = await ruijieFetch<HourlyTrafficResponse>(
-      '/logbizagent/logbiz/api/flow/show/hour',
+    const body = buildHourlyFlowRequest({ sn, hours: windowHours });
+    const response = await ruijieLogbizFetch<HourlyTrafficResponse>(
+      '/flow/show/hour',
       {
         method: 'POST',
-        body: JSON.stringify({
-          groupId: parseInt(groupId, 10),
-        }),
+        body: JSON.stringify(body),
       }
     );
 
     if (response.code !== 0 || !response.list) {
-      console.error(`[Ruijie] Failed to fetch traffic data:`, response.msg);
+      console.error(`[Ruijie] Failed to fetch traffic data for ${sn}:`, response.msg);
       return getEmptyTrafficSummary();
     }
 
-    // Filter to requested time range
-    const cutoffTime = Date.now() - (hours * 60 * 60 * 1000);
+    const cutoffTime = body.startDate;
     const filteredData = response.list
-      .filter(item => item.timeStamp >= cutoffTime)
-      .map(item => ({
+      .filter((item) => item.timeStamp >= cutoffTime)
+      .map((item) => ({
         timestamp: item.timeStamp,
         timeString: item.timeString,
         rxBytes: item.rxBytes,
@@ -824,10 +966,12 @@ export async function getNetworkTraffic(groupId: string, hours: number = 24): Pr
 
     return calculateTrafficSummary(filteredData);
   } catch (error) {
-    console.error(`[Ruijie] Error fetching network traffic:`, error);
+    console.error(`[Ruijie] Error fetching network traffic for ${sn}:`, error);
     return getEmptyTrafficSummary();
   }
 }
+
+export { pickFlowDeviceSn };
 
 /**
  * Get application flow breakdown
@@ -841,8 +985,8 @@ export async function getAppFlow(groupId: string): Promise<AppFlowData[]> {
   }
 
   try {
-    const response = await ruijieFetch<AppFlowResponse>(
-      '/logbizagent/logbiz/api/flow/app',
+    const response = await ruijieLogbizFetch<AppFlowResponse>(
+      '/flow/app',
       {
         method: 'POST',
         body: JSON.stringify({

--- a/lib/ruijie/index.ts
+++ b/lib/ruijie/index.ts
@@ -14,15 +14,34 @@ export {
   getAllGroups,
   getAllDevices,
   getDevice,
+  getDeviceMetrics,
+  getDeviceCurrentPerformance,
+  getGroupStaUsers,
+  enrichDevicesWithLiveMetrics,
+  getNetworkTraffic,
+  pickFlowDeviceSn,
   createTunnel,
   deleteTunnel,
   rebootDevice,
   isMockMode,
 } from './client';
 
+export {
+  mapCurrentPerformance,
+  aggregateStaMetricsForDevice,
+  buildHourlyFlowRequest,
+} from './performance-metrics';
+
+export {
+  RUIJIE_ACTIVE_WINDOW_DAYS,
+  isDeviceActiveInWindow,
+  filterActiveDevices,
+} from './active-window';
+
 // Sync Service
 export {
   upsertDevices,
+  pruneDevicesNotInSet,
   logSyncRun,
   createSyncLog,
   getActiveTunnelCount,

--- a/lib/ruijie/performance-metrics.ts
+++ b/lib/ruijie/performance-metrics.ts
@@ -1,0 +1,162 @@
+/**
+ * Pure mappers for Ruijie Cloud performance APIs (V2.0.3)
+ * - 2.6.6 current_performance
+ * - 2.5.1 sta_users
+ * - 2.6.2 flow/show/hour request body
+ */
+
+export type CurrentPerformanceRaw = {
+  cpuRate?: number;
+  memoryRate?: number;
+  memoryFree?: number;
+  flashRate?: number;
+  processNum?: number;
+  cpuTemp?: number;
+  flashFree?: number;
+  diskRate?: number;
+  diskFree?: number;
+};
+
+export type StaUserRaw = {
+  sn?: string;
+  mac?: string;
+  band?: string;
+  channel?: string | number;
+  utilization?: number | string;
+  rssi?: string | number;
+  ssid?: string;
+  userIp?: string;
+  uplinkRate?: number;
+  downlinkRate?: number;
+  wifiUp?: number;
+  wifiDown?: number;
+  floorNoise?: number;
+  pktLoseRate?: number;
+  score?: number;
+};
+
+export type StaDeviceMetrics = {
+  online_clients: number;
+  radio_2g_channel: number | null;
+  radio_5g_channel: number | null;
+  radio_2g_utilization: number | null;
+  radio_5g_utilization: number | null;
+};
+
+function is2g(band: string | undefined): boolean {
+  if (!band) return false;
+  const b = band.toLowerCase().replace(/\s/g, '');
+  return b.includes('2.4') || b === '2g' || b.startsWith('2g');
+}
+
+function is5g(band: string | undefined): boolean {
+  if (!band) return false;
+  const b = band.toLowerCase().replace(/\s/g, '');
+  return b.includes('5g') || b.startsWith('5');
+}
+
+function avg(nums: number[]): number | null {
+  if (!nums.length) return null;
+  return Math.round(nums.reduce((s, n) => s + n, 0) / nums.length);
+}
+
+function modeChannel(channels: number[]): number | null {
+  if (!channels.length) return null;
+  const counts = new Map<number, number>();
+  for (const c of channels) {
+    counts.set(c, (counts.get(c) || 0) + 1);
+  }
+  let best = channels[0];
+  let bestCount = 0;
+  for (const [ch, n] of counts) {
+    if (n > bestCount) {
+      best = ch;
+      bestCount = n;
+    }
+  }
+  return best;
+}
+
+export function mapCurrentPerformance(data: CurrentPerformanceRaw | null | undefined): {
+  cpu_usage: number | null;
+  memory_usage: number | null;
+} {
+  if (!data) {
+    return { cpu_usage: null, memory_usage: null };
+  }
+  const cpu =
+    typeof data.cpuRate === 'number' && Number.isFinite(data.cpuRate) ? data.cpuRate : null;
+  const mem =
+    typeof data.memoryRate === 'number' && Number.isFinite(data.memoryRate)
+      ? data.memoryRate
+      : null;
+  return { cpu_usage: cpu, memory_usage: mem };
+}
+
+export function aggregateStaMetricsForDevice(
+  stas: StaUserRaw[],
+  sn: string
+): StaDeviceMetrics {
+  const mine = stas.filter((s) => s.sn === sn);
+  const util2g: number[] = [];
+  const util5g: number[] = [];
+  const ch2g: number[] = [];
+  const ch5g: number[] = [];
+
+  for (const sta of mine) {
+    const util =
+      typeof sta.utilization === 'number'
+        ? sta.utilization
+        : parseFloat(String(sta.utilization ?? ''));
+    const channel =
+      typeof sta.channel === 'number'
+        ? sta.channel
+        : parseInt(String(sta.channel ?? ''), 10);
+
+    if (is2g(sta.band)) {
+      if (Number.isFinite(util)) util2g.push(util);
+      if (Number.isFinite(channel) && channel > 0) ch2g.push(channel);
+    } else if (is5g(sta.band)) {
+      if (Number.isFinite(util)) util5g.push(util);
+      if (Number.isFinite(channel) && channel > 0) ch5g.push(channel);
+    }
+  }
+
+  return {
+    online_clients: mine.length,
+    radio_2g_channel: modeChannel(ch2g),
+    radio_5g_channel: modeChannel(ch5g),
+    radio_2g_utilization: avg(util2g),
+    radio_5g_utilization: avg(util5g),
+  };
+}
+
+export function buildHourlyFlowRequest(opts: {
+  sn: string;
+  hours: number;
+  endMs?: number;
+}): { sn: string; startDate: number; endDate: number } {
+  const endDate = opts.endMs ?? Date.now();
+  const hours = Math.max(1, opts.hours);
+  return {
+    sn: opts.sn,
+    startDate: endDate - hours * 60 * 60 * 1000,
+    endDate,
+  };
+}
+
+/** Prefer gateway/EG serials for flow APIs that target Reyee EG. */
+export function pickFlowDeviceSn(
+  devices: Array<{ sn: string; status?: string; model?: string | null; role?: string }>
+): string | null {
+  if (!devices.length) return null;
+  const online = devices.filter((d) => d.status === 'online');
+  const pool = online.length ? online : devices;
+  const gateway = pool.find(
+    (d) =>
+      d.role === 'gateway' ||
+      /egw?|gateway|firewall/i.test(d.model || '') ||
+      /^eg/i.test(d.model || '')
+  );
+  return (gateway || pool[0])?.sn ?? null;
+}

--- a/lib/ruijie/sync-service.ts
+++ b/lib/ruijie/sync-service.ts
@@ -96,15 +96,49 @@ export async function upsertDevices(
   const supabase = await createClient();
   const result: SyncResult = { updated: 0, added: 0, errors: [] };
 
-  // Get existing SNs to determine added vs updated
+  type ExistingMetrics = {
+    sn: string;
+    cpu_usage: number | null;
+    memory_usage: number | null;
+    uptime_seconds: number | null;
+    online_clients: number | null;
+    radio_2g_channel: number | null;
+    radio_5g_channel: number | null;
+    radio_2g_utilization: number | null;
+    radio_5g_utilization: number | null;
+  };
+
+  // Get existing rows — preserve metrics when live enrich leaves them unset
   const { data: existing } = await supabase
     .from('ruijie_device_cache')
-    .select('sn');
+    .select(
+      'sn, cpu_usage, memory_usage, uptime_seconds, online_clients, radio_2g_channel, radio_5g_channel, radio_2g_utilization, radio_5g_utilization'
+    );
 
-  const existingSnSet = new Set(existing?.map(e => e.sn) || []);
+  const existingRows = (existing || []) as ExistingMetrics[];
+  const existingSnSet = new Set(existingRows.map((e) => e.sn));
+  const existingBySn = new Map(existingRows.map((e) => [e.sn, e]));
 
-  // Convert to rows
-  const rows = devices.map(d => deviceToRow(d, mockData));
+  // Convert to rows (keep prior CPU/mem/radio when new sync has null/undefined)
+  const rows = devices.map((d) => {
+    const prev = existingBySn.get(d.sn);
+    return deviceToRow(
+      {
+        ...d,
+        cpu_usage: d.cpu_usage ?? prev?.cpu_usage ?? undefined,
+        memory_usage: d.memory_usage ?? prev?.memory_usage ?? undefined,
+        uptime_seconds: d.uptime_seconds ?? prev?.uptime_seconds ?? undefined,
+        online_clients: d.online_clients || prev?.online_clients || 0,
+        radio_2g_channel: d.radio_2g_channel ?? prev?.radio_2g_channel ?? undefined,
+        radio_5g_channel: d.radio_5g_channel ?? prev?.radio_5g_channel ?? undefined,
+        radio_2g_utilization:
+          d.radio_2g_utilization ?? prev?.radio_2g_utilization ?? undefined,
+        radio_5g_utilization:
+          d.radio_5g_utilization ?? prev?.radio_5g_utilization ?? undefined,
+      },
+      mockData
+    );
+  });
 
   // Upsert all at once
   const { error } = await supabase
@@ -126,6 +160,46 @@ export async function upsertDevices(
   }
 
   return result;
+}
+
+/**
+ * Delete cache rows whose SN is not in `keepSns`.
+ * Used after filtering Ruijie API devices to the 14-day active window.
+ */
+export async function pruneDevicesNotInSet(
+  keepSns: string[]
+): Promise<{ deleted: number; deletedSns: string[] }> {
+  const supabase = await createClient();
+  const keep = new Set(keepSns);
+
+  const { data: existing, error: listError } = await supabase
+    .from('ruijie_device_cache')
+    .select('sn');
+
+  if (listError) {
+    console.error('[RuijieSync] Failed to list devices for prune:', listError);
+    return { deleted: 0, deletedSns: [] };
+  }
+
+  const deletedSns = (existing || [])
+    .map((row) => row.sn as string)
+    .filter((sn) => !keep.has(sn));
+
+  if (deletedSns.length === 0) {
+    return { deleted: 0, deletedSns: [] };
+  }
+
+  const { error: deleteError } = await supabase
+    .from('ruijie_device_cache')
+    .delete()
+    .in('sn', deletedSns);
+
+  if (deleteError) {
+    console.error('[RuijieSync] Failed to prune inactive devices:', deleteError);
+    return { deleted: 0, deletedSns: [] };
+  }
+
+  return { deleted: deletedSns.length, deletedSns };
 }
 
 // =============================================================================

--- a/lib/ruijie/types.ts
+++ b/lib/ruijie/types.ts
@@ -163,3 +163,19 @@ export interface RuijieAuditLogRow {
   error_message: string | null;
   created_at: string;
 }
+
+export interface RuijieTrafficRollupRow {
+  id: string;
+  group_id: string;
+  group_name: string | null;
+  captured_at: string;
+  hours_window: number;
+  total_rx_bytes: number;
+  total_tx_bytes: number;
+  avg_rx_bps: number;
+  avg_tx_bps: number;
+  peak_rx_bps: number;
+  peak_tx_bps: number;
+  raw_summary: Record<string, unknown> | null;
+  created_at: string;
+}

--- a/public/icons/network-overview-sprite.svg
+++ b/public/icons/network-overview-sprite.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="position:absolute;width:0;height:0;overflow:hidden" aria-hidden="true">
+  <!-- Source: omada-clone omada-icons.svg (Network Overview subset) -->
+  <symbol id="dashboard-gateway-light" viewBox="0 0 32 32">
+    <path d="M5.564 15.207c0-.342.276-.619.618-.619h19.636c.342 0 .618.277.618.619v6.37H5.564v-6.37ZM5.83 14.573 8.12 9.63h15.76l2.29 4.943H5.83Z" stroke="currentColor" stroke-width=".945" fill="none"/>
+    <path d="M8 17.454h1.455v1.455H8v-1.454ZM10.91 17.454h4.363v1.455h-4.364v-1.454Z" fill="#00A870"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M20.874 16.582h1.163v1.163h-1.163zm-2.038 0H20v1.164h-1.164zm5.237 0h-1.164v1.163h1.164zM18.836 18.327H20v1.164h-1.164zm2.038 0h1.163v1.164h-1.163zm3.199 0h-1.164v1.164h1.164z" fill="#00A870"/>
+  </symbol>
+  <symbol id="dashboard-ap-light" viewBox="0 0 33 32">
+    <rect x="7.685" y="7.018" width="17.964" height="17.964" rx="8.982" stroke="currentColor" stroke-width=".945" fill="none"/>
+    <path d="M16.666 19.638c2.008 0 3.637-1.716 3.637-3.637s-1.629-3.637-3.637-3.637c-1.006 0-1.916.43-2.575 1.101l.9.998a2.273 2.273 0 1 1-.55 2.002l-1.302.396c.046.177.104.348.175.515l1.029-.315-.927.534c.092.181.198.355.318.52l.668-.386-.562.524c.668.831 1.685 1.385 2.826 1.385Z" fill="#00A870"/>
+  </symbol>
+  <symbol id="dashboard-switch-light" viewBox="0 0 33 32">
+    <path d="M6.397 15.207c0-.342.277-.619.618-.619h19.636c.342 0 .619.277.619.619v6.37H6.397v-6.37Z" stroke="currentColor" stroke-width=".945" fill="none"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M20.148 17.423h-1.47v1.47h1.47v-1.47Zm-2.573 0h-1.469v1.47h1.47v-1.47Zm3.674 0h1.469v1.47h-1.47v-1.47Zm4.035 0h-1.469v1.47h1.47v-1.47Z" fill="#00A870"/>
+    <path d="M8.833 17.423h4.379v1.47H8.833v-1.47Z" fill="#00A870"/>
+    <path d="m6.664 14.573 2.29-4.943h15.76l2.289 4.943H6.664Z" stroke="currentColor" stroke-width=".945" fill="none"/>
+  </symbol>
+  <symbol id="clients-light" viewBox="0 0 44 44">
+    <path d="M26.479 11.819H10.555v13.818h21.927V23.85M7.817 29.47a.707.707 0 0 0 .576 1.12h26.25c.576 0 .91-.65.576-1.12l-2.738-3.832H10.555l-2.738 3.833Z" stroke="currentColor" stroke-width="1.3" fill="none"/>
+    <path d="M7.725 32.662c0 .057.047.104.104.104h27.378a.103.103 0 0 0 .103-.104v-2.074H7.725v2.074ZM27.892 10.65h6.331v11.674h-6.331V10.65ZM29.531 20.357h3.053" stroke="currentColor" stroke-width="1.3" fill="none"/>
+    <path fill="#00A870" d="M13.723 15.069h6.868v2.092h-6.868z"/>
+  </symbol>
+  <symbol id="dashboard-guest-light" viewBox="0 0 33 32">
+    <circle cx="13.061" cy="11.273" r="3.527" stroke="currentColor" stroke-width=".945" fill="none"/>
+    <path d="M20.21 23.527H5.91c.233-3.955 3.364-7.054 7.15-7.054 3.787 0 6.918 3.1 7.15 7.054Z" stroke="currentColor" stroke-width=".945" fill="none"/>
+    <circle cx="21.424" cy="14.274" r="2.073" stroke="currentColor" stroke-width=".945" fill="none"/>
+    <path d="M16.333 23.49h10.182a5.09 5.09 0 0 0-5.091-5.09 5.07 5.07 0 0 0-3.182 1.114" stroke="currentColor" stroke-width=".945" fill="none"/>
+  </symbol>
+</svg>

--- a/scripts/ruijie-check-sites.ts
+++ b/scripts/ruijie-check-sites.ts
@@ -1,0 +1,108 @@
+/**
+ * Verify Barcelona + Alexandra Reyee AP inventory from Ruijie Cloud.
+ * Usage: npx tsx scripts/ruijie-check-sites.ts
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+function loadEnvLocal() {
+  const path = resolve(process.cwd(), '.env.local');
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    let v = m[2];
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    if (process.env[m[1]] === undefined) process.env[m[1]] = v;
+  }
+}
+
+function classifyFormFactor(model: string | undefined, name: string): string {
+  const hay = `${model || ''} ${name}`.toLowerCase();
+  if (/od|outdoor|-od|out\b/.test(hay)) return 'outdoor';
+  if (/indoor|in\b|rap2200|rap2260|eap/.test(hay)) return 'indoor-likely';
+  return 'unknown';
+}
+
+async function main() {
+  loadEnvLocal();
+  process.env.RUIJIE_MOCK_MODE = 'false';
+
+  const { getAllDevices } = await import('../lib/ruijie');
+  const { createClient } = await import('../lib/supabase/server');
+
+  const all = await getAllDevices();
+  const patterns = [
+    { site: 'Barcelona', re: /barc|barcelona/i },
+    { site: 'Alexandra', re: /alex|alexandra/i },
+  ];
+
+  console.log(`API total devices: ${all.length}\n`);
+
+  for (const { site, re } of patterns) {
+    const matches = all.filter(
+      (d) => re.test(d.device_name) || re.test(d.group_name || '') || re.test(d.sn)
+    );
+    console.log(`=== ${site} (API matches: ${matches.length}) ===`);
+    if (matches.length === 0) {
+      console.log('  (none)\n');
+      continue;
+    }
+    for (const d of matches.sort((a, b) => a.device_name.localeCompare(b.device_name))) {
+      const form = classifyFormFactor(d.model, d.device_name);
+      console.log(
+        JSON.stringify({
+          sn: d.sn,
+          name: d.device_name,
+          model: d.model,
+          formFactorHint: form,
+          status: d.status,
+          group: d.group_name,
+          last_seen: d.last_seen_at,
+          ip: d.management_ip,
+        })
+      );
+    }
+    console.log('');
+  }
+
+  // Also dump any RAP62-OD (outdoor) + nearby naming for context
+  const outdoors = all.filter((d) => /od|outdoor|rap62/i.test(`${d.model} ${d.device_name}`));
+  console.log(`=== Outdoor-ish models in fleet (${outdoors.length}) ===`);
+  for (const d of outdoors.sort((a, b) => a.device_name.localeCompare(b.device_name))) {
+    console.log(
+      `  ${d.device_name} | ${d.model} | ${d.status} | ${d.group_name} | ${d.sn}`
+    );
+  }
+
+  const supabase = await createClient();
+  const { data: cached } = await supabase
+    .from('ruijie_device_cache')
+    .select('sn, device_name, model, status, group_name, last_seen_at')
+    .or(
+      'device_name.ilike.%barc%,device_name.ilike.%barcelona%,device_name.ilike.%alex%,device_name.ilike.%alexandra%'
+    )
+    .order('device_name');
+
+  console.log(`\n=== Cache (Barcelona/Alex) count=${cached?.length || 0} ===`);
+  for (const row of cached || []) {
+    console.log(
+      `  ${row.device_name} | ${row.model} | ${row.status} | ${row.group_name} | ${row.sn}`
+    );
+  }
+
+  // Full name list for Unjani to spot misnamed second APs
+  console.log('\n=== All Unjani / Newgen device names ===');
+  for (const d of all.sort((a, b) => a.device_name.localeCompare(b.device_name))) {
+    console.log(`  ${d.device_name} | ${d.model} | ${d.status} | ${d.group_name}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ruijie-prune-stale-devices.ts
+++ b/scripts/ruijie-prune-stale-devices.ts
@@ -1,0 +1,107 @@
+/**
+ * Fetch Ruijie Cloud devices, keep only those active in the last 14 days
+ * (online now, or lastOnline within window), upsert keepers, delete the rest.
+ *
+ * Usage: npx tsx scripts/ruijie-prune-stale-devices.ts
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+function loadEnvLocal() {
+  const path = resolve(process.cwd(), '.env.local');
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    let v = m[2];
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    if (process.env[m[1]] === undefined) process.env[m[1]] = v;
+  }
+}
+
+function daysAgo(iso: string | null | undefined, nowMs: number): number | null {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return null;
+  return (nowMs - t) / (24 * 60 * 60 * 1000);
+}
+
+async function main() {
+  loadEnvLocal();
+  process.env.RUIJIE_MOCK_MODE = 'false';
+
+  const {
+    getAllDevices,
+    enrichDevicesWithLiveMetrics,
+    upsertDevices,
+    pruneDevicesNotInSet,
+    filterActiveDevices,
+    RUIJIE_ACTIVE_WINDOW_DAYS,
+  } = await import('../lib/ruijie');
+
+  const nowMs = Date.now();
+  console.log(
+    `[prune] Fetching Ruijie devices (retain active ≤ ${RUIJIE_ACTIVE_WINDOW_DAYS}d)…`
+  );
+
+  const all = await getAllDevices();
+  console.log(`[prune] API returned ${all.length} devices`);
+
+  const inactive = all.filter(
+    (d) => !filterActiveDevices([d], nowMs, RUIJIE_ACTIVE_WINDOW_DAYS).length
+  );
+  const active = filterActiveDevices(all, nowMs, RUIJIE_ACTIVE_WINDOW_DAYS);
+
+  console.log(`[prune] Active (keep): ${active.length}`);
+  for (const d of active) {
+    const age = daysAgo(d.last_seen_at, nowMs);
+    console.log(
+      `  KEEP  ${d.sn}  ${d.device_name}  status=${d.status}  last_seen=${d.last_seen_at || '—'}  ageDays=${age == null ? '—' : age.toFixed(1)}`
+    );
+  }
+
+  console.log(`[prune] Inactive (drop): ${inactive.length}`);
+  for (const d of inactive) {
+    const age = daysAgo(d.last_seen_at, nowMs);
+    console.log(
+      `  DROP  ${d.sn}  ${d.device_name}  status=${d.status}  last_seen=${d.last_seen_at || '—'}  ageDays=${age == null ? '—' : age.toFixed(1)}`
+    );
+  }
+
+  console.log('[prune] Enriching active devices…');
+  const enriched = await enrichDevicesWithLiveMetrics(active);
+  const upsert = await upsertDevices(enriched, false);
+  console.log(
+    `[prune] Upsert added=${upsert.added} updated=${upsert.updated} errors=${upsert.errors.length}`
+  );
+
+  const keepSns = enriched.map((d) => d.sn);
+  const pruned = await pruneDevicesNotInSet(keepSns);
+  console.log(
+    `[prune] Deleted from cache: ${pruned.deleted}` +
+      (pruned.deletedSns.length
+        ? ` (${pruned.deletedSns.join(', ')})`
+        : '')
+  );
+
+  console.log(
+    JSON.stringify({
+      ok: upsert.errors.length === 0,
+      apiTotal: all.length,
+      kept: active.length,
+      droppedFromApi: inactive.length,
+      deletedFromDb: pruned.deleted,
+      deletedSns: pruned.deletedSns,
+      windowDays: RUIJIE_ACTIVE_WINDOW_DAYS,
+    })
+  );
+}
+
+main().catch((e) => {
+  console.error('[prune] FATAL', e);
+  process.exit(1);
+});

--- a/scripts/ruijie-sync-now.ts
+++ b/scripts/ruijie-sync-now.ts
@@ -1,167 +1,176 @@
 /**
- * Manual Ruijie Sync Script
- * Run with: npx tsx scripts/ruijie-sync-now.ts
- *
- * Directly syncs devices from Ruijie Cloud to Supabase cache
+ * One-shot Ruijie sync: devices + live metrics + traffic rollups.
+ * Usage: npx tsx scripts/ruijie-sync-now.ts
  */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 
-import { config } from 'dotenv';
-config({ path: '.env.local' });
-
-import { createClient } from '@supabase/supabase-js';
-
-const RUIJIE_BASE_URL = process.env.RUIJIE_BASE_URL || 'https://cloud-eu.ruijienetworks.com/service/api';
-const RUIJIE_APP_ID = process.env.RUIJIE_APP_ID || '';
-const RUIJIE_SECRET = process.env.RUIJIE_SECRET || '';
-const AUTH_TOKEN_PARAM = 'd63dss0a81e4415a889ac5b78fsc904a';
-
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-
-async function syncNow() {
-  console.log('='.repeat(60));
-  console.log('Ruijie Manual Sync');
-  console.log('='.repeat(60));
-
-  const startTime = Date.now();
-
-  // 1. Authenticate with Ruijie
-  console.log('\n1. Authenticating with Ruijie Cloud...');
-  const authUrl = `${RUIJIE_BASE_URL}/oauth20/client/access_token?token=${AUTH_TOKEN_PARAM}`;
-  const authResponse = await fetch(authUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ appid: RUIJIE_APP_ID, secret: RUIJIE_SECRET }),
-  });
-  const authData = await authResponse.json();
-
-  if (authData.code !== 0) {
-    console.error('   Auth failed:', authData.msg);
-    process.exit(1);
-  }
-  const accessToken = authData.accessToken;
-  console.log('   ✓ Authenticated');
-
-  // 2. Get all groups
-  console.log('\n2. Fetching groups...');
-  const groupsUrl = `${RUIJIE_BASE_URL}/maint/groups?access_token=${accessToken}`;
-  const groupsResponse = await fetch(groupsUrl);
-  const groupsData = await groupsResponse.json();
-
-  interface GroupNode { id: number; name: string; children?: GroupNode[] }
-  function extractGroupIds(node: GroupNode): number[] {
-    const ids: number[] = [];
-    if (node.id && node.name !== 'dumy') ids.push(node.id);
-    if (node.children) {
-      for (const child of node.children) ids.push(...extractGroupIds(child));
+function loadEnvLocal() {
+  const path = resolve(process.cwd(), '.env.local');
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    let v = m[2];
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
     }
-    return ids;
+    if (process.env[m[1]] === undefined) process.env[m[1]] = v;
   }
-
-  const groupIds = extractGroupIds(groupsData.groupTree || {});
-  console.log(`   ✓ Found ${groupIds.length} groups`);
-
-  // 3. Fetch devices from all groups
-  console.log('\n3. Fetching devices...');
-  const deviceMap = new Map<string, any>();
-
-  for (const gid of groupIds) {
-    const devicesUrl = `${RUIJIE_BASE_URL}/maint/devices?access_token=${accessToken}&group_id=${gid}&page=0&per_page=500`;
-    const devicesResponse = await fetch(devicesUrl);
-    const devicesData = await devicesResponse.json();
-
-    if (devicesData.code === 0 && devicesData.deviceList) {
-      for (const d of devicesData.deviceList) {
-        if (!deviceMap.has(d.serialNumber)) {
-          deviceMap.set(d.serialNumber, {
-            sn: d.serialNumber,
-            device_name: d.aliasName || d.name || d.serialNumber,
-            model: d.productClass || null,
-            group_id: String(d.groupId),
-            group_name: d.groupName || null,
-            management_ip: d.localIp || null,
-            wan_ip: d.cpeIp || null,
-            egress_ip: d.cpeIp || null,
-            online_clients: 0,
-            status: d.onlineStatus === 'ON' ? 'online' : 'offline',
-            config_status: d.confSyncType || null,
-            firmware_version: d.softwareVersion || null,
-            mac_address: d.mac || null,
-            cpu_usage: null,
-            memory_usage: null,
-            uptime_seconds: null,
-            radio_2g_channel: null,
-            radio_5g_channel: null,
-            radio_2g_utilization: null,
-            radio_5g_utilization: null,
-            project_id: String(d.groupId),
-            last_seen_at: d.lastOnline ? new Date(d.lastOnline).toISOString() : null,
-            synced_at: new Date().toISOString(),
-            raw_json: d,
-            mock_data: false,
-          });
-        }
-      }
-    }
-  }
-
-  const devices = Array.from(deviceMap.values());
-  console.log(`   ✓ Found ${devices.length} unique devices`);
-
-  // 4. Upsert to Supabase
-  console.log('\n4. Upserting to Supabase...');
-  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
-
-  // Get existing count
-  const { count: existingCount } = await supabase
-    .from('ruijie_device_cache')
-    .select('sn', { count: 'exact', head: true });
-
-  // Clear mock data first
-  const { error: deleteError } = await supabase
-    .from('ruijie_device_cache')
-    .delete()
-    .eq('mock_data', true);
-
-  if (deleteError) {
-    console.log(`   Warning: Could not clear mock data: ${deleteError.message}`);
-  }
-
-  // Upsert real devices
-  const { error: upsertError } = await supabase
-    .from('ruijie_device_cache')
-    .upsert(devices, { onConflict: 'sn' });
-
-  if (upsertError) {
-    console.error('   Upsert failed:', upsertError.message);
-    process.exit(1);
-  }
-
-  // Get new count
-  const { count: newCount } = await supabase
-    .from('ruijie_device_cache')
-    .select('sn', { count: 'exact', head: true });
-
-  console.log(`   ✓ Upserted ${devices.length} devices (was ${existingCount}, now ${newCount})`);
-
-  // 5. Log sync
-  console.log('\n5. Logging sync...');
-  const duration = Date.now() - startTime;
-  await supabase.from('ruijie_sync_logs').insert({
-    status: 'completed',
-    devices_fetched: devices.length,
-    devices_updated: devices.length,
-    devices_added: 0,
-    triggered_by: 'manual',
-    started_at: new Date(startTime).toISOString(),
-    completed_at: new Date().toISOString(),
-    duration_ms: duration,
-  });
-
-  console.log('\n' + '='.repeat(60));
-  console.log(`✓ Sync completed in ${duration}ms`);
-  console.log(`  ${devices.length} devices synced to ruijie_device_cache`);
-  console.log('='.repeat(60));
 }
 
-syncNow().catch(console.error);
+async function main() {
+  loadEnvLocal();
+  process.env.RUIJIE_MOCK_MODE = 'false';
+
+  const {
+    getAllDevices,
+    enrichDevicesWithLiveMetrics,
+    getNetworkTraffic,
+    pickFlowDeviceSn,
+  } = await import('../lib/ruijie/client');
+  const { upsertDevices, createSyncLog, logSyncRun } = await import(
+    '../lib/ruijie/sync-service'
+  );
+  const { createClient } = await import('../lib/supabase/server');
+
+  const started = Date.now();
+  const syncLogId = await createSyncLog('manual');
+  console.log(`[sync-now] log=${syncLogId}`);
+
+  console.log('[sync-now] fetching devices…');
+  const devices = await getAllDevices();
+  console.log(`[sync-now] fetched ${devices.length}`);
+
+  console.log('[sync-now] enriching CPU/mem + STA…');
+  const enriched = await enrichDevicesWithLiveMetrics(devices);
+  const withCpu = enriched.filter((d) => d.cpu_usage != null).length;
+  const clients = enriched.reduce((s, d) => s + (d.online_clients || 0), 0);
+  const withRadio = enriched.filter(
+    (d) => d.radio_2g_utilization != null || d.radio_5g_utilization != null
+  ).length;
+  console.log(
+    `[sync-now] metrics: cpu=${withCpu} clients=${clients} radioUtil=${withRadio}`
+  );
+
+  const result = await upsertDevices(enriched, false);
+  console.log(
+    `[sync-now] upsert added=${result.added} updated=${result.updated} errors=${result.errors.length}`
+  );
+
+  // Traffic rollups (same as Inngest function)
+  const supabase = await createClient();
+  const { data: groupRows } = await supabase
+    .from('ruijie_device_cache')
+    .select('group_id, group_name, sn, status, model')
+    .not('group_id', 'is', null);
+
+  const byGroup = new Map<
+    string,
+    { group_name: string | null; devices: Array<{ sn: string; status?: string; model?: string | null }> }
+  >();
+  for (const row of groupRows || []) {
+    if (!row.group_id) continue;
+    if (!byGroup.has(row.group_id)) {
+      byGroup.set(row.group_id, { group_name: row.group_name, devices: [] });
+    }
+    byGroup.get(row.group_id)!.devices.push({
+      sn: row.sn,
+      status: row.status,
+      model: row.model,
+    });
+  }
+
+  const hourBucket = new Date();
+  hourBucket.setUTCMinutes(0, 0, 0);
+  const capturedAt = hourBucket.toISOString();
+  let rollups = 0;
+
+  for (const [groupId, info] of byGroup) {
+    const flowSn = pickFlowDeviceSn(info.devices);
+    if (!flowSn) {
+      console.log(`[sync-now] skip traffic group=${groupId} (no sn)`);
+      continue;
+    }
+    try {
+      const traffic = await getNetworkTraffic({ sn: flowSn, hours: 24 });
+      const hoursSeconds = 24 * 3600;
+      const { error } = await supabase.from('ruijie_traffic_rollups').upsert(
+        {
+          group_id: groupId,
+          group_name: info.group_name,
+          captured_at: capturedAt,
+          hours_window: 24,
+          total_rx_bytes: Math.round(traffic.totalRxBytes),
+          total_tx_bytes: Math.round(traffic.totalTxBytes),
+          avg_rx_bps: traffic.avgRxRate,
+          avg_tx_bps: traffic.avgTxRate,
+          peak_rx_bps: (traffic.peakRxBytes * 8) / hoursSeconds,
+          peak_tx_bps: (traffic.peakTxBytes * 8) / hoursSeconds,
+          raw_summary: {
+            totalBytes: traffic.totalBytes,
+            dataPointCount: traffic.dataPoints.length,
+            flowSn,
+          },
+        },
+        { onConflict: 'group_id,captured_at,hours_window' }
+      );
+      if (error) {
+        console.log(`[sync-now] traffic upsert fail group=${groupId}: ${error.message}`);
+      } else {
+        rollups += 1;
+        console.log(
+          `[sync-now] traffic group=${groupId} sn=${flowSn} points=${traffic.dataPoints.length} bytes=${traffic.totalBytes}`
+        );
+      }
+    } catch (e) {
+      console.log(
+        `[sync-now] traffic error group=${groupId}: ${e instanceof Error ? e.message : e}`
+      );
+    }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+
+  const durationMs = Date.now() - started;
+  await logSyncRun(
+    {
+      ...result,
+      devicesFetched: devices.length,
+      durationMs,
+    },
+    'manual',
+    undefined,
+    syncLogId
+  );
+
+  console.log(
+    JSON.stringify({
+      ok: result.errors.length === 0,
+      devices: devices.length,
+      withCpu,
+      clients,
+      withRadio,
+      rollups,
+      durationMs,
+      sample: enriched
+        .filter((d) => d.status === 'online')
+        .slice(0, 5)
+        .map((d) => ({
+          sn: d.sn,
+          name: d.device_name,
+          cpu: d.cpu_usage,
+          mem: d.memory_usage,
+          clients: d.online_clients,
+          r2: d.radio_2g_utilization,
+          r5: d.radio_5g_utilization,
+        })),
+    })
+  );
+}
+
+main().catch((e) => {
+  console.error('[sync-now] FATAL', e);
+  process.exit(1);
+});

--- a/supabase/migrations/20260725151606_ruijie_traffic_rollups.sql
+++ b/supabase/migrations/20260725151606_ruijie_traffic_rollups.sql
@@ -1,0 +1,52 @@
+-- Network performance: persist Ruijie traffic rollups for Health + Analytics dashboards
+-- Written by Inngest after ruijie/sync.completed; read by admin APIs (service role / admin RLS)
+
+CREATE TABLE IF NOT EXISTS public.ruijie_traffic_rollups (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id text NOT NULL,
+  group_name text,
+  captured_at timestamptz NOT NULL DEFAULT now(),
+  hours_window integer NOT NULL DEFAULT 1,
+  total_rx_bytes bigint NOT NULL DEFAULT 0,
+  total_tx_bytes bigint NOT NULL DEFAULT 0,
+  avg_rx_bps double precision NOT NULL DEFAULT 0,
+  avg_tx_bps double precision NOT NULL DEFAULT 0,
+  peak_rx_bps double precision NOT NULL DEFAULT 0,
+  peak_tx_bps double precision NOT NULL DEFAULT 0,
+  raw_summary jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.ruijie_traffic_rollups IS
+  'Hourly Ruijie network traffic aggregates per group, for System Health / Analytics dashboards';
+
+ALTER TABLE public.ruijie_traffic_rollups
+  ADD CONSTRAINT ruijie_traffic_rollups_group_captured_window_key
+  UNIQUE (group_id, captured_at, hours_window);
+
+CREATE INDEX IF NOT EXISTS idx_ruijie_traffic_rollups_group_time
+  ON public.ruijie_traffic_rollups (group_id, captured_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ruijie_traffic_rollups_time
+  ON public.ruijie_traffic_rollups (captured_at DESC);
+
+ALTER TABLE public.ruijie_traffic_rollups ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admin users can read traffic rollups"
+  ON public.ruijie_traffic_rollups
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.admin_users
+      WHERE admin_users.email = (auth.jwt() ->> 'email')
+    )
+  );
+
+CREATE POLICY "Service role full access traffic rollups"
+  ON public.ruijie_traffic_rollups
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- Omada-inspired System Health, Devices, and Analytics admin UI backed by real Ruijie/Supabase data
- Live CPU/mem/STA/radio sync via corrected logbiz URLs, traffic rollups, and 14-day active-device pruning
- Honest empty states when app-flow / SSID / radio metrics are unavailable

## Test plan
- [ ] Staging: `/admin/network/health` shows overview tiles, alerts, edge card, KPIs
- [ ] Staging: `/admin/network/devices` matches Health styling; CPU/Mem columns populated after sync
- [ ] Staging: `/admin/network/analytics` Cached/Live, group traffic, top apps / radio empty states when missing
- [ ] Confirm only devices active in last 14 days remain in cache after sync


Made with [Cursor](https://cursor.com)