### PR TITLE
feat(network): cache-first analytics with live opt-in hardening

### DIFF
--- a/__tests__/lib/network/analytics-aggregates.test.ts
+++ b/__tests__/lib/network/analytics-aggregates.test.ts
@@ -1,7 +1,10 @@
 import {
   aggregateSsidActivity,
+  buildHourlyRollupUpserts,
   computeGroupTrafficCards,
   computeRadioUtilSummary,
+  hourBucketIso,
+  HOURLY_ROLLUP_WINDOW,
 } from '@/lib/network/analytics-aggregates';
 
 describe('computeGroupTrafficCards', () => {
@@ -96,5 +99,41 @@ describe('aggregateSsidActivity', () => {
       { ssid: 'Clinic', clients: 2 },
       { ssid: 'Guest', clients: 1 },
     ]);
+  });
+});
+
+describe('buildHourlyRollupUpserts', () => {
+  it('buckets flow points to UTC hours with hours_window=1', () => {
+    const rows = buildHourlyRollupUpserts({
+      groupId: '9124474',
+      groupName: 'UnjanihAPaxS',
+      flowSn: 'SN123',
+      dataPoints: [
+        {
+          timestamp: Date.parse('2026-07-25T20:15:00+02:00'),
+          rxBytes: 10_000_000,
+          txBytes: 1_000_000,
+        },
+        {
+          timestamp: Date.parse('2026-07-25T20:45:00+02:00'),
+          rxBytes: 5_000_000,
+          txBytes: 500_000,
+        },
+        {
+          timestamp: Date.parse('2026-07-25T21:10:00+02:00'),
+          rxBytes: 2_000_000,
+          txBytes: 200_000,
+        },
+      ],
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.hours_window === HOURLY_ROLLUP_WINDOW)).toBe(true);
+    expect(rows[0].captured_at).toBe(hourBucketIso(Date.parse('2026-07-25T20:15:00+02:00')));
+    expect(rows[0].total_rx_bytes).toBe(15_000_000);
+    expect(rows[0].total_tx_bytes).toBe(1_500_000);
+    expect(rows[0].avg_rx_bps).toBeCloseTo((15_000_000 * 8) / 3600);
+    expect(rows[1].total_rx_bytes).toBe(2_000_000);
+    expect(rows[0].raw_summary.flowSn).toBe('SN123');
   });
 });

--- a/app/admin/network/analytics/page.tsx
+++ b/app/admin/network/analytics/page.tsx
@@ -33,6 +33,7 @@ import {
   RadioUtilSummaryCard,
 } from '@/components/admin/network/performance';
 import type { GroupTrafficCard, RadioUtilSummary, SsidActivityCard } from '@/lib/network/analytics-aggregates';
+import { formatRelative } from '@/lib/dates';
 
 interface TrafficDataPoint {
   timestamp: number;
@@ -77,6 +78,8 @@ interface AnalyticsApiResponse {
   groupTraffic?: GroupTrafficCard[];
   ssidActivity?: SsidActivityCard[];
   radio?: RadioUtilSummary;
+  lastRollupAt?: string | null;
+  lastSyncedAt?: string | null;
   fetchedAt: string;
 }
 
@@ -150,10 +153,12 @@ export default function NetworkAnalyticsPage() {
     fetchTrafficData();
   }, [fetchTrafficData]);
 
+  // Auto-refresh only in Cached mode — Live must stay opt-in / manual.
   useEffect(() => {
-    const interval = setInterval(() => fetchTrafficData(true), 5 * 60 * 1000);
+    if (preferLive) return;
+    const interval = setInterval(() => fetchTrafficData(true, false), 5 * 60 * 1000);
     return () => clearInterval(interval);
-  }, [fetchTrafficData]);
+  }, [fetchTrafficData, preferLive]);
 
   const selectedGroup = groups.find((g) => g.id === selectedGroupId);
 
