### PR TITLE
fix(coverage): stop Openserve requests returning DFA data

### DIFF
--- a/lib/coverage/aggregation-service.ts
+++ b/lib/coverage/aggregation-service.ts
@@ -182,9 +182,9 @@ export class CoverageAggregationService {
 
       // Add other providers here as they become available
       case 'dfa':
-      case 'openserve':
         return this.getDFACoverage(coordinates, serviceTypes);
 
+      case 'openserve':
       case 'vodacom':
       case 'cell_c':
       case 'telkom':


### PR DESCRIPTION
## What

`case 'openserve'` fell through to `getDFACoverage()` in the coverage aggregation switch, so a request for Openserve coverage silently returned DFA's ArcGIS result branded as Openserve.

```diff
   case 'dfa':
-  case 'openserve':
     return this.getDFACoverage(coordinates, serviceTypes);
 
+  case 'openserve':
   case 'vodacom':
   case 'cell_c':
   case 'telkom':
     throw new Error(`Provider ${provider} not yet implemented`);
```

## Why it's safe

- Nothing in the codebase passes `'openserve'` to `aggregateCoverage` today — only `['mtn']` and `['mtn', 'dfa']` are used, so this changes behaviour only for future/explicit callers.
- The throw is caught per-provider by the aggregation loop into `{ available: false, confidence: 'low', services: [], error }`, so one unimplemented provider never fails the whole request.
- `'openserve'` was deliberately left in the valid-provider list in `lib/coverage/utils/validation.ts`, so an explicit request still validates and gets an honest "not implemented" rather than another provider's data.
- The switch remains exhaustive over `CoverageProvider`.

## Verification

- `npm run type-check:memory` — no errors in the touched file
- Pre-push hook passed: build-config check + scoped type-check
- All PR checks green: Build, TypeScript, ESLint, Dockerfile config, type-error ratchet, brand-literal ratchet, claude-review
- Deployed to staging via run [30200190527](https://github.com/jdeweedata/circletel/actions/runs/30200190527) — container healthy, `https://staging.circletel.co.za` serving 200

Net diff vs `main` is 1 file / 1 line; the extra merge commits carry content already present in `main`.

## Note on scope

This was found while auditing the DFA coverage path. A second suspected issue in the same file — that the near-net lookup queried a mislabelled layer — was investigated and **disproven**: layer 1 is genuinely DFA's near-net layer (its records carry `promotion: "Near-Net (Massive Promo)"`, and `docs/integrations/DFA_ARCGIS_INTEGRATION_ANALYSIS.md` maps near-net to that layer). No change was made there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)