### PR TITLE
fix(ui): make analytics network group Select options selectable

### DIFF
--- a/app/admin/network/analytics/page.tsx
+++ b/app/admin/network/analytics/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import {
   PiArrowsClockwiseBold,
@@ -109,18 +109,29 @@ export default function NetworkAnalyticsPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [preferLive, setPreferLive] = useState(false);
+  const hasLoadedRef = useRef(false);
 
   const fetchTrafficData = useCallback(
-    async (isRefresh = false, live = preferLive) => {
+    async (options?: {
+      isRefresh?: boolean;
+      live?: boolean;
+      groupId?: string;
+      hours?: string;
+    }) => {
+      const isRefresh = options?.isRefresh ?? false;
+      const live = options?.live ?? preferLive;
+      const groupId = options?.groupId ?? selectedGroupId;
+      const hours = options?.hours ?? selectedHours;
+
       if (isRefresh) setRefreshing(true);
       else setLoading(true);
 
       try {
         const params = new URLSearchParams({
-          hours: selectedHours,
+          hours,
           includeApps: 'true',
         });
-        if (selectedGroupId) params.set('groupId', selectedGroupId);
+        if (groupId) params.set('groupId', groupId);
         if (live) params.set('live', 'true');
 
         const response = await fetch(`/api/admin/network/analytics?${params}`, {
@@ -132,9 +143,13 @@ export default function NetworkAnalyticsPage() {
         const result: AnalyticsApiResponse = await response.json();
         setData(result);
         if (result.groups?.length) {
-          setGroups(result.groups);
-          if (!selectedGroupId && result.groupId) {
-            setSelectedGroupId(result.groupId);
+          // Normalize ids to strings — Radix Select rejects empty/non-string values.
+          const normalized = result.groups
+            .map((g) => ({ id: String(g.id), name: g.name || String(g.id) }))
+            .filter((g) => g.id.length > 0);
+          setGroups(normalized);
+          if (!groupId && result.groupId) {
+            setSelectedGroupId(String(result.groupId));
           }
         }
         setError(null);
@@ -150,15 +165,25 @@ export default function NetworkAnalyticsPage() {
   );
 
   useEffect(() => {
-    fetchTrafficData();
+    void fetchTrafficData({ isRefresh: hasLoadedRef.current }).finally(() => {
+      hasLoadedRef.current = true;
+    });
   }, [fetchTrafficData]);
 
   // Auto-refresh only in Cached mode — Live must stay opt-in / manual.
   useEffect(() => {
     if (preferLive) return;
-    const interval = setInterval(() => fetchTrafficData(true, false), 5 * 60 * 1000);
+    const interval = setInterval(
+      () => fetchTrafficData({ isRefresh: true, live: false }),
+      5 * 60 * 1000
+    );
     return () => clearInterval(interval);
   }, [fetchTrafficData, preferLive]);
+
+  const handleGroupChange = (groupId: string) => {
+    if (!groupId || groupId === selectedGroupId) return;
+    setSelectedGroupId(groupId);
+  };
 
   const selectedGroup = groups.find((g) => g.id === selectedGroupId);
 
@@ -208,7 +233,10 @@ export default function NetworkAnalyticsPage() {
           <Button variant="outline" size="sm" asChild>
             <Link href="/admin/network/devices">Devices</Link>
           </Button>
-          <Select value={selectedGroupId} onValueChange={setSelectedGroupId}>
+          <Select
+            value={selectedGroupId || undefined}
+            onValueChange={handleGroupChange}
+          >
             <SelectTrigger className="w-[200px] rounded-lg border-slate-200">
               <SelectValue placeholder="Select network group" />
             </SelectTrigger>
@@ -238,7 +266,7 @@ export default function NetworkAnalyticsPage() {
             onClick={() => {
               const next = !preferLive;
               setPreferLive(next);
-              fetchTrafficData(true, next);
+              void fetchTrafficData({ isRefresh: true, live: next });
             }}
           >
             <PiBroadcastBold className="w-4 h-4 mr-2" />
@@ -247,7 +275,7 @@ export default function NetworkAnalyticsPage() {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => fetchTrafficData(true)}
+            onClick={() => void fetchTrafficData({ isRefresh: true })}
             disabled={refreshing}
           >
             <PiArrowsClockwiseBold className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
@@ -340,7 +368,7 @@ export default function NetworkAnalyticsPage() {
           <GroupTrafficCards
             groups={groupTraffic}
             selectedGroupId={selectedGroupId}
-            onSelectGroup={setSelectedGroupId}
+            onSelectGroup={handleGroupChange}
           />
 
           <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -73,7 +73,9 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-gray-200 bg-white text-gray-900 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        // Cap height to available viewport space so items stay scrollable/selectable.
+        // Do NOT lock Viewport to trigger height — that clips options to ~1 row.
+        "relative z-[100] max-h-[min(24rem,var(--radix-select-content-available-height))] min-w-[8rem] overflow-hidden rounded-md border border-gray-200 bg-white text-gray-900 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -86,7 +88,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "w-full min-w-[var(--radix-select-trigger-width)]"
         )}
       >
         {children}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixed the shared Radix/shadcn `Select` viewport: it was locked to the trigger height (`h-[var(--radix-select-trigger-height)]`), which clipped dropdown options to roughly one row and made other network groups hard/impossible to choose.
- Analytics group dropdown now uses a non-empty controlled value (`undefined` instead of `''`), normalizes group ids to strings, and wires group-card clicks through the same handler.

## Root cause
`components/ui/select.tsx` set the viewport height equal to the trigger (~40px) while content used `overflow-hidden`, so Unjani / Newgen / etc. were clipped out of the interactive list.

## Test plan
- [x] Pre-push scoped type-check passed
- [ ] Open `/admin/network/analytics`
- [ ] Open Network group dropdown — all groups visible
- [ ] Select a different group — trigger label + KPIs/chart update
- [ ] Click a Group Traffic card — same group selection behavior
- [ ] Spot-check another admin Select (e.g. hours range) still works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50f1a75a-5563-4a12-9800-ee1c05abbc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50f1a75a-5563-4a12-9800-ee1c05abbc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