@@ -193,7 +198,7 @@ export default function NetworkAnalyticsPage() {
             Network Analytics
           </h1>
           <p className="text-slate-500 mt-1 text-sm">
-            Group-scoped Ruijie throughput · app-flow · radio util from cache
+            Traffic and utilization by network group
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -273,7 +278,7 @@ export default function NetworkAnalyticsPage() {
 
       {data ? (
         <>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Badge
               variant="outline"
               className={
@@ -282,11 +287,23 @@ export default function NetworkAnalyticsPage() {
                   : 'border-slate-200 bg-slate-50 text-slate-600'
               }
             >
-              Source: {data.source === 'live' ? 'Ruijie live' : 'Supabase rollups'}
+              {data.source === 'live' ? 'Ruijie live' : 'Supabase rollups'}
             </Badge>
             <span className="text-xs text-slate-400">
               {selectedGroup?.name || 'Network'} · {formatDuration(parseInt(selectedHours, 10))}
             </span>
+            {data.lastRollupAt ? (
+              <span className="text-xs text-slate-500">
+                Last rollup {formatRelative(data.lastRollupAt)}
+              </span>
+            ) : (
+              <span className="text-xs text-amber-600">No rollup samples yet</span>
+            )}
+            {data.lastSyncedAt ? (
+              <span className="text-xs text-slate-400">
+                · Device sync {formatRelative(data.lastSyncedAt)}
+              </span>
+            ) : null}
           </div>
 
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
@@ -361,9 +378,18 @@ export default function NetworkAnalyticsPage() {
             <RadioUtilSummaryCard radio={radio} />
           </div>
 
-          <div className="flex items-center justify-end gap-2 text-sm text-slate-500">
-            <PiClockBold className="w-4 h-4" />
-            Last updated: {new Date(data.fetchedAt).toLocaleString('en-ZA')}
+          <div className="flex flex-wrap items-center justify-end gap-3 text-sm text-slate-500">
+            <span className="inline-flex items-center gap-2">
+              <PiClockBold className="w-4 h-4" />
+              {data.source === 'live'
+                ? `Live fetch ${formatRelative(data.fetchedAt)}`
+                : data.lastRollupAt
+                  ? `Rollup data ${formatRelative(data.lastRollupAt)}`
+                  : 'Waiting for first traffic rollup'}
+            </span>
+            {preferLive ? (
+              <span className="text-xs text-slate-400">Auto-refresh paused in Live mode</span>
+            ) : null}
           </div>
         </>
       ) : null}

--- a/app/api/admin/network/analytics/route.ts
+++ b/app/api/admin/network/analytics/route.ts
@@ -4,8 +4,10 @@
  * GET /api/admin/network/analytics
  * Query: groupId (optional), hours (default 24, max 168), live=true, includeApps
  *
- * Returns rollup throughput, app-flow, group traffic cards, SSID STA activity,
- * and radio util from device cache (honest empty when missing).
+ * Cache-first (default): traffic KPIs/series + group cards from ruijie_traffic_rollups
+ * (hours_window=1). Radio from device cache. No live Ruijie calls.
+ *
+ * Live (?live=true): traffic + optional app-flow + STA from Ruijie (10s timeout).
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -22,6 +24,7 @@ import {
   aggregateSsidActivity,
   computeGroupTrafficCards,
   computeRadioUtilSummary,
+  HOURLY_ROLLUP_WINDOW,
 } from '@/lib/network/analytics-aggregates';
 
 export const dynamic = 'force-dynamic';
@@ -39,6 +42,73 @@ const emptyTraffic = {
   dataPoints: [] as unknown[],
 };
 
+type RollupRow = {
+  group_id: string;
+  group_name: string | null;
+  captured_at: string;
+  hours_window: number;
+  total_rx_bytes: number | null;
+  total_tx_bytes: number | null;
+  avg_rx_bps: number | null;
+  avg_tx_bps: number | null;
+  peak_rx_bps: number | null;
+  peak_tx_bps: number | null;
+  raw_summary: unknown;
+};
+
+function maxIso(dates: Array<string | null | undefined>): string | null {
+  let best: string | null = null;
+  let bestMs = -Infinity;
+  for (const value of dates) {
+    if (!value) continue;
+    const ms = new Date(value).getTime();
+    if (!Number.isFinite(ms)) continue;
+    if (ms > bestMs) {
+      bestMs = ms;
+      best = value;
+    }
+  }
+  return best;
+}
+
+function trafficFromHourlyRollups(rollups: RollupRow[]) {
+  const dataPoints = rollups.map((row) => ({
+    timestamp: new Date(row.captured_at).getTime(),
+    timeString: row.captured_at,
+    rxBytes: Number(row.total_rx_bytes) || 0,
+    txBytes: Number(row.total_tx_bytes) || 0,
+    rxPkts: 0,
+    txPkts: 0,
+    buildingId: 0,
+    avgRxMbps: roundPercent(bpsToMbps(row.avg_rx_bps || 0)),
+    avgTxMbps: roundPercent(bpsToMbps(row.avg_tx_bps || 0)),
+  }));
+
+  const totalRxBytes = dataPoints.reduce((s, p) => s + p.rxBytes, 0);
+  const totalTxBytes = dataPoints.reduce((s, p) => s + p.txBytes, 0);
+  const avgRxRate =
+    rollups.length > 0
+      ? rollups.reduce((s, r) => s + (r.avg_rx_bps || 0), 0) / rollups.length
+      : 0;
+  const avgTxRate =
+    rollups.length > 0
+      ? rollups.reduce((s, r) => s + (r.avg_tx_bps || 0), 0) / rollups.length
+      : 0;
+
+  return {
+    totalRxBytes,
+    totalTxBytes,
+    totalBytes: totalRxBytes + totalTxBytes,
+    avgRxRate,
+    avgTxRate,
+    peakRxBytes: Math.max(0, ...dataPoints.map((p) => p.rxBytes), 0),
+    peakTxBytes: Math.max(0, ...dataPoints.map((p) => p.txBytes), 0),
+    avgRxMbps: roundPercent(bpsToMbps(avgRxRate)),
+    avgTxMbps: roundPercent(bpsToMbps(avgTxRate)),
+    dataPoints,
+  };
+}
+
 export async function GET(request: NextRequest) {
   try {
     const authResult = await authenticateAdmin(request);
@@ -55,12 +125,23 @@ export async function GET(request: NextRequest) {
     const supabase = await createClient();
     const since = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
 
-    const { data: deviceGroups } = await supabase
-      .from('ruijie_device_cache')
-      .select(
-        'group_id, group_name, sn, device_name, status, model, radio_2g_utilization, radio_5g_utilization, radio_2g_channel, radio_5g_channel'
-      )
-      .not('group_id', 'is', null);
+    const [{ data: deviceGroups }, { data: lastSync }] = await Promise.all([
+      supabase
+        .from('ruijie_device_cache')
+        .select(
+          'group_id, group_name, sn, device_name, status, model, radio_2g_utilization, radio_5g_utilization, radio_2g_channel, radio_5g_channel'
+        )
+        .not('group_id', 'is', null),
+      supabase
+        .from('ruijie_sync_logs')
+        .select('completed_at')
+        .eq('status', 'completed')
+        .order('completed_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+
+    const lastSyncedAt = lastSync?.completed_at ?? null;
 
     const groupMap = new Map<string, string>();
     for (const row of deviceGroups || []) {
@@ -71,19 +152,49 @@ export async function GET(request: NextRequest) {
     const groups = Array.from(groupMap.entries()).map(([id, name]) => ({ id, name }));
     const effectiveGroupId = groupId || groups[0]?.id || null;
 
-    // Group traffic cards from all rollups in window
-    const { data: allRollups } = await supabase
+    // Prefer hours_window=1 (true hourly samples). Fall back to legacy window blobs.
+    const { data: hourlyRollups } = await supabase
       .from('ruijie_traffic_rollups')
       .select(
-        'group_id, group_name, total_rx_bytes, total_tx_bytes, captured_at'
+        'group_id, group_name, total_rx_bytes, total_tx_bytes, captured_at, hours_window, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, raw_summary'
       )
-      .gte('captured_at', since);
+      .eq('hours_window', HOURLY_ROLLUP_WINDOW)
+      .gte('captured_at', since)
+      .order('captured_at', { ascending: true });
 
-    const groupTraffic = computeGroupTrafficCards(allRollups || []);
+    const usingHourlySeries = (hourlyRollups || []).length > 0;
+    let rollupsForCards = (hourlyRollups || []) as RollupRow[];
 
-    const groupDevices = (deviceGroups || []).filter(
-      (d) => d.group_id === effectiveGroupId
-    );
+    if (!usingHourlySeries) {
+      const { data: legacyRollups } = await supabase
+        .from('ruijie_traffic_rollups')
+        .select(
+          'group_id, group_name, total_rx_bytes, total_tx_bytes, captured_at, hours_window, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, raw_summary'
+        )
+        .gte('captured_at', since)
+        .order('captured_at', { ascending: true });
+
+      // Legacy rows are overlapping window totals — keep only the newest per group.
+      const latestByGroup = new Map<string, RollupRow>();
+      for (const row of (legacyRollups || []) as RollupRow[]) {
+        const prev = latestByGroup.get(row.group_id);
+        if (
+          !prev ||
+          new Date(row.captured_at).getTime() > new Date(prev.captured_at).getTime()
+        ) {
+          latestByGroup.set(row.group_id, row);
+        }
+      }
+      rollupsForCards = Array.from(latestByGroup.values());
+    }
+
+    const groupTraffic = computeGroupTrafficCards(rollupsForCards);
+    const lastRollupAt = maxIso([
+      ...rollupsForCards.map((r) => r.captured_at),
+      ...groupTraffic.map((g) => g.lastCapturedAt),
+    ]);
+
+    const groupDevices = (deviceGroups || []).filter((d) => d.group_id === effectiveGroupId);
     const radio = computeRadioUtilSummary(
       groupDevices.map((d) => ({
         sn: d.sn,
@@ -96,16 +207,6 @@ export async function GET(request: NextRequest) {
       }))
     );
 
-    let ssidActivity: ReturnType<typeof aggregateSsidActivity> = [];
-    if (effectiveGroupId) {
-      try {
-        const stas = await getGroupStaUsers(effectiveGroupId);
-        ssidActivity = aggregateSsidActivity(stas);
-      } catch {
-        ssidActivity = [];
-      }
-    }
-
     if (!effectiveGroupId) {
       return NextResponse.json({
         groups,
@@ -117,20 +218,32 @@ export async function GET(request: NextRequest) {
         groupTraffic,
         ssidActivity: [],
         radio,
+        lastRollupAt,
+        lastSyncedAt,
         fetchedAt: new Date().toISOString(),
       });
     }
 
+    // Live Ruijie extras only when explicitly requested — keeps Cached first paint fast.
+    let ssidActivity: ReturnType<typeof aggregateSsidActivity> = [];
     let appFlow: Awaited<ReturnType<typeof getAppFlow>> = [];
-    if (includeApps) {
-      try {
-        appFlow = await getAppFlow(effectiveGroupId);
-      } catch {
-        appFlow = [];
-      }
-    }
 
     if (live) {
+      try {
+        const stas = await getGroupStaUsers(effectiveGroupId);
+        ssidActivity = aggregateSsidActivity(stas);
+      } catch {
+        ssidActivity = [];
+      }
+
+      if (includeApps) {
+        try {
+          appFlow = await getAppFlow(effectiveGroupId);
+        } catch {
+          appFlow = [];
+        }
+      }
+
       const flowSn = pickFlowDeviceSn(
         groupDevices.map((d) => ({ sn: d.sn, status: d.status, model: d.model }))
       );
@@ -158,68 +271,33 @@ export async function GET(request: NextRequest) {
         groupTraffic,
         ssidActivity,
         radio,
+        lastRollupAt,
+        lastSyncedAt,
         fetchedAt: new Date().toISOString(),
       });
     }
 
-    const { data: rollups, error } = await supabase
-      .from('ruijie_traffic_rollups')
-      .select(
-        'group_id, group_name, captured_at, hours_window, total_rx_bytes, total_tx_bytes, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, raw_summary'
-      )
-      .eq('group_id', effectiveGroupId)
-      .gte('captured_at', since)
-      .order('captured_at', { ascending: true });
+    const seriesRows = rollupsForCards
+      .filter((row) => row.group_id === effectiveGroupId)
+      .sort(
+        (a, b) => new Date(a.captured_at).getTime() - new Date(b.captured_at).getTime()
+      );
 
-    if (error) {
-      console.error('[AnalyticsAPI] Failed to fetch rollups:', error);
-      return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 });
-    }
-
-    const dataPoints = (rollups || []).map((row) => ({
-      timestamp: new Date(row.captured_at).getTime(),
-      timeString: row.captured_at,
-      rxBytes: Number(row.total_rx_bytes) || 0,
-      txBytes: Number(row.total_tx_bytes) || 0,
-      rxPkts: 0,
-      txPkts: 0,
-      buildingId: 0,
-      avgRxMbps: roundPercent(bpsToMbps(row.avg_rx_bps || 0)),
-      avgTxMbps: roundPercent(bpsToMbps(row.avg_tx_bps || 0)),
-    }));
-
-    const totalRxBytes = dataPoints.reduce((s, p) => s + p.rxBytes, 0);
-    const totalTxBytes = dataPoints.reduce((s, p) => s + p.txBytes, 0);
-    const avgRxRate =
-      rollups && rollups.length > 0
-        ? rollups.reduce((s, r) => s + (r.avg_rx_bps || 0), 0) / rollups.length
-        : 0;
-    const avgTxRate =
-      rollups && rollups.length > 0
-        ? rollups.reduce((s, r) => s + (r.avg_tx_bps || 0), 0) / rollups.length
-        : 0;
+    const traffic = trafficFromHourlyRollups(seriesRows);
+    const groupLastRollupAt = maxIso(seriesRows.map((r) => r.captured_at)) ?? lastRollupAt;
 
     return NextResponse.json({
       groups,
       groupId: effectiveGroupId,
       hours,
       source: 'supabase',
-      traffic: {
-        totalRxBytes,
-        totalTxBytes,
-        totalBytes: totalRxBytes + totalTxBytes,
-        avgRxRate,
-        avgTxRate,
-        peakRxBytes: Math.max(0, ...dataPoints.map((p) => p.rxBytes), 0),
-        peakTxBytes: Math.max(0, ...dataPoints.map((p) => p.txBytes), 0),
-        avgRxMbps: roundPercent(bpsToMbps(avgRxRate)),
-        avgTxMbps: roundPercent(bpsToMbps(avgTxRate)),
-        dataPoints,
-      },
-      appFlow,
+      traffic,
+      appFlow: [],
       groupTraffic,
-      ssidActivity,
+      ssidActivity: [],
       radio,
+      lastRollupAt: groupLastRollupAt,
+      lastSyncedAt,
       fetchedAt: new Date().toISOString(),
     });
   } catch (error) {

--- a/lib/inngest/functions/ruijie-traffic-rollup.ts
+++ b/lib/inngest/functions/ruijie-traffic-rollup.ts
@@ -2,7 +2,8 @@
  * Ruijie Traffic Rollup
  *
  * After each device sync, fetch hourly flow per group (via a representative
- * device SN — API V2.0.3 §2.6.2) and persist rollups for Health / Analytics.
+ * device SN — API V2.0.3 §2.6.2) and persist one hours_window=1 row per hour
+ * so Analytics charts have a usable series (not a single 24h window blob).
  *
  * Trigger: ruijie/sync.completed
  */
@@ -10,6 +11,7 @@
 import { inngest } from '../client';
 import { createClient } from '@/lib/supabase/server';
 import { getNetworkTraffic, pickFlowDeviceSn } from '@/lib/ruijie/client';
+import { buildHourlyRollupUpserts } from '@/lib/network/analytics-aggregates';
 
 const HOURS_WINDOW = 24;
 const RETENTION_DAYS = 14;
@@ -58,11 +60,6 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
       return { groupsProcessed: 0, rowsInserted: 0 };
     }
 
-    // Bucket to the hour so retries/upserts coalesce within the same window
-    const hourBucket = new Date();
-    hourBucket.setUTCMinutes(0, 0, 0);
-    const capturedAt = hourBucket.toISOString();
-
     const rowsInserted = await step.run('rollup-groups', async () => {
       const supabase = await createClient();
       let inserted = 0;
@@ -81,35 +78,28 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
           }
 
           const traffic = await getNetworkTraffic({ sn: flowSn, hours: HOURS_WINDOW });
-          const hoursSeconds = Math.max(HOURS_WINDOW, 1) * 3600;
-          const peakRxBps = (traffic.peakRxBytes * 8) / hoursSeconds;
-          const peakTxBps = (traffic.peakTxBytes * 8) / hoursSeconds;
+          const upserts = buildHourlyRollupUpserts({
+            groupId: group.group_id,
+            groupName: group.group_name,
+            flowSn,
+            dataPoints: traffic.dataPoints,
+          });
 
-          const { error } = await supabase.from('ruijie_traffic_rollups').upsert(
-            {
-              group_id: group.group_id,
-              group_name: group.group_name,
-              captured_at: capturedAt,
-              hours_window: HOURS_WINDOW,
-              total_rx_bytes: Math.round(traffic.totalRxBytes),
-              total_tx_bytes: Math.round(traffic.totalTxBytes),
-              avg_rx_bps: traffic.avgRxRate,
-              avg_tx_bps: traffic.avgTxRate,
-              peak_rx_bps: peakRxBps,
-              peak_tx_bps: peakTxBps,
-              raw_summary: {
-                totalBytes: traffic.totalBytes,
-                dataPointCount: traffic.dataPoints.length,
-                flowSn,
-              },
-            },
-            { onConflict: 'group_id,captured_at,hours_window' }
-          );
+          if (upserts.length === 0) {
+            console.warn(
+              `[TrafficRollup] No hourly points for group ${group.group_id} (sn=${flowSn})`
+            );
+            continue;
+          }
+
+          const { error } = await supabase.from('ruijie_traffic_rollups').upsert(upserts, {
+            onConflict: 'group_id,captured_at,hours_window',
+          });
 
           if (error) {
             console.error(`[TrafficRollup] Upsert failed for ${group.group_id}:`, error);
           } else {
-            inserted += 1;
+            inserted += upserts.length;
           }
         } catch (err) {
           console.error(`[TrafficRollup] Group ${group.group_id} failed:`, err);

--- a/lib/network/analytics-aggregates.ts
+++ b/lib/network/analytics-aggregates.ts
@@ -5,6 +5,9 @@
 
 import { avgOrNull, roundPercent } from './performance-aggregates';
 
+/** Persist one row per Ruijie hourly flow sample (not a rolling 24h window total). */
+export const HOURLY_ROLLUP_WINDOW = 1;
+
 export type GroupRollupRow = {
   group_id: string;
   group_name: string | null;
@@ -12,6 +15,83 @@ export type GroupRollupRow = {
   total_tx_bytes: number | null;
   captured_at: string;
 };
+
+export type HourlyTrafficPoint = {
+  timestamp: number;
+  rxBytes: number;
+  txBytes: number;
+};
+
+export type HourlyRollupUpsert = {
+  group_id: string;
+  group_name: string | null;
+  captured_at: string;
+  hours_window: number;
+  total_rx_bytes: number;
+  total_tx_bytes: number;
+  avg_rx_bps: number;
+  avg_tx_bps: number;
+  peak_rx_bps: number;
+  peak_tx_bps: number;
+  raw_summary: {
+    flowSn: string;
+    source: 'hourly_flow';
+  };
+};
+
+/**
+ * Bucket a timestamp to the UTC hour ISO string used as rollup captured_at.
+ */
+export function hourBucketIso(timestamp: number): string {
+  const d = new Date(timestamp);
+  d.setUTCMinutes(0, 0, 0);
+  return d.toISOString();
+}
+
+/**
+ * Build hours_window=1 upserts from Ruijie hourly flow points.
+ * One row per hour — analytics charts and group cards can sum without double-counting.
+ */
+export function buildHourlyRollupUpserts(params: {
+  groupId: string;
+  groupName: string | null;
+  flowSn: string;
+  dataPoints: HourlyTrafficPoint[];
+}): HourlyRollupUpsert[] {
+  const byHour = new Map<string, { rx: number; tx: number }>();
+
+  for (const point of params.dataPoints) {
+    if (!Number.isFinite(point.timestamp)) continue;
+    const key = hourBucketIso(point.timestamp);
+    const prev = byHour.get(key) || { rx: 0, tx: 0 };
+    prev.rx += Number(point.rxBytes) || 0;
+    prev.tx += Number(point.txBytes) || 0;
+    byHour.set(key, prev);
+  }
+
+  return Array.from(byHour.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([captured_at, { rx, tx }]) => {
+      const avgRxBps = (rx * 8) / 3600;
+      const avgTxBps = (tx * 8) / 3600;
+      return {
+        group_id: params.groupId,
+        group_name: params.groupName,
+        captured_at,
+        hours_window: HOURLY_ROLLUP_WINDOW,
+        total_rx_bytes: Math.round(rx),
+        total_tx_bytes: Math.round(tx),
+        avg_rx_bps: avgRxBps,
+        avg_tx_bps: avgTxBps,
+        peak_rx_bps: avgRxBps,
+        peak_tx_bps: avgTxBps,
+        raw_summary: {
+          flowSn: params.flowSn,
+          source: 'hourly_flow' as const,
+        },
+      };
+    });
+}
 
 export type GroupTrafficCard = {
   groupId: string;

--- a/lib/ruijie/client.ts
+++ b/lib/ruijie/client.ts
@@ -21,6 +21,9 @@ import {
 const RUIJIE_BASE_URL = process.env.RUIJIE_BASE_URL || 'https://cloud.ruijienetworks.com/service/api';
 const MOCK_MODE = process.env.RUIJIE_MOCK_MODE === 'true';
 
+/** Live Ruijie calls must fail fast — analytics Live mode and rollups depend on this. */
+export const RUIJIE_FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * Logbiz (STA / performance / flow) is hosted at cloud root, NOT under /service/api.
  * Example: https://cloud-eu.ruijienetworks.com/logbizagent/logbiz/api/...
@@ -32,6 +35,24 @@ function getLogbizBaseUrl(): string {
   }
   const host = RUIJIE_BASE_URL.replace(/\/service\/api\/?$/, '');
   return `${host}/logbizagent/logbiz/api`;
+}
+
+function mergeAbortSignals(signals: AbortSignal[]): AbortSignal | undefined {
+  const active = signals.filter(Boolean);
+  if (active.length === 0) return undefined;
+  if (active.length === 1) return active[0];
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any(active);
+  }
+  const controller = new AbortController();
+  for (const signal of active) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    signal.addEventListener('abort', () => controller.abort(signal.reason), { once: true });
+  }
+  return controller.signal;
 }
 
 // =============================================================================
@@ -53,8 +74,14 @@ async function ruijieFetch<T>(
   const url = new URL(`${baseUrl}${endpoint}`);
   url.searchParams.set('access_token', token);
 
+  const timeoutSignal = AbortSignal.timeout(RUIJIE_FETCH_TIMEOUT_MS);
+  const signal = mergeAbortSignals(
+    [options.signal, timeoutSignal].filter((s): s is AbortSignal => Boolean(s))
+  );
+
   const response = await fetch(url.toString(), {
     ...options,
+    signal,
     headers: {
       'Content-Type': 'application/json',
       'Accept': 'application/json',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep `/admin/network/analytics` **Cached (Supabase rollups) by default**; Live Ruijie remains an explicit toggle.
- Pause the 5-minute auto-refresh while Live is selected so idle admin tabs do not hammer Ruijie.
- Surface **last rollup** and **device sync** relative age in the header (not just API `fetchedAt`).
- Add a **10s timeout** on all Ruijie fetches (`AbortSignal.timeout`) so Live mode fails fast.
- Fix sparse Cached charts: traffic rollups now persist **one `hours_window=1` row per hourly flow sample** instead of a single overlapping 24h window blob. Cached mode also skips live app-flow/STA so first paint stays DB-only.

## Test plan
- [x] `npm test -- __tests__/lib/network/analytics-aggregates.test.ts`
- [x] Pre-push scoped type-check passed
- [ ] Open `/admin/network/analytics` — default shows Supabase rollups, last rollup age, no Live auto-refresh
- [ ] Toggle Live — fetches with timeout; auto-refresh paused notice shown
- [ ] After next `ruijie/sync.completed` rollup, Cached chart should show multiple hourly points (not 1 sample)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50f1a75a-5563-4a12-9800-ee1c05abbc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50f1a75a-5563-4a12-9800-ee1c05abbc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

