### PR TITLE
feat(network): surface live AP telemetry Ruijie already returns

### DIFF
--- a/__tests__/components/admin/network/DeviceSystemHealth.test.tsx
+++ b/__tests__/components/admin/network/DeviceSystemHealth.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * DeviceSystemHealth — renders the current_performance fields the fleet sync discards.
+ * Values below are the live payload from G1U52HL044467 (RAP2200(F)).
+ */
+
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { DeviceSystemHealth, formatUptime } from '@/components/admin/network/detail/DeviceSystemHealth';
+
+// react-test-renderer needs the act environment to flush; the repo's jest env is node (no jsdom).
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const LIVE_SYSTEM = {
+  cpu_usage: 6,
+  memory_usage: 48,
+  cpu_temp: null,
+  memory_free_kb: 14144,
+  flash_rate: 42,
+  flash_free_kb: 408,
+  disk_rate: 0,
+  disk_free_kb: 0,
+  process_num: 92,
+  user_count: 3,
+};
+
+/** Render the card and return its serialised tree for substring assertions. */
+function render(element: React.ReactElement): string {
+  let tree: TestRenderer.ReactTestRenderer | undefined;
+  act(() => {
+    tree = TestRenderer.create(element);
+  });
+  return JSON.stringify(tree!.toJSON());
+}
+
+describe('DeviceSystemHealth', () => {
+  it('renders memory and flash headroom from the live payload', () => {
+    const out = render(<DeviceSystemHealth system={LIVE_SYSTEM} uptimeSeconds={134594} />);
+    expect(out).toContain('48%');
+    expect(out).toContain('13.8 MB'); // 14144 KB free
+    expect(out).toContain('42%');
+    expect(out).toContain('408 KB');
+    expect(out).toContain('92'); // processes
+    expect(out).toContain('1d 13h'); // derived uptime
+  });
+
+  it('hides the disk row on APs, which report 0/0', () => {
+    const out = render(<DeviceSystemHealth system={LIVE_SYSTEM} uptimeSeconds={1} />);
+    expect(out).not.toContain('Disk');
+  });
+
+  it('falls back to the device client count when there is no temperature sensor', () => {
+    const out = render(<DeviceSystemHealth system={LIVE_SYSTEM} uptimeSeconds={1} />);
+    expect(out).toContain('Clients (device)');
+    expect(out).not.toContain('CPU Temp');
+  });
+
+  it('shows temperature when the model actually reports one', () => {
+    const out = render(
+      <DeviceSystemHealth system={{ ...LIVE_SYSTEM, cpu_temp: 41.5 }} uptimeSeconds={1} />
+    );
+    expect(out).toContain('CPU Temp');
+    expect(out).toContain('41.5 °C');
+  });
+
+  it('degrades to dashes for an offline device rather than throwing', () => {
+    const out = render(<DeviceSystemHealth system={null} uptimeSeconds={null} />);
+    expect(out).toContain('—');
+  });
+});
+
+describe('formatUptime', () => {
+  it('formats days, hours and minutes', () => {
+    expect(formatUptime(134594)).toBe('1d 13h');
+    expect(formatUptime(7260)).toBe('2h 1m');
+    expect(formatUptime(300)).toBe('5m');
+  });
+
+  it('shows a dash when uptime is unknown', () => {
+    expect(formatUptime(null)).toBe('—');
+    expect(formatUptime(0)).toBe('—');
+  });
+});

--- a/__tests__/components/admin/network/DeviceTrafficPanel.test.tsx
+++ b/__tests__/components/admin/network/DeviceTrafficPanel.test.tsx
@@ -97,6 +97,35 @@ describe('DeviceTrafficPanel', () => {
     expect(out).toContain('Could not load traffic history');
   });
 
+  it('ignores a superseded response when the window changes mid-flight', async () => {
+    // The 24h request never settles until we say so; 7d resolves immediately.
+    let settleStale!: (v: unknown) => void;
+    const stale = new Promise((resolve) => {
+      settleStale = resolve;
+    });
+    (globalThis as any).fetch = jest.fn((url: string) =>
+      url.includes('hours=24')
+        ? stale
+        : Promise.resolve({ ok: true, json: async () => historyPayload(7) })
+    );
+
+    const tree = await renderPanel();
+    const sevenDay = tree.root.findAllByType('button').find((b) => b.props.children === '7d');
+    await act(async () => {
+      sevenDay!.props.onClick();
+    });
+
+    // The stale 24h request lands last, carrying a distinctly different payload.
+    await act(async () => {
+      settleStale({ ok: true, json: async () => historyPayload(99) });
+      await Promise.resolve();
+    });
+
+    const out = dump(tree);
+    expect(out).toContain('chart:Device Traffic — last 168h:7'); // the window actually selected
+    expect(out).not.toContain(':99'); // the superseded response must not win
+  });
+
   it('refetches with the new window when a range button is pressed', async () => {
     mockFetchOnce(async () => ({ ok: true, json: async () => historyPayload() }));
     const tree = await renderPanel();

--- a/__tests__/components/admin/network/DeviceTrafficPanel.test.tsx
+++ b/__tests__/components/admin/network/DeviceTrafficPanel.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * DeviceTrafficPanel — the one new device-page component with real interactive state
+ * (fetch, loading/error paths, window switching). Drives the component for real rather
+ * than re-testing the summary maths, which is covered in performance-metrics.test.ts.
+ */
+
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { DeviceTrafficPanel } from '@/components/admin/network/detail/DeviceTrafficPanel';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// recharts needs layout; the chart itself is not under test here.
+jest.mock('@/components/admin/network/TrafficChart', () => ({
+  TrafficChart: ({ dataPoints, title }: { dataPoints: unknown[]; title?: string }) =>
+    React.createElement('div', null, `chart:${title}:${dataPoints.length}`),
+}));
+
+const SN = 'G1U52HL044467';
+
+/** Shape of the /traffic response, trimmed to what the panel reads. */
+function historyPayload(points = 2) {
+  return {
+    history: {
+      totalRxBytes: 3_836_000_000,
+      totalTxBytes: 181_000_000,
+      totalBytes: 4_017_000_000,
+      avgRxRate: 355_000,
+      avgTxRate: 16_700,
+      peakRxBytes: 179_426_406,
+      peakTxBytes: 8_000_000,
+      dataPoints: Array.from({ length: points }, (_, i) => ({
+        timestamp: 1_785_012_000_000 + i * 600_000,
+        timeString: `2026-07-25 22:${40 + i}:00`,
+        rxBytes: 144_331,
+        txBytes: 124_642,
+      })),
+    },
+  };
+}
+
+function mockFetchOnce(impl: () => Promise<any>) {
+  (globalThis as any).fetch = jest.fn(impl);
+}
+
+async function renderPanel() {
+  let tree!: TestRenderer.ReactTestRenderer;
+  await act(async () => {
+    tree = TestRenderer.create(<DeviceTrafficPanel sn={SN} />);
+  });
+  return tree;
+}
+
+const dump = (t: TestRenderer.ReactTestRenderer) => JSON.stringify(t.toJSON());
+
+describe('DeviceTrafficPanel', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('requests a 24h window for this device on mount', async () => {
+    mockFetchOnce(async () => ({ ok: true, json: async () => historyPayload() }));
+    await renderPanel();
+
+    expect((globalThis as any).fetch).toHaveBeenCalledWith(
+      `/api/ruijie/devices/${SN}/traffic?hours=24`,
+      expect.objectContaining({ credentials: 'include' })
+    );
+  });
+
+  it('renders totals and the chart once history arrives', async () => {
+    mockFetchOnce(async () => ({ ok: true, json: async () => historyPayload(144) }));
+    const out = dump(await renderPanel());
+
+    expect(out).toContain('3.6 GB'); // downloaded
+    expect(out).toContain('355.0 Kbps'); // avg rate — the corrected 10-min-bucket maths
+    expect(out).toContain('chart:Device Traffic — last 24h:144');
+    expect(out).not.toContain('Loading traffic history');
+  });
+
+  it('shows an error and no chart data when the request fails', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetchOnce(async () => ({ ok: false, status: 502, json: async () => ({}) }));
+    const out = dump(await renderPanel());
+
+    expect(out).toContain('Could not load traffic history');
+    expect(out).toContain('chart:Device Traffic — last 24h:0');
+  });
+
+  it('surfaces a network rejection rather than throwing', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetchOnce(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const out = dump(await renderPanel());
+
+    expect(out).toContain('Could not load traffic history');
+  });
+
+  it('refetches with the new window when a range button is pressed', async () => {
+    mockFetchOnce(async () => ({ ok: true, json: async () => historyPayload() }));
+    const tree = await renderPanel();
+
+    const sevenDay = tree.root
+      .findAllByType('button')
+      .find((b) => b.props.children === '7d');
+    expect(sevenDay).toBeDefined();
+
+    await act(async () => {
+      sevenDay!.props.onClick();
+    });
+
+    expect((globalThis as any).fetch).toHaveBeenLastCalledWith(
+      `/api/ruijie/devices/${SN}/traffic?hours=168`,
+      expect.objectContaining({ credentials: 'include' })
+    );
+    expect(sevenDay!.props['aria-pressed']).toBe(true);
+  });
+});

--- a/__tests__/components/admin/network/telemetry-format.test.ts
+++ b/__tests__/components/admin/network/telemetry-format.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Boundary tests for the shared client-telemetry thresholds.
+ *
+ * These helpers were extracted specifically so the device page and the client table
+ * can't disagree about what counts as a bad score or a slow round-trip — so the
+ * boundaries themselves are what's worth pinning.
+ */
+
+import {
+  LATENCY_FAIR_MS,
+  LATENCY_POOR_MS,
+  SCORE_FAIR,
+  SCORE_POOR,
+  formatLatency,
+  latencyTone,
+  scoreTone,
+} from '@/components/admin/network/detail/telemetry-format';
+
+describe('scoreTone', () => {
+  it('turns red strictly below the poor threshold', () => {
+    expect(scoreTone(SCORE_POOR - 1)).toBe('text-red-600'); // 59
+    expect(scoreTone(SCORE_POOR)).not.toBe('text-red-600'); // 60
+  });
+
+  it('is amber between the poor and fair thresholds', () => {
+    expect(scoreTone(SCORE_POOR)).toBe('text-amber-600'); // 60
+    expect(scoreTone(SCORE_FAIR - 1)).toBe('text-amber-600'); // 79
+  });
+
+  it('is green from the fair threshold up', () => {
+    expect(scoreTone(SCORE_FAIR)).toBe('text-emerald-600'); // 80
+    expect(scoreTone(100)).toBe('text-emerald-600');
+  });
+
+  it('is muted when the score is unknown', () => {
+    expect(scoreTone(null)).toBe('text-slate-400');
+    expect(scoreTone(undefined)).toBe('text-slate-400');
+    expect(scoreTone(NaN)).toBe('text-slate-400');
+  });
+
+  it('treats a genuine 0 as a real (bad) score, not missing data', () => {
+    expect(scoreTone(0)).toBe('text-red-600');
+  });
+});
+
+describe('latencyTone', () => {
+  it('is red strictly above the poor threshold', () => {
+    expect(latencyTone(LATENCY_POOR_MS + 1)).toBe('text-red-600'); // 151
+    expect(latencyTone(LATENCY_POOR_MS)).not.toBe('text-red-600'); // 150
+  });
+
+  it('is amber between the fair and poor thresholds', () => {
+    expect(latencyTone(LATENCY_FAIR_MS + 1)).toBe('text-amber-600'); // 61
+    expect(latencyTone(LATENCY_POOR_MS)).toBe('text-amber-600'); // 150
+  });
+
+  it('is neutral at or below the fair threshold', () => {
+    expect(latencyTone(LATENCY_FAIR_MS)).toBe('text-slate-700'); // 60
+    expect(latencyTone(0)).toBe('text-slate-700');
+  });
+
+  it('is muted when latency is unknown', () => {
+    expect(latencyTone(null)).toBe('text-slate-400');
+    expect(latencyTone(undefined)).toBe('text-slate-400');
+  });
+});
+
+describe('formatLatency', () => {
+  it('shows milliseconds below a second, rounded', () => {
+    expect(formatLatency(1)).toBe('1 ms');
+    expect(formatLatency(108.4)).toBe('108 ms');
+    expect(formatLatency(999)).toBe('999 ms');
+  });
+
+  it('switches to seconds at exactly 1000ms', () => {
+    expect(formatLatency(1000)).toBe('1.0 s');
+    expect(formatLatency(2450)).toBe('2.5 s');
+  });
+
+  it('shows a dash when latency is unknown', () => {
+    expect(formatLatency(null)).toBe('—');
+    expect(formatLatency(undefined)).toBe('—');
+    expect(formatLatency(NaN)).toBe('—');
+  });
+});

