### PR TITLE
fix(ruijie): protect device cache + backfill historic traffic to Supabase

### DIFF
--- a/.claude/rules/anti-patterns.md
+++ b/.claude/rules/anti-patterns.md
@@ -73,3 +73,5 @@ ALWAYS ask before modifying more than 3 files at once
 | Wrong API param | Silent failure | Check working implementation first |
 | Root-level file dump | Cluttered repo | Always use subdirectories |
 | Assumed function exists | Runtime error | Grep for function before calling |
+| Prune Ruijie device cache after empty/partial fetch | Entire fleet disappears from admin UI | Follow `ruijie-cache-and-history.md`; use `shouldSkipDevicePrune` |
+| Live-only Network analytics/devices | Slow/fragile pages, empty on Ruijie outage | Cache-first Supabase display; Live opt-in only |

--- a/.claude/rules/ruijie-cache-and-history.md
+++ b/.claude/rules/ruijie-cache-and-history.md
@@ -1,0 +1,60 @@
+Rule: ruijie-cache-and-history  
+Loaded by: CLAUDE.md  
+Scope: Ruijie Cloud → Supabase cache, historic retention, admin Network UI
+
+---
+
+## Principle
+
+**Supabase is the display source of truth for admin Network pages.**  
+Ruijie Cloud is the origin system. Pull what Ruijie can provide, upsert into Supabase, and render from cache. Live Ruijie calls are opt-in (diagnostics), not the default page load.
+
+## NEVER
+
+```
+NEVER prune/delete ruijie_device_cache when a Ruijie fetch returns 0 devices
+NEVER prune device cache after a partial group fetch failure
+NEVER make /admin/network/devices or analytics depend on live Ruijie for first paint
+NEVER invent traffic, radio util, SSID bytes, or dBm density when Ruijie/cache has no data
+NEVER wipe historic ruijie_traffic_rollups because a single sync failed
+```
+
+Use `shouldSkipDevicePrune()` / empty-keep guards in sync. Prefer failing the sync step (Inngest retry) over deleting fleet rows.
+
+## Cache tables (display)
+
+| Data | Supabase table | Populated by | Historic? |
+|------|----------------|--------------|-----------|
+| Fleet inventory + radio util | `ruijie_device_cache` | `ruijie-sync` (cron + manual) | Current snapshot only (Ruijie list API has no deep history) |
+| Hourly group traffic | `ruijie_traffic_rollups` (`hours_window=1`) | `ruijie-traffic-rollup` after sync | Yes — upsert Ruijie `flow/show/hour` points (up to API window, retain 14d) |
+| Health scores / anomalies | `device_health_snapshots` | `ruijie-health-monitor` | Yes — accumulates over time |
+| Sync audit | `ruijie_sync_logs` | sync function | Operational history |
+
+## Pull → cache → display
+
+1. **Sync devices** from Ruijie → upsert `ruijie_device_cache` (preserve customer links / prior metrics when live enrich returns null).
+2. **Roll up traffic** per group via representative EG/gateway SN → `getNetworkTraffic({ sn, hours })` → `buildHourlyRollupUpserts` → upsert `ruijie_traffic_rollups`.
+3. **Admin UI defaults to Cached**:
+   - Devices → `/api/ruijie/devices` (cache)
+   - Analytics → `/api/admin/network/analytics` without `live=true` (rollups + cache)
+4. **Live** (`?live=true` / Live toggle) is optional and must use fetch timeouts; do not auto-refresh Live on a timer.
+
+## Historic backfill rules
+
+- On every successful sync completion, traffic rollup must **re-pull the longest practical Ruijie hourly window** (currently up to **168 hours / 7 days**) and upsert all points — not only the last 24h blob.
+- Upserts are idempotent on `(group_id, captured_at, hours_window)`.
+- Retention prune of rollups only deletes rows older than retention (14 days); never truncate the table.
+- If Ruijie returns no points for a group, leave existing rollup rows for that group intact.
+- Device list history cannot be reconstructed beyond what we have already stored — do not fake past inventory.
+
+## Auth
+
+Ruijie admin APIs must use `authenticateAdmin()` (email / admin claim), not brittle `admin_users.id = auth.uid` only.
+
+## Related code
+
+- Sync: `lib/inngest/functions/ruijie-sync.ts`, `lib/ruijie/sync-service.ts`
+- Traffic rollup: `lib/inngest/functions/ruijie-traffic-rollup.ts`
+- Aggregates: `lib/network/analytics-aggregates.ts` (`buildHourlyRollupUpserts`, `HOURLY_ROLLUP_WINDOW`)
+- Analytics API: `app/api/admin/network/analytics/route.ts`
+- Devices API: `app/api/ruijie/devices/route.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,7 @@ All detailed patterns are in `.claude/rules/`:
 | `invoice-pdf-patterns.md` | VAT calc (excl-VAT multiply), fetch/blob download, print:hidden, jsPDF patterns |
 | `pre-push-hook.md` | Shared `.githooks/pre-push` — build-config + scoped type-check, escape hatches |
 | `icon-system.md` | Phosphor UI icons, Iconify brand logos, local hosting, licensing, and accessibility |
+| `ruijie-cache-and-history.md` | Ruijie→Supabase cache-first display, never wipe on empty fetch, historic traffic rollups |
 
 ---
 

--- a/__tests__/lib/ruijie/sync-prune-guard.test.ts
+++ b/__tests__/lib/ruijie/sync-prune-guard.test.ts
@@ -1,0 +1,25 @@
+import { shouldSkipDevicePrune } from '@/lib/ruijie/sync-service';
+
+describe('shouldSkipDevicePrune', () => {
+  it('skips when keep set is empty (would wipe fleet)', () => {
+    expect(shouldSkipDevicePrune({ keepCount: 0, failedGroupIds: [] })).toEqual({
+      skip: true,
+      reason: 'empty_keep_set',
+    });
+  });
+
+  it('skips when any Ruijie group fetch failed', () => {
+    expect(
+      shouldSkipDevicePrune({ keepCount: 12, failedGroupIds: [9058218] })
+    ).toEqual({
+      skip: true,
+      reason: 'partial_group_fetch_failure',
+    });
+  });
+
+  it('allows prune when keep set is non-empty and all groups succeeded', () => {
+    expect(shouldSkipDevicePrune({ keepCount: 12, failedGroupIds: [] })).toEqual({
+      skip: false,
+    });
+  });
+});

--- a/__tests__/lib/ruijie/traffic-history.test.ts
+++ b/__tests__/lib/ruijie/traffic-history.test.ts
@@ -1,0 +1,17 @@
+import {
+  clampTrafficHistoryHours,
+  RUIJIE_TRAFFIC_HISTORY_HOURS,
+} from '@/lib/ruijie/traffic-history';
+
+describe('clampTrafficHistoryHours', () => {
+  it('defaults to the full historic window', () => {
+    expect(clampTrafficHistoryHours(undefined)).toBe(RUIJIE_TRAFFIC_HISTORY_HOURS);
+    expect(clampTrafficHistoryHours(Number.NaN)).toBe(RUIJIE_TRAFFIC_HISTORY_HOURS);
+  });
+
+  it('clamps to 1..168', () => {
+    expect(clampTrafficHistoryHours(0)).toBe(1);
+    expect(clampTrafficHistoryHours(24)).toBe(24);
+    expect(clampTrafficHistoryHours(500)).toBe(168);
+  });
+});

--- a/app/admin/network/devices/page.tsx
+++ b/app/admin/network/devices/page.tsx
@@ -243,6 +243,7 @@ export default function RuijieDevicesPage() {
   }
 
   const devices = data?.devices || [];
+  const hasFilters = Boolean(search || statusFilter || groupFilter || modelFilter);
   const onlineCount = devices.filter((d) => d.status === 'online').length;
   const offlineCount = devices.filter((d) => d.status === 'offline').length;
   const totalClients = devices.reduce((sum, d) => sum + (d.online_clients || 0), 0);
@@ -374,8 +375,13 @@ export default function RuijieDevicesPage() {
         ))}
         {devices.length === 0 && (
           <Card className="border border-slate-200/80 shadow-sm rounded-xl">
-            <CardContent className="py-8 text-center text-slate-400">
-              No devices found
+            <CardContent className="py-8 text-center space-y-2">
+              <p className="text-slate-600 font-medium">No devices in cache</p>
+              <p className="text-sm text-slate-400">
+                {hasFilters
+                  ? 'Try clearing filters, or refresh to re-sync from Ruijie Cloud.'
+                  : 'Click Refresh to sync from Ruijie Cloud into Supabase cache.'}
+              </p>
             </CardContent>
           </Card>
         )}

--- a/app/admin/network/devices/page.tsx
+++ b/app/admin/network/devices/page.tsx
@@ -136,7 +136,15 @@ export default function RuijieDevicesPage() {
   const handleRefresh = async () => {
     setRefreshing(true);
     try {
+      // Device sync first; traffic backfill needs group SNs in ruijie_device_cache.
       await fetch('/api/ruijie/sync', { method: 'POST', credentials: 'include' });
+      // Also queue historic hourly traffic pull (7d) into ruijie_traffic_rollups.
+      await fetch('/api/ruijie/traffic/backfill', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hours: 168 }),
+      });
       await new Promise((r) => setTimeout(r, 2000));
       await fetchDevices(true);
     } catch (err) {

--- a/app/api/ruijie/devices/route.ts
+++ b/app/api/ruijie/devices/route.ts
@@ -4,34 +4,20 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClientWithSession, createClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
 import { apiLogger } from '@/lib/logging/logger';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
   try {
-    // Use session client for authentication (reads cookies)
-    const supabase = await createClientWithSession();
-
-    // Verify user is authenticated
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) {
+      return authResult.response;
     }
 
-    // Use service role client to check admin_users (bypasses RLS)
     const supabaseAdmin = await createClient();
-    const { data: adminUser } = await supabaseAdmin
-      .from('admin_users')
-      .select('id, role')
-      .eq('id', user.id)
-      .eq('is_active', true)
-      .single();
-
-    if (!adminUser) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
-    }
 
     // Parse query params
     const { searchParams } = new URL(request.url);
@@ -40,7 +26,7 @@ export async function GET(request: NextRequest) {
     const group = searchParams.get('group') || '';
     const model = searchParams.get('model') || '';
 
-    // Build query (use admin client to bypass RLS)
+    // Build query (service role bypasses RLS)
     let query = supabaseAdmin
       .from('ruijie_device_cache')
       .select('*')
@@ -70,18 +56,18 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch devices' }, { status: 500 });
     }
 
-    // Get last sync time
+    // Get last sync time (maybeSingle — empty logs are normal before first sync)
     const { data: lastSync } = await supabaseAdmin
       .from('ruijie_sync_logs')
       .select('completed_at')
       .eq('status', 'completed')
       .order('completed_at', { ascending: false })
       .limit(1)
-      .single();
+      .maybeSingle();
 
     // Get unique groups and models for filter dropdowns
-    const groups = [...new Set(devices?.map(d => d.group_name).filter(Boolean))] as string[];
-    const models = [...new Set(devices?.map(d => d.model).filter(Boolean))] as string[];
+    const groups = [...new Set(devices?.map((d) => d.group_name).filter(Boolean))] as string[];
+    const models = [...new Set(devices?.map((d) => d.model).filter(Boolean))] as string[];
 
     return NextResponse.json({
       devices: devices || [],
@@ -89,7 +75,6 @@ export async function GET(request: NextRequest) {
       lastSynced: lastSync?.completed_at || null,
       filters: { groups, models },
     });
-
   } catch (error) {
     apiLogger.error('Ruijie devices API error', { error });
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/ruijie/sync/route.ts
+++ b/app/api/ruijie/sync/route.ts
@@ -4,7 +4,8 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClientWithSession, createClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
 import { apiLogger } from '@/lib/logging/logger';
 import { inngest } from '@/lib/inngest/client';
 
@@ -12,27 +13,13 @@ export const dynamic = 'force-dynamic';
 
 export async function POST(request: NextRequest) {
   try {
-    // Use session client for authentication (reads cookies)
-    const supabase = await createClientWithSession();
-
-    // Verify user is authenticated
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) {
+      return authResult.response;
     }
 
-    // Use service role client to check admin_users (bypasses RLS)
+    const adminUser = authResult.adminUser!;
     const supabaseAdmin = await createClient();
-    const { data: adminUser } = await supabaseAdmin
-      .from('admin_users')
-      .select('id, role')
-      .eq('id', user.id)
-      .eq('is_active', true)
-      .single();
-
-    if (!adminUser) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
-    }
 
     // Send Inngest event
     await inngest.send({
@@ -44,7 +31,10 @@ export async function POST(request: NextRequest) {
     });
 
     // Audit log
-    const clientIp = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown';
+    const clientIp =
+      request.headers.get('x-forwarded-for') ||
+      request.headers.get('x-real-ip') ||
+      'unknown';
     await supabaseAdmin.from('ruijie_audit_log').insert({
       admin_user_id: adminUser.id,
       device_sn: null,
@@ -58,7 +48,6 @@ export async function POST(request: NextRequest) {
       status: 'queued',
       message: 'Sync triggered successfully',
     });
-
   } catch (error) {
     apiLogger.error('Ruijie sync trigger API error', { error });
     return NextResponse.json({ error: 'Failed to trigger sync' }, { status: 500 });

--- a/app/api/ruijie/traffic/backfill/route.ts
+++ b/app/api/ruijie/traffic/backfill/route.ts
@@ -1,0 +1,57 @@
+/**
+ * Ruijie Traffic History Backfill
+ * POST /api/ruijie/traffic/backfill
+ *
+ * Queues Inngest `ruijie/traffic.backfill.requested` to pull the longest
+ * practical hourly window from Ruijie into `ruijie_traffic_rollups`.
+ *
+ * Body (optional JSON): { hours?: number } — clamped to 1..168
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { inngest } from '@/lib/inngest/client';
+import { apiLogger } from '@/lib/logging/logger';
+import {
+  clampTrafficHistoryHours,
+  RUIJIE_TRAFFIC_HISTORY_HOURS,
+} from '@/lib/ruijie/traffic-history';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) {
+      return authResult.response;
+    }
+
+    let hours = RUIJIE_TRAFFIC_HISTORY_HOURS;
+    try {
+      const body = await request.json();
+      if (body && typeof body.hours === 'number') {
+        hours = clampTrafficHistoryHours(body.hours);
+      }
+    } catch {
+      // empty body is fine — use default history window
+    }
+
+    await inngest.send({
+      name: 'ruijie/traffic.backfill.requested',
+      data: {
+        hours,
+        triggered_by: 'manual',
+        admin_user_id: authResult.adminUser!.id,
+      },
+    });
+
+    return NextResponse.json({
+      status: 'queued',
+      message: 'Traffic history backfill queued',
+      hours,
+    });
+  } catch (error) {
+    apiLogger.error('Ruijie traffic backfill trigger error', { error });
+    return NextResponse.json({ error: 'Failed to queue traffic backfill' }, { status: 500 });
+  }
+}

--- a/components/admin/network/DeviceTable.tsx
+++ b/components/admin/network/DeviceTable.tsx
@@ -92,8 +92,11 @@ export function DeviceTable({
             <tbody>
               {devices.length === 0 ? (
                 <tr>
-                  <td colSpan={10} className="px-4 py-10 text-center text-slate-400">
-                    No devices found
+                  <td colSpan={10} className="px-4 py-10 text-center">
+                    <p className="text-slate-600 font-medium">No devices in cache</p>
+                    <p className="text-sm text-slate-400 mt-1">
+                      Click Refresh to sync from Ruijie Cloud, or clear any active filters.
+                    </p>
                   </td>
                 </tr>
               ) : (

--- a/lib/inngest/functions/ruijie-sync.ts
+++ b/lib/inngest/functions/ruijie-sync.ts
@@ -12,10 +12,11 @@
 
 import { inngest } from '../client';
 import {
-  getAllDevices,
+  getAllDevicesDetailed,
   enrichDevicesWithLiveMetrics,
   upsertDevices,
   pruneDevicesNotInSet,
+  shouldSkipDevicePrune,
   filterActiveDevices,
   RUIJIE_ACTIVE_WINDOW_DAYS,
   createSyncLog,
@@ -89,13 +90,31 @@ export const ruijieSyncFunction = inngest.createFunction(
       });
     }
 
-    // Step 3: Fetch devices
-    const devices = await step.run('fetch-devices', async () => {
+    // Step 3: Fetch devices (with per-group failure metadata)
+    const fetchResult = await step.run('fetch-devices', async () => {
       console.log('[RuijieSync] Fetching devices...');
-      const result = await getAllDevices();
-      console.log(`[RuijieSync] Fetched ${result.length} devices`);
+      const result = await getAllDevicesDetailed();
+      console.log(
+        `[RuijieSync] Fetched ${result.devices.length} devices ` +
+          `from ${result.groupIds.length} groups ` +
+          `(${result.failedGroupIds.length} group fetch failures)`
+      );
+
+      // Empty/non-mock fetch is a hard failure — do not continue to prune.
+      if (result.devices.length === 0 && !isMockMode()) {
+        throw new Error(
+          `Ruijie returned 0 devices (groups=${result.groupIds.length}, ` +
+            `failedGroups=${result.failedGroupIds.join(',') || 'none'}). ` +
+            'Aborting sync to protect device cache.'
+        );
+      }
+
       return result;
     });
+
+    const devices = (fetchResult as { devices: RuijieDevice[] }).devices;
+    const failedGroupIds =
+      ((fetchResult as { failedGroupIds?: number[] }).failedGroupIds || []) as number[];
 
     // Step 3b: Keep only online or last_seen within 14 days
     const activeDevices = await step.run('filter-active-window', async () => {
@@ -135,9 +154,30 @@ export const ruijieSyncFunction = inngest.createFunction(
       return result;
     });
 
-    // Step 5b: Remove cache rows outside the active window
+    // Step 5b: Remove cache rows outside the active window.
+    // Skip prune on partial group failures — missing groups would look "inactive"
+    // and wipe real devices from the cache.
     const pruneResult = await step.run('prune-inactive-devices', async () => {
       const keepSns = (enrichedDevices as unknown as RuijieDevice[]).map((d) => d.sn);
+      const guard = shouldSkipDevicePrune({
+        keepCount: keepSns.length,
+        failedGroupIds,
+      });
+      if (guard.skip) {
+        console.warn(
+          `[RuijieSync] Skipping prune (${guard.reason})` +
+            (failedGroupIds.length
+              ? `; failed groups: ${failedGroupIds.join(', ')}`
+              : '')
+        );
+        return {
+          deleted: 0,
+          deletedSns: [] as string[],
+          skipped: true,
+          reason: guard.reason,
+        };
+      }
+
       const result = await pruneDevicesNotInSet(keepSns);
       if (result.deleted > 0) {
         console.log(

--- a/lib/inngest/functions/ruijie-traffic-rollup.ts
+++ b/lib/inngest/functions/ruijie-traffic-rollup.ts
@@ -1,25 +1,35 @@
 /**
- * Ruijie Traffic Rollup
+ * Ruijie Traffic Rollup / Historic Backfill
  *
- * After each device sync, fetch hourly flow per group (via a representative
- * device SN — API V2.0.3 §2.6.2) and persist one hours_window=1 row per hour
- * so Analytics charts have a usable series (not a single 24h window blob).
+ * After each device sync (and on explicit backfill events), fetch hourly flow
+ * per group via a representative device SN (API V2.0.3 §2.6.2) and upsert
+ * hours_window=1 rows so Analytics can display Supabase-cached history.
  *
- * Trigger: ruijie/sync.completed
+ * Triggers:
+ * - ruijie/sync.completed
+ * - ruijie/traffic.backfill.requested  (manual / recovery)
  */
 
 import { inngest } from '../client';
 import { createClient } from '@/lib/supabase/server';
 import { getNetworkTraffic, pickFlowDeviceSn } from '@/lib/ruijie/client';
 import { buildHourlyRollupUpserts } from '@/lib/network/analytics-aggregates';
-
-const HOURS_WINDOW = 24;
-const RETENTION_DAYS = 14;
-const GROUP_DELAY_MS = 400;
+import {
+  clampTrafficHistoryHours,
+  RUIJIE_TRAFFIC_GROUP_DELAY_MS,
+  RUIJIE_TRAFFIC_HISTORY_HOURS,
+  RUIJIE_TRAFFIC_RETENTION_DAYS,
+} from '@/lib/ruijie/traffic-history';
 
 type GroupRow = {
   group_id: string;
   group_name: string | null;
+};
+
+type BackfillEventData = {
+  hours?: number;
+  triggered_by?: string;
+  admin_user_id?: string;
 };
 
 export const ruijieTrafficRollupFunction = inngest.createFunction(
@@ -28,8 +38,16 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
     name: 'Ruijie Traffic Rollup',
     retries: 2,
   },
-  { event: 'ruijie/sync.completed' },
-  async ({ step }) => {
+  [
+    { event: 'ruijie/sync.completed' },
+    { event: 'ruijie/traffic.backfill.requested' },
+  ],
+  async ({ event, step }) => {
+    const eventData = (event?.data || {}) as BackfillEventData;
+    const hoursWindow = clampTrafficHistoryHours(
+      eventData.hours ?? RUIJIE_TRAFFIC_HISTORY_HOURS
+    );
+
     const groups = await step.run('fetch-groups', async () => {
       const supabase = await createClient();
       const { data, error } = await supabase
@@ -57,7 +75,12 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
     });
 
     if (groups.length === 0) {
-      return { groupsProcessed: 0, rowsInserted: 0 };
+      return {
+        groupsProcessed: 0,
+        rowsInserted: 0,
+        hoursWindow,
+        note: 'no_groups_in_device_cache',
+      };
     }
 
     const rowsInserted = await step.run('rollup-groups', async () => {
@@ -77,7 +100,7 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
             continue;
           }
 
-          const traffic = await getNetworkTraffic({ sn: flowSn, hours: HOURS_WINDOW });
+          const traffic = await getNetworkTraffic({ sn: flowSn, hours: hoursWindow });
           const upserts = buildHourlyRollupUpserts({
             groupId: group.group_id,
             groupName: group.group_name,
@@ -86,8 +109,9 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
           });
 
           if (upserts.length === 0) {
+            // Leave existing historic rows intact when Ruijie returns nothing.
             console.warn(
-              `[TrafficRollup] No hourly points for group ${group.group_id} (sn=${flowSn})`
+              `[TrafficRollup] No hourly points for group ${group.group_id} (sn=${flowSn}); keeping existing rollups`
             );
             continue;
           }
@@ -105,7 +129,7 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
           console.error(`[TrafficRollup] Group ${group.group_id} failed:`, err);
         }
 
-        await new Promise((r) => setTimeout(r, GROUP_DELAY_MS));
+        await new Promise((r) => setTimeout(r, RUIJIE_TRAFFIC_GROUP_DELAY_MS));
       }
 
       return inserted;
@@ -113,7 +137,9 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
 
     await step.run('prune-old-rollups', async () => {
       const supabase = await createClient();
-      const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+      const cutoff = new Date(
+        Date.now() - RUIJIE_TRAFFIC_RETENTION_DAYS * 24 * 60 * 60 * 1000
+      ).toISOString();
       const { error } = await supabase
         .from('ruijie_traffic_rollups')
         .delete()
@@ -124,6 +150,11 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
       }
     });
 
-    return { groupsProcessed: groups.length, rowsInserted };
+    return {
+      groupsProcessed: groups.length,
+      rowsInserted,
+      hoursWindow,
+      triggeredBy: eventData.triggered_by || event?.name || 'unknown',
+    };
   }
 );

--- a/lib/ruijie/client.ts
+++ b/lib/ruijie/client.ts
@@ -247,23 +247,33 @@ export async function getAllGroups(): Promise<number[]> {
 // DEVICE OPERATIONS
 // =============================================================================
 
+export type RuijieDeviceFetchResult = {
+  devices: RuijieDevice[];
+  groupIds: number[];
+  failedGroupIds: number[];
+};
+
 /**
- * Get all devices from Ruijie Cloud
- * Fetches from all groups and deduplicates by serial number
+ * Get all devices from Ruijie Cloud (with per-group failure metadata).
+ * Sync uses this so it can refuse to prune the cache on empty/partial fetches.
  */
-export async function getAllDevices(groupId?: number): Promise<RuijieDevice[]> {
+export async function getAllDevicesDetailed(
+  groupId?: number
+): Promise<RuijieDeviceFetchResult> {
   if (MOCK_MODE) {
-    return getMockDevices();
+    const devices = getMockDevices();
+    return { devices, groupIds: [1, 2], failedGroupIds: [] };
   }
 
   const deviceMap = new Map<string, RuijieDevice>();
+  const failedGroupIds: number[] = [];
 
   // If specific group provided, fetch from that group only
   const groupIds = groupId ? [groupId] : await getAllGroups();
 
   if (groupIds.length === 0) {
     console.warn('[Ruijie] No groups found, cannot fetch devices');
-    return [];
+    return { devices: [], groupIds: [], failedGroupIds: [] };
   }
 
   // Fetch devices from each group
@@ -284,13 +294,33 @@ export async function getAllDevices(groupId?: number): Promise<RuijieDevice[]> {
             deviceMap.set(device.serialNumber, mapApiDevice(device));
           }
         }
+      } else {
+        failedGroupIds.push(gid);
+        console.error(
+          `[Ruijie] Device list failed for group ${gid}:`,
+          response.msg || `code=${response.code}`
+        );
       }
     } catch (error) {
+      failedGroupIds.push(gid);
       console.error(`[Ruijie] Failed to fetch devices from group ${gid}:`, error);
     }
   }
 
-  return Array.from(deviceMap.values());
+  return {
+    devices: Array.from(deviceMap.values()),
+    groupIds,
+    failedGroupIds,
+  };
+}
+
+/**
+ * Get all devices from Ruijie Cloud
+ * Fetches from all groups and deduplicates by serial number
+ */
+export async function getAllDevices(groupId?: number): Promise<RuijieDevice[]> {
+  const result = await getAllDevicesDetailed(groupId);
+  return result.devices;
 }
 
 /**

--- a/lib/ruijie/index.ts
+++ b/lib/ruijie/index.ts
@@ -39,6 +39,13 @@ export {
   filterActiveDevices,
 } from './active-window';
 
+export {
+  RUIJIE_TRAFFIC_HISTORY_HOURS,
+  RUIJIE_TRAFFIC_RETENTION_DAYS,
+  RUIJIE_TRAFFIC_GROUP_DELAY_MS,
+  clampTrafficHistoryHours,
+} from './traffic-history';
+
 // Sync Service
 export {
   upsertDevices,

--- a/lib/ruijie/index.ts
+++ b/lib/ruijie/index.ts
@@ -13,6 +13,7 @@ export { authenticateRuijie, getAccessToken, clearRuijieAuth, hasRuijieAuth } fr
 export {
   getAllGroups,
   getAllDevices,
+  getAllDevicesDetailed,
   getDevice,
   getDeviceMetrics,
   getDeviceCurrentPerformance,
@@ -42,6 +43,7 @@ export {
 export {
   upsertDevices,
   pruneDevicesNotInSet,
+  shouldSkipDevicePrune,
   logSyncRun,
   createSyncLog,
   getActiveTunnelCount,

--- a/lib/ruijie/sync-service.ts
+++ b/lib/ruijie/sync-service.ts
@@ -163,12 +163,45 @@ export async function upsertDevices(
 }
 
 /**
+ * Whether sync should skip pruning the device cache.
+ * Empty keep-sets and partial Ruijie group failures must never wipe the fleet.
+ */
+export function shouldSkipDevicePrune(opts: {
+  keepCount: number;
+  failedGroupIds: number[];
+}): { skip: boolean; reason?: string } {
+  if (opts.failedGroupIds.length > 0) {
+    return { skip: true, reason: 'partial_group_fetch_failure' };
+  }
+  if (opts.keepCount === 0) {
+    return { skip: true, reason: 'empty_keep_set' };
+  }
+  return { skip: false };
+}
+
+/**
  * Delete cache rows whose SN is not in `keepSns`.
  * Used after filtering Ruijie API devices to the 14-day active window.
+ *
+ * SAFETY: never prune when keepSns is empty — an empty Ruijie fetch/timeout
+ * must not wipe the entire fleet cache.
  */
 export async function pruneDevicesNotInSet(
   keepSns: string[]
-): Promise<{ deleted: number; deletedSns: string[] }> {
+): Promise<{ deleted: number; deletedSns: string[]; skipped?: boolean; reason?: string }> {
+  const guard = shouldSkipDevicePrune({ keepCount: keepSns.length, failedGroupIds: [] });
+  if (guard.skip) {
+    console.warn(
+      '[RuijieSync] Refusing to prune device cache with empty keep set (would wipe fleet)'
+    );
+    return {
+      deleted: 0,
+      deletedSns: [],
+      skipped: true,
+      reason: guard.reason,
+    };
+  }
+
   const supabase = await createClient();
   const keep = new Set(keepSns);
 

--- a/lib/ruijie/traffic-history.ts
+++ b/lib/ruijie/traffic-history.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared constants + helpers for Ruijie → Supabase traffic history.
+ * Keep admin Analytics charts populated from cache, not live-only pulls.
+ */
+
+/** Max hourly window we request from Ruijie flow/show/hour (matches analytics UI). */
+export const RUIJIE_TRAFFIC_HISTORY_HOURS = 168;
+
+/** How long to retain hourly rollup rows in Supabase. */
+export const RUIJIE_TRAFFIC_RETENTION_DAYS = 14;
+
+/** Pace Ruijie group requests during rollup/backfill. */
+export const RUIJIE_TRAFFIC_GROUP_DELAY_MS = 400;
+
+export function clampTrafficHistoryHours(hours: number | undefined): number {
+  if (hours == null || !Number.isFinite(hours)) return RUIJIE_TRAFFIC_HISTORY_HOURS;
+  return Math.min(RUIJIE_TRAFFIC_HISTORY_HOURS, Math.max(1, Math.floor(hours)));
+}

--- a/memory-os/long-term/patterns.md
+++ b/memory-os/long-term/patterns.md
@@ -74,6 +74,12 @@
 - Export to PNG: `pencil --in designs/filename.pen --export designs/filename.png`
 - Default model: `claude-opus-4-6`
 
+## Ruijie cache-first + historic rollups (2026-07-26)
+- Admin Network UI reads **Supabase** (`ruijie_device_cache`, `ruijie_traffic_rollups`) by default; Live Ruijie is opt-in.
+- **Never prune** device cache on empty/partial Ruijie fetches (`shouldSkipDevicePrune`).
+- Traffic history: upsert hourly `hours_window=1` rows from `flow/show/hour` up to **168h**; retain 14 days.
+- Rule: `.claude/rules/ruijie-cache-and-history.md`. Manual backfill: `POST /api/ruijie/traffic/backfill` or `scripts/ruijie-backfill-traffic.ts`.
+
 ---
 
 > **Rule**: When you discover a new pattern that works, add it here. When a pattern breaks, move it to mistakes.md with explanation.

--- a/scripts/ruijie-backfill-traffic.ts
+++ b/scripts/ruijie-backfill-traffic.ts
@@ -1,0 +1,35 @@
+/**
+ * Queue Ruijie → Supabase traffic history backfill (up to 168h hourly points).
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a && npx tsx scripts/ruijie-backfill-traffic.ts
+ *   npx tsx scripts/ruijie-backfill-traffic.ts --hours=168
+ */
+
+import { inngest } from '../lib/inngest/client';
+import {
+  clampTrafficHistoryHours,
+  RUIJIE_TRAFFIC_HISTORY_HOURS,
+} from '../lib/ruijie/traffic-history';
+
+async function main() {
+  const hoursArg = process.argv.find((a) => a.startsWith('--hours='));
+  const hours = clampTrafficHistoryHours(
+    hoursArg ? Number(hoursArg.split('=')[1]) : RUIJIE_TRAFFIC_HISTORY_HOURS
+  );
+
+  console.log(`[Backfill] Queueing ruijie/traffic.backfill.requested hours=${hours}`);
+  await inngest.send({
+    name: 'ruijie/traffic.backfill.requested',
+    data: {
+      hours,
+      triggered_by: 'script',
+    },
+  });
+  console.log('[Backfill] Queued. Inngest will upsert ruijie_traffic_rollups.');
+}
+
+main().catch((err) => {
+  console.error('[Backfill] Failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes empty `/admin/network/devices` and hardens Ruijie → Supabase caching so admin Network pages can show **historic cached data**.

### Cache wipe protection
- Abort sync when Ruijie returns **0 devices**
- **Skip prune** on empty keep-set or partial group fetch failures (`shouldSkipDevicePrune`)
- Align `/api/ruijie/devices` + `/api/ruijie/sync` with `authenticateAdmin`

### Rule
- New `.claude/rules/ruijie-cache-and-history.md` (linked from `CLAUDE.md` + anti-patterns)
- Cache-first display; never invent missing metrics; never wipe on empty fetch

### Historic population
- Traffic rollup now pulls up to **168h** of Ruijie `flow/show/hour` points into `ruijie_traffic_rollups` (`hours_window=1`)
- Dual trigger: `ruijie/sync.completed` + `ruijie/traffic.backfill.requested`
- Manual backfill: `POST /api/ruijie/traffic/backfill` and `scripts/ruijie-backfill-traffic.ts`
- Devices **Refresh** queues device sync + traffic backfill

## After deploy
1. Open `/admin/network/devices` → **Refresh**
2. Wait for Inngest sync + rollup
3. Confirm devices reappear and Analytics Cached charts gain multi-hour samples

## Test plan
- [x] Prune-guard + traffic-history + analytics-aggregate unit tests
- [x] Pre-push scoped type-check
- [ ] Prod Refresh restores fleet
- [ ] Analytics shows denser historic series after backfill
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50f1a75a-5563-4a12-9800-ee1c05abbc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50f1a75a-5563-4a12-9800-ee1c05abbc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

