### PR TITLE
chore(inngest): upgrade to v4 and tag Ruijie pipeline with sessions

### DIFF
--- a/docs/integrations/INNGEST_SETUP.md
+++ b/docs/integrations/INNGEST_SETUP.md
@@ -165,3 +165,25 @@ curl -X PUT https://www.circletel.co.za/api/inngest -H 'Content-Type: applicatio
 ```
 
 Also verify at [app.inngest.com](https://app.inngest.com) that `ruijie-traffic-rollup` is listed for the `circletel` app.
+
+## Ruijie pipeline sessions
+
+When device sync finishes it emits `ruijie/sync.completed` with:
+
+```ts
+meta: {
+  sessions: {
+    sync_log_id: "<uuid from ruijie_sync_logs>",
+  },
+}
+```
+
+Fan-out handlers (traffic rollup, health monitor, offline alerts, completion logger)
+share that session. In the Inngest dashboard:
+
+1. Open the correct environment
+2. Go to **AI → Sessions**
+3. Search session key `sync_log_id`
+4. Open the UUID to see all runs for that network refresh
+
+Requires Inngest TS SDK ≥ 4.7. Local: set `INNGEST_DEV=1`.

--- a/lib/inngest/client.ts
+++ b/lib/inngest/client.ts
@@ -10,12 +10,20 @@
 
 import { Inngest } from 'inngest';
 
+/**
+ * v4 defaults to cloud mode (requires INNGEST_SIGNING_KEY in production).
+ * Local: set INNGEST_DEV=1, or rely on NODE_ENV=development.
+ * @see https://www.inngest.com/docs/reference/typescript/v4/migrations/v3-to-v4
+ */
+const isDev =
+  process.env.INNGEST_DEV === '1' || process.env.NODE_ENV === 'development';
+
 // Create the Inngest client
 export const inngest = new Inngest({
   id: 'circletel',
   name: 'CircleTel',
-  // Event key is optional for development
-  // In production, set INNGEST_EVENT_KEY environment variable
+  isDev,
+  // INNGEST_EVENT_KEY / INNGEST_SIGNING_KEY are read from env automatically.
 });
 
 // =============================================================================

--- a/lib/inngest/events/ruijie.ts
+++ b/lib/inngest/events/ruijie.ts
@@ -1,0 +1,35 @@
+/**
+ * Typed Ruijie Inngest events + session helpers (SDK v4).
+ *
+ * Sessions group sync → rollup → health → offline-alert runs in the
+ * Inngest dashboard (AI → Sessions → search sync_log_id).
+ *
+ * @see https://www.inngest.com/docs/features/events-triggers/sessions
+ */
+
+import { eventType, staticSchema } from 'inngest';
+
+export type RuijieSyncCompletedData = {
+  sync_log_id: string;
+  devices_fetched: number;
+  added: number;
+  updated: number;
+  pruned: number;
+  errors: number;
+  duration_ms: number;
+};
+
+/** Event: device sync finished; fans out to rollup / health / offline alerts. */
+export const ruijieSyncCompleted = eventType('ruijie/sync.completed', {
+  schema: staticSchema<RuijieSyncCompletedData>(),
+});
+
+/**
+ * Session metadata for the Ruijie network refresh pipeline.
+ * High-cardinality: one ID per sync run (UUID from ruijie_sync_logs).
+ */
+export function ruijieSyncSessions(syncLogId: string) {
+  return {
+    sync_log_id: syncLogId,
+  } as const;
+}

--- a/lib/inngest/functions/b2b-site-activation-invoice.ts
+++ b/lib/inngest/functions/b2b-site-activation-invoice.ts
@@ -5,12 +5,12 @@ const VAT_RATE = 0.15;
 
 export const b2bSiteActivationInvoice = inngest.createFunction(
   {
+
     id: 'b2b-site-activation-invoice',
     name: 'B2B Site Activation Pro-Rata Invoice',
     retries: 3,
-  },
-  { event: 'b2b/site.activated' },
-  async ({ event, step }) => {
+  triggers: { event: 'b2b/site.activated' },
+}, async ({ event, step }) => {
     const { site_id, organisation_id, activated_at, package_id, monthly_fee, service_id } = event.data;
 
     if (!monthly_fee || monthly_fee <= 0) {

--- a/lib/inngest/functions/billing-day.ts
+++ b/lib/inngest/functions/billing-day.ts
@@ -61,6 +61,7 @@ interface InvoiceRecord {
  */
 export const billingDayFunction = inngest.createFunction(
   {
+
     id: 'billing-day-processing',
     name: 'Billing Day Processing',
     retries: 3,
@@ -70,14 +71,13 @@ export const billingDayFunction = inngest.createFunction(
         match: 'data.process_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: 07:00 SAST = 05:00 UTC (fallback if not triggered by debit-completion)
     { cron: '0 5 * * *' },
     // Event trigger: manual requests or debit-completion chain
     { event: 'billing/day.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     // Extract options from event data (if triggered manually or by debit-completion)
     const eventData = event?.data as {
       process_log_id?: string;
@@ -544,11 +544,11 @@ export const billingDayFunction = inngest.createFunction(
  */
 export const billingDayCompletedFunction = inngest.createFunction(
   {
+
     id: 'billing-day-completed',
     name: 'Billing Day Completed Handler',
-  },
-  { event: 'billing/day.completed' },
-  async ({ event, step }) => {
+  triggers: { event: 'billing/day.completed' },
+}, async ({ event, step }) => {
     const {
       process_log_id,
       billing_date,
@@ -580,11 +580,11 @@ export const billingDayCompletedFunction = inngest.createFunction(
  */
 export const billingDayFailedFunction = inngest.createFunction(
   {
+
     id: 'billing-day-failed',
     name: 'Billing Day Failed Handler',
-  },
-  { event: 'billing/day.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'billing/day.failed' },
+}, async ({ event, step }) => {
     const { process_log_id, error, attempt } = event.data;
 
     await step.run('handle-failure', async () => {

--- a/lib/inngest/functions/clinic-mandate-poll.ts
+++ b/lib/inngest/functions/clinic-mandate-poll.ts
@@ -20,13 +20,13 @@ import { maybeMarkBillingReady } from '@/lib/onboarding/billing-ready';
 
 export const clinicMandatePollFunction = inngest.createFunction(
   {
+
     id: 'clinic-mandate-poll',
     name: 'Clinic Mandate Status Poll (NetCash backstop) - DISABLED',
     retries: 2,
     concurrency: { limit: 1 },
-  },
-  { cron: 'TZ=Africa/Johannesburg 0 8 * * *' }, // Daily at 08:00 SAST
-  async ({ step }) => {
+  triggers: { cron: 'TZ=Africa/Johannesburg 0 8 * * *' },
+}, async ({ step }) => {
     // DISABLED: billing no longer depends on eMandate signing; click-wrap mandate + TwoDay debit is the path
     // The original mandate polling code is retained below but not executed (unreachable after this return).
     apiLogger.info('[Mandate Poll] DISABLED: billing no longer depends on eMandate signing');

--- a/lib/inngest/functions/clinic-vetting-sla.ts
+++ b/lib/inngest/functions/clinic-vetting-sla.ts
@@ -33,13 +33,13 @@ interface OverdueClinic {
 
 export const clinicVettingSlaFunction = inngest.createFunction(
   {
+
     id: 'clinic-vetting-sla',
     name: 'Clinic Vetting SLA Reminder',
     retries: 2,
-    concurrency: { limit: 1 }, // Digest only; no parallelization needed
-  },
-  { cron: 'TZ=Africa/Johannesburg 0 9 * * *' }, // Daily at 09:00 SAST
-  async ({ step }) => {
+    concurrency: { limit: 1 }, // Digest only; no parallelization needed,
+  triggers: { cron: 'TZ=Africa/Johannesburg 0 9 * * *' },
+}, async ({ step }) => {
     const supabase = await createClient();
     const now = new Date();
     const reminderDeadline = new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000); // 1 day from now

--- a/lib/inngest/functions/competitor-scrape.ts
+++ b/lib/inngest/functions/competitor-scrape.ts
@@ -33,6 +33,7 @@ import type {
  */
 export const competitorScrapeFunction = inngest.createFunction(
   {
+
     id: 'competitor-scrape',
     name: 'Competitor Product Scrape',
     // Retry configuration
@@ -44,9 +45,8 @@ export const competitorScrapeFunction = inngest.createFunction(
         match: 'data.scrape_log_id',
       },
     ],
-  },
-  { event: 'competitor/scrape.requested' },
-  async ({ event, step }) => {
+  triggers: { event: 'competitor/scrape.requested' },
+}, async ({ event, step }) => {
     const { provider_id, provider_slug, provider_name, scrape_log_id, scrape_urls } = event.data;
 
     // Step 1: Update status to running
@@ -327,11 +327,11 @@ export const competitorScrapeFunction = inngest.createFunction(
  */
 export const priceAlertFunction = inngest.createFunction(
   {
+
     id: 'competitor-price-alert',
     name: 'Competitor Price Alert',
-  },
-  { event: 'competitor/price.alert' },
-  async ({ event, step }) => {
+  triggers: { event: 'competitor/price.alert' },
+}, async ({ event, step }) => {
     const { provider_name, product_name, old_price, new_price, change_percent } = event.data;
 
     await step.run('log-price-alert', async () => {
@@ -360,12 +360,11 @@ export const priceAlertFunction = inngest.createFunction(
  */
 export const scheduledScrapeFunction = inngest.createFunction(
   {
+
     id: 'competitor-scheduled-scrape',
     name: 'Scheduled Competitor Scrape',
-  },
-  // Run daily at 6 AM SAST (4 AM UTC)
-  { cron: '0 4 * * *' },
-  async ({ step }) => {
+  triggers: { cron: '0 4 * * *' },
+}, async ({ step }) => {
     // Get providers due for scraping
     const providers = await step.run('get-due-providers', async () => {
       const supabase = await createClient();

--- a/lib/inngest/functions/debit-orders.ts
+++ b/lib/inngest/functions/debit-orders.ts
@@ -60,6 +60,7 @@ interface MandateStatusMap {
  */
 export const debitOrdersFunction = inngest.createFunction(
   {
+
     id: 'debit-orders-batch',
     name: 'Debit Orders Batch Processing',
     retries: 3,
@@ -69,14 +70,13 @@ export const debitOrdersFunction = inngest.createFunction(
         match: 'data.batch_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: 06:00 SAST = 04:00 UTC
     { cron: '0 4 * * *' },
     // Event trigger: manual requests
     { event: 'billing/debit-orders.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     // Extract options from event data (if triggered manually)
     const eventData = event?.data as {
       batch_log_id?: string;
@@ -725,11 +725,11 @@ export const debitOrdersFunction = inngest.createFunction(
  */
 export const debitOrdersCompletedFunction = inngest.createFunction(
   {
+
     id: 'debit-orders-completed',
     name: 'Debit Orders Completed Handler',
-  },
-  { event: 'billing/debit-orders.completed' },
-  async ({ event, step }) => {
+  triggers: { event: 'billing/debit-orders.completed' },
+}, async ({ event, step }) => {
     const {
       batch_log_id,
       billing_date,
@@ -795,11 +795,11 @@ export const debitOrdersCompletedFunction = inngest.createFunction(
  */
 export const debitOrdersFailedFunction = inngest.createFunction(
   {
+
     id: 'debit-orders-failed',
     name: 'Debit Orders Failed Handler',
-  },
-  { event: 'billing/debit-orders.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'billing/debit-orders.failed' },
+}, async ({ event, step }) => {
     const { batch_log_id, error, attempt } = event.data;
 
     await step.run('handle-failure', async () => {

--- a/lib/inngest/functions/dfa-sync.ts
+++ b/lib/inngest/functions/dfa-sync.ts
@@ -27,6 +27,7 @@ import { dfaSyncService } from '@/lib/coverage/providers/dfa/dfa-sync-service';
  */
 export const dfaSyncFunction = inngest.createFunction(
   {
+
     id: 'dfa-sync',
     name: 'DFA Building Sync',
     retries: 3,
@@ -36,14 +37,13 @@ export const dfaSyncFunction = inngest.createFunction(
         match: 'data.sync_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: 2 AM SAST = 00:00 UTC
     { cron: '0 0 * * *' },
     // Event trigger: manual requests
     { event: 'dfa/sync.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     // Extract options from event data (if triggered manually)
     const eventData = event?.data as
       | {
@@ -221,11 +221,11 @@ export const dfaSyncFunction = inngest.createFunction(
  */
 export const dfaSyncCompletedFunction = inngest.createFunction(
   {
+
     id: 'dfa-sync-completed',
     name: 'DFA Sync Completed Handler',
-  },
-  { event: 'dfa/sync.completed' },
-  async ({ event, step }) => {
+  triggers: { event: 'dfa/sync.completed' },
+}, async ({ event, step }) => {
     const {
       sync_log_id,
       connected_count,
@@ -261,11 +261,11 @@ export const dfaSyncCompletedFunction = inngest.createFunction(
  */
 export const dfaSyncFailedFunction = inngest.createFunction(
   {
+
     id: 'dfa-sync-failed',
     name: 'DFA Sync Failed Handler',
-  },
-  { event: 'dfa/sync.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'dfa/sync.failed' },
+}, async ({ event, step }) => {
     const { sync_log_id, error, attempt } = event.data;
 
     await step.run('handle-failure', async () => {

--- a/lib/inngest/functions/eft-reconciliation.ts
+++ b/lib/inngest/functions/eft-reconciliation.ts
@@ -26,6 +26,7 @@ import { cronLogger } from '@/lib/logging';
 
 export const eftReconciliationFunction = inngest.createFunction(
   {
+
     id: 'eft-reconciliation',
     name: 'EFT Daily Reconciliation',
     retries: 3,
@@ -35,12 +36,11 @@ export const eftReconciliationFunction = inngest.createFunction(
         match: 'data.process_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     { cron: '30 7 * * *' },
     { event: 'eft/reconciliation.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const eventData = event?.data as {
       process_log_id?: string;
       triggered_by?: 'cron' | 'manual';
@@ -431,11 +431,11 @@ export const eftReconciliationFunction = inngest.createFunction(
 
 export const eftReconciliationCompletedFunction = inngest.createFunction(
   {
+
     id: 'eft-reconciliation-completed',
     name: 'EFT Reconciliation Completed Handler',
-  },
-  { event: 'eft/reconciliation.completed' },
-  async ({ event }) => {
+  triggers: { event: 'eft/reconciliation.completed' },
+}, async ({ event }) => {
     const {
       process_log_id,
       reconciliation_date,

--- a/lib/inngest/functions/feasibility-check.ts
+++ b/lib/inngest/functions/feasibility-check.ts
@@ -51,6 +51,7 @@ interface ProviderCheckResult {
 
 export const feasibilityCheckFunction = inngest.createFunction(
   {
+
     id: 'feasibility-check',
     name: 'Feasibility Coverage Check',
     retries: 3,
@@ -60,9 +61,8 @@ export const feasibilityCheckFunction = inngest.createFunction(
         match: 'data.lead_id',
       },
     ],
-  },
-  { event: 'feasibility/check.requested' },
-  async ({ event, step }) => {
+  triggers: { event: 'feasibility/check.requested' },
+}, async ({ event, step }) => {
     const { lead_id, coordinates, requirements } = event.data;
     const startTime = Date.now();
 
@@ -434,11 +434,11 @@ async function checkDFA(coordinates: Coordinates): Promise<ProviderCheckResult> 
 
 export const feasibilityCheckCompletedFunction = inngest.createFunction(
   {
+
     id: 'feasibility-check-completed',
     name: 'Feasibility Check Completed Handler',
-  },
-  { event: 'feasibility/check.completed' },
-  async ({ event, step }) => {
+  triggers: { event: 'feasibility/check.completed' },
+}, async ({ event, step }) => {
     const { lead_id, is_feasible, best_technology, duration_ms } = event.data;
 
     await step.run('log-completion', async () => {
@@ -461,11 +461,11 @@ export const feasibilityCheckCompletedFunction = inngest.createFunction(
 
 export const feasibilityCheckFailedFunction = inngest.createFunction(
   {
+
     id: 'feasibility-check-failed',
     name: 'Feasibility Check Failed Handler',
-  },
-  { event: 'feasibility/check.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'feasibility/check.failed' },
+}, async ({ event, step }) => {
     const { lead_id, error, attempt } = event.data;
 
     await step.run('handle-failure', async () => {

--- a/lib/inngest/functions/invoice-notification.ts
+++ b/lib/inngest/functions/invoice-notification.ts
@@ -77,13 +77,13 @@ function buildSmsMessage(params: {
 
 export const invoiceNotificationFunction = inngest.createFunction(
   {
+
     id: 'invoice-notification',
     name: 'Invoice Notification (Email + SMS)',
     retries: 3,
-    concurrency: { limit: 5 }, // Inngest Hobby plan max = 5; any value >5 makes the ENTIRE app sync fail (no crons register)
-  },
-  { event: 'billing/invoice.generated' },
-  async ({ event, step }) => {
+    concurrency: { limit: 5 }, // Inngest Hobby plan max = 5; any value >5 makes the ENTIRE app sync fail (no crons register),
+  triggers: { event: 'billing/invoice.generated' },
+}, async ({ event, step }) => {
     const { invoice_id, customer_id } = event.data;
 
     // -------------------------------------------------------------------------

--- a/lib/inngest/functions/marketing-triggers.ts
+++ b/lib/inngest/functions/marketing-triggers.ts
@@ -21,12 +21,12 @@ import { createClient } from '@/lib/supabase/server';
  */
 export const marketingDfaLeadMatchFunction = inngest.createFunction(
   {
+
     id: 'marketing-dfa-lead-match',
     name: 'Marketing: Match DFA Buildings to No-Coverage Leads',
     retries: 2,
-  },
-  { event: 'dfa/sync.completed' },
-  async ({ event, step }) => {
+  triggers: { event: 'dfa/sync.completed' },
+}, async ({ event, step }) => {
     const result = await step.run('match-leads-to-buildings', async () => {
       const supabase = await createClient();
 
@@ -115,14 +115,14 @@ export const marketingDfaLeadMatchFunction = inngest.createFunction(
  */
 export const marketingDemandThresholdFunction = inngest.createFunction(
   {
+
     id: 'marketing-demand-threshold-check',
     name: 'Marketing: Demand Threshold Alert',
     retries: 2,
-  },
-  [
+  triggers: [
     { cron: '0 8 * * 1' }, // Weekly on Monday at 8 AM
   ],
-  async ({ step }) => {
+}, async ({ step }) => {
     const result = await step.run('check-demand-thresholds', async () => {
       const supabase = await createClient();
       const THRESHOLD = 5; // Minimum leads in an area to flag

--- a/lib/inngest/functions/mikrotik-sync.ts
+++ b/lib/inngest/functions/mikrotik-sync.ts
@@ -27,6 +27,7 @@ import { MikrotikRouterService } from '@/lib/mikrotik';
  */
 export const mikrotikSyncFunction = inngest.createFunction(
   {
+
     id: 'mikrotik-sync',
     name: 'MikroTik Router Sync',
     retries: 3,
@@ -36,14 +37,13 @@ export const mikrotikSyncFunction = inngest.createFunction(
         match: 'data.sync_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: every 30 minutes (reduced to stay within Inngest free tier)
     { cron: '*/30 * * * *' },
     // Event trigger: manual requests
     { event: 'mikrotik/sync.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const startTime = Date.now();
 
     // Extract options from event data (if triggered manually)
@@ -104,11 +104,11 @@ export const mikrotikSyncFunction = inngest.createFunction(
  */
 export const mikrotikSyncCompletedFunction = inngest.createFunction(
   {
+
     id: 'mikrotik-sync-completed',
     name: 'MikroTik Sync Completed Handler',
-  },
-  { event: 'mikrotik/sync.completed' },
-  async ({ event, step }) => {
+  triggers: { event: 'mikrotik/sync.completed' },
+}, async ({ event, step }) => {
     const { routers_online, routers_offline, routers_failed, duration_ms } = event.data;
 
     await step.run('log-completion', async () => {

--- a/lib/inngest/functions/osm-poi-sync.ts
+++ b/lib/inngest/functions/osm-poi-sync.ts
@@ -13,17 +13,17 @@ import { createClient } from '@/lib/supabase/server';
 
 export const osmPoiSyncFunction = inngest.createFunction(
   {
+
     id: 'osm-poi-sync',
     name: 'OSM POI Sync',
     retries: 2,
-  },
-  [
+  triggers: [
     // Monthly: 1st at 2AM SAST = midnight UTC
     { cron: '0 0 1 * *' },
     // Manual trigger
     { event: 'osm/poi.sync.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const startTime = Date.now();
 
     // Step 1: Check if ward data exists

--- a/lib/inngest/functions/paynow-reconciliation.ts
+++ b/lib/inngest/functions/paynow-reconciliation.ts
@@ -50,6 +50,7 @@ const PAYNOW_TRANSACTION_CODES = new Set([
  */
 export const paynowReconciliationFunction = inngest.createFunction(
   {
+
     id: 'paynow-reconciliation',
     name: 'PayNow Daily Reconciliation',
     retries: 3,
@@ -59,14 +60,13 @@ export const paynowReconciliationFunction = inngest.createFunction(
         match: 'data.process_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: daily at 07:00 UTC (09:00 SAST)
     { cron: '0 7 * * *' },
     // Event trigger: manual requests
     { event: 'paynow/reconciliation.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     // Extract options from event data (if manually triggered)
     const eventData = event?.data as {
       process_log_id?: string;
@@ -535,11 +535,11 @@ export const paynowReconciliationFunction = inngest.createFunction(
  */
 export const paynowReconciliationCompletedFunction = inngest.createFunction(
   {
+
     id: 'paynow-reconciliation-completed',
     name: 'PayNow Reconciliation Completed Handler',
-  },
-  { event: 'paynow/reconciliation.completed' },
-  async ({ event, step }) => {
+  triggers: { event: 'paynow/reconciliation.completed' },
+}, async ({ event, step }) => {
     const {
       process_log_id,
       reconciliation_date,
@@ -575,11 +575,11 @@ export const paynowReconciliationCompletedFunction = inngest.createFunction(
  */
 export const paynowReconciliationFailedFunction = inngest.createFunction(
   {
+
     id: 'paynow-reconciliation-failed',
     name: 'PayNow Reconciliation Failed Handler',
-  },
-  { event: 'paynow/reconciliation.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'paynow/reconciliation.failed' },
+}, async ({ event, step }) => {
     const { process_log_id, error, attempt } = event.data;
 
     await step.run('handle-failure', async () => {

--- a/lib/inngest/functions/recompute-offer-pricing.ts
+++ b/lib/inngest/functions/recompute-offer-pricing.ts
@@ -53,12 +53,12 @@ async function loadDraft(offerId: string): Promise<OfferDraft | null> {
 
 export const recomputeOfferPricing = inngest.createFunction(
   {
+
     id: 'recompute-offer-pricing',
     name: 'Recompute Offer Pricing Snapshot',
     retries: 2,
-  },
-  { event: 'offer/pricing.recompute.requested' },
-  async ({ event, step }) => {
+  triggers: { event: 'offer/pricing.recompute.requested' },
+}, async ({ event, step }) => {
     const { offerId, all, triggeredBy } = event.data;
 
     // Resolve which offers to recompute

--- a/lib/inngest/functions/reconciliation-monthly-sweep.ts
+++ b/lib/inngest/functions/reconciliation-monthly-sweep.ts
@@ -24,6 +24,7 @@ import { cronLogger } from '@/lib/logging';
 
 export const reconciliationMonthlySweepFunction = inngest.createFunction(
   {
+
     id: 'reconciliation-monthly-sweep',
     name: 'Monthly Reconciliation Sweep',
     retries: 2,
@@ -33,12 +34,11 @@ export const reconciliationMonthlySweepFunction = inngest.createFunction(
         match: 'data.process_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     { cron: '0 6 3 * *' },
     { event: 'reconciliation/monthly-sweep.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const eventData = event?.data as {
       process_log_id?: string;
       triggered_by?: 'cron' | 'manual';

--- a/lib/inngest/functions/ruijie-health-monitor.ts
+++ b/lib/inngest/functions/ruijie-health-monitor.ts
@@ -11,6 +11,7 @@
  */
 
 import { inngest } from '../client';
+import { ruijieSyncCompleted } from '../events/ruijie';
 import { createClient } from '@/lib/supabase/server';
 
 // =============================================================================
@@ -177,12 +178,12 @@ function detectAnomaly(
  */
 export const ruijieHealthMonitorFunction = inngest.createFunction(
   {
+
     id: 'ruijie-health-monitor',
     name: 'Ruijie Device Health Monitor',
     retries: 2,
-  },
-  { event: 'ruijie/sync.completed' },
-  async ({ event, step }) => {
+  triggers: [ruijieSyncCompleted],
+}, async ({ event, step }) => {
     const syncLogId = event.data?.sync_log_id;
     const capturedAt = new Date().toISOString();
 

--- a/lib/inngest/functions/ruijie-offline-alerts.ts
+++ b/lib/inngest/functions/ruijie-offline-alerts.ts
@@ -8,6 +8,7 @@
  */
 
 import { inngest } from '../client';
+import { ruijieSyncCompleted } from '../events/ruijie';
 import { createClient } from '@/lib/supabase/server';
 
 const SLACK_WEBHOOK_URL = process.env.SLACK_NETWORK_ALERTS_WEBHOOK;
@@ -32,12 +33,12 @@ interface OfflineDevice {
  */
 export const ruijieOfflineAlertsFunction = inngest.createFunction(
   {
+
     id: 'ruijie-offline-alerts',
     name: 'Ruijie Offline Device Alerts',
     retries: 2,
-  },
-  { event: 'ruijie/sync.completed' },
-  async ({ event, step }) => {
+  triggers: [ruijieSyncCompleted],
+}, async ({ event, step }) => {
     // Step 1: Find devices offline > threshold
     const offlineDevices = await step.run('find-offline-devices', async () => {
       const supabase = await createClient();

--- a/lib/inngest/functions/ruijie-sync.ts
+++ b/lib/inngest/functions/ruijie-sync.ts
@@ -11,6 +11,7 @@
  */
 
 import { inngest } from '../client';
+import { ruijieSyncCompleted, ruijieSyncSessions } from '../events/ruijie';
 import {
   getAllDevices,
   enrichDevicesWithLiveMetrics,
@@ -38,6 +39,7 @@ import {
  */
 export const ruijieSyncFunction = inngest.createFunction(
   {
+
     id: 'ruijie-sync',
     name: 'Ruijie Device Sync',
     retries: 3,
@@ -47,14 +49,13 @@ export const ruijieSyncFunction = inngest.createFunction(
         match: 'data.sync_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: every 30 minutes (reduced to stay within Inngest free tier)
     { cron: '*/30 * * * *' },
     // Event trigger: manual requests
     { event: 'ruijie/sync.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const startTime = Date.now();
 
     // Extract options from event data (if triggered manually)
@@ -163,11 +164,11 @@ export const ruijieSyncFunction = inngest.createFunction(
       console.log(`[RuijieSync] Updated sync log ${syncLogId}`);
     });
 
-    // Step 7: Send completion event
-    await step.run('send-completion-event', async () => {
-      await inngest.send({
-        name: 'ruijie/sync.completed',
-        data: {
+    // Step 7: Send completion event (session groups fan-out runs in dashboard)
+    await step.sendEvent(
+      'send-completion-event',
+      ruijieSyncCompleted.create(
+        {
           sync_log_id: syncLogId,
           devices_fetched: (activeDevices as unknown as RuijieDevice[]).length,
           added: syncResult.added,
@@ -176,8 +177,13 @@ export const ruijieSyncFunction = inngest.createFunction(
           errors: syncResult.errors.length,
           duration_ms: duration,
         },
-      });
-    });
+        {
+          meta: {
+            sessions: ruijieSyncSessions(syncLogId),
+          },
+        }
+      )
+    );
 
     return {
       success: syncResult.errors.length === 0,
@@ -202,17 +208,18 @@ export const ruijieSyncFunction = inngest.createFunction(
  */
 export const ruijieSyncCompletedFunction = inngest.createFunction(
   {
+
     id: 'ruijie-sync-completed',
     name: 'Ruijie Sync Completed Handler',
-  },
-  { event: 'ruijie/sync.completed' },
-  async ({ event, step }) => {
+  triggers: [ruijieSyncCompleted],
+}, async ({ event, step }) => {
     const { sync_log_id, devices_fetched, added, updated, errors, duration_ms } = event.data;
 
     await step.run('log-completion', async () => {
       console.log(
         `[RuijieSync] Sync ${sync_log_id} completed: ` +
-        `${devices_fetched} fetched, ${added} added, ${updated} updated, ${errors} errors (${duration_ms}ms)`
+        `${devices_fetched} fetched, ${added} added, ${updated} updated, ${errors} errors (${duration_ms}ms)` +
+        ` [session:sync_log_id=${sync_log_id}]`
       );
 
       // Future: Send Slack notification for large syncs or errors

--- a/lib/inngest/functions/ruijie-token-refresh.ts
+++ b/lib/inngest/functions/ruijie-token-refresh.ts
@@ -20,17 +20,17 @@ import { authenticateRuijie, clearRuijieAuth, isMockMode } from '@/lib/ruijie';
  */
 export const ruijieTokenRefreshFunction = inngest.createFunction(
   {
+
     id: 'ruijie-token-refresh',
     name: 'Ruijie Token Refresh',
     retries: 3,
-  },
-  [
+  triggers: [
     // Cron trigger: every 7 days at 3am UTC (5am South Africa)
     { cron: '0 3 */7 * *' },
     // Event trigger: manual refresh
     { event: 'ruijie/token.refresh' },
   ],
-  async ({ step }) => {
+}, async ({ step }) => {
     // Skip in mock mode
     if (isMockMode()) {
       return { skipped: true, reason: 'Mock mode enabled' };
@@ -92,11 +92,11 @@ export const ruijieTokenRefreshFunction = inngest.createFunction(
  */
 export const ruijieTokenRefreshFailedFunction = inngest.createFunction(
   {
+
     id: 'ruijie-token-refresh-failed',
     name: 'Ruijie Token Refresh Failed Handler',
-  },
-  { event: 'ruijie/token.refresh.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'ruijie/token.refresh.failed' },
+}, async ({ event, step }) => {
     const { error, timestamp } = event.data;
 
     await step.run('log-failure', async () => {

--- a/lib/inngest/functions/ruijie-traffic-rollup.ts
+++ b/lib/inngest/functions/ruijie-traffic-rollup.ts
@@ -15,6 +15,7 @@
  */
 
 import { inngest } from '../client';
+import { ruijieSyncCompleted } from '../events/ruijie';
 import { createClient } from '@/lib/supabase/server';
 import { getNetworkTraffic, pickFlowDeviceSn } from '@/lib/ruijie/client';
 import { buildHourlyRollupUpserts } from '@/lib/network/analytics-aggregates';
@@ -33,6 +34,7 @@ type GroupRow = {
 
 export const ruijieTrafficRollupFunction = inngest.createFunction(
   {
+
     id: 'ruijie-traffic-rollup',
     name: 'Ruijie Traffic Rollup',
     retries: 2,
@@ -40,9 +42,8 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
       // One rollup at a time — avoids Ruijie rate limits when syncs overlap.
       limit: 1,
     },
-  },
-  { event: 'ruijie/sync.completed' },
-  async ({ event, step }) => {
+  triggers: [ruijieSyncCompleted],
+}, async ({ event, step }) => {
     const syncLogId = (event.data as { sync_log_id?: string } | undefined)?.sync_log_id;
 
     await step.sleep('cooldown-after-sync', '12s');

--- a/lib/inngest/functions/ruijie-tunnel-cleanup.ts
+++ b/lib/inngest/functions/ruijie-tunnel-cleanup.ts
@@ -22,12 +22,12 @@ import { expireStaleTunnels } from '@/lib/ruijie';
  */
 export const ruijieTunnelCleanupFunction = inngest.createFunction(
   {
+
     id: 'ruijie-tunnel-cleanup',
     name: 'Ruijie Tunnel Cleanup',
     retries: 2,
-  },
-  { cron: '0 * * * *' },
-  async ({ step }) => {
+  triggers: { cron: '0 * * * *' },
+}, async ({ step }) => {
     const expiredCount = await step.run('expire-stale-tunnels', async () => {
       const count = await expireStaleTunnels();
       if (count > 0) {

--- a/lib/inngest/functions/sales-engine-orchestrator.ts
+++ b/lib/inngest/functions/sales-engine-orchestrator.ts
@@ -26,17 +26,17 @@ import { inngest } from '../client';
  */
 export const salesEngineDailyOrchestrator = inngest.createFunction(
   {
+
     id: 'sales-engine-daily-orchestrator',
     name: 'Sales Engine Daily Orchestrator',
     retries: 2,
-  },
-  [
+  triggers: [
     // Cron trigger: 5:30 AM SAST = 3:30 UTC
     { cron: '30 3 * * *' },
     // Manual/programmatic trigger
     { event: 'sales-engine/orchestrator.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const startTime = Date.now();
 
     // =========================================================================
@@ -200,17 +200,17 @@ export const salesEngineDailyOrchestrator = inngest.createFunction(
  */
 export const salesEngineWeeklyReview = inngest.createFunction(
   {
+
     id: 'sales-engine-weekly-review',
     name: 'Sales Engine Weekly Review',
     retries: 2,
-  },
-  [
+  triggers: [
     // Cron trigger: Monday 6:00 AM SAST = 4:00 UTC
     { cron: '0 4 * * 1' },
     // Manual/programmatic trigger
     { event: 'sales-engine/weekly-review.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const startTime = Date.now();
 
     // =========================================================================
@@ -580,11 +580,11 @@ export const salesEngineWeeklyReview = inngest.createFunction(
  */
 export const salesEngineOrchestratorCompleted = inngest.createFunction(
   {
+
     id: 'sales-engine-orchestrator-completed',
     name: 'Sales Engine Orchestrator Completed',
-  },
-  { event: 'sales-engine/orchestrator.completed' },
-  async ({ event }) => {
+  triggers: { event: 'sales-engine/orchestrator.completed' },
+}, async ({ event }) => {
     const { duration_ms, steps, errors } = event.data as {
       duration_ms: number;
       steps: {

--- a/lib/inngest/functions/supplier-sync.ts
+++ b/lib/inngest/functions/supplier-sync.ts
@@ -26,6 +26,7 @@ import { syncAllSuppliers } from '@/lib/suppliers/sync-orchestrator'
  */
 export const supplierSyncFunction = inngest.createFunction(
   {
+
     id: 'supplier-sync',
     name: 'Supplier Product Sync',
     retries: 3,
@@ -35,14 +36,13 @@ export const supplierSyncFunction = inngest.createFunction(
         match: 'data.sync_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: 2am SAST = midnight UTC
     { cron: '0 0 * * *' },
     // Event trigger: manual requests
     { event: 'supplier/sync.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     // Extract options from event data
     const eventData = event?.data as {
       sync_log_id?: string
@@ -160,14 +160,14 @@ export const supplierSyncFunction = inngest.createFunction(
  */
 export const supplierSyncCompletedFunction = inngest.createFunction(
   {
+
     id: 'supplier-sync-completed',
     name: 'Supplier Sync Completed Handler',
-  },
-  [
+  triggers: [
     { event: 'supplier/sync.completed' },
     { event: 'supplier/sync.completed_with_errors' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const { suppliers_synced, totals, errors, duration_ms, dry_run } = event.data as {
       suppliers_synced: string[]
       totals: {
@@ -217,11 +217,11 @@ export const supplierSyncCompletedFunction = inngest.createFunction(
  */
 export const supplierSyncFailedFunction = inngest.createFunction(
   {
+
     id: 'supplier-sync-failed',
     name: 'Supplier Sync Failed Handler',
-  },
-  { event: 'supplier/sync.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'supplier/sync.failed' },
+}, async ({ event, step }) => {
     const { supplier_code, error, attempt } = event.data as {
       supplier_code: string
       error: string

--- a/lib/inngest/functions/tarana-metrics-collection.ts
+++ b/lib/inngest/functions/tarana-metrics-collection.ts
@@ -22,17 +22,17 @@ import { collectLinkMetrics } from '@/lib/tarana/metrics-service';
  */
 export const taranaMetricsCollectionFunction = inngest.createFunction(
   {
+
     id: 'tarana-metrics-collection',
     name: 'Tarana Link Metrics Collection',
     retries: 2,
-  },
-  [
+  triggers: [
     // Cron trigger: every 15 minutes
     { cron: '*/15 * * * *' },
     // Event trigger: manual requests
     { event: 'tarana/metrics.collection.requested' },
   ],
-  async ({ step }) => {
+}, async ({ step }) => {
     const startTime = Date.now();
 
     // Step 1 — collect link metrics from TCS Portal

--- a/lib/inngest/functions/tarana-sync.ts
+++ b/lib/inngest/functions/tarana-sync.ts
@@ -28,6 +28,7 @@ import type { TaranaRadio } from '@/lib/tarana/types';
  */
 export const taranaSyncFunction = inngest.createFunction(
   {
+
     id: 'tarana-sync',
     name: 'Tarana Base Station Sync',
     retries: 3,
@@ -37,14 +38,13 @@ export const taranaSyncFunction = inngest.createFunction(
         match: 'data.sync_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: midnight SAST = 22:00 UTC
     { cron: '0 22 * * *' },
     // Event trigger: manual requests
     { event: 'tarana/sync.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     // Extract options from event data (if triggered manually)
     const eventData = event?.data as {
       sync_log_id?: string;
@@ -413,11 +413,11 @@ export const taranaSyncFunction = inngest.createFunction(
  */
 export const taranaSyncCompletedFunction = inngest.createFunction(
   {
+
     id: 'tarana-sync-completed',
     name: 'Tarana Sync Completed Handler',
-  },
-  { event: 'tarana/sync.completed' },
-  async ({ event, step }) => {
+  triggers: { event: 'tarana/sync.completed' },
+}, async ({ event, step }) => {
     const { sync_log_id, inserted, updated, deleted, duration_ms } = event.data;
 
     await step.run('log-completion', async () => {
@@ -445,11 +445,11 @@ export const taranaSyncCompletedFunction = inngest.createFunction(
  */
 export const taranaSyncFailedFunction = inngest.createFunction(
   {
+
     id: 'tarana-sync-failed',
     name: 'Tarana Sync Failed Handler',
-  },
-  { event: 'tarana/sync.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'tarana/sync.failed' },
+}, async ({ event, step }) => {
     const { sync_log_id, error, attempt } = event.data;
 
     await step.run('handle-failure', async () => {

--- a/lib/inngest/functions/whatsapp-campaign-report.ts
+++ b/lib/inngest/functions/whatsapp-campaign-report.ts
@@ -154,12 +154,12 @@ ${newSignUps.length > 0 ? `NEW SIGN-UPS YESTERDAY\n${signUpLines}\n` : ''}View f
 
 export const whatsappCampaignReportFunction = inngest.createFunction(
   {
+
     id: 'whatsapp-campaign-daily-report',
     name: 'WhatsApp Campaign Daily Report',
     retries: 2,
-  },
-  { cron: '0 6 * * *' }, // 06:00 UTC = 08:00 SAST
-  async ({ step }) => {
+  triggers: { cron: '0 6 * * *' },
+}, async ({ step }) => {
     const campaignService = createCampaignZohoDeskService();
     const supabase = await createClient();
 

--- a/lib/inngest/functions/whatsapp-notifications.ts
+++ b/lib/inngest/functions/whatsapp-notifications.ts
@@ -60,6 +60,7 @@ interface InvoiceRecord {
  */
 export const whatsappBillingNotifications = inngest.createFunction(
   {
+
     id: 'whatsapp-billing-notifications',
     name: 'WhatsApp Billing Notifications',
     retries: 3,
@@ -69,14 +70,13 @@ export const whatsappBillingNotifications = inngest.createFunction(
         match: 'data.process_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: 08:00 SAST = 06:00 UTC
     { cron: '0 6 * * *' },
     // Event trigger: manual requests
     { event: 'billing/whatsapp.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const eventData = event?.data as {
       process_log_id?: string;
       triggered_by?: 'cron' | 'manual';
@@ -486,11 +486,11 @@ export const whatsappBillingNotifications = inngest.createFunction(
  */
 export const whatsappNotificationsCompleted = inngest.createFunction(
   {
+
     id: 'whatsapp-notifications-completed',
     name: 'WhatsApp Notifications Completed Handler',
-  },
-  { event: 'billing/whatsapp.completed' },
-  async ({ event, step }) => {
+  triggers: { event: 'billing/whatsapp.completed' },
+}, async ({ event, step }) => {
     const {
       process_log_id,
       billing_date,
@@ -521,11 +521,11 @@ export const whatsappNotificationsCompleted = inngest.createFunction(
  */
 export const whatsappNotificationsFailed = inngest.createFunction(
   {
+
     id: 'whatsapp-notifications-failed',
     name: 'WhatsApp Notifications Failed Handler',
-  },
-  { event: 'billing/whatsapp.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'billing/whatsapp.failed' },
+}, async ({ event, step }) => {
     const { process_log_id, error, attempt } = event.data;
 
     await step.run('handle-failure', async () => {

--- a/lib/inngest/functions/zoho-desk-token-refresh.ts
+++ b/lib/inngest/functions/zoho-desk-token-refresh.ts
@@ -23,17 +23,17 @@ import { zohoLogger } from '@/lib/logging';
  */
 export const zohoDeskTokenRefreshFunction = inngest.createFunction(
   {
+
     id: 'zoho-desk-token-refresh',
     name: 'Zoho Desk Token Refresh',
     retries: 3,
-  },
-  [
+  triggers: [
     // Cron trigger: every 45 minutes
     { cron: '*/45 * * * *' },
     // Event trigger: manual refresh
     { event: 'zoho-desk/token.refresh' },
   ],
-  async ({ step }) => {
+}, async ({ step }) => {
     const result = await step.run('refresh-zoho-desk-token', async () => {
       try {
         const auth = createZohoDeskAuthService();
@@ -85,11 +85,11 @@ export const zohoDeskTokenRefreshFunction = inngest.createFunction(
 
 export const zohoDeskTokenRefreshFailedFunction = inngest.createFunction(
   {
+
     id: 'zoho-desk-token-refresh-failed',
     name: 'Zoho Desk Token Refresh Failed Handler',
-  },
-  { event: 'zoho-desk/token.refresh.failed' },
-  async ({ event, step }) => {
+  triggers: { event: 'zoho-desk/token.refresh.failed' },
+}, async ({ event, step }) => {
     const { error, timestamp } = event.data;
 
     await step.run('log-failure', async () => {

--- a/lib/inngest/functions/zone-demographic-enrichment.ts
+++ b/lib/inngest/functions/zone-demographic-enrichment.ts
@@ -23,6 +23,7 @@ import {
 
 export const zoneDemographicEnrichmentFunction = inngest.createFunction(
   {
+
     id: 'zone-demographic-enrichment',
     name: 'Zone Demographic Enrichment',
     retries: 3,
@@ -32,14 +33,13 @@ export const zoneDemographicEnrichmentFunction = inngest.createFunction(
         match: 'data.enrichment_log_id',
       },
     ],
-  },
-  [
+  triggers: [
     // Cron trigger: Sunday 3AM SAST = 1:00 UTC
     { cron: '0 1 * * 0' },
     // Event trigger: manual requests
     { event: 'zone/demographics.enrichment.requested' },
   ],
-  async ({ event, step }) => {
+}, async ({ event, step }) => {
     const eventData = event?.data as {
       enrichment_log_id?: string;
       triggered_by?: 'cron' | 'manual';
@@ -151,11 +151,11 @@ export const zoneDemographicEnrichmentFunction = inngest.createFunction(
 
 export const zoneDemographicEnrichmentCompletedFunction = inngest.createFunction(
   {
+
     id: 'zone-demographic-enrichment-completed',
     name: 'Zone Demographic Enrichment Completed',
-  },
-  { event: 'zone/demographics.enrichment.completed' },
-  async ({ event }) => {
+  triggers: { event: 'zone/demographics.enrichment.completed' },
+}, async ({ event }) => {
     const data = event.data;
     console.log(
       `[Demographic Enrichment] Completed: ${data.enriched}/${data.total_zones} zones enriched in ${data.duration_ms}ms`
@@ -169,11 +169,11 @@ export const zoneDemographicEnrichmentCompletedFunction = inngest.createFunction
 
 export const zoneDemographicEnrichmentFailedFunction = inngest.createFunction(
   {
+
     id: 'zone-demographic-enrichment-failed',
     name: 'Zone Demographic Enrichment Failed',
-  },
-  { event: 'zone/demographics.enrichment.failed' },
-  async ({ event }) => {
+  triggers: { event: 'zone/demographics.enrichment.failed' },
+}, async ({ event }) => {
     console.error(
       `[Demographic Enrichment] Failed: ${event.data.error} (attempt ${event.data.attempt})`
     );

--- a/lib/inngest/index.ts
+++ b/lib/inngest/index.ts
@@ -397,3 +397,5 @@ export const functions = [
   // Offer pricing recomputation
   recomputeOfferPricing,
 ];
+
+export { ruijieSyncCompleted, ruijieSyncSessions } from './events/ruijie';

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "exceljs": "^4.4.0",
         "framer-motion": "^12.23.24",
         "immer": "^11.0.0",
-        "inngest": "^3.46.0",
+        "inngest": "^4.13.0",
         "input-otp": "^1.2.4",
         "jspdf": "^4.1.0",
         "jspdf-autotable": "^5.0.2",
@@ -13341,6 +13341,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -17222,16 +17223,16 @@
       "license": "ISC"
     },
     "node_modules/inngest": {
-      "version": "3.54.2",
-      "resolved": "https://registry.npmjs.org/inngest/-/inngest-3.54.2.tgz",
-      "integrity": "sha512-SAAc52c7n34E9dBEapy99g0vO5MPJP2yttoZpCu3LcYy1d8tz6CrkdoEQ4FBBgzMNnQxNpeAH5lvNeFCGNXbtA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/inngest/-/inngest-4.13.0.tgz",
+      "integrity": "sha512-VC/I8KmqNmIFR9vrYrGkIXwLjevIVds1YqR1vw1WHIYWK9ZVFgfviyR7ciKTaKGwuKWlQKo6EdpY/jc8mucifQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.3",
         "@inngest/ai": "^0.1.3",
         "@jpwilliams/waitgroup": "^2.1.1",
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/auto-instrumentations-node": ">=0.66.0 <1.0.0",
+        "@opentelemetry/auto-instrumentations-node": ">=0.75.0 <1.0.0",
         "@opentelemetry/context-async-hooks": ">=2.0.0 <3.0.0",
         "@opentelemetry/exporter-trace-otlp-http": ">=0.200.0 <0.300.0",
         "@opentelemetry/instrumentation": ">=0.200.0 <0.300.0",
@@ -17242,14 +17243,12 @@
         "@types/debug": "^4.1.12",
         "@types/ms": "~2.1.0",
         "canonicalize": "^1.0.8",
-        "chalk": "^4.1.2",
         "cross-fetch": "^4.0.0",
         "debug": "^4.3.4",
         "hash.js": "^1.1.7",
         "json-stringify-safe": "^5.0.1",
         "ms": "^2.1.3",
         "serialize-error-cjs": "^0.1.3",
-        "strip-ansi": "^5.2.0",
         "temporal-polyfill": "^0.2.5",
         "ulid": "^2.3.0",
         "zod": "^3.25.0"
@@ -17267,6 +17266,7 @@
         "hono": ">=4.2.7",
         "koa": ">=2.14.2",
         "next": ">=12.0.0",
+        "react": ">=18.0.0",
         "typescript": ">=5.8.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
@@ -17298,30 +17298,12 @@
         "next": {
           "optional": true
         },
+        "react": {
+          "optional": true
+        },
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/inngest/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/inngest/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/input-otp": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "exceljs": "^4.4.0",
     "framer-motion": "^12.23.24",
     "immer": "^11.0.0",
-    "inngest": "^3.46.0",
+    "inngest": "^4.13.0",
     "input-otp": "^1.2.4",
     "jspdf": "^4.1.0",
     "jspdf-autotable": "^5.0.2",


### PR DESCRIPTION
## Summary

Upgrade Inngest TS SDK **v3 → v4.13** (required for Sessions) and attach `meta.sessions.sync_log_id` when Ruijie device sync emits `ruijie/sync.completed`, so traffic rollup, health monitor, offline alerts, and the completion logger group as one inspectable pipeline in the Inngest Sessions UI.

## Why

- Sessions need SDK ≥ 4.7.
- Ruijie refresh is multi-function; debugging empty analytics / alerts needs a single dashboard join key (`sync_log_id`).
- v4 moves triggers into `createFunction` options and defaults to cloud mode.

## Changes

- `inngest` ^3.46 → ^4.13.
- Mechanical migration: all `createFunction` triggers moved into options (`triggers:`) across ~30 function files.
- Client: `isDev` when `INNGEST_DEV=1` or `NODE_ENV=development`.
- New `lib/inngest/events/ruijie.ts`: typed `ruijieSyncCompleted` + `ruijieSyncSessions()`.
- `ruijie-sync` emits via `step.sendEvent` + `meta.sessions.sync_log_id`.
- Rollup / health / offline / completed handlers use `triggers: [ruijieSyncCompleted]`.
- Docs: Sessions usage + local `INNGEST_DEV=1` notes.

## How to verify sessions after merge

1. Deploy (post-healthy `PUT /api/inngest` already in deploy workflow).
2. Wait for a Ruijie sync (or trigger manual).
3. Inngest dashboard → **AI → Sessions** → search `sync_log_id` → open UUID.
4. Expect sibling runs: sync-completed, traffic-rollup, health-monitor, offline-alerts.

## Test plan

- [x] Pre-push type-check on 33 changed TS files (clean)
- [ ] Staging: one sync, four child runs under same session
- [ ] Confirm rollup still upserts `hours_window=1` and health snapshots still write
- [ ] Local: `INNGEST_DEV=1 npm run dev:memory` with Inngest Dev Server

## Risk notes

- v4 cloud-mode default: production must keep `INNGEST_SIGNING_KEY` set (already present).
- Sessions lag a few minutes (historical index, not live).