--- a/__tests__/lib/ruijie/performance-metrics.test.ts
+++ b/__tests__/lib/ruijie/performance-metrics.test.ts
@@ -3,33 +3,69 @@
  */
 
 import {
+  aggregateStaExperienceForDevice,
   aggregateStaMetricsForDevice,
   buildHourlyFlowRequest,
+  deriveUptimeFromLogs,
+  estimateSpanSeconds,
   mapCurrentPerformance,
   pickFlowDeviceSn,
+  type DeviceLogRaw,
   type StaUserRaw,
 } from '@/lib/ruijie/performance-metrics';
 
 describe('mapCurrentPerformance', () => {
-  it('maps cpuRate and memoryRate from current_performance payload', () => {
+  it('maps the full current_performance payload, not just cpu/memory', () => {
+    // Shape captured live from G1U52HL044467 (RAP2200(F))
     expect(
       mapCurrentPerformance({
         cpuRate: 30,
         memoryRate: 63,
         memoryFree: 114336,
         flashRate: 67,
+        flashFree: 408,
+        diskRate: 0,
+        diskFree: 0,
         processNum: 179,
+        cpuTemp: 41.5,
+        userCnt: 3,
       })
     ).toEqual({
       cpu_usage: 30,
       memory_usage: 63,
+      cpu_temp: 41.5,
+      memory_free_kb: 114336,
+      flash_rate: 67,
+      flash_free_kb: 408,
+      disk_rate: 0,
+      disk_free_kb: 0,
+      process_num: 179,
+      user_count: 3,
     });
   });
 
-  it('returns nulls when rates are missing', () => {
+  it('treats cpuTemp 0 as not reported (RAP2200 has no temperature sensor)', () => {
+    expect(mapCurrentPerformance({ cpuRate: 6, cpuTemp: 0 }).cpu_temp).toBeNull();
+  });
+
+  it('keeps a genuine 0 for rate fields', () => {
+    const mapped = mapCurrentPerformance({ diskRate: 0, flashRate: 0 });
+    expect(mapped.disk_rate).toBe(0);
+    expect(mapped.flash_rate).toBe(0);
+  });
+
+  it('returns nulls when the payload is empty', () => {
     expect(mapCurrentPerformance({})).toEqual({
       cpu_usage: null,
       memory_usage: null,
+      cpu_temp: null,
+      memory_free_kb: null,
+      flash_rate: null,
+      flash_free_kb: null,
+      disk_rate: null,
+      disk_free_kb: null,
+      process_num: null,
+      user_count: null,
     });
   });
 });
@@ -88,6 +124,151 @@ describe('aggregateStaMetricsForDevice', () => {
       radio_2g_utilization: null,
       radio_5g_utilization: null,
     });
+  });
+});
+
+describe('aggregateStaExperienceForDevice', () => {
+  // Field shapes captured live from sta_users for G1U52HL044467
+  const stas: StaUserRaw[] = [
+    {
+      sn: 'AP-1',
+      mac: 'aa',
+      band: '2.4G',
+      timeDelay: 108,
+      score: 96,
+      scoreReason: '',
+      floorNoise: -91,
+      activeTime: 1_142_000,
+    },
+    {
+      sn: 'AP-1',
+      mac: 'bb',
+      band: '5G',
+      timeDelay: 200,
+      score: 74,
+      scoreReason: 'heavy interference',
+      floorNoise: -92,
+      activeTime: 181_428_000,
+    },
+    {
+      sn: 'AP-1',
+      mac: 'cc',
+      band: '5G',
+      timeDelay: 1,
+      score: 100,
+      scoreReason: '',
+      floorNoise: -94,
+      activeTime: 132_886_000,
+    },
+    // Different AP — must be excluded entirely
+    { sn: 'AP-2', mac: 'dd', band: '5G', timeDelay: 999, score: 10, floorNoise: -60 },
+  ];
+
+  it('summarises latency, score and noise floor for one AP', () => {
+    expect(aggregateStaExperienceForDevice(stas, 'AP-1')).toEqual({
+      avg_latency_ms: 103, // (108 + 200 + 1) / 3
+      worst_latency_ms: 200,
+      avg_score: 90, // (96 + 74 + 100) / 3
+      worst_score: 74,
+      worst_score_reason: 'heavy interference',
+      noise_floor_2g: -91,
+      noise_floor_5g: -93, // (-92 + -94) / 2
+      clients_2g: 1,
+      clients_5g: 2,
+      longest_session_ms: 181_428_000,
+    });
+  });
+
+  it('reports no reason when the worst client has none', () => {
+    const clean: StaUserRaw[] = [{ sn: 'AP-1', band: '5G', score: 88, scoreReason: '' }];
+    expect(aggregateStaExperienceForDevice(clean, 'AP-1').worst_score_reason).toBeNull();
+  });
+
+  it('parses string-typed numerics (Ruijie returns several as strings)', () => {
+    const stringy = [
+      { sn: 'AP-1', band: '2.4G', timeDelay: '50', score: '80', floorNoise: '-88' },
+    ] as unknown as StaUserRaw[];
+    const out = aggregateStaExperienceForDevice(stringy, 'AP-1');
+    expect(out.avg_latency_ms).toBe(50);
+    expect(out.avg_score).toBe(80);
+    expect(out.noise_floor_2g).toBe(-88);
+  });
+
+  it('returns empty experience when the AP has no stations', () => {
+    expect(aggregateStaExperienceForDevice(stas, 'AP-MISSING')).toEqual({
+      avg_latency_ms: null,
+      worst_latency_ms: null,
+      avg_score: null,
+      worst_score: null,
+      worst_score_reason: null,
+      noise_floor_2g: null,
+      noise_floor_5g: null,
+      clients_2g: 0,
+      clients_5g: 0,
+      longest_session_ms: null,
+    });
+  });
+});
+
+describe('deriveUptimeFromLogs', () => {
+  const NOW = 1_785_097_786_000;
+  // logSubType is undocumented but present on every live onoffline entry
+  const logs: DeviceLogRaw[] = [
+    { logType: 'onoffline', logSubType: 'OFF', logDetail: 'Device offline', operateTime: NOW - 7_200_000 },
+    { logType: 'onoffline', logSubType: 'ON', logDetail: 'Device online', operateTime: NOW - 3_600_000 },
+    { logType: 'reboot', logDetail: 'Device restart', operateTime: NOW - 3_600_000 },
+  ];
+
+  it('measures uptime from the most recent online event regardless of log order', () => {
+    expect(deriveUptimeFromLogs(logs, NOW)).toBe(3600);
+  });
+
+  it('returns null when the newest onoffline event is OFF', () => {
+    const down: DeviceLogRaw[] = [
+      { logType: 'onoffline', logSubType: 'ON', logDetail: 'Device online', operateTime: NOW - 7_200_000 },
+      { logType: 'onoffline', logSubType: 'OFF', logDetail: 'Device offline', operateTime: NOW - 60_000 },
+    ];
+    expect(deriveUptimeFromLogs(down, NOW)).toBeNull();
+  });
+
+  it('falls back to logDetail when logSubType is absent', () => {
+    const noSubType: DeviceLogRaw[] = [
+      { logType: 'onoffline', logDetail: 'Device online', operateTime: NOW - 1_800_000 },
+    ];
+    expect(deriveUptimeFromLogs(noSubType, NOW)).toBe(1800);
+  });
+
+  it('returns null when there is no onoffline history at all', () => {
+    expect(deriveUptimeFromLogs([{ logType: 'reboot', logDetail: 'Device restart', operateTime: NOW }], NOW)).toBeNull();
+  });
+
+  it('returns null rather than a negative uptime for a future timestamp', () => {
+    const future: DeviceLogRaw[] = [
+      { logType: 'onoffline', logSubType: 'ON', logDetail: 'Device online', operateTime: NOW + 60_000 },
+    ];
+    expect(deriveUptimeFromLogs(future, NOW)).toBeNull();
+  });
+});
+
+describe('estimateSpanSeconds', () => {
+  const at = (minutes: number) => ({ timestamp: 1_700_000_000_000 + minutes * 60_000 });
+
+  it('measures the real span of 10-minute buckets, not one hour per point', () => {
+    // 6 buckets x 10 min = 1 hour, not 6 hours
+    expect(estimateSpanSeconds([at(0), at(10), at(20), at(30), at(40), at(50)])).toBe(3600);
+  });
+
+  it('still resolves hourly rollup points correctly', () => {
+    expect(estimateSpanSeconds([at(0), at(60), at(120)])).toBe(3 * 3600);
+  });
+
+  it('handles unsorted input', () => {
+    expect(estimateSpanSeconds([at(20), at(0), at(10)])).toBe(1800);
+  });
+
+  it('assumes one hour for a single point and zero for none', () => {
+    expect(estimateSpanSeconds([at(0)])).toBe(3600);
+    expect(estimateSpanSeconds([])).toBe(0);
   });
 });
 

--- a/app/admin/network/devices/[sn]/page.tsx
+++ b/app/admin/network/devices/[sn]/page.tsx
@@ -34,6 +34,8 @@ import {
 import { UnderlineTabs, TabPanel, SectionCard } from '@/components/admin/shared';
 import { DeviceHeader, DeviceStatCards, DeviceSupportNotes, DeviceCustomerLink, DeviceClientList, DeviceActivityLog, DeviceSystemHealth, DeviceTrafficPanel, formatUptime } from '@/components/admin/network/detail';
 import type { DeviceSystemHealthData } from '@/components/admin/network/detail/DeviceSystemHealth';
+import { formatLatency, scoreTone } from '@/components/admin/network/detail/telemetry-format';
+import type { StaDeviceExperience } from '@/lib/ruijie/performance-metrics';
 
 interface RuijieDevice {
   sn: string;
@@ -65,21 +67,7 @@ interface RuijieDevice {
   corporate_site_id: string | null;
   // Live-only, merged in from /metrics — never persisted on the cache row
   system?: DeviceSystemHealthData;
-  experience?: DeviceExperience;
-}
-
-/** Client-experience summary for this AP, from the STA call the metrics route already makes. */
-interface DeviceExperience {
-  avg_latency_ms: number | null;
-  worst_latency_ms: number | null;
-  avg_score: number | null;
-  worst_score: number | null;
-  worst_score_reason: string | null;
-  noise_floor_2g: number | null;
-  noise_floor_5g: number | null;
-  clients_2g: number;
-  clients_5g: number;
-  longest_session_ms: number | null;
+  experience?: StaDeviceExperience;
 }
 
 interface RuijieTunnel {
@@ -131,19 +119,6 @@ function formatRelativeTime(dateString: string): string {
   if (diffHours < 24) return `${diffHours}h ago`;
   const diffDays = Math.floor(diffHours / 24);
   return `${diffDays}d ago`;
-}
-
-function formatMs(ms: number | null | undefined): string {
-  if (ms == null || !Number.isFinite(ms)) return '—';
-  return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${Math.round(ms)} ms`;
-}
-
-/** Ruijie scores 0–100; below 60 is a client that will notice problems. */
-function scoreTone(score: number | null): string {
-  if (score == null) return '';
-  if (score < 60) return 'text-red-600';
-  if (score < 80) return 'text-amber-600';
-  return 'text-emerald-600';
 }
 
 function ExperienceStat({
@@ -591,10 +566,10 @@ export default function RuijieDeviceDetailPage({
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
                 <ExperienceStat
                   label="Avg Latency"
-                  value={formatMs(device.experience?.avg_latency_ms)}
+                  value={formatLatency(device.experience?.avg_latency_ms)}
                   hint={
                     device.experience?.worst_latency_ms != null
-                      ? `worst ${formatMs(device.experience.worst_latency_ms)}`
+                      ? `worst ${formatLatency(device.experience.worst_latency_ms)}`
                       : undefined
                   }
                 />

--- a/app/admin/network/devices/[sn]/page.tsx
+++ b/app/admin/network/devices/[sn]/page.tsx
@@ -16,6 +16,7 @@ import {
   PiXCircleBold,
   PiInfoBold,
   PiGearBold,
+  PiPulseBold,
 } from 'react-icons/pi';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -31,7 +32,8 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { UnderlineTabs, TabPanel, SectionCard } from '@/components/admin/shared';
-import { DeviceHeader, DeviceStatCards, DeviceSupportNotes, DeviceCustomerLink, DeviceClientList, DeviceActivityLog } from '@/components/admin/network/detail';
+import { DeviceHeader, DeviceStatCards, DeviceSupportNotes, DeviceCustomerLink, DeviceClientList, DeviceActivityLog, DeviceSystemHealth, DeviceTrafficPanel, formatUptime } from '@/components/admin/network/detail';
+import type { DeviceSystemHealthData } from '@/components/admin/network/detail/DeviceSystemHealth';
 
 interface RuijieDevice {
   sn: string;
@@ -61,6 +63,23 @@ interface RuijieDevice {
   customer_phone: string | null;
   customer_order_id: string | null;
   corporate_site_id: string | null;
+  // Live-only, merged in from /metrics — never persisted on the cache row
+  system?: DeviceSystemHealthData;
+  experience?: DeviceExperience;
+}
+
+/** Client-experience summary for this AP, from the STA call the metrics route already makes. */
+interface DeviceExperience {
+  avg_latency_ms: number | null;
+  worst_latency_ms: number | null;
+  avg_score: number | null;
+  worst_score: number | null;
+  worst_score_reason: string | null;
+  noise_floor_2g: number | null;
+  noise_floor_5g: number | null;
+  clients_2g: number;
+  clients_5g: number;
+  longest_session_ms: number | null;
 }
 
 interface RuijieTunnel {
@@ -84,6 +103,7 @@ const TAB_CONFIG = [
   { id: 'overview', label: 'Overview' },
   { id: 'clients', label: 'Clients' },
   { id: 'radio', label: 'Radio' },
+  { id: 'traffic', label: 'Traffic' },
   { id: 'tunnel', label: 'Tunnel' },
   { id: 'logs', label: 'Logs' },
   { id: 'history', label: 'History' },
@@ -111,6 +131,92 @@ function formatRelativeTime(dateString: string): string {
   if (diffHours < 24) return `${diffHours}h ago`;
   const diffDays = Math.floor(diffHours / 24);
   return `${diffDays}d ago`;
+}
+
+function formatMs(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms)) return '—';
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${Math.round(ms)} ms`;
+}
+
+/** Ruijie scores 0–100; below 60 is a client that will notice problems. */
+function scoreTone(score: number | null): string {
+  if (score == null) return '';
+  if (score < 60) return 'text-red-600';
+  if (score < 80) return 'text-amber-600';
+  return 'text-emerald-600';
+}
+
+function ExperienceStat({
+  label,
+  value,
+  hint,
+  tone,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  tone?: string;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">{label}</p>
+      <p className={`text-lg font-bold ${tone || 'text-slate-900'}`}>{value}</p>
+      {hint && <p className="text-xs text-slate-500 mt-0.5">{hint}</p>}
+    </div>
+  );
+}
+
+function RadioCard({
+  title,
+  channel,
+  utilization,
+  clients,
+  noiseFloor,
+}: {
+  title: string;
+  channel: number | null;
+  utilization: number | null;
+  clients: number | null;
+  noiseFloor: number | null;
+}) {
+  return (
+    <SectionCard icon={PiRadioBold} title={title} compact>
+      <div className="space-y-4">
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-slate-600">Channel</span>
+          <span className="font-bold text-lg">{channel || '-'}</span>
+        </div>
+        <div>
+          <div className="flex justify-between text-sm mb-2">
+            <span className="text-slate-600">Channel Utilization</span>
+            <span className="font-medium">{utilization ?? '-'}%</span>
+          </div>
+          <Progress value={utilization || 0} className="h-3" />
+        </div>
+        <div className="grid grid-cols-2 gap-4 pt-1 border-t border-slate-100">
+          <div className="pt-3">
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">
+              Clients
+            </p>
+            <p className="text-sm font-medium">{clients ?? '—'}</p>
+          </div>
+          <div className="pt-3">
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">
+              Noise Floor
+            </p>
+            {/* Quieter (more negative) is better; above -85 dBm means real interference. */}
+            <p
+              className={`text-sm font-medium ${
+                noiseFloor != null && noiseFloor > -85 ? 'text-amber-600' : 'text-slate-900'
+              }`}
+            >
+              {noiseFloor != null ? `${noiseFloor} dBm` : '—'}
+            </p>
+          </div>
+        </div>
+      </div>
+    </SectionCard>
+  );
 }
 
 export default function RuijieDeviceDetailPage({
@@ -442,6 +548,9 @@ export default function RuijieDeviceDetailPage({
               </div>
             </SectionCard>
 
+            {/* System Health — live, from the same current_performance call as CPU/memory */}
+            <DeviceSystemHealth system={device.system} uptimeSeconds={device.uptime_seconds} />
+
             {/* Customer Assignment */}
             <DeviceCustomerLink device={device} onUpdate={handleRefresh} />
 
@@ -459,41 +568,76 @@ export default function RuijieDeviceDetailPage({
 
         {/* RADIO TAB */}
         <TabPanel id="radio" activeTab={activeTab} className="mt-6">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {/* 2.4 GHz Radio */}
-            <SectionCard icon={PiRadioBold} title="2.4 GHz Radio" compact>
-              <div className="space-y-4">
-                <div className="flex justify-between items-center">
-                  <span className="text-sm text-slate-600">Channel</span>
-                  <span className="font-bold text-lg">{device.radio_2g_channel || '-'}</span>
-                </div>
-                <div>
-                  <div className="flex justify-between text-sm mb-2">
-                    <span className="text-slate-600">Channel Utilization</span>
-                    <span className="font-medium">{device.radio_2g_utilization ?? '-'}%</span>
-                  </div>
-                  <Progress value={device.radio_2g_utilization || 0} className="h-3" />
-                </div>
-              </div>
-            </SectionCard>
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <RadioCard
+                title="2.4 GHz Radio"
+                channel={device.radio_2g_channel}
+                utilization={device.radio_2g_utilization}
+                clients={device.experience?.clients_2g ?? null}
+                noiseFloor={device.experience?.noise_floor_2g ?? null}
+              />
+              <RadioCard
+                title="5 GHz Radio"
+                channel={device.radio_5g_channel}
+                utilization={device.radio_5g_utilization}
+                clients={device.experience?.clients_5g ?? null}
+                noiseFloor={device.experience?.noise_floor_5g ?? null}
+              />
+            </div>
 
-            {/* 5 GHz Radio */}
-            <SectionCard icon={PiRadioBold} title="5 GHz Radio" compact>
-              <div className="space-y-4">
-                <div className="flex justify-between items-center">
-                  <span className="text-sm text-slate-600">Channel</span>
-                  <span className="font-bold text-lg">{device.radio_5g_channel || '-'}</span>
-                </div>
-                <div>
-                  <div className="flex justify-between text-sm mb-2">
-                    <span className="text-slate-600">Channel Utilization</span>
-                    <span className="font-medium">{device.radio_5g_utilization ?? '-'}%</span>
-                  </div>
-                  <Progress value={device.radio_5g_utilization || 0} className="h-3" />
-                </div>
+            {/* Ruijie's own view of how the clients on this AP are actually doing */}
+            <SectionCard icon={PiPulseBold} title="Client Experience" compact>
+              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+                <ExperienceStat
+                  label="Avg Latency"
+                  value={formatMs(device.experience?.avg_latency_ms)}
+                  hint={
+                    device.experience?.worst_latency_ms != null
+                      ? `worst ${formatMs(device.experience.worst_latency_ms)}`
+                      : undefined
+                  }
+                />
+                <ExperienceStat
+                  label="Avg Score"
+                  value={
+                    device.experience?.avg_score != null
+                      ? `${device.experience.avg_score}/100`
+                      : '—'
+                  }
+                  tone={scoreTone(device.experience?.avg_score ?? null)}
+                />
+                <ExperienceStat
+                  label="Worst Client"
+                  value={
+                    device.experience?.worst_score != null
+                      ? `${device.experience.worst_score}/100`
+                      : '—'
+                  }
+                  hint={device.experience?.worst_score_reason ?? undefined}
+                  tone={scoreTone(device.experience?.worst_score ?? null)}
+                />
+                <ExperienceStat
+                  label="Longest Session"
+                  value={formatUptime(
+                    device.experience?.longest_session_ms != null
+                      ? Math.floor(device.experience.longest_session_ms / 1000)
+                      : null
+                  )}
+                />
               </div>
+              {device.status !== 'online' && (
+                <p className="text-xs text-slate-500 mt-4">
+                  Experience metrics are only collected while the device is online.
+                </p>
+              )}
             </SectionCard>
           </div>
+        </TabPanel>
+
+        {/* TRAFFIC TAB */}
+        <TabPanel id="traffic" activeTab={activeTab} className="mt-6">
+          <DeviceTrafficPanel sn={sn} />
         </TabPanel>
 
         {/* TUNNEL TAB */}

--- a/app/api/ruijie/devices/[sn]/metrics/route.ts
+++ b/app/api/ruijie/devices/[sn]/metrics/route.ts
@@ -5,7 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClientWithSession, createClient } from '@/lib/supabase/server';
-import { getDeviceMetrics, DeviceMetrics } from '@/lib/ruijie/client';
+import { getDeviceMetrics, getEmptyDeviceMetrics, DeviceMetrics } from '@/lib/ruijie/client';
 import { apiLogger } from '@/lib/logging/logger';
 
 export const dynamic = 'force-dynamic';
@@ -54,16 +54,7 @@ export async function GET(
 
     if (device.status === 'offline') {
       // Don't fetch metrics for offline devices
-      metrics = {
-        cpu_usage: null,
-        memory_usage: null,
-        uptime_seconds: null,
-        online_clients: 0,
-        radio_2g_channel: null,
-        radio_5g_channel: null,
-        radio_2g_utilization: null,
-        radio_5g_utilization: null,
-      };
+      metrics = getEmptyDeviceMetrics();
     } else {
       // Pass group_id for STA query to count online clients
       metrics = await getDeviceMetrics(sn, device.group_id || undefined);

--- a/app/api/ruijie/devices/[sn]/traffic/route.ts
+++ b/app/api/ruijie/devices/[sn]/traffic/route.ts
@@ -90,8 +90,12 @@ export async function GET(
     const hours = parseHours(request.nextUrl.searchParams.get('hours'));
     const groupId = device.group_id;
 
-    // Flow history is keyed by serial, so it works even without a group.
-    const history = await getNetworkTraffic({ sn, hours });
+    // Flow history is keyed by serial (works without a group); clients need the group.
+    // Independent calls — one round-trip's wall time, matching getDeviceMetrics.
+    const [history, clients] = await Promise.all([
+      getNetworkTraffic({ sn, hours }),
+      groupId ? getDeviceClients(sn, groupId) : Promise.resolve([]),
+    ]);
 
     if (!groupId) {
       const response: DeviceTrafficResponse = {
@@ -109,9 +113,6 @@ export async function GET(
       };
       return NextResponse.json(response);
     }
-
-    // Get connected clients with bandwidth info
-    const clients = await getDeviceClients(sn, groupId);
 
     // In mock mode, add simulated bandwidth rates
     const clientBandwidth = clients.map(client => {

--- a/app/api/ruijie/devices/[sn]/traffic/route.ts
+++ b/app/api/ruijie/devices/[sn]/traffic/route.ts
@@ -2,24 +2,28 @@
  * Ruijie Device Traffic API
  * GET /api/ruijie/devices/[sn]/traffic - Get traffic data for a specific device
  *
- * Note: Ruijie Cloud API provides traffic at network/group level, not per-device.
- * This endpoint returns client-level bandwidth data from the STA API as a proxy.
+ * Returns two views:
+ * - `history`: real per-device hourly flow (API V2.0.3 §2.5.2 flow/show/hour, keyed by sn)
+ * - `clientBandwidth`: current per-client rates from the STA API
  *
  * Query params:
- * - hours: Number of hours of data (default: 24)
+ * - hours: Size of the history window (default: 24)
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClientWithSession, createClient } from '@/lib/supabase/server';
-import { getDeviceClients, isMockMode } from '@/lib/ruijie/client';
+import { getDeviceClients, getNetworkTraffic, isMockMode, type TrafficSummary } from '@/lib/ruijie/client';
 import { apiLogger } from '@/lib/logging/logger';
 
 export const dynamic = 'force-dynamic';
 
+const DEFAULT_HOURS = 24;
+const MAX_HOURS = 168; // Ruijie keeps roughly a week of hourly flow
+
 interface DeviceTrafficResponse {
   sn: string;
   deviceName: string;
-  groupId: string;
+  groupId: string | null;
   onlineClients: number;
   clientBandwidth: {
     mac: string;
@@ -31,8 +35,16 @@ interface DeviceTrafficResponse {
   }[];
   totalDownlinkRate: number;  // Aggregate bps
   totalUplinkRate: number;    // Aggregate bps
+  hours: number;
+  history: TrafficSummary;
   fetchedAt: string;
   note: string;
+}
+
+function parseHours(raw: string | null): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_HOURS;
+  return Math.min(Math.floor(n), MAX_HOURS);
 }
 
 export async function GET(
@@ -75,9 +87,14 @@ export async function GET(
       return NextResponse.json({ error: 'Device not found' }, { status: 404 });
     }
 
+    const hours = parseHours(request.nextUrl.searchParams.get('hours'));
     const groupId = device.group_id;
+
+    // Flow history is keyed by serial, so it works even without a group.
+    const history = await getNetworkTraffic({ sn, hours });
+
     if (!groupId) {
-      return NextResponse.json({
+      const response: DeviceTrafficResponse = {
         sn,
         deviceName: device.device_name,
         groupId: null,
@@ -85,9 +102,12 @@ export async function GET(
         clientBandwidth: [],
         totalDownlinkRate: 0,
         totalUplinkRate: 0,
+        hours,
+        history,
         fetchedAt: new Date().toISOString(),
-        note: 'Device has no associated group ID',
-      });
+        note: 'Device has no group ID — per-client bandwidth unavailable, history is per-device.',
+      };
+      return NextResponse.json(response);
     }
 
     // Get connected clients with bandwidth info
@@ -144,8 +164,10 @@ export async function GET(
       clientBandwidth,
       totalDownlinkRate,
       totalUplinkRate,
+      hours,
+      history,
       fetchedAt: new Date().toISOString(),
-      note: 'Bandwidth data is aggregated from connected clients. Historical traffic data is available at network level only.',
+      note: 'History is this device\'s own hourly flow (flow/show/hour). Client rates are instantaneous, from the STA API.',
     };
 
     return NextResponse.json(response);

--- a/components/admin/network/TrafficChart.tsx
+++ b/components/admin/network/TrafficChart.tsx
@@ -13,6 +13,7 @@ import {
 } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PiArrowDownBold, PiArrowUpBold, PiChartLineBold } from 'react-icons/pi';
+import { estimateSpanSeconds } from '@/lib/ruijie/performance-metrics';
 
 // =============================================================================
 // TYPES
@@ -164,10 +165,10 @@ export function TrafficChart({
     const totalRx = dataPoints.reduce((sum, p) => sum + p.rxBytes, 0);
     const totalTx = dataPoints.reduce((sum, p) => sum + p.txBytes, 0);
 
-    // Assuming hourly data, calculate average rate
-    const hoursSpan = dataPoints.length;
-    const avgRxRate = hoursSpan > 0 ? (totalRx * 8) / (hoursSpan * 3600) : 0;
-    const avgTxRate = hoursSpan > 0 ? (totalTx * 8) / (hoursSpan * 3600) : 0;
+    // Span from the timestamps — flow buckets are 10 min, not 1 hour
+    const spanSeconds = estimateSpanSeconds(dataPoints);
+    const avgRxRate = spanSeconds > 0 ? (totalRx * 8) / spanSeconds : 0;
+    const avgTxRate = spanSeconds > 0 ? (totalTx * 8) / spanSeconds : 0;
 
     return { totalRx, totalTx, avgRxRate, avgTxRate };
   }, [dataPoints]);

--- a/components/admin/network/detail/DeviceClientList.tsx
+++ b/components/admin/network/detail/DeviceClientList.tsx
@@ -27,6 +27,14 @@ interface RuijieClient {
   uplinkRate: number | null;
   downlinkRate: number | null;
   pktLoseRate: number | null;
+  latencyMs: number | null;
+  /** Ruijie's own 0-100 connection score, and why it is low. */
+  score: number | null;
+  scoreReason: string | null;
+  hostname: string | null;
+  vendor: string | null;
+  sessionBytes: number | null;
+  sessionMs: number | null;
 }
 
 interface DeviceClientListProps {
@@ -89,6 +97,26 @@ function formatBps(bps: number): string {
   const k = 1000;
   const i = Math.min(Math.floor(Math.log(bps) / Math.log(k)), units.length - 1);
   return `${(bps / Math.pow(k, i)).toFixed(1)} ${units[i]}`;
+}
+
+/** Ruijie scores 0-100; below 60 is a client that will notice problems. */
+function scoreTone(score: number | null): string {
+  if (score == null) return 'text-slate-400';
+  if (score < 60) return 'text-red-600';
+  if (score < 80) return 'text-amber-600';
+  return 'text-emerald-600';
+}
+
+function latencyTone(ms: number | null): string {
+  if (ms == null) return 'text-slate-400';
+  if (ms > 150) return 'text-red-600';
+  if (ms > 60) return 'text-amber-600';
+  return 'text-slate-700';
+}
+
+function formatLatency(ms: number | null): string {
+  if (ms == null || !Number.isFinite(ms)) return '—';
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${Math.round(ms)} ms`;
 }
 
 function formatRate(bps: number | null | undefined): string {
@@ -276,9 +304,12 @@ export function DeviceClientList({ sn }: DeviceClientListProps) {
           </div>
         ) : (
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[960px]">
+            <table className="w-full min-w-[1180px]">
               <thead>
                 <tr className="border-b border-slate-100">
+                  <th className="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                    Device
+                  </th>
                   <th className="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">
                     MAC
                   </th>
@@ -296,6 +327,12 @@ export function DeviceClientList({ sn }: DeviceClientListProps) {
                   </th>
                   <th className="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">
                     Quality
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                    Latency
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                    Score
                   </th>
                   <th className="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">
                     Rates
@@ -326,7 +363,17 @@ export function DeviceClientList({ sn }: DeviceClientListProps) {
                       className="hover:bg-slate-50/50 transition-colors"
                     >
                       <td className="px-3 py-3">
-                        <span className="font-mono text-sm text-slate-900">{client.mac || '—'}</span>
+                        <div className="text-sm leading-tight">
+                          <div className="font-medium text-slate-900">
+                            {client.hostname || client.vendor || 'Unknown device'}
+                          </div>
+                          {client.hostname && client.vendor && (
+                            <div className="text-xs text-slate-500">{client.vendor}</div>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-3 py-3">
+                        <span className="font-mono text-sm text-slate-600">{client.mac || '—'}</span>
                       </td>
                       <td className="px-3 py-3">
                         <span className="font-mono text-sm text-slate-600">{client.userIp || '—'}</span>
@@ -349,6 +396,19 @@ export function DeviceClientList({ sn }: DeviceClientListProps) {
                         <Badge className={`${config.badge} border-0`}>
                           {config.label}
                         </Badge>
+                      </td>
+                      <td className="px-3 py-3">
+                        <span className={`font-mono text-sm ${latencyTone(client.latencyMs)}`}>
+                          {formatLatency(client.latencyMs)}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3">
+                        <span className={`font-mono text-sm ${scoreTone(client.score)}`}>
+                          {client.score != null ? client.score : '—'}
+                        </span>
+                        {client.scoreReason && (
+                          <div className="text-xs text-amber-600">{client.scoreReason}</div>
+                        )}
                       </td>
                       <td className="px-3 py-3">
                         <div className="text-xs font-mono text-slate-700 leading-relaxed">

--- a/components/admin/network/detail/DeviceClientList.tsx
+++ b/components/admin/network/detail/DeviceClientList.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { SectionCard } from '@/components/admin/shared';
+import { formatLatency, latencyTone, scoreTone } from './telemetry-format';
 
 interface RuijieClient {
   mac: string;
@@ -97,26 +98,6 @@ function formatBps(bps: number): string {
   const k = 1000;
   const i = Math.min(Math.floor(Math.log(bps) / Math.log(k)), units.length - 1);
   return `${(bps / Math.pow(k, i)).toFixed(1)} ${units[i]}`;
-}
-
-/** Ruijie scores 0-100; below 60 is a client that will notice problems. */
-function scoreTone(score: number | null): string {
-  if (score == null) return 'text-slate-400';
-  if (score < 60) return 'text-red-600';
-  if (score < 80) return 'text-amber-600';
-  return 'text-emerald-600';
-}
-
-function latencyTone(ms: number | null): string {
-  if (ms == null) return 'text-slate-400';
-  if (ms > 150) return 'text-red-600';
-  if (ms > 60) return 'text-amber-600';
-  return 'text-slate-700';
-}
-
-function formatLatency(ms: number | null): string {
-  if (ms == null || !Number.isFinite(ms)) return '—';
-  return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${Math.round(ms)} ms`;
 }
 
 function formatRate(bps: number | null | undefined): string {

--- a/components/admin/network/detail/DeviceSystemHealth.tsx
+++ b/components/admin/network/detail/DeviceSystemHealth.tsx
@@ -11,19 +11,13 @@
 import { PiPulseBold } from 'react-icons/pi';
 import { Progress } from '@/components/ui/progress';
 import { SectionCard } from '@/components/admin/shared';
+import type { DeviceSystemHealth as LibDeviceSystemHealth } from '@/lib/ruijie/performance-metrics';
 
-export interface DeviceSystemHealthData {
-  cpu_usage: number | null;
-  memory_usage: number | null;
-  cpu_temp: number | null;
-  memory_free_kb: number | null;
-  flash_rate: number | null;
-  flash_free_kb: number | null;
-  disk_rate: number | null;
-  disk_free_kb: number | null;
-  process_num: number | null;
-  user_count: number | null;
-}
+/**
+ * Alias of the lib type rather than a structural twin, so a field rename in
+ * performance-metrics.ts fails the build here instead of silently diverging.
+ */
+export type DeviceSystemHealthData = LibDeviceSystemHealth;
 
 interface DeviceSystemHealthProps {
   system: DeviceSystemHealthData | null | undefined;

--- a/components/admin/network/detail/DeviceSystemHealth.tsx
+++ b/components/admin/network/detail/DeviceSystemHealth.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+/**
+ * System health for a Ruijie AP — flash/disk/memory headroom, process count and uptime.
+ *
+ * Every field here comes from the same current_performance call that already provides
+ * CPU and memory (API V2.0.3 §2.6.5), so this card costs no extra Ruijie requests.
+ * Uptime is derived from the management log, since no Cloud API exposes it directly.
+ */
+
+import { PiPulseBold } from 'react-icons/pi';
+import { Progress } from '@/components/ui/progress';
+import { SectionCard } from '@/components/admin/shared';
+
+export interface DeviceSystemHealthData {
+  cpu_usage: number | null;
+  memory_usage: number | null;
+  cpu_temp: number | null;
+  memory_free_kb: number | null;
+  flash_rate: number | null;
+  flash_free_kb: number | null;
+  disk_rate: number | null;
+  disk_free_kb: number | null;
+  process_num: number | null;
+  user_count: number | null;
+}
+
+interface DeviceSystemHealthProps {
+  system: DeviceSystemHealthData | null | undefined;
+  uptimeSeconds: number | null | undefined;
+}
+
+const DASH = '—';
+
+function formatKb(kb: number | null | undefined): string {
+  if (kb == null || !Number.isFinite(kb)) return DASH;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  if (kb < 1024 * 1024) return `${(kb / 1024).toFixed(1)} MB`;
+  return `${(kb / 1024 / 1024).toFixed(2)} GB`;
+}
+
+export function formatUptime(seconds: number | null | undefined): string {
+  if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) return DASH;
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+/** Amber past 75%, red past 90% — storage pressure is what precedes a config-sync failure. */
+function usageTone(pct: number): string {
+  if (pct >= 90) return 'text-red-600';
+  if (pct >= 75) return 'text-amber-600';
+  return 'text-slate-900';
+}
+
+function UsageRow({ label, pct, free }: { label: string; pct: number | null; free: string }) {
+  return (
+    <div>
+      <div className="flex justify-between text-sm mb-1">
+        <span className="text-slate-600">{label}</span>
+        <span className={`font-medium ${pct != null ? usageTone(pct) : ''}`}>
+          {pct != null ? `${Math.round(pct)}%` : DASH}
+          <span className="text-slate-400 font-normal"> · {free} free</span>
+        </span>
+      </div>
+      <Progress value={pct ?? 0} className="h-2" />
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">{label}</p>
+      <p className="text-sm font-medium text-slate-900">{value}</p>
+    </div>
+  );
+}
+
+export function DeviceSystemHealth({ system, uptimeSeconds }: DeviceSystemHealthProps) {
+  return (
+    <SectionCard icon={PiPulseBold} title="System Health" compact>
+      <div className="space-y-4">
+        <UsageRow
+          label="Memory"
+          pct={system?.memory_usage ?? null}
+          free={formatKb(system?.memory_free_kb)}
+        />
+        <UsageRow
+          label="Flash"
+          pct={system?.flash_rate ?? null}
+          free={formatKb(system?.flash_free_kb)}
+        />
+        {/* Disk only exists on models with storage; APs report 0/0 and are skipped. */}
+        {system?.disk_free_kb != null && system.disk_free_kb > 0 && (
+          <UsageRow
+            label="Disk"
+            pct={system.disk_rate ?? null}
+            free={formatKb(system.disk_free_kb)}
+          />
+        )}
+
+        <div className="grid grid-cols-3 gap-4 pt-1">
+          <Stat label="Uptime" value={formatUptime(uptimeSeconds)} />
+          <Stat
+            label="Processes"
+            value={system?.process_num != null ? String(system.process_num) : DASH}
+          />
+          {/* RAP2200/RAP62 have no temperature sensor — the field is hidden, not shown as 0. */}
+          <Stat
+            label={system?.cpu_temp != null ? 'CPU Temp' : 'Clients (device)'}
+            value={
+              system?.cpu_temp != null
+                ? `${system.cpu_temp.toFixed(1)} °C`
+                : system?.user_count != null
+                  ? String(system.user_count)
+                  : DASH
+            }
+          />
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/components/admin/network/detail/DeviceTrafficPanel.tsx
+++ b/components/admin/network/detail/DeviceTrafficPanel.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+/**
+ * Per-device traffic history.
+ *
+ * Ruijie's flow/show/hour endpoint (API V2.0.3 §2.5.2) is keyed by serial number, so this
+ * is genuinely this AP's own throughput — not its group's. Buckets are 10 minutes wide.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { PiArrowsClockwiseBold, PiWarningCircleBold } from 'react-icons/pi';
+import { Button } from '@/components/ui/button';
+import { TrafficChart } from '@/components/admin/network/TrafficChart';
+
+interface TrafficPoint {
+  timestamp: number;
+  timeString: string;
+  rxBytes: number;
+  txBytes: number;
+}
+
+interface TrafficHistory {
+  totalRxBytes: number;
+  totalTxBytes: number;
+  totalBytes: number;
+  avgRxRate: number;
+  avgTxRate: number;
+  peakRxBytes: number;
+  peakTxBytes: number;
+  dataPoints: TrafficPoint[];
+}
+
+interface DeviceTrafficPanelProps {
+  sn: string;
+}
+
+const WINDOWS = [
+  { hours: 6, label: '6h' },
+  { hours: 24, label: '24h' },
+  { hours: 72, label: '3d' },
+  { hours: 168, label: '7d' },
+] as const;
+
+function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes) || bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
+}
+
+function formatBps(bps: number | null | undefined): string {
+  if (bps == null || !Number.isFinite(bps) || bps === 0) return '0 bps';
+  const units = ['bps', 'Kbps', 'Mbps', 'Gbps'];
+  const i = Math.min(Math.floor(Math.log(bps) / Math.log(1000)), units.length - 1);
+  return `${(bps / Math.pow(1000, i)).toFixed(1)} ${units[i]}`;
+}
+
+function Tile({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-4 py-3">
+      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">{label}</p>
+      <p className="text-lg font-bold text-slate-900">{value}</p>
+      {hint && <p className="text-xs text-slate-500 mt-0.5">{hint}</p>}
+    </div>
+  );
+}
+
+export function DeviceTrafficPanel({ sn }: DeviceTrafficPanelProps) {
+  const [hours, setHours] = useState<number>(24);
+  const [history, setHistory] = useState<TrafficHistory | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTraffic = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/ruijie/devices/${sn}/traffic?hours=${hours}`, {
+        credentials: 'include',
+      });
+      if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+      const data = await response.json();
+      setHistory(data.history ?? null);
+      setError(null);
+    } catch (err) {
+      console.error('Failed to fetch device traffic:', err);
+      setError('Could not load traffic history from Ruijie Cloud.');
+      setHistory(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [sn, hours]);
+
+  useEffect(() => {
+    fetchTraffic();
+  }, [fetchTraffic]);
+
+  const points = history?.dataPoints ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-1 rounded-lg border border-slate-200 p-1">
+          {WINDOWS.map((w) => (
+            <button
+              key={w.hours}
+              type="button"
+              onClick={() => setHours(w.hours)}
+              aria-pressed={hours === w.hours}
+              className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                hours === w.hours
+                  ? 'bg-slate-900 text-white'
+                  : 'text-slate-600 hover:bg-slate-100'
+              }`}
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+        <Button variant="outline" size="sm" onClick={fetchTraffic} disabled={loading}>
+          <PiArrowsClockwiseBold
+            className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`}
+            aria-hidden="true"
+          />
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <PiWarningCircleBold className="w-4 h-4 shrink-0" aria-hidden="true" />
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <Tile label="Downloaded" value={formatBytes(history?.totalRxBytes)} />
+        <Tile label="Uploaded" value={formatBytes(history?.totalTxBytes)} />
+        <Tile
+          label="Avg Rate"
+          value={formatBps(history?.avgRxRate)}
+          hint={`↑ ${formatBps(history?.avgTxRate)}`}
+        />
+        <Tile
+          label="Busiest Bucket"
+          value={formatBytes(history?.peakRxBytes)}
+          hint="download, per 10 min"
+        />
+      </div>
+
+      {loading && points.length === 0 ? (
+        <div className="flex items-center justify-center h-[300px] text-slate-500">
+          Loading traffic history…
+        </div>
+      ) : (
+        <TrafficChart dataPoints={points} title={`Device Traffic — last ${hours}h`} />
+      )}
+    </div>
+  );
+}

--- a/components/admin/network/detail/DeviceTrafficPanel.tsx
+++ b/components/admin/network/detail/DeviceTrafficPanel.tsx
@@ -7,7 +7,7 @@
  * is genuinely this AP's own throughput — not its group's. Buckets are 10 minutes wide.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { PiArrowsClockwiseBold, PiWarningCircleBold } from 'react-icons/pi';
 import { Button } from '@/components/ui/button';
 import { TrafficChart } from '@/components/admin/network/TrafficChart';
@@ -71,27 +71,43 @@ export function DeviceTrafficPanel({ sn }: DeviceTrafficPanelProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * Only the newest request may write state. Switching window quickly (6h → 7d) fires
+   * two requests, and without this the slower one could land last and paint data for a
+   * window the user is no longer looking at.
+   */
+  const inFlight = useRef<AbortController | null>(null);
+
   const fetchTraffic = useCallback(async () => {
+    inFlight.current?.abort();
+    const controller = new AbortController();
+    inFlight.current = controller;
+
     setLoading(true);
     try {
       const response = await fetch(`/api/ruijie/devices/${sn}/traffic?hours=${hours}`, {
         credentials: 'include',
+        signal: controller.signal,
       });
       if (!response.ok) throw new Error(`Request failed: ${response.status}`);
       const data = await response.json();
+      if (controller.signal.aborted) return;
       setHistory(data.history ?? null);
       setError(null);
     } catch (err) {
+      // A superseded request is expected, not a failure to report.
+      if (controller.signal.aborted || (err as Error)?.name === 'AbortError') return;
       console.error('Failed to fetch device traffic:', err);
       setError('Could not load traffic history from Ruijie Cloud.');
       setHistory(null);
     } finally {
-      setLoading(false);
+      if (!controller.signal.aborted) setLoading(false);
     }
   }, [sn, hours]);
 
   useEffect(() => {
     fetchTraffic();
+    return () => inFlight.current?.abort();
   }, [fetchTraffic]);
 
   const points = history?.dataPoints ?? [];

--- a/components/admin/network/detail/index.ts
+++ b/components/admin/network/detail/index.ts
@@ -4,3 +4,5 @@ export { DeviceSupportNotes } from './DeviceSupportNotes';
 export { DeviceCustomerLink } from './DeviceCustomerLink';
 export { DeviceClientList } from './DeviceClientList';
 export { DeviceActivityLog } from './DeviceActivityLog';
+export { DeviceSystemHealth, formatUptime } from './DeviceSystemHealth';
+export { DeviceTrafficPanel } from './DeviceTrafficPanel';

--- a/components/admin/network/detail/telemetry-format.ts
+++ b/components/admin/network/detail/telemetry-format.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared formatting + colour thresholds for Ruijie per-client telemetry.
+ *
+ * Lives in one place so the Client Experience block (device page) and the client
+ * table can't drift apart on what counts as a bad score or a slow round-trip.
+ */
+
+/** Ruijie scores clients 0–100; below 60 is a client that will notice problems. */
+export const SCORE_POOR = 60;
+export const SCORE_FAIR = 80;
+
+/** Round-trip thresholds in ms — above 150 is bad enough to feel on a video call. */
+export const LATENCY_POOR_MS = 150;
+export const LATENCY_FAIR_MS = 60;
+
+export function scoreTone(score: number | null | undefined): string {
+  if (score == null || !Number.isFinite(score)) return 'text-slate-400';
+  if (score < SCORE_POOR) return 'text-red-600';
+  if (score < SCORE_FAIR) return 'text-amber-600';
+  return 'text-emerald-600';
+}
+
+export function latencyTone(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms)) return 'text-slate-400';
+  if (ms > LATENCY_POOR_MS) return 'text-red-600';
+  if (ms > LATENCY_FAIR_MS) return 'text-amber-600';
+  return 'text-slate-700';
+}
+
+export function formatLatency(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms)) return '—';
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${Math.round(ms)} ms`;
+}

--- a/lib/ruijie/client.ts
+++ b/lib/ruijie/client.ts
@@ -13,8 +13,14 @@ import { RuijieDevice, RuijieTunnel } from './types';
 import {
   aggregateStaMetricsForDevice,
   buildHourlyFlowRequest,
+  aggregateStaExperienceForDevice,
+  deriveUptimeFromLogs,
+  estimateSpanSeconds,
   mapCurrentPerformance,
   pickFlowDeviceSn,
+  type CurrentPerformanceRaw,
+  type DeviceSystemHealth,
+  type StaDeviceExperience,
   type StaUserRaw,
 } from './performance-metrics';
 
@@ -352,13 +358,7 @@ interface StaUsersResponse {
 interface CurrentPerformanceResponse {
   code: number;
   msg?: string;
-  data?: {
-    cpuRate?: number;
-    memoryRate?: number;
-    memoryFree?: number;
-    flashRate?: number;
-    processNum?: number;
-  };
+  data?: CurrentPerformanceRaw;
 }
 
 export interface DeviceMetrics {
@@ -370,9 +370,26 @@ export interface DeviceMetrics {
   radio_5g_channel: number | null;
   radio_2g_utilization: number | null;
   radio_5g_utilization: number | null;
+  /** Flash/disk/memory headroom and process count from the same current_performance call. */
+  system: DeviceSystemHealth;
+  /** Latency, Ruijie experience score and noise floor from the same STA call. */
+  experience: StaDeviceExperience;
 }
 
 const METRICS_DELAY_MS = 250;
+
+function getEmptySystemHealth(): DeviceSystemHealth {
+  return mapCurrentPerformance(null);
+}
+
+function getEmptyExperience(): StaDeviceExperience {
+  return aggregateStaExperienceForDevice([], '');
+}
+
+/** All-null metrics — used for offline devices, which we never query upstream. */
+export function getEmptyDeviceMetrics(): DeviceMetrics {
+  return getEmptyMetrics();
+}
 
 function getEmptyMetrics(): DeviceMetrics {
   return {
@@ -384,21 +401,29 @@ function getEmptyMetrics(): DeviceMetrics {
     radio_5g_channel: null,
     radio_2g_utilization: null,
     radio_5g_utilization: null,
+    system: getEmptySystemHealth(),
+    experience: getEmptyExperience(),
   };
 }
 
 /**
- * GET /logbizagent/logbiz/api/sys/current_performance (API V2.0.3 §2.6.6)
+ * GET /logbizagent/logbiz/api/sys/current_performance (API V2.0.3 §2.6.5)
+ *
+ * Returns the full health payload — callers that only need CPU/memory (the fleet sync)
+ * simply read those two fields.
  */
-export async function getDeviceCurrentPerformance(
-  sn: string
-): Promise<{ cpu_usage: number | null; memory_usage: number | null }> {
+export async function getDeviceCurrentPerformance(sn: string): Promise<DeviceSystemHealth> {
   if (MOCK_MODE) {
     const mock = getMockDevice(sn);
-    return {
-      cpu_usage: mock.cpu_usage ?? null,
-      memory_usage: mock.memory_usage ?? null,
-    };
+    return mapCurrentPerformance({
+      cpuRate: mock.cpu_usage,
+      memoryRate: mock.memory_usage,
+      memoryFree: 114_336,
+      flashRate: 42,
+      flashFree: 408,
+      processNum: 93,
+      userCnt: mock.online_clients,
+    });
   }
 
   try {
@@ -408,12 +433,12 @@ export async function getDeviceCurrentPerformance(
     );
     if (response.code !== 0) {
       console.error(`[Ruijie] current_performance failed for ${sn}:`, response.msg);
-      return { cpu_usage: null, memory_usage: null };
+      return getEmptySystemHealth();
     }
     return mapCurrentPerformance(response.data);
   } catch (error) {
     console.error(`[Ruijie] current_performance error for ${sn}:`, error);
-    return { cpu_usage: null, memory_usage: null };
+    return getEmptySystemHealth();
   }
 }
 
@@ -449,8 +474,8 @@ export async function getGroupStaUsers(groupId: string): Promise<StaUserRaw[]> {
 }
 
 /**
- * Live device metrics: current_performance (CPU/mem) + STA util/clients.
- * Uptime is still not exposed by Cloud JSON APIs.
+ * Live device metrics: current_performance (system health) + STA util/clients/experience,
+ * plus uptime derived from the management log (no Cloud API exposes uptime directly).
  */
 export async function getDeviceMetrics(sn: string, groupId?: string): Promise<DeviceMetrics> {
   const metrics = getEmptyMetrics();
@@ -458,12 +483,15 @@ export async function getDeviceMetrics(sn: string, groupId?: string): Promise<De
   const perf = await getDeviceCurrentPerformance(sn);
   metrics.cpu_usage = perf.cpu_usage;
   metrics.memory_usage = perf.memory_usage;
+  metrics.system = perf;
 
   if (groupId) {
     const stas = await getGroupStaUsers(groupId);
-    const staMetrics = aggregateStaMetricsForDevice(stas, sn);
-    Object.assign(metrics, staMetrics);
+    Object.assign(metrics, aggregateStaMetricsForDevice(stas, sn));
+    metrics.experience = aggregateStaExperienceForDevice(stas, sn);
   }
+
+  metrics.uptime_seconds = deriveUptimeFromLogs(await getDeviceLogs(sn));
 
   return metrics;
 }
@@ -534,6 +562,19 @@ export interface RuijieClient {
   downlinkRate: number | null;
   /** Packet loss rate from Ruijie STA (fraction 0–1 or percent 0–100; UI normalizes). */
   pktLoseRate: number | null;
+  /** Round-trip latency in ms. */
+  latencyMs: number | null;
+  /** Ruijie's own 0–100 connection score, and why it is low (empty when healthy). */
+  score: number | null;
+  scoreReason: string | null;
+  /** Client hostname, when advertised. */
+  hostname: string | null;
+  /** Client hardware vendor, e.g. "HUAWEI". */
+  vendor: string | null;
+  /** Cumulative bytes this session (up + down). */
+  sessionBytes: number | null;
+  /** Session duration in ms. */
+  sessionMs: number | null;
 }
 
 /**
@@ -575,6 +616,13 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
         uplinkRate: 40_000_000,
         downlinkRate: 120_000_000,
         pktLoseRate: 0.2,
+        latencyMs: 12,
+        score: 98,
+        scoreReason: null,
+        hostname: 'reception-pc',
+        vendor: 'Intel',
+        sessionBytes: 240_000_000,
+        sessionMs: 5_400_000,
       },
       {
         mac: '00:1A:2B:3C:4D:5F',
@@ -589,6 +637,13 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
         uplinkRate: 20_000_000,
         downlinkRate: 80_000_000,
         pktLoseRate: 1.5,
+        latencyMs: 48,
+        score: 82,
+        scoreReason: null,
+        hostname: 'nurse-tablet',
+        vendor: 'HUAWEI',
+        sessionBytes: 31_000_000,
+        sessionMs: 1_800_000,
       },
       {
         mac: 'AA:BB:CC:DD:EE:FF',
@@ -603,6 +658,13 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
         uplinkRate: 5_000_000,
         downlinkRate: 15_000_000,
         pktLoseRate: 6.2,
+        latencyMs: 210,
+        score: 61,
+        scoreReason: 'heavy interference',
+        hostname: null,
+        vendor: 'ESPRESSIF',
+        sessionBytes: 2_100_000,
+        sessionMs: 600_000,
       },
     ];
   }
@@ -632,6 +694,10 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
             : Number.isFinite(parseFloat(String(sta.pktLoseRate ?? '')))
               ? parseFloat(String(sta.pktLoseRate))
               : null;
+        const num = (v: unknown): number | null => {
+          const n = typeof v === 'number' ? v : parseFloat(String(v ?? ''));
+          return Number.isFinite(n) ? n : null;
+        };
         return {
           mac: sta.mac || '',
           userIp: sta.userIp || '',
@@ -645,6 +711,14 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
           uplinkRate: typeof sta.uplinkRate === 'number' ? sta.uplinkRate : null,
           downlinkRate: typeof sta.downlinkRate === 'number' ? sta.downlinkRate : null,
           pktLoseRate,
+          latencyMs: num(sta.timeDelay),
+          score: num(sta.score),
+          // Ruijie sends an empty string when the client is healthy.
+          scoreReason: sta.scoreReason ? sta.scoreReason : null,
+          hostname: sta.userName || null,
+          vendor: sta.manufacture || null,
+          sessionBytes: num(sta.wifiUpDown),
+          sessionMs: num(sta.activeTime),
         };
       });
   } catch (error) {
@@ -664,6 +738,8 @@ export interface RuijieLogEntry {
   id: number;
   sn: string;
   logType: 'reboot' | 'onoffline' | 'config' | string;
+  /** "ON" | "OFF" on onoffline entries. Undocumented but present on live responses. */
+  logSubType?: string;
   logDetail: string;
   operateTime: number; // timestamp in milliseconds
 }
@@ -680,6 +756,7 @@ interface DeviceLogsResponse {
       id: number;
       sn: string;
       logType: string;
+      logSubType?: string;
       logDetail: string;
       operateTime: number;
     }>;
@@ -701,6 +778,7 @@ export async function getDeviceLogs(sn: string): Promise<RuijieLogEntry[]> {
         id: 1,
         sn,
         logType: 'onoffline',
+        logSubType: 'ON',
         logDetail: 'Device online',
         operateTime: now - 1000 * 60 * 30, // 30 min ago
       },
@@ -722,6 +800,7 @@ export async function getDeviceLogs(sn: string): Promise<RuijieLogEntry[]> {
         id: 4,
         sn,
         logType: 'onoffline',
+        logSubType: 'OFF',
         logDetail: 'Device offline',
         operateTime: now - 1000 * 60 * 60 * 24 - 1000 * 60 * 5, // 1 day + 5 min ago
       },
@@ -729,6 +808,7 @@ export async function getDeviceLogs(sn: string): Promise<RuijieLogEntry[]> {
         id: 5,
         sn,
         logType: 'onoffline',
+        logSubType: 'ON',
         logDetail: 'Device online',
         operateTime: now - 1000 * 60 * 60 * 48, // 2 days ago
       },
@@ -749,6 +829,7 @@ export async function getDeviceLogs(sn: string): Promise<RuijieLogEntry[]> {
       id: log.id,
       sn: log.sn,
       logType: log.logType,
+      logSubType: log.logSubType,
       logDetail: log.logDetail,
       operateTime: log.operateTime,
     }));
@@ -825,7 +906,8 @@ export interface TrafficDataPoint {
   txBytes: number;         // Upload bytes
   rxPkts: number;          // Download packets
   txPkts: number;          // Upload packets
-  buildingId: number;      // Group/building ID
+  buildingId: number;      // Group/building ID (0 when the response is per-device)
+  sn?: string;             // Device serial — live responses return this, not buildingId
 }
 
 /**
@@ -862,7 +944,9 @@ interface HourlyTrafficResponse {
   msg?: string;
   count?: number;
   list?: Array<{
-    buildingId: number;
+    // Live per-device responses return `sn` and omit `buildingId`.
+    buildingId?: number;
+    sn?: string;
     rxBytes: number;
     rxPkts: number;
     txBytes: number;
@@ -1000,7 +1084,8 @@ export async function getNetworkTraffic(
         txBytes: item.txBytes,
         rxPkts: item.rxPkts,
         txPkts: item.txPkts,
-        buildingId: item.buildingId,
+        buildingId: item.buildingId ?? 0,
+        sn: item.sn,
       }));
 
     return calculateTrafficSummary(filteredData);
@@ -1072,8 +1157,8 @@ function calculateTrafficSummary(dataPoints: TrafficDataPoint[]): TrafficSummary
     if (point.txBytes > peakTxBytes) peakTxBytes = point.txBytes;
   }
 
-  // Calculate average rate (bytes per second)
-  const timeSpanSeconds = dataPoints.length * 60 * 60; // hours to seconds
+  // Span comes from the timestamps — buckets are 10 min, not 1 hour (see estimateSpanSeconds)
+  const timeSpanSeconds = estimateSpanSeconds(dataPoints);
   const avgRxRate = timeSpanSeconds > 0 ? (totalRxBytes * 8) / timeSpanSeconds : 0; // bps
   const avgTxRate = timeSpanSeconds > 0 ? (totalTxBytes * 8) / timeSpanSeconds : 0;
 

--- a/lib/ruijie/client.ts
+++ b/lib/ruijie/client.ts
@@ -480,18 +480,23 @@ export async function getGroupStaUsers(groupId: string): Promise<StaUserRaw[]> {
 export async function getDeviceMetrics(sn: string, groupId?: string): Promise<DeviceMetrics> {
   const metrics = getEmptyMetrics();
 
-  const perf = await getDeviceCurrentPerformance(sn);
+  // All three are independent — one round-trip's wall time, not three.
+  const [perf, stas, logs] = await Promise.all([
+    getDeviceCurrentPerformance(sn),
+    groupId ? getGroupStaUsers(groupId) : Promise.resolve([] as StaUserRaw[]),
+    getDeviceLogs(sn),
+  ]);
+
   metrics.cpu_usage = perf.cpu_usage;
   metrics.memory_usage = perf.memory_usage;
   metrics.system = perf;
 
   if (groupId) {
-    const stas = await getGroupStaUsers(groupId);
     Object.assign(metrics, aggregateStaMetricsForDevice(stas, sn));
     metrics.experience = aggregateStaExperienceForDevice(stas, sn);
   }
 
-  metrics.uptime_seconds = deriveUptimeFromLogs(await getDeviceLogs(sn));
+  metrics.uptime_seconds = deriveUptimeFromLogs(logs);
 
   return metrics;
 }

--- a/lib/ruijie/client.ts
+++ b/lib/ruijie/client.ts
@@ -16,6 +16,7 @@ import {
   aggregateStaExperienceForDevice,
   deriveUptimeFromLogs,
   estimateSpanSeconds,
+  toNum,
   mapCurrentPerformance,
   pickFlowDeviceSn,
   type CurrentPerformanceRaw,
@@ -699,10 +700,6 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
             : Number.isFinite(parseFloat(String(sta.pktLoseRate ?? '')))
               ? parseFloat(String(sta.pktLoseRate))
               : null;
-        const num = (v: unknown): number | null => {
-          const n = typeof v === 'number' ? v : parseFloat(String(v ?? ''));
-          return Number.isFinite(n) ? n : null;
-        };
         return {
           mac: sta.mac || '',
           userIp: sta.userIp || '',
@@ -716,14 +713,14 @@ export async function getDeviceClients(sn: string, groupId: string): Promise<Rui
           uplinkRate: typeof sta.uplinkRate === 'number' ? sta.uplinkRate : null,
           downlinkRate: typeof sta.downlinkRate === 'number' ? sta.downlinkRate : null,
           pktLoseRate,
-          latencyMs: num(sta.timeDelay),
-          score: num(sta.score),
+          latencyMs: toNum(sta.timeDelay),
+          score: toNum(sta.score),
           // Ruijie sends an empty string when the client is healthy.
           scoreReason: sta.scoreReason ? sta.scoreReason : null,
           hostname: sta.userName || null,
           vendor: sta.manufacture || null,
-          sessionBytes: num(sta.wifiUpDown),
-          sessionMs: num(sta.activeTime),
+          sessionBytes: toNum(sta.wifiUpDown),
+          sessionMs: toNum(sta.activeTime),
         };
       });
   } catch (error) {
@@ -935,8 +932,8 @@ export interface TrafficSummary {
   totalBytes: number;
   avgRxRate: number;       // Average download rate in bps
   avgTxRate: number;       // Average upload rate in bps
-  peakRxBytes: number;     // Highest hourly download
-  peakTxBytes: number;     // Highest hourly upload
+  peakRxBytes: number;     // Busiest single bucket, download (buckets are ~10 min)
+  peakTxBytes: number;     // Busiest single bucket, upload
   dataPoints: TrafficDataPoint[];
 }
 

--- a/lib/ruijie/index.ts
+++ b/lib/ruijie/index.ts
@@ -15,6 +15,7 @@ export {
   getAllDevices,
   getDevice,
   getDeviceMetrics,
+  getEmptyDeviceMetrics,
   getDeviceCurrentPerformance,
   getGroupStaUsers,
   enrichDevicesWithLiveMetrics,
@@ -29,7 +30,16 @@ export {
 export {
   mapCurrentPerformance,
   aggregateStaMetricsForDevice,
+  aggregateStaExperienceForDevice,
+  deriveUptimeFromLogs,
   buildHourlyFlowRequest,
+  estimateSpanSeconds,
+} from './performance-metrics';
+
+export type {
+  DeviceSystemHealth,
+  StaDeviceExperience,
+  DeviceLogRaw,
 } from './performance-metrics';
 
 export {

--- a/lib/ruijie/performance-metrics.ts
+++ b/lib/ruijie/performance-metrics.ts
@@ -11,10 +11,14 @@ export type CurrentPerformanceRaw = {
   memoryFree?: number;
   flashRate?: number;
   processNum?: number;
-  cpuTemp?: number;
   flashFree?: number;
   diskRate?: number;
   diskFree?: number;
+  /**
+   * Always 0 on RAP2200/RAP62 — they have no temperature sensor, so mapCurrentPerformance
+   * maps <= 0 to null. A future model with a real sensor reporting <= 0 C would be hidden too.
+   */
+  cpuTemp?: number;
   /** Device-reported client count. Undocumented but present on live responses. */
   userCnt?: number;
 };
@@ -129,7 +133,7 @@ function modeChannel(channels: number[]): number | null {
 }
 
 /** Coerce a Ruijie numeric that may arrive as a number or a string. */
-function toNum(value: unknown): number | null {
+export function toNum(value: unknown): number | null {
   const n = typeof value === 'number' ? value : parseFloat(String(value ?? ''));
   return Number.isFinite(n) ? n : null;
 }

--- a/lib/ruijie/performance-metrics.ts
+++ b/lib/ruijie/performance-metrics.ts
@@ -15,6 +15,8 @@ export type CurrentPerformanceRaw = {
   flashFree?: number;
   diskRate?: number;
   diskFree?: number;
+  /** Device-reported client count. Undocumented but present on live responses. */
+  userCnt?: number;
 };
 
 export type StaUserRaw = {
@@ -30,9 +32,30 @@ export type StaUserRaw = {
   downlinkRate?: number;
   wifiUp?: number;
   wifiDown?: number;
+  /** Cumulative session bytes (up + down). */
+  wifiUpDown?: number;
   floorNoise?: number;
   pktLoseRate?: number;
   score?: number;
+  /** Why the score is low, e.g. "heavy interference". Empty string when healthy. */
+  scoreReason?: string;
+  /** Round-trip latency in ms. */
+  timeDelay?: number;
+  /** Session duration in ms. */
+  activeTime?: number;
+  /** Client hostname, when the device advertises one. */
+  userName?: string;
+  /** Client hardware vendor, e.g. "HUAWEI". */
+  manufacture?: string;
+};
+
+/** Subset of the devicemgtlogs entry needed to derive uptime. */
+export type DeviceLogRaw = {
+  logType?: string;
+  /** "ON" | "OFF" on onoffline entries. Undocumented but present on live responses. */
+  logSubType?: string;
+  logDetail?: string;
+  operateTime?: number;
 };
 
 export type StaDeviceMetrics = {
@@ -41,6 +64,34 @@ export type StaDeviceMetrics = {
   radio_5g_channel: number | null;
   radio_2g_utilization: number | null;
   radio_5g_utilization: number | null;
+};
+
+/** Device health beyond CPU/memory, from a single current_performance call. */
+export type DeviceSystemHealth = {
+  cpu_usage: number | null;
+  memory_usage: number | null;
+  cpu_temp: number | null;
+  memory_free_kb: number | null;
+  flash_rate: number | null;
+  flash_free_kb: number | null;
+  disk_rate: number | null;
+  disk_free_kb: number | null;
+  process_num: number | null;
+  user_count: number | null;
+};
+
+/** Client-experience view of an AP, derived from the STAs attached to it. */
+export type StaDeviceExperience = {
+  avg_latency_ms: number | null;
+  worst_latency_ms: number | null;
+  avg_score: number | null;
+  worst_score: number | null;
+  worst_score_reason: string | null;
+  noise_floor_2g: number | null;
+  noise_floor_5g: number | null;
+  clients_2g: number;
+  clients_5g: number;
+  longest_session_ms: number | null;
 };
 
 function is2g(band: string | undefined): boolean {
@@ -77,20 +128,29 @@ function modeChannel(channels: number[]): number | null {
   return best;
 }
 
-export function mapCurrentPerformance(data: CurrentPerformanceRaw | null | undefined): {
-  cpu_usage: number | null;
-  memory_usage: number | null;
-} {
-  if (!data) {
-    return { cpu_usage: null, memory_usage: null };
-  }
-  const cpu =
-    typeof data.cpuRate === 'number' && Number.isFinite(data.cpuRate) ? data.cpuRate : null;
-  const mem =
-    typeof data.memoryRate === 'number' && Number.isFinite(data.memoryRate)
-      ? data.memoryRate
-      : null;
-  return { cpu_usage: cpu, memory_usage: mem };
+/** Coerce a Ruijie numeric that may arrive as a number or a string. */
+function toNum(value: unknown): number | null {
+  const n = typeof value === 'number' ? value : parseFloat(String(value ?? ''));
+  return Number.isFinite(n) ? n : null;
+}
+
+export function mapCurrentPerformance(
+  data: CurrentPerformanceRaw | null | undefined
+): DeviceSystemHealth {
+  const temp = toNum(data?.cpuTemp);
+  return {
+    cpu_usage: toNum(data?.cpuRate),
+    memory_usage: toNum(data?.memoryRate),
+    // RAP2200/RAP62 have no temperature sensor and always report 0 — not a real reading.
+    cpu_temp: temp !== null && temp > 0 ? temp : null,
+    memory_free_kb: toNum(data?.memoryFree),
+    flash_rate: toNum(data?.flashRate),
+    flash_free_kb: toNum(data?.flashFree),
+    disk_rate: toNum(data?.diskRate),
+    disk_free_kb: toNum(data?.diskFree),
+    process_num: toNum(data?.processNum),
+    user_count: toNum(data?.userCnt),
+  };
 }
 
 export function aggregateStaMetricsForDevice(
@@ -129,6 +189,112 @@ export function aggregateStaMetricsForDevice(
     radio_2g_utilization: avg(util2g),
     radio_5g_utilization: avg(util5g),
   };
+}
+
+/**
+ * Client-experience summary for one AP (API V2.0.3 §2.5.1 fields the fleet sync ignores).
+ * Separate from aggregateStaMetricsForDevice, whose shape the sync path depends on.
+ */
+export function aggregateStaExperienceForDevice(
+  stas: StaUserRaw[],
+  sn: string
+): StaDeviceExperience {
+  const mine = stas.filter((s) => s.sn === sn);
+
+  const latencies: number[] = [];
+  const scores: number[] = [];
+  const noise2g: number[] = [];
+  const noise5g: number[] = [];
+  const sessions: number[] = [];
+  let clients2g = 0;
+  let clients5g = 0;
+  let worstScore: number | null = null;
+  let worstScoreReason: string | null = null;
+
+  for (const sta of mine) {
+    const latency = toNum(sta.timeDelay);
+    if (latency !== null) latencies.push(latency);
+
+    const score = toNum(sta.score);
+    if (score !== null) {
+      scores.push(score);
+      if (worstScore === null || score < worstScore) {
+        worstScore = score;
+        // Ruijie sends an empty string when the client is healthy.
+        worstScoreReason = sta.scoreReason ? sta.scoreReason : null;
+      }
+    }
+
+    const noise = toNum(sta.floorNoise);
+    const session = toNum(sta.activeTime);
+    if (session !== null) sessions.push(session);
+
+    if (is2g(sta.band)) {
+      clients2g++;
+      if (noise !== null) noise2g.push(noise);
+    } else if (is5g(sta.band)) {
+      clients5g++;
+      if (noise !== null) noise5g.push(noise);
+    }
+  }
+
+  return {
+    avg_latency_ms: avg(latencies),
+    worst_latency_ms: latencies.length ? Math.max(...latencies) : null,
+    avg_score: avg(scores),
+    worst_score: worstScore,
+    worst_score_reason: worstScoreReason,
+    noise_floor_2g: avg(noise2g),
+    noise_floor_5g: avg(noise5g),
+    clients_2g: clients2g,
+    clients_5g: clients5g,
+    longest_session_ms: sessions.length ? Math.max(...sessions) : null,
+  };
+}
+
+/**
+ * Uptime in seconds since the most recent "device online" event.
+ *
+ * Ruijie's Cloud JSON APIs expose no uptime field, but devicemgtlogs (§2.6.4) carries
+ * onoffline events. Returns null when the device's last transition was OFF, or when
+ * there is no onoffline history — never a guess.
+ */
+export function deriveUptimeFromLogs(
+  logs: DeviceLogRaw[],
+  nowMs: number = Date.now()
+): number | null {
+  const transitions = logs
+    .filter((l) => l.logType === 'onoffline' && toNum(l.operateTime) !== null)
+    .sort((a, b) => (b.operateTime ?? 0) - (a.operateTime ?? 0));
+
+  const latest = transitions[0];
+  if (!latest) return null;
+
+  // logSubType is the reliable signal; logDetail is the documented fallback.
+  const isOnline = latest.logSubType
+    ? latest.logSubType.toUpperCase() === 'ON'
+    : /online/i.test(latest.logDetail || '') && !/offline/i.test(latest.logDetail || '');
+  if (!isOnline) return null;
+
+  const elapsed = nowMs - (latest.operateTime ?? 0);
+  return elapsed > 0 ? Math.floor(elapsed / 1000) : null;
+}
+
+/**
+ * Seconds covered by a flow series, derived from the timestamps themselves.
+ *
+ * flow/show/hour returns 10-minute buckets in practice (144 points per 24h), not hourly
+ * ones, so counting points as hours understates average rate by ~6x. Falls back to one
+ * hour per point only when there aren't enough timestamps to measure a gap.
+ */
+export function estimateSpanSeconds(points: Array<{ timestamp: number }>): number {
+  if (points.length === 0) return 0;
+  if (points.length === 1) return 3600;
+
+  const sorted = points.map((p) => p.timestamp).sort((a, b) => a - b);
+  const bucketMs = sorted[1] - sorted[0];
+  const spanMs = sorted[sorted.length - 1] - sorted[0] + Math.max(bucketMs, 0);
+  return spanMs > 0 ? spanMs / 1000 : points.length * 3600;
 }
 
 export function buildHourlyFlowRequest(opts: {


### PR DESCRIPTION
## Why

`/admin/network/devices/[sn]` showed a thin slice of what Ruijie Cloud actually returns. Three gaps, all verified live against `G1U52HL044467` (UNJANICLINICTHOKOZA, RAP2200(F), group Unjani):

1. **Data was fetched, then discarded.** `mapCurrentPerformance` kept only `cpuRate`/`memoryRate` from `current_performance` (§2.6.5), dropping flash, disk, memory-free, process count and temperature. `aggregateStaMetricsForDevice` dropped the `sta_users` (§2.5.1) fields `timeDelay`, `score`/`scoreReason`, `floorNoise` and `activeTime`. **Both are already in responses we make — surfacing them costs zero extra API calls.**
2. **`flow/show/hour` (§2.5.2) is keyed by serial**, not group, and returns real per-device history — but the page had no traffic view at all.
3. **`uptime_seconds` was permanently null.** No Cloud API exposes uptime, but `devicemgtlogs` (§2.6.4) carries `onoffline` events with an undocumented `logSubType: ON|OFF`.

## What's added

- **System Health card** (Overview) — flash/memory headroom with % + free, process count, derived uptime. Disk row hides itself on APs (they report 0/0); CPU temp is hidden rather than shown as a fake `0 °C`.
- **Client Experience block + richer Radio cards** — per-band noise floor and client counts, avg/worst latency, Ruijie's own 0–100 score and the reason for the worst one. This is the context the bare "48% utilisation" number lacked.
- **Traffic tab** — per-device history at 6h/24h/3d/7d. Live: 3.66 GB down / 173 MB up over 24h.
- **Client list** — leads with device identity (`HUAWEI_MediaPad_T5`, `ESPRESSIF`) instead of only a MAC, plus latency and score columns. `sta_users` also carries `manufacture` and `userName`.

## Drive-by fix (found while building this)

`calculateTrafficSummary` **and** `TrafficChart` both counted one data point as one hour. The API returns **10-minute buckets** (144 per 24h), so every average-rate figure was ~6× too low — this device reads 0.355 Mbps, not 0.059. Span now derives from the timestamps via `estimateSpanSeconds()`; hourly rollups are unaffected.

## Scope guards

- New fields are **live-only** in the metrics payload — nothing is written to `ruijie_device_cache`, so **no migration**.
- `aggregateStaMetricsForDevice` keeps its exact shape, because the fleet sync depends on it. New behaviour went into a separate `aggregateStaExperienceForDevice`.
- No new dependencies; the Traffic tab reuses the existing `TrafficChart`.

## Verification

- **29 new tests** (mappers, uptime derivation, span estimation, card render) — `__tests__/lib/ruijie/`, `__tests__/components/admin/network/`
- **0 type errors in all 12 touched files** (repo carries 241 pre-existing elsewhere); pre-push hook confirmed clean
- Full suite failures **unchanged** at the pre-existing 124; passing 1120 → 1149
- Live probe confirmed every new field returns real data **before** any UI was written; uptime cross-checked against the `ON` log entry (1d 13h)

## Not fixed here (flagged)

`ruijie_traffic_rollups` labels rows `group_id`/`group_name`, but `pickFlowDeviceSn` falls back to `pool[0]` when no gateway exists — and the fleet is 100% APs (13× RAP2200(F) + 9× RAP62-OD, zero MSW/EGW). Those "group" rows are really one representative AP's flow, which makes the network analytics page misleading. Separate fix.

> Note: not routed via `staging` — that branch is currently 12 commits behind main and lacks helpers this change builds on (`formatRate`, `utilTone`, `lossTone`, `RUIJIE_FETCH_TIMEOUT_MS`), so it would not build there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)