### PR TITLE
feat(admin): billing recon hub for NetCash cash-match

### DIFF
--- a/__tests__/lib/billing/recon-hub/build-exceptions.test.ts
+++ b/__tests__/lib/billing/recon-hub/build-exceptions.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  buildExceptionRows,
+  countUnmatchedCash,
+  filterExceptions,
+} from '@/lib/billing/recon-hub/build-exceptions';
+import type {
+  OpenArLike,
+  PaymentLike,
+  PaynowUnmatchedLike,
+} from '@/lib/billing/recon-hub/types';
+
+const basePayment = (overrides: Partial<PaymentLike> = {}): PaymentLike => ({
+  id: 'pay-1',
+  status: 'completed',
+  amount: 1499,
+  reference: 'NC-REF-001',
+  completed_at: '2026-07-30T10:00:00.000Z',
+  customer_invoice_id: null,
+  invoice_number: null,
+  invoice_status: null,
+  zoho_sync_status: null,
+  ...overrides,
+});
+
+describe('buildExceptionRows', () => {
+  it('marks completed payment without CT invoice as red unmatched cash', () => {
+    const rows = buildExceptionRows({
+      payments: [basePayment()],
+      paynowUnmatched: [],
+      openArInvoices: [],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].severity).toBe('red');
+    expect(rows[0].reasonCode).toBe('no_ct_invoice');
+    expect(rows[0].kind).toBe('payment');
+    expect(rows[0].netcashRef).toBe('NC-REF-001');
+    expect(rows[0].href).toBe('/admin/finance/reconciliation');
+    expect(countUnmatchedCash(rows)).toBe(1);
+  });
+
+  it('marks linked payment with zoho failed as amber and not unmatched cash', () => {
+    const rows = buildExceptionRows({
+      payments: [
+        basePayment({
+          id: 'pay-2',
+          customer_invoice_id: 'inv-uuid-1',
+          invoice_number: 'CT-INV-001',
+          invoice_status: 'paid',
+          zoho_sync_status: 'failed',
+        }),
+      ],
+      paynowUnmatched: [],
+      openArInvoices: [],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].severity).toBe('amber');
+    expect(rows[0].reasonCode).toBe('zoho_payment_failed');
+    expect(rows[0].zohoStatus).toBe('failed');
+    expect(rows[0].invoiceId).toBe('inv-uuid-1');
+    expect(rows[0].href).toBe('/admin/billing/invoices/inv-uuid-1');
+    expect(countUnmatchedCash(rows)).toBe(0);
+  });
+
+  it('marks linked payment with zoho pending as amber zoho lag', () => {
+    const rows = buildExceptionRows({
+      payments: [
+        basePayment({
+          id: 'pay-3',
+          customer_invoice_id: 'inv-uuid-2',
+          invoice_number: 'CT-INV-002',
+          zoho_sync_status: 'pending',
+        }),
+      ],
+      paynowUnmatched: [],
+      openArInvoices: [],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].severity).toBe('amber');
+    expect(rows[0].reasonCode).toBe('zoho_payment_pending');
+    expect(countUnmatchedCash(rows)).toBe(0);
+  });
+
+  it('includes paynow unmatched details as red', () => {
+    const unmatched: PaynowUnmatchedLike[] = [
+      {
+        id: 'pn-1',
+        amount: 899,
+        date: '2026-07-30T08:00:00.000Z',
+        netcashRef: 'PN-REF-99',
+      },
+    ];
+
+    const rows = buildExceptionRows({
+      payments: [],
+      paynowUnmatched: unmatched,
+      openArInvoices: [],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('paynow_unmatched');
+    expect(rows[0].severity).toBe('red');
+    expect(rows[0].reasonCode).toBe('paynow_unmatched');
+    expect(rows[0].href).toBe('/admin/finance/reconciliation');
+    expect(countUnmatchedCash(rows)).toBe(1);
+  });
+
+  it('includes open AR invoices as neutral', () => {
+    const openAr: OpenArLike[] = [
+      {
+        id: 'inv-ar-1',
+        invoice_number: 'CT-AR-001',
+        amount: 2500,
+        status: 'overdue',
+        date: '2026-07-01T00:00:00.000Z',
+      },
+    ];
+
+    const rows = buildExceptionRows({
+      payments: [],
+      paynowUnmatched: [],
+      openArInvoices: openAr,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('invoice_ar');
+    expect(rows[0].severity).toBe('neutral');
+    expect(rows[0].reasonCode).toBe('open_ar');
+    expect(rows[0].href).toBe('/admin/billing/invoices/inv-ar-1');
+  });
+
+  it('skips completed payments that are fully linked and zoho-synced', () => {
+    const rows = buildExceptionRows({
+      payments: [
+        basePayment({
+          customer_invoice_id: 'inv-ok',
+          invoice_number: 'CT-OK',
+          zoho_sync_status: 'synced',
+        }),
+      ],
+      paynowUnmatched: [],
+      openArInvoices: [],
+    });
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('skips non-completed payments', () => {
+    const rows = buildExceptionRows({
+      payments: [basePayment({ status: 'pending' })],
+      paynowUnmatched: [],
+      openArInvoices: [],
+    });
+
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe('filterExceptions', () => {
+  const rows = buildExceptionRows({
+    payments: [
+      basePayment({ id: 'red-1' }),
+      basePayment({
+        id: 'amber-1',
+        customer_invoice_id: 'inv-1',
+        zoho_sync_status: 'failed',
+      }),
+    ],
+    paynowUnmatched: [],
+    openArInvoices: [
+      {
+        id: 'ar-1',
+        invoice_number: 'CT-AR',
+        amount: 100,
+        status: 'unpaid',
+        date: '2026-07-01T00:00:00.000Z',
+      },
+    ],
+  });
+
+  it('filters unmatched_cash to red rows only', () => {
+    const filtered = filterExceptions(rows, 'unmatched_cash');
+    expect(filtered.every((r) => r.severity === 'red')).toBe(true);
+    expect(filtered).toHaveLength(1);
+  });
+
+  it('filters zoho_lag to amber rows only', () => {
+    const filtered = filterExceptions(rows, 'zoho_lag');
+    expect(filtered.every((r) => r.severity === 'amber')).toBe(true);
+    expect(filtered).toHaveLength(1);
+  });
+
+  it('filters open_ar to open_ar reason only', () => {
+    const filtered = filterExceptions(rows, 'open_ar');
+    expect(filtered.every((r) => r.reasonCode === 'open_ar')).toBe(true);
+    expect(filtered).toHaveLength(1);
+  });
+
+  it('returns all rows for all filter', () => {
+    expect(filterExceptions(rows, 'all')).toHaveLength(3);
+  });
+});
+
+describe('countUnmatchedCash', () => {
+  it('counts only red severity rows', () => {
+    expect(
+      countUnmatchedCash([
+        { severity: 'red' } as never,
+        { severity: 'red' } as never,
+        { severity: 'amber' } as never,
+        { severity: 'neutral' } as never,
+      ])
+    ).toBe(2);
+  });
+});

--- a/__tests__/lib/billing/recon-hub/window.test.ts
+++ b/__tests__/lib/billing/recon-hub/window.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from '@jest/globals';
+import { resolveReconWindow } from '@/lib/billing/recon-hub/window';
+
+describe('resolveReconWindow', () => {
+  const now = new Date('2026-07-30T12:00:00.000Z');
+
+  it('today is the UTC calendar day of now [start, next midnight)', () => {
+    const w = resolveReconWindow('today', now);
+    expect(w.from).toBe('2026-07-30T00:00:00.000Z');
+    expect(w.to).toBe('2026-07-31T00:00:00.000Z');
+  });
+
+  it('yesterday is the UTC calendar day before now', () => {
+    const w = resolveReconWindow('yesterday', now);
+    expect(w.from.startsWith('2026-07-29')).toBe(true);
+    expect(w.to.startsWith('2026-07-30')).toBe(true);
+    expect(w.from).toBe('2026-07-29T00:00:00.000Z');
+    expect(w.to).toBe('2026-07-30T00:00:00.000Z');
+  });
+
+  it('48h is now minus 48 hours through now', () => {
+    const w = resolveReconWindow('48h', now);
+    expect(new Date(w.to).getTime()).toBe(now.getTime());
+    expect(new Date(w.from).getTime()).toBe(now.getTime() - 48 * 3600 * 1000);
+  });
+});

--- a/app/admin/billing/page.tsx
+++ b/app/admin/billing/page.tsx
@@ -1,152 +1,170 @@
 'use client';
 
-import {
-  PiArrowRightBold,
-  PiArrowsClockwiseBold,
-  PiCheckCircleBold,
-  PiClockBold,
-  PiCreditCardBold,
-  PiCurrencyDollarBold,
-  PiFileTextBold,
-  PiTrendUpBold,
-  PiUsersBold,
-  PiWarningCircleBold,
-} from 'react-icons/pi';
-import React, { useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
+import React, { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import {
+  PiArrowsClockwiseBold,
+  PiFileTextBold,
+  PiPlayBold,
+} from 'react-icons/pi';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   AdminPage,
   PageHeader,
-  StatCard,
-  SectionCard,
-  StatusBadge,
   LoadingState,
   ErrorState,
-  EmptyState,
-  type StatusVariant,
 } from '@/components/backend';
+import {
+  CashMatchStrip,
+  DayDoneBanner,
+  DeepLinks,
+  ExceptionTable,
+  SecondaryKpis,
+} from '@/components/admin/billing/recon';
+import type {
+  ReconHubResponse,
+  ReconWindow,
+} from '@/lib/billing/recon-hub/types';
 
-interface BillingStats {
-  totalOutstanding: number;
-  pendingInvoices: number;
-  overdueInvoices: number;
-  paidLast30Days: number;
-  collectedLast30Days: number;
-  activeCustomers: number;
-  activeServices: number;
+const WINDOW_OPTIONS: Array<{ value: ReconWindow; label: string }> = [
+  { value: 'today', label: 'Today' },
+  { value: 'yesterday', label: 'Yesterday' },
+  { value: '48h', label: 'Last 48 hours' },
+];
+
+function windowLabel(window: ReconWindow): string {
+  return WINDOW_OPTIONS.find((o) => o.value === window)?.label ?? window;
 }
-
-interface RecentInvoice {
-  id: string;
-  invoice_number: string;
-  customer_name: string;
-  total_amount: number;
-  amount_due: number;
-  status: string;
-  due_date: string;
-}
-
-interface RecentPayment {
-  id: string;
-  invoice_number: string;
-  customer_name: string;
-  amount: number;
-  paid_at: string;
-  method: string;
-}
-
-const INVOICE_STATUS_VARIANT: Record<string, StatusVariant> = {
-  paid: 'success',
-  sent: 'info',
-  overdue: 'error',
-  draft: 'neutral',
-  partial: 'warning',
-  voided: 'neutral',
-  cancelled: 'neutral',
-};
 
 export default function BillingDashboard() {
-  const [stats, setStats] = useState<BillingStats | null>(null);
-  const [recentInvoices, setRecentInvoices] = useState<RecentInvoice[]>([]);
-  const [recentPayments, setRecentPayments] = useState<RecentPayment[]>([]);
+  const [window, setWindow] = useState<ReconWindow>('yesterday');
+  const [data, setData] = useState<ReconHubResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [triggerLoading, setTriggerLoading] = useState(false);
 
-  const fetchBillingData = async () => {
+  const fetchHub = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
 
-      const response = await fetch('/api/admin/billing/stats');
-      if (!response.ok) {
-        throw new Error('Failed to fetch billing data');
+      const res = await fetch(
+        `/api/admin/billing/recon-hub?window=${encodeURIComponent(window)}`
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error || 'Failed to load recon hub'
+        );
       }
 
-      const data = await response.json();
-      setStats(data.stats);
-      setRecentInvoices(data.recentInvoices || []);
-      setRecentPayments(data.recentPayments || []);
+      const body = (await res.json()) as ReconHubResponse;
+      setData(body);
     } catch (err) {
-      console.error('Error fetching billing data:', err);
-      setError(err instanceof Error ? err.message : 'Failed to load billing data');
+      console.error('Error fetching recon hub:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load recon hub');
+      setData(null);
     } finally {
       setLoading(false);
     }
-  };
+  }, [window]);
 
   useEffect(() => {
-    fetchBillingData();
-  }, []);
+    fetchHub();
+  }, [fetchHub]);
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-ZA', {
-      style: 'currency',
-      currency: 'ZAR',
-    }).format(amount);
+  const handleTriggerPayNow = async () => {
+    setTriggerLoading(true);
+    try {
+      const res = await fetch('/api/admin/billing/reconciliation/trigger', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'paynow' }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          (body as { error?: string }).error || 'Failed to trigger PayNow recon'
+        );
+      }
+      await fetchHub();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to trigger PayNow recon'
+      );
+    } finally {
+      setTriggerLoading(false);
+    }
   };
 
-  const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString('en-ZA', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-    });
-  };
-
-  const getStatusBadge = (status: string) => (
-    <StatusBadge
-      status={status.charAt(0).toUpperCase() + status.slice(1)}
-      variant={INVOICE_STATUS_VARIANT[status] ?? 'neutral'}
-    />
-  );
-
-  if (loading) {
+  if (loading && !data) {
     return (
       <AdminPage>
-        <LoadingState message="Loading billing data..." />
+        <LoadingState message="Loading cash-match recon hub..." />
       </AdminPage>
     );
   }
 
-  if (error) {
+  if (error && !data) {
     return (
       <AdminPage>
-        <ErrorState title="Unable to load billing data" message={error} onRetry={fetchBillingData} />
+        <ErrorState
+          title="Unable to load recon hub"
+          message={error}
+          onRetry={fetchHub}
+        />
       </AdminPage>
     );
   }
+
+  const summary = data?.summary;
 
   return (
     <AdminPage>
       <PageHeader
-        title="Billing Dashboard"
-        subtitle="Overview of billing and revenue"
+        title="Billing"
+        subtitle="Daily cash match — NetCash completed payments to CircleTel invoices"
         actions={
           <>
-            <Button variant="outline" onClick={fetchBillingData}>
-              <PiArrowsClockwiseBold className="h-4 w-4 mr-2" />
+            <Select
+              value={window}
+              onValueChange={(value) => setWindow(value as ReconWindow)}
+            >
+              <SelectTrigger className="w-[160px]" aria-label="Recon window">
+                <SelectValue placeholder="Window" />
+              </SelectTrigger>
+              <SelectContent>
+                {WINDOW_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              variant="outline"
+              onClick={fetchHub}
+              disabled={loading || triggerLoading}
+            >
+              <PiArrowsClockwiseBold
+                className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`}
+              />
               Refresh
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleTriggerPayNow}
+              disabled={triggerLoading || loading}
+            >
+              <PiPlayBold className="h-4 w-4 mr-2" />
+              {triggerLoading ? 'Triggering…' : 'Trigger PayNow recon'}
             </Button>
             <Link href="/admin/billing/invoices">
               <Button className="bg-circleTel-orange hover:bg-circleTel-orange-dark">
@@ -158,157 +176,42 @@ export default function BillingDashboard() {
         }
       />
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard
-          label="Total Outstanding"
-          value={formatCurrency(stats?.totalOutstanding || 0)}
-          icon={<PiCurrencyDollarBold className="h-5 w-5" />}
-          subtitle={`${stats?.pendingInvoices || 0} pending invoices`}
-        />
-        <StatCard
-          label="Overdue Invoices"
-          value={stats?.overdueInvoices || 0}
-          icon={<PiWarningCircleBold className="h-5 w-5" />}
-          subtitle="Requires attention"
-        />
-        <StatCard
-          label="Collected (30 days)"
-          value={formatCurrency(stats?.collectedLast30Days || 0)}
-          icon={<PiTrendUpBold className="h-5 w-5" />}
-          subtitle={`${stats?.paidLast30Days || 0} invoices paid`}
-        />
-        <StatCard
-          label="Active Services"
-          value={stats?.activeServices || 0}
-          icon={<PiUsersBold className="h-5 w-5" />}
-          subtitle={`${stats?.activeCustomers || 0} customers`}
-        />
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <SectionCard
-          title="Recent Invoices"
-          action={
-            <Link href="/admin/billing/invoices">
-              <Button variant="ghost" size="sm">
-                View All <PiArrowRightBold className="h-4 w-4 ml-1" />
-              </Button>
-            </Link>
-          }
+      {error && data && (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
         >
-          {recentInvoices.length === 0 ? (
-            <EmptyState
-              icon={<PiFileTextBold />}
-              title="No invoices found"
-              description="New invoices will appear here once generated."
-            />
-          ) : (
-            <div className="space-y-3">
-              {recentInvoices.map((invoice) => (
-                <Link
-                  key={invoice.id}
-                  href={`/admin/billing/invoices/${invoice.id}`}
-                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="h-10 w-10 rounded-full bg-circleTel-orange/10 flex items-center justify-center">
-                      <PiFileTextBold className="h-5 w-5 text-circleTel-orange" />
-                    </div>
-                    <div>
-                      <p className="font-medium text-gray-900">{invoice.invoice_number}</p>
-                      <p className="text-sm text-gray-500">{invoice.customer_name}</p>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-semibold text-gray-900 tabular-nums">
-                      {formatCurrency(invoice.total_amount)}
-                    </p>
-                    <div className="flex items-center justify-end gap-2 mt-1">
-                      {getStatusBadge(invoice.status)}
-                      <span className="text-xs text-gray-500">Due {formatDate(invoice.due_date)}</span>
-                    </div>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          )}
-        </SectionCard>
-
-        <SectionCard
-          title="Recent Payments"
-          action={
-            <Link href="/admin/payments/transactions">
-              <Button variant="ghost" size="sm">
-                View All <PiArrowRightBold className="h-4 w-4 ml-1" />
-              </Button>
-            </Link>
-          }
-        >
-          {recentPayments.length === 0 ? (
-            <EmptyState
-              icon={<PiCheckCircleBold />}
-              title="No recent payments"
-              description="Successful payments will show up here."
-            />
-          ) : (
-            <div className="space-y-3">
-              {recentPayments.map((payment) => (
-                <div
-                  key={payment.id}
-                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="h-10 w-10 rounded-full bg-green-100 flex items-center justify-center">
-                      <PiCheckCircleBold className="h-5 w-5 text-green-600" />
-                    </div>
-                    <div>
-                      <p className="font-medium text-gray-900">{payment.customer_name}</p>
-                      <p className="text-sm text-gray-500">
-                        {payment.invoice_number} · {payment.method}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-semibold text-green-600 tabular-nums">
-                      +{formatCurrency(payment.amount)}
-                    </p>
-                    <p className="text-xs text-gray-500">{formatDate(payment.paid_at)}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </SectionCard>
-      </div>
-
-      <SectionCard title="Quick Actions">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <Link href="/admin/billing/invoices">
-            <Button variant="outline" className="w-full h-auto py-4 flex flex-col items-center gap-2">
-              <PiFileTextBold className="h-6 w-6 text-circleTel-orange" />
-              <span>Manage Invoices</span>
-            </Button>
-          </Link>
-          <Link href="/admin/billing/customers">
-            <Button variant="outline" className="w-full h-auto py-4 flex flex-col items-center gap-2">
-              <PiUsersBold className="h-6 w-6 text-blue-500" />
-              <span>Customer Billing</span>
-            </Button>
-          </Link>
-          <Link href="/admin/billing/payment-methods">
-            <Button variant="outline" className="w-full h-auto py-4 flex flex-col items-center gap-2">
-              <PiCreditCardBold className="h-6 w-6 text-green-500" />
-              <span>Payment Methods</span>
-            </Button>
-          </Link>
-          <Link href="/admin/billing/cron-logs">
-            <Button variant="outline" className="w-full h-auto py-4 flex flex-col items-center gap-2">
-              <PiClockBold className="h-6 w-6 text-purple-500" />
-              <span>Cron Logs</span>
-            </Button>
-          </Link>
+          {error}
         </div>
-      </SectionCard>
+      )}
+
+      {summary && (
+        <>
+          <DayDoneBanner
+            dayDone={summary.dayDone}
+            unmatchedCount={summary.unmatchedNetcashToCt}
+            windowLabel={windowLabel(window)}
+          />
+
+          <CashMatchStrip
+            unmatchedNetcashToCt={summary.unmatchedNetcashToCt}
+            netcashCompletedInWindow={summary.netcashCompletedInWindow}
+            netcashMatchedInWindow={summary.netcashMatchedInWindow}
+            zohoPaymentLagCount={summary.zohoPaymentLagCount}
+            paynowRecon={summary.paynowRecon}
+          />
+
+          <SecondaryKpis
+            openAr={summary.secondary.openAr}
+            collectedLast30Days={summary.secondary.collectedLast30Days}
+            activeServices={summary.secondary.activeServices}
+          />
+        </>
+      )}
+
+      <ExceptionTable exceptions={data?.exceptions ?? []} />
+
+      <DeepLinks />
     </AdminPage>
   );
 }

--- a/app/api/admin/billing/recon-hub/route.ts
+++ b/app/api/admin/billing/recon-hub/route.ts
@@ -1,0 +1,436 @@
+/**
+ * GET /api/admin/billing/recon-hub
+ *
+ * Daily cash-match hub for admin billing.
+ * Day-done = zero unmatched NetCash → CircleTel invoice (red exceptions).
+ *
+ * Query: ?window=today|yesterday|48h (default: yesterday)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { apiLogger } from '@/lib/logging';
+import { resolveReconWindow } from '@/lib/billing/recon-hub/window';
+import {
+  buildExceptionRows,
+  countUnmatchedCash,
+} from '@/lib/billing/recon-hub/build-exceptions';
+import type {
+  OpenArLike,
+  PaymentLike,
+  PaynowUnmatchedLike,
+  ReconHubResponse,
+  ReconHubSummary,
+  ReconWindow,
+} from '@/lib/billing/recon-hub/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const VALID_WINDOWS = new Set<ReconWindow>(['today', 'yesterday', '48h']);
+const EXCEPTION_CAP = 100;
+const PAYMENT_FETCH_LIMIT = 1000;
+
+type PaynowReconStatus = ReconHubSummary['paynowRecon']['status'];
+
+interface PaynowUnmatchedDetail {
+  netcashRef?: string;
+  yourRef?: string;
+  amount?: number;
+  reason?: string;
+  date?: string;
+  id?: string;
+}
+
+interface PaynowReconLoad {
+  lastRunAt: string | null;
+  status: PaynowReconStatus;
+  durationMs: number;
+  unmatchedFromLastRun: number;
+  unmatchedDetails: PaynowUnmatchedDetail[];
+}
+
+function parseWindowParam(raw: string | null): ReconWindow {
+  if (raw && VALID_WINDOWS.has(raw as ReconWindow)) {
+    return raw as ReconWindow;
+  }
+  return 'yesterday';
+}
+
+function inWindow(iso: string | null | undefined, from: string, to: string): boolean {
+  if (!iso) return false;
+  return iso >= from && iso < to;
+}
+
+function mapPaynowRunStatus(dbStatus: string | null | undefined): PaynowReconStatus {
+  if (!dbStatus) return null;
+  if (dbStatus === 'completed' || dbStatus === 'success') return 'success';
+  if (
+    dbStatus === 'completed_with_errors' ||
+    dbStatus === 'partial'
+  ) {
+    return 'partial';
+  }
+  if (dbStatus === 'running') return null;
+  return 'failed';
+}
+
+/**
+ * Load latest paynow-reconciliation cron row.
+ * Live schema uses execution_start / execution_details / duration_seconds
+ * (not started_at / result used by some older writers).
+ */
+async function loadPaynowRecon(
+  supabase: Awaited<ReturnType<typeof createClient>>
+): Promise<PaynowReconLoad> {
+  const empty: PaynowReconLoad = {
+    lastRunAt: null,
+    status: null,
+    durationMs: 0,
+    unmatchedFromLastRun: 0,
+    unmatchedDetails: [],
+  };
+
+  const { data: latestRun, error } = await supabase
+    .from('cron_execution_log')
+    .select(
+      'status, execution_start, execution_end, duration_seconds, execution_details, records_failed, records_processed'
+    )
+    .eq('job_name', 'paynow-reconciliation')
+    .order('execution_start', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    // PGRST116 = no rows; other errors log and return empty
+    if (error.code !== 'PGRST116') {
+      apiLogger.warn('[recon-hub] paynow recon log query failed', {
+        error: error.message,
+      });
+    }
+    return empty;
+  }
+
+  if (!latestRun) {
+    return empty;
+  }
+
+  const details =
+    (latestRun.execution_details as Record<string, unknown> | null) ?? {};
+  const unmatchedDetails = (details.unmatchedDetails ??
+    details.unmatched_details ??
+    []) as PaynowUnmatchedDetail[];
+  const unmatchedCount = Number(
+    details.unmatched ??
+      unmatchedDetails.length ??
+      latestRun.records_failed ??
+      0
+  );
+  const durationFromDetails = Number(details.duration_ms ?? 0);
+  const durationMs =
+    durationFromDetails ||
+    (typeof latestRun.duration_seconds === 'number'
+      ? Math.round(latestRun.duration_seconds * 1000)
+      : 0);
+
+  return {
+    lastRunAt: latestRun.execution_start ?? null,
+    status: mapPaynowRunStatus(latestRun.status),
+    durationMs,
+    unmatchedFromLastRun: Number.isFinite(unmatchedCount) ? unmatchedCount : 0,
+    unmatchedDetails: Array.isArray(unmatchedDetails) ? unmatchedDetails : [],
+  };
+}
+
+function mapPaynowUnmatched(
+  details: PaynowUnmatchedDetail[],
+  fallbackDate: string
+): PaynowUnmatchedLike[] {
+  return details.map((d, idx) => ({
+    id: d.id ?? `paynow-unmatched-${idx}-${d.netcashRef ?? d.yourRef ?? idx}`,
+    amount: Number(d.amount ?? 0),
+    date: d.date ?? fallbackDate,
+    netcashRef: d.netcashRef ?? d.yourRef ?? null,
+  }));
+}
+
+/**
+ * Pending reconciliation_queue rows are the durable store for PayNow cash
+ * that never linked to a CT invoice (paynow recon upserts here).
+ */
+async function loadPendingQueueUnmatched(
+  supabase: Awaited<ReturnType<typeof createClient>>
+): Promise<PaynowUnmatchedLike[]> {
+  const { data, error } = await supabase
+    .from('reconciliation_queue')
+    .select(
+      'id, amount, source_date, source_reference, payer_reference, created_at'
+    )
+    .eq('status', 'pending')
+    .order('source_date', { ascending: false })
+    .limit(200);
+
+  if (error) {
+    apiLogger.warn('[recon-hub] reconciliation_queue query failed', {
+      error: error.message,
+    });
+    return [];
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id as string,
+    amount: Number(row.amount ?? 0),
+    date:
+      (row.source_date as string) ||
+      (row.created_at as string) ||
+      new Date().toISOString(),
+    netcashRef:
+      (row.source_reference as string | null) ??
+      (row.payer_reference as string | null) ??
+      null,
+  }));
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response;
+
+    const { searchParams } = new URL(request.url);
+    const window = parseWindowParam(searchParams.get('window'));
+    const now = new Date();
+    const bounds = resolveReconWindow(window, now);
+    const { from: windowFrom, to: windowTo } = bounds;
+
+    const supabase = await createClient();
+    const thirtyDaysAgo = new Date(now);
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    const thirtyDaysAgoIso = thirtyDaysAgo.toISOString();
+
+    const [
+      paymentsResult,
+      paynowRecon,
+      queueUnmatched,
+      sentInvoicesResult,
+      overdueInvoicesResult,
+      paidInvoicesResult,
+      activeServicesResult,
+      failedPaymentsResult,
+      failedInvoicesResult,
+    ] = await Promise.all([
+      // NetCash completed payments — filter window in JS (completed_at preferred)
+      supabase
+        .from('payment_transactions')
+        .select(
+          'id, status, amount, reference, provider_reference, completed_at, updated_at, invoice_id, customer_invoice_id, zoho_sync_status'
+        )
+        .eq('provider', 'netcash')
+        .eq('status', 'completed')
+        .or(
+          `completed_at.gte.${windowFrom},and(completed_at.is.null,updated_at.gte.${windowFrom})`
+        )
+        .order('completed_at', { ascending: false, nullsFirst: false })
+        .limit(PAYMENT_FETCH_LIMIT),
+
+      loadPaynowRecon(supabase),
+      loadPendingQueueUnmatched(supabase),
+
+      supabase
+        .from('customer_invoices')
+        .select('id, invoice_number, amount_due, status, invoice_date, due_date')
+        .eq('status', 'sent'),
+
+      supabase
+        .from('customer_invoices')
+        .select('id, invoice_number, amount_due, status, invoice_date, due_date')
+        .eq('status', 'overdue'),
+
+      supabase
+        .from('customer_invoices')
+        .select('amount_paid, paid_at')
+        .eq('status', 'paid')
+        .gte('paid_at', thirtyDaysAgoIso),
+
+      supabase
+        .from('customer_services')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'active'),
+
+      supabase
+        .from('payment_transactions')
+        .select('id', { count: 'exact', head: true })
+        .eq('zoho_sync_status', 'failed'),
+
+      supabase
+        .from('customer_invoices')
+        .select('id', { count: 'exact', head: true })
+        .eq('zoho_sync_status', 'failed'),
+    ]);
+
+    if (paymentsResult.error) {
+      throw new Error(
+        `payment_transactions query failed: ${paymentsResult.error.message}`
+      );
+    }
+
+    const rawPayments = (paymentsResult.data ?? []).filter((p) => {
+      const ts = (p.completed_at as string | null) ?? (p.updated_at as string | null);
+      return inWindow(ts, windowFrom, windowTo);
+    });
+
+    // Join customer_invoices for number/status
+    const invoiceIds = Array.from(
+      new Set(
+        rawPayments
+          .map(
+            (p) =>
+              (p.customer_invoice_id as string | null) ??
+              (p.invoice_id as string | null)
+          )
+          .filter((id): id is string => Boolean(id))
+      )
+    );
+
+    const invoiceMap = new Map<
+      string,
+      { invoice_number: string | null; status: string | null }
+    >();
+
+    if (invoiceIds.length > 0) {
+      const { data: invoices, error: invError } = await supabase
+        .from('customer_invoices')
+        .select('id, invoice_number, status')
+        .in('id', invoiceIds);
+
+      if (invError) {
+        apiLogger.warn('[recon-hub] invoice join failed', {
+          error: invError.message,
+        });
+      } else {
+        for (const inv of invoices ?? []) {
+          invoiceMap.set(inv.id as string, {
+            invoice_number: (inv.invoice_number as string | null) ?? null,
+            status: (inv.status as string | null) ?? null,
+          });
+        }
+      }
+    }
+
+    const payments: PaymentLike[] = rawPayments.map((p) => {
+      const linkedId =
+        (p.customer_invoice_id as string | null) ??
+        (p.invoice_id as string | null) ??
+        null;
+      const inv = linkedId ? invoiceMap.get(linkedId) : undefined;
+      return {
+        id: p.id as string,
+        status: (p.status as string) ?? 'completed',
+        amount: Number(p.amount ?? 0),
+        reference:
+          (p.reference as string | null) ??
+          (p.provider_reference as string | null) ??
+          null,
+        completed_at:
+          (p.completed_at as string | null) ??
+          (p.updated_at as string | null) ??
+          null,
+        customer_invoice_id: linkedId,
+        invoice_number: inv?.invoice_number ?? null,
+        invoice_status: inv?.status ?? null,
+        zoho_sync_status: (p.zoho_sync_status as string | null) ?? null,
+      };
+    });
+
+    const netcashCompletedInWindow = payments.length;
+    const netcashMatchedInWindow = payments.filter(
+      (p) => Boolean(p.customer_invoice_id)
+    ).length;
+    const zohoPaymentLagCount = payments.filter((p) => {
+      if (!p.customer_invoice_id) return false;
+      return p.zoho_sync_status === 'pending' || p.zoho_sync_status === 'failed';
+    }).length;
+
+    // Prefer last-run unmatched details; fall back to pending queue
+    const fromLastRun = mapPaynowUnmatched(
+      paynowRecon.unmatchedDetails,
+      paynowRecon.lastRunAt ?? windowFrom
+    );
+    const paynowUnmatched: PaynowUnmatchedLike[] =
+      fromLastRun.length > 0 ? fromLastRun : queueUnmatched;
+
+    const openArRows: OpenArLike[] = [
+      ...(sentInvoicesResult.data ?? []),
+      ...(overdueInvoicesResult.data ?? []),
+    ].map((inv) => ({
+      id: inv.id as string,
+      invoice_number: (inv.invoice_number as string | null) ?? null,
+      amount: Number(inv.amount_due ?? 0),
+      status: (inv.status as string | null) ?? null,
+      date:
+        (inv.due_date as string | null) ??
+        (inv.invoice_date as string | null) ??
+        '',
+    }));
+
+    const openAr = openArRows.reduce((sum, inv) => sum + inv.amount, 0);
+    const collectedLast30Days = (paidInvoicesResult.data ?? []).reduce(
+      (sum, inv) => sum + Number(inv.amount_paid ?? 0),
+      0
+    );
+
+    const failedEntityCount =
+      (failedPaymentsResult.count ?? 0) + (failedInvoicesResult.count ?? 0);
+    let zohoHealth: ReconHubSummary['zohoBooks']['healthStatus'] = 'unknown';
+    if (!failedPaymentsResult.error && !failedInvoicesResult.error) {
+      zohoHealth = failedEntityCount > 0 ? 'degraded' : 'healthy';
+    }
+
+    const exceptionRows = buildExceptionRows({
+      payments,
+      paynowUnmatched,
+      openArInvoices: openArRows,
+    });
+
+    exceptionRows.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+    const exceptions = exceptionRows.slice(0, EXCEPTION_CAP);
+
+    const unmatchedNetcashToCt = countUnmatchedCash(exceptionRows);
+
+    const summary: ReconHubSummary = {
+      window,
+      windowFrom,
+      windowTo,
+      unmatchedNetcashToCt,
+      netcashCompletedInWindow,
+      netcashMatchedInWindow,
+      zohoPaymentLagCount,
+      dayDone: unmatchedNetcashToCt === 0,
+      paynowRecon: {
+        lastRunAt: paynowRecon.lastRunAt,
+        status: paynowRecon.status,
+        durationMs: paynowRecon.durationMs,
+        unmatchedFromLastRun: paynowRecon.unmatchedFromLastRun,
+      },
+      zohoBooks: {
+        healthStatus: zohoHealth,
+        failedEntityCount,
+      },
+      secondary: {
+        openAr,
+        collectedLast30Days,
+        activeServices: activeServicesResult.count ?? 0,
+      },
+    };
+
+    const body: ReconHubResponse = { summary, exceptions };
+    return NextResponse.json(body);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    apiLogger.error('[recon-hub] Failed to build hub response', { error: message });
+    return NextResponse.json(
+      { error: 'Failed to load recon hub' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/billing/recon-hub/route.ts
+++ b/app/api/admin/billing/recon-hub/route.ts
@@ -155,19 +155,31 @@ function mapPaynowUnmatched(
   }));
 }
 
+/** Sources that count as NetCash / PayNow for daily cash match (not EFT/cashbook). */
+const NETCASH_QUEUE_SOURCES = [
+  'netcash_paynow',
+  'netcash',
+  'paynow',
+  'netcash_debit',
+] as const;
+
 /**
  * Pending reconciliation_queue rows are the durable store for PayNow cash
  * that never linked to a CT invoice (paynow recon upserts here).
+ * Restricted to NetCash sources and optional window bounds.
  */
 async function loadPendingQueueUnmatched(
-  supabase: Awaited<ReturnType<typeof createClient>>
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  windowFrom: string,
+  windowTo: string
 ): Promise<PaynowUnmatchedLike[]> {
   const { data, error } = await supabase
     .from('reconciliation_queue')
     .select(
-      'id, amount, source_date, source_reference, payer_reference, created_at'
+      'id, amount, source_date, source_reference, payer_reference, created_at, source'
     )
     .eq('status', 'pending')
+    .in('source', [...NETCASH_QUEUE_SOURCES])
     .order('source_date', { ascending: false })
     .limit(200);
 
@@ -178,18 +190,24 @@ async function loadPendingQueueUnmatched(
     return [];
   }
 
-  return (data ?? []).map((row) => ({
-    id: row.id as string,
-    amount: Number(row.amount ?? 0),
-    date:
-      (row.source_date as string) ||
-      (row.created_at as string) ||
-      new Date().toISOString(),
-    netcashRef:
-      (row.source_reference as string | null) ??
-      (row.payer_reference as string | null) ??
-      null,
-  }));
+  return (data ?? [])
+    .map((row) => ({
+      id: row.id as string,
+      amount: Number(row.amount ?? 0),
+      date:
+        (row.source_date as string) ||
+        (row.created_at as string) ||
+        new Date().toISOString(),
+      netcashRef:
+        (row.source_reference as string | null) ??
+        (row.payer_reference as string | null) ??
+        null,
+    }))
+    .filter((row) => {
+      // source_date may be date-only (YYYY-MM-DD) — compare as ISO prefix
+      const d = row.date.length === 10 ? `${row.date}T00:00:00.000Z` : row.date;
+      return inWindow(d, windowFrom, windowTo);
+    });
 }
 
 export async function GET(request: NextRequest) {
@@ -214,6 +232,7 @@ export async function GET(request: NextRequest) {
       queueUnmatched,
       sentInvoicesResult,
       overdueInvoicesResult,
+      partialInvoicesResult,
       paidInvoicesResult,
       activeServicesResult,
       failedPaymentsResult,
@@ -234,7 +253,7 @@ export async function GET(request: NextRequest) {
         .limit(PAYMENT_FETCH_LIMIT),
 
       loadPaynowRecon(supabase),
-      loadPendingQueueUnmatched(supabase),
+      loadPendingQueueUnmatched(supabase, windowFrom, windowTo),
 
       supabase
         .from('customer_invoices')
@@ -245,6 +264,11 @@ export async function GET(request: NextRequest) {
         .from('customer_invoices')
         .select('id, invoice_number, amount_due, status, invoice_date, due_date')
         .eq('status', 'overdue'),
+
+      supabase
+        .from('customer_invoices')
+        .select('id, invoice_number, amount_due, status, invoice_date, due_date')
+        .eq('status', 'partial'),
 
       supabase
         .from('customer_invoices')
@@ -351,17 +375,21 @@ export async function GET(request: NextRequest) {
       return p.zoho_sync_status === 'pending' || p.zoho_sync_status === 'failed';
     }).length;
 
-    // Prefer last-run unmatched details; fall back to pending queue
+    // Prefer last-run unmatched details (window-filtered); fall back to pending NetCash queue
     const fromLastRun = mapPaynowUnmatched(
       paynowRecon.unmatchedDetails,
       paynowRecon.lastRunAt ?? windowFrom
-    );
+    ).filter((row) => {
+      const d = row.date.length === 10 ? `${row.date}T00:00:00.000Z` : row.date;
+      return inWindow(d, windowFrom, windowTo);
+    });
     const paynowUnmatched: PaynowUnmatchedLike[] =
       fromLastRun.length > 0 ? fromLastRun : queueUnmatched;
 
     const openArRows: OpenArLike[] = [
       ...(sentInvoicesResult.data ?? []),
       ...(overdueInvoicesResult.data ?? []),
+      ...(partialInvoicesResult.data ?? []),
     ].map((inv) => ({
       id: inv.id as string,
       invoice_number: (inv.invoice_number as string | null) ?? null,

--- a/components/admin/billing/recon/CashMatchStrip.tsx
+++ b/components/admin/billing/recon/CashMatchStrip.tsx
@@ -1,0 +1,142 @@
+import {
+  PiCheckCircleBold,
+  PiClockBold,
+  PiCurrencyCircleDollarBold,
+  PiWarningBold,
+  PiXCircleBold,
+} from 'react-icons/pi';
+import { StatCard } from '@/components/admin/shared';
+import type { ReconHubSummary } from '@/lib/billing/recon-hub/types';
+
+export interface CashMatchStripProps {
+  unmatchedNetcashToCt: number;
+  netcashCompletedInWindow: number;
+  netcashMatchedInWindow: number;
+  zohoPaymentLagCount: number;
+  paynowRecon: ReconHubSummary['paynowRecon'];
+}
+
+const PAYNOW_STATUS_LABEL: Record<
+  NonNullable<ReconHubSummary['paynowRecon']['status']>,
+  string
+> = {
+  success: 'Success',
+  partial: 'Partial',
+  failed: 'Failed',
+};
+
+function formatLastRunAt(iso: string | null): string {
+  if (!iso) return 'No runs yet';
+  return new Date(iso).toLocaleString('en-ZA', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'Africa/Johannesburg',
+  });
+}
+
+/**
+ * Primary KPI strip: unmatched cash, NetCash completed, Zoho lag, PayNow last run.
+ */
+export function CashMatchStrip({
+  unmatchedNetcashToCt,
+  netcashCompletedInWindow,
+  netcashMatchedInWindow,
+  zohoPaymentLagCount,
+  paynowRecon,
+}: CashMatchStripProps) {
+  const unmatchedClear = unmatchedNetcashToCt === 0;
+  const paynowStatus = paynowRecon.status;
+  const paynowLabel = paynowStatus
+    ? PAYNOW_STATUS_LABEL[paynowStatus]
+    : 'Unknown';
+
+  const paynowIcon =
+    paynowStatus === 'success' ? (
+      <PiCheckCircleBold className="h-5 w-5" />
+    ) : paynowStatus === 'failed' ? (
+      <PiXCircleBold className="h-5 w-5" />
+    ) : (
+      <PiClockBold className="h-5 w-5" />
+    );
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <StatCard
+        label="Unmatched NetCash→CT"
+        value={unmatchedNetcashToCt}
+        icon={
+          unmatchedClear ? (
+            <PiCheckCircleBold className="h-5 w-5" />
+          ) : (
+            <PiWarningBold className="h-5 w-5" />
+          )
+        }
+        iconBgColor={unmatchedClear ? 'bg-green-100' : 'bg-red-100'}
+        iconColor={unmatchedClear ? 'text-green-700' : 'text-red-700'}
+        subtitle={
+          unmatchedClear
+            ? 'Day-done clear'
+            : 'Needs invoice match'
+        }
+        className={
+          unmatchedClear
+            ? 'border-green-200 bg-green-50/40'
+            : 'border-red-200 bg-red-50/40'
+        }
+      />
+
+      <StatCard
+        label="NetCash completed"
+        value={netcashCompletedInWindow}
+        icon={<PiCurrencyCircleDollarBold className="h-5 w-5" />}
+        iconBgColor="bg-slate-100"
+        iconColor="text-slate-700"
+        subtitle={`${netcashMatchedInWindow} matched in window`}
+      />
+
+      <StatCard
+        label="Zoho payment sync lag"
+        value={zohoPaymentLagCount}
+        icon={<PiWarningBold className="h-5 w-5" />}
+        iconBgColor={
+          zohoPaymentLagCount > 0 ? 'bg-amber-100' : 'bg-slate-100'
+        }
+        iconColor={
+          zohoPaymentLagCount > 0 ? 'text-amber-700' : 'text-slate-600'
+        }
+        subtitle="Pending or failed sync"
+        href="/admin/integrations/zoho-books"
+        className={
+          zohoPaymentLagCount > 0
+            ? 'border-amber-200 bg-amber-50/40'
+            : undefined
+        }
+      />
+
+      <StatCard
+        label="PayNow recon last run"
+        value={paynowLabel}
+        icon={paynowIcon}
+        iconBgColor={
+          paynowStatus === 'success'
+            ? 'bg-green-100'
+            : paynowStatus === 'failed'
+              ? 'bg-red-100'
+              : paynowStatus === 'partial'
+                ? 'bg-amber-100'
+                : 'bg-slate-100'
+        }
+        iconColor={
+          paynowStatus === 'success'
+            ? 'text-green-700'
+            : paynowStatus === 'failed'
+              ? 'text-red-700'
+              : paynowStatus === 'partial'
+                ? 'text-amber-700'
+                : 'text-slate-600'
+        }
+        subtitle={formatLastRunAt(paynowRecon.lastRunAt)}
+      />
+    </div>
+  );
+}

--- a/components/admin/billing/recon/DayDoneBanner.tsx
+++ b/components/admin/billing/recon/DayDoneBanner.tsx
@@ -1,0 +1,63 @@
+import {
+  PiCheckCircleBold,
+  PiWarningCircleBold,
+} from 'react-icons/pi';
+
+export interface DayDoneBannerProps {
+  dayDone: boolean;
+  unmatchedCount: number;
+  windowLabel: string;
+}
+
+/**
+ * Day-done status banner for the cash-match recon hub.
+ * Red when unmatched NetCash→CT payments remain; green when clear.
+ */
+export function DayDoneBanner({
+  dayDone,
+  unmatchedCount,
+  windowLabel,
+}: DayDoneBannerProps) {
+  if (dayDone) {
+    return (
+      <div
+        role="status"
+        className="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 px-4 py-3"
+      >
+        <PiCheckCircleBold
+          className="mt-0.5 h-5 w-5 shrink-0 text-green-600"
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-green-800">
+            Cash matched: all NetCash completed payments have CT invoices.
+          </p>
+          <p className="mt-0.5 text-xs text-green-700">
+            Window: {windowLabel}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const countLabel =
+    unmatchedCount === 1
+      ? '1 unmatched NetCash payment needs a CT invoice'
+      : `${unmatchedCount} unmatched NetCash payments need a CT invoice`;
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3"
+    >
+      <PiWarningCircleBold
+        className="mt-0.5 h-5 w-5 shrink-0 text-red-600"
+        aria-hidden="true"
+      />
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-red-800">{countLabel}</p>
+        <p className="mt-0.5 text-xs text-red-700">Window: {windowLabel}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/billing/recon/DeepLinks.tsx
+++ b/components/admin/billing/recon/DeepLinks.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import {
+  PiArrowRightBold,
+  PiArrowsLeftRightBold,
+  PiBooksBold,
+  PiCreditCardBold,
+  PiFileTextBold,
+} from 'react-icons/pi';
+
+const LINKS = [
+  {
+    href: '/admin/finance/reconciliation',
+    title: 'Finance reconciliation',
+    description: 'Match NetCash cash to CircleTel invoices',
+    icon: PiArrowsLeftRightBold,
+  },
+  {
+    href: '/admin/integrations/zoho-books',
+    title: 'Zoho Books',
+    description: 'Payment sync health and failed entities',
+    icon: PiBooksBold,
+  },
+  {
+    href: '/admin/payments/transactions',
+    title: 'Payment transactions',
+    description: 'Browse NetCash / PayNow payment history',
+    icon: PiCreditCardBold,
+  },
+  {
+    href: '/admin/billing/invoices',
+    title: 'Invoices',
+    description: 'Open AR and invoice detail pages',
+    icon: PiFileTextBold,
+  },
+] as const;
+
+/**
+ * Deep-link cards into recon-adjacent admin surfaces.
+ */
+export function DeepLinks() {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {LINKS.map(({ href, title, description, icon: Icon }) => (
+        <Link
+          key={href}
+          href={href}
+          className="group flex items-start gap-3 rounded-lg border border-slate-200 bg-white p-4 transition-colors hover:border-circleTel-orange/40 hover:bg-orange-50/40"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-circleTel-orange/10 text-circleTel-orange">
+            <Icon className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1">
+              <p className="text-sm font-semibold text-slate-900 group-hover:text-circleTel-orange">
+                {title}
+              </p>
+              <PiArrowRightBold
+                className="h-3.5 w-3.5 shrink-0 text-slate-400 opacity-0 transition-opacity group-hover:opacity-100"
+                aria-hidden="true"
+              />
+            </div>
+            <p className="mt-0.5 text-xs text-slate-500">{description}</p>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/components/admin/billing/recon/ExceptionTable.tsx
+++ b/components/admin/billing/recon/ExceptionTable.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  PiArrowRightBold,
+  PiLinkBold,
+  PiWarningBold,
+} from 'react-icons/pi';
+import { SectionCard, StatusBadge } from '@/components/admin/shared';
+import type { StatusVariant } from '@/components/admin/shared';
+import { filterExceptions } from '@/lib/billing/recon-hub/build-exceptions';
+import type {
+  ExceptionFilter,
+  ReconExceptionRow,
+  ZohoStatus,
+} from '@/lib/billing/recon-hub/types';
+
+export interface ExceptionTableProps {
+  exceptions: ReconExceptionRow[];
+}
+
+const FILTER_CHIPS: Array<{ id: ExceptionFilter; label: string }> = [
+  { id: 'unmatched_cash', label: 'Unmatched cash' },
+  { id: 'zoho_lag', label: 'Zoho lag' },
+  { id: 'open_ar', label: 'Open AR' },
+  { id: 'all', label: 'All' },
+];
+
+const UNMATCHED_HREF = '/admin/finance/reconciliation';
+
+const ZOHO_VARIANT: Record<ZohoStatus, StatusVariant> = {
+  synced: 'success',
+  pending: 'warning',
+  failed: 'error',
+  skipped: 'neutral',
+  'n/a': 'neutral',
+};
+
+const ZOHO_LABEL: Record<ZohoStatus, string> = {
+  synced: 'Synced',
+  pending: 'Pending',
+  failed: 'Failed',
+  skipped: 'Skipped',
+  'n/a': 'N/A',
+};
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-ZA', {
+    style: 'currency',
+    currency: 'ZAR',
+    minimumFractionDigits: 2,
+  }).format(amount);
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('en-ZA', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'Africa/Johannesburg',
+  });
+}
+
+function invoiceStatusVariant(status: string | null): StatusVariant {
+  if (!status) return 'neutral';
+  const s = status.toLowerCase();
+  if (s === 'paid' || s === 'completed') return 'success';
+  if (s === 'overdue') return 'error';
+  if (s === 'partial' || s === 'sent') return 'warning';
+  if (s === 'draft' || s === 'voided' || s === 'cancelled') return 'neutral';
+  return 'info';
+}
+
+function isUnmatchedRow(row: ReconExceptionRow): boolean {
+  return (
+    row.severity === 'red' ||
+    row.reasonCode === 'no_ct_invoice' ||
+    row.reasonCode === 'paynow_unmatched'
+  );
+}
+
+/**
+ * Exception queue with client-side filter chips (default: unmatched cash).
+ */
+export function ExceptionTable({ exceptions }: ExceptionTableProps) {
+  const [filter, setFilter] = useState<ExceptionFilter>('unmatched_cash');
+
+  const rows = useMemo(
+    () => filterExceptions(exceptions, filter),
+    [exceptions, filter]
+  );
+
+  const chipCounts = useMemo(() => {
+    return {
+      unmatched_cash: filterExceptions(exceptions, 'unmatched_cash').length,
+      zoho_lag: filterExceptions(exceptions, 'zoho_lag').length,
+      open_ar: filterExceptions(exceptions, 'open_ar').length,
+      all: exceptions.length,
+    } satisfies Record<ExceptionFilter, number>;
+  }, [exceptions]);
+
+  return (
+    <SectionCard
+      title="Exceptions"
+      action={
+        <span className="text-xs font-medium text-slate-500">
+          {rows.length} shown
+        </span>
+      }
+    >
+      <div className="space-y-4">
+        <div
+          className="flex flex-wrap gap-2"
+          role="tablist"
+          aria-label="Exception filters"
+        >
+          {FILTER_CHIPS.map((chip) => {
+            const active = filter === chip.id;
+            const count = chipCounts[chip.id];
+            return (
+              <button
+                key={chip.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => setFilter(chip.id)}
+                className={
+                  active
+                    ? 'inline-flex items-center gap-1.5 rounded-full border border-circleTel-orange bg-circleTel-orange/10 px-3 py-1 text-xs font-semibold text-circleTel-orange'
+                    : 'inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600 hover:border-slate-300 hover:bg-slate-50'
+                }
+              >
+                {chip.label}
+                <span
+                  className={
+                    active
+                      ? 'rounded-full bg-circleTel-orange px-1.5 py-0.5 text-[10px] font-bold text-white'
+                      : 'rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold text-slate-600'
+                  }
+                >
+                  {count}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {rows.length === 0 ? (
+          <div className="flex items-center gap-2 rounded-lg border border-slate-100 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+            <PiWarningBold className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
+            No exceptions for this filter.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-slate-200">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 bg-slate-50">
+                  <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Date
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    NetCash ref
+                  </th>
+                  <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Amount
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    CT invoice
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Invoice status
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Zoho
+                  </th>
+                  <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Reason
+                  </th>
+                  <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Action
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {rows.map((row) => {
+                  const unmatched = isUnmatchedRow(row);
+                  const actionHref = row.href ?? (unmatched ? UNMATCHED_HREF : null);
+                  const invoiceHref =
+                    row.invoiceId != null
+                      ? row.href ?? `/admin/billing/invoices/${row.invoiceId}`
+                      : null;
+
+                  return (
+                    <tr
+                      key={`${row.kind}-${row.id}`}
+                      className="transition-colors hover:bg-slate-50"
+                    >
+                      <td className="whitespace-nowrap px-3 py-2.5 text-slate-700">
+                        {formatDate(row.date)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5 font-mono text-xs text-slate-700">
+                        {row.netcashRef || '—'}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                        {formatCurrency(row.amount)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5">
+                        {row.invoiceNumber && invoiceHref ? (
+                          <Link
+                            href={invoiceHref}
+                            className="font-medium text-circleTel-orange hover:underline"
+                          >
+                            {row.invoiceNumber}
+                          </Link>
+                        ) : (
+                          <span className="text-slate-400">—</span>
+                        )}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5">
+                        {row.invoiceStatus ? (
+                          <StatusBadge
+                            status={
+                              row.invoiceStatus.charAt(0).toUpperCase() +
+                              row.invoiceStatus.slice(1)
+                            }
+                            variant={invoiceStatusVariant(row.invoiceStatus)}
+                          />
+                        ) : (
+                          <span className="text-slate-400">—</span>
+                        )}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5">
+                        <StatusBadge
+                          status={ZOHO_LABEL[row.zohoStatus]}
+                          variant={ZOHO_VARIANT[row.zohoStatus]}
+                        />
+                      </td>
+                      <td className="max-w-[220px] px-3 py-2.5 text-xs text-slate-600">
+                        <span
+                          className={
+                            row.severity === 'red'
+                              ? 'font-medium text-red-700'
+                              : row.severity === 'amber'
+                                ? 'font-medium text-amber-700'
+                                : 'text-slate-600'
+                          }
+                        >
+                          {row.reasonLabel}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-right">
+                        {unmatched && actionHref ? (
+                          <Link
+                            href={actionHref}
+                            className="inline-flex items-center gap-1 text-xs font-semibold text-circleTel-orange hover:underline"
+                          >
+                            <PiLinkBold className="h-3.5 w-3.5" aria-hidden="true" />
+                            Match…
+                          </Link>
+                        ) : actionHref ? (
+                          <Link
+                            href={actionHref}
+                            className="inline-flex items-center gap-1 text-xs font-semibold text-slate-600 hover:text-circleTel-orange hover:underline"
+                          >
+                            Open
+                            <PiArrowRightBold className="h-3.5 w-3.5" aria-hidden="true" />
+                          </Link>
+                        ) : (
+                          <span className="text-slate-400">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </SectionCard>
+  );
+}

--- a/components/admin/billing/recon/SecondaryKpis.tsx
+++ b/components/admin/billing/recon/SecondaryKpis.tsx
@@ -1,0 +1,75 @@
+import {
+  PiCurrencyDollarBold,
+  PiFileTextBold,
+  PiUsersBold,
+} from 'react-icons/pi';
+
+export interface SecondaryKpisProps {
+  openAr: number;
+  collectedLast30Days: number;
+  activeServices: number;
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-ZA', {
+    style: 'currency',
+    currency: 'ZAR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+function formatCount(n: number): string {
+  return new Intl.NumberFormat('en-ZA').format(n);
+}
+
+/**
+ * Compact secondary KPIs (dashed cards) — open AR, collected 30d, active services.
+ * Visually subordinate to the primary CashMatchStrip.
+ */
+export function SecondaryKpis({
+  openAr,
+  collectedLast30Days,
+  activeServices,
+}: SecondaryKpisProps) {
+  const items = [
+    {
+      label: 'Open AR',
+      value: formatCurrency(openAr),
+      icon: PiFileTextBold,
+    },
+    {
+      label: 'Collected (30 days)',
+      value: formatCurrency(collectedLast30Days),
+      icon: PiCurrencyDollarBold,
+    },
+    {
+      label: 'Active services',
+      value: formatCount(activeServices),
+      icon: PiUsersBold,
+    },
+  ] as const;
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {items.map(({ label, value, icon: Icon }) => (
+        <div
+          key={label}
+          className="flex items-center gap-3 rounded-lg border border-dashed border-slate-300 bg-slate-50/60 px-4 py-3"
+        >
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-white text-slate-500 shadow-sm ring-1 ring-slate-200">
+            <Icon className="h-4 w-4" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-slate-500">
+              {label}
+            </p>
+            <p className="truncate text-base font-semibold tabular-nums text-slate-800">
+              {value}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/admin/billing/recon/index.ts
+++ b/components/admin/billing/recon/index.ts
@@ -1,0 +1,13 @@
+export { DayDoneBanner } from './DayDoneBanner';
+export type { DayDoneBannerProps } from './DayDoneBanner';
+
+export { CashMatchStrip } from './CashMatchStrip';
+export type { CashMatchStripProps } from './CashMatchStrip';
+
+export { ExceptionTable } from './ExceptionTable';
+export type { ExceptionTableProps } from './ExceptionTable';
+
+export { SecondaryKpis } from './SecondaryKpis';
+export type { SecondaryKpisProps } from './SecondaryKpis';
+
+export { DeepLinks } from './DeepLinks';

--- a/components/admin/layout/AdminHeader.tsx
+++ b/components/admin/layout/AdminHeader.tsx
@@ -144,7 +144,10 @@ const getPageInfo = (pathname: string): { title: string; description: string } =
     if (pathname.includes('/transactions')) {
       return { title: 'Transactions', description: 'View payment transactions' };
     }
-    return { title: 'Billing & Revenue', description: 'Manage billing and revenue operations' };
+    return {
+      title: 'Billing',
+      description: 'Daily cash match · NetCash → invoices → Zoho',
+    };
   }
 
   // Admin section

--- a/docs/superpowers/plans/2026-07-30-admin-billing-recon-hub.md
+++ b/docs/superpowers/plans/2026-07-30-admin-billing-recon-hub.md
@@ -1,0 +1,489 @@
+# Admin Billing Recon Hub Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-layout `/admin/billing` as a **daily cash-match recon hub** (NetCash → CT invoice primary; Zoho Books secondary) so finance can see day-done status and work an exception list without tab-hopping.
+
+**Architecture:** Single page rewrite of `app/admin/billing/page.tsx` plus small presentational components under `components/admin/billing/`. Prefer **one thin hub API** (`GET /api/admin/billing/recon-hub`) that composes existing Supabase tables + patterns from recon status / stats / Zoho health — avoids fragile multi-fetch race logic in the client. Deep-links keep Finance queue, Zoho Books admin, and Payments pages as systems of record for approve/retry.
+
+**Tech Stack:** Next.js 15 App Router, React client page, existing `components/backend` / `components/admin/shared` (PageHeader, StatCard, SectionCard, StatusBadge, AdminPage), Phosphor icons via `react-icons/pi`, admin auth via `authenticateAdmin`, Supabase service client.
+
+**Wayfinder source (decisions locked):** `.scratch/admin-billing-recon-workspace/map.md`  
+**Wireframe:** `.scratch/admin-billing-recon-workspace/assets/admin-billing-recon-hub-wireframe.html`
+
+| Decision | Lock |
+|----------|------|
+| Job | Daily cash match |
+| Home | Full hub on `/admin/billing` |
+| MVP | Status strip + exception table |
+| Day-done | **Zero unmatched NetCash→CT** (red until 0); Zoho lag = yellow |
+| Out of MVP | Bulk three-way editor, bulk Zoho retry, CSV, debit-batch UI |
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `app/api/admin/billing/recon-hub/route.ts` | **Create** — windowed hub payload (summary + exceptions) |
+| `lib/billing/recon-hub/types.ts` | **Create** — shared request/response types |
+| `lib/billing/recon-hub/build-exceptions.ts` | **Create** — pure classifiers for exception rows (unit-tested) |
+| `lib/billing/recon-hub/window.ts` | **Create** — parse window → `{ from, to }` ISO bounds (Africa/Johannesburg day optional; use UTC day bounds with documented note if TZ helper missing) |
+| `__tests__/lib/billing/recon-hub/build-exceptions.test.ts` | **Create** — pure tests for row classification |
+| `__tests__/lib/billing/recon-hub/window.test.ts` | **Create** — window parsing |
+| `components/admin/billing/recon/DayDoneBanner.tsx` | **Create** — green/red day-done banner |
+| `components/admin/billing/recon/CashMatchStrip.tsx` | **Create** — 4 primary tiles |
+| `components/admin/billing/recon/ExceptionTable.tsx` | **Create** — payment-first table + filter chips |
+| `components/admin/billing/recon/SecondaryKpis.tsx` | **Create** — compact AR / collected / services |
+| `components/admin/billing/recon/DeepLinks.tsx` | **Create** — Finance / Zoho Books / Payments / Invoices |
+| `app/admin/billing/page.tsx` | **Rewrite** — compose hub; drop old “recent invoices” as hero |
+| `components/admin/layout/AdminHeader.tsx` | **Optional** — title/description if still “Billing & Revenue” only |
+| `docs/architecture/BILLING_ENGINE.md` or short note in `docs/admin/` | **Optional** — one paragraph linking hub to recon APIs |
+
+**Do not modify in MVP:** Finance reconciliation page, Zoho Books admin (except deep-link), payment rails, billing engine ledger writers.
+
+---
+
+## Data contract
+
+### Window query
+
+`GET /api/admin/billing/recon-hub?window=today|yesterday|48h`
+
+Default: `yesterday` (matches ops “run recon on yesterday’s cash”).
+
+### Response shape
+
+```typescript
+// lib/billing/recon-hub/types.ts
+export type ReconWindow = 'today' | 'yesterday' | '48h';
+
+export type ExceptionFilter = 'unmatched_cash' | 'zoho_lag' | 'open_ar' | 'all';
+
+export interface ReconHubSummary {
+  window: ReconWindow;
+  windowFrom: string; // ISO
+  windowTo: string;
+  /** Primary day-done metric */
+  unmatchedNetcashToCt: number;
+  netcashCompletedInWindow: number;
+  netcashMatchedInWindow: number;
+  zohoPaymentLagCount: number; // pending|failed among matched payments in window
+  dayDone: boolean; // unmatchedNetcashToCt === 0
+  paynowRecon: {
+    lastRunAt: string | null;
+    status: 'success' | 'partial' | 'failed' | null;
+    durationMs: number;
+    unmatchedFromLastRun: number;
+  };
+  zohoBooks: {
+    healthStatus: 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+    failedEntityCount: number;
+  };
+  secondary: {
+    openAr: number;
+    collectedLast30Days: number;
+    activeServices: number;
+  };
+}
+
+export type ExceptionReasonCode =
+  | 'no_ct_invoice'
+  | 'paynow_unmatched'
+  | 'zoho_payment_pending'
+  | 'zoho_payment_failed'
+  | 'open_ar';
+
+export interface ReconExceptionRow {
+  id: string; // payment id or synthetic unmatched key
+  kind: 'payment' | 'paynow_unmatched' | 'invoice_ar';
+  date: string; // ISO
+  netcashRef: string | null;
+  amount: number;
+  invoiceId: string | null;
+  invoiceNumber: string | null;
+  invoiceStatus: string | null;
+  zohoStatus: 'n/a' | 'synced' | 'pending' | 'failed' | 'skipped';
+  reasonCode: ExceptionReasonCode;
+  reasonLabel: string;
+  severity: 'red' | 'amber' | 'neutral'; // red = unmatched cash
+  href: string | null; // /admin/billing/invoices/{id} or finance queue
+}
+
+export interface ReconHubResponse {
+  summary: ReconHubSummary;
+  exceptions: ReconExceptionRow[];
+}
+```
+
+### Exception classification rules (pure)
+
+| Condition | severity | reasonCode | filter chips |
+|-----------|----------|------------|--------------|
+| Completed NetCash payment, no `customer_invoice_id` / invoice link | `red` | `no_ct_invoice` | unmatched_cash, all |
+| PayNow recon last-run unmatched detail (even if no payment row) | `red` | `paynow_unmatched` | unmatched_cash, all |
+| Payment linked to invoice, `zoho_sync_status` in `pending`,`failed` | `amber` | `zoho_payment_*` | zoho_lag, all |
+| Optional: open AR invoices (`sent`/`partial`/`overdue`) with collection method — only if cheap | `neutral` | `open_ar` | open_ar, all |
+
+**Day-done:** `summary.dayDone === true` iff no `severity === 'red'` rows in window (equivalently `unmatchedNetcashToCt === 0`).
+
+### Hub API composition (server)
+
+1. Auth: `authenticateAdmin(request)`.
+2. Compute window bounds.
+3. Query `payment_transactions` where `provider = 'netcash'` and `completed_at` (or `updated_at` if completed_at null) in window; select invoice + zoho fields.
+4. Load recon status (inline same logic as `/api/admin/billing/reconciliation/status` or internal helper extract — **prefer extract shared loader** to avoid drift).
+5. Zoho: lightweight counts from `payment_transactions` failed/pending globally or window; health optional (call existing logic or skip full health and only count failed rows — YAGNI).
+6. Secondary: reuse patterns from `/api/admin/billing/stats` (open AR sum, collected 30d, active services count).
+7. Build exceptions via pure functions; return JSON.
+
+If extract of recon status is too large for one PR: **duplicate the small select** from status route once, leave TODO comment to share later (do not block ship).
+
+---
+
+### Task 1: Pure window + exception helpers (TDD)
+
+**Files:**
+- Create: `lib/billing/recon-hub/types.ts`
+- Create: `lib/billing/recon-hub/window.ts`
+- Create: `lib/billing/recon-hub/build-exceptions.ts`
+- Create: `__tests__/lib/billing/recon-hub/window.test.ts`
+- Create: `__tests__/lib/billing/recon-hub/build-exceptions.test.ts`
+
+- [ ] **Step 1: Write window tests**
+
+```typescript
+// __tests__/lib/billing/recon-hub/window.test.ts
+import { resolveReconWindow } from '@/lib/billing/recon-hub/window';
+
+describe('resolveReconWindow', () => {
+  const now = new Date('2026-07-30T12:00:00.000Z');
+
+  it('yesterday is the UTC calendar day before now', () => {
+    const w = resolveReconWindow('yesterday', now);
+    expect(w.from.startsWith('2026-07-29')).toBe(true);
+    expect(w.to.startsWith('2026-07-30')).toBe(true);
+  });
+
+  it('48h is now minus 48 hours through now', () => {
+    const w = resolveReconWindow('48h', now);
+    expect(new Date(w.to).getTime()).toBe(now.getTime());
+    expect(new Date(w.from).getTime()).toBe(now.getTime() - 48 * 3600 * 1000);
+  });
+});
+```
+
+- [ ] **Step 2: Implement `window.ts` + types; tests pass**
+
+- [ ] **Step 3: Write exception builder tests**
+
+```typescript
+// __tests__/lib/billing/recon-hub/build-exceptions.test.ts
+import { buildExceptionRows, countUnmatchedCash } from '@/lib/billing/recon-hub/build-exceptions';
+
+describe('buildExceptionRows', () => {
+  it('marks completed payment without invoice as red unmatched', () => {
+    const rows = buildExceptionRows({
+      payments: [{
+        id: 'p1',
+        status: 'completed',
+        provider: 'netcash',
+        provider_reference: 'NC-1',
+        amount: 450,
+        completed_at: '2026-07-29T10:00:00Z',
+        customer_invoice_id: null,
+        zoho_sync_status: 'pending',
+      }],
+      paynowUnmatched: [],
+      openArInvoices: [],
+    });
+    expect(rows.some((r) => r.severity === 'red' && r.reasonCode === 'no_ct_invoice')).toBe(true);
+    expect(countUnmatchedCash(rows)).toBe(1);
+  });
+
+  it('marks linked payment with failed zoho as amber only', () => {
+    const rows = buildExceptionRows({
+      payments: [{
+        id: 'p2',
+        status: 'completed',
+        provider: 'netcash',
+        provider_reference: 'NC-2',
+        amount: 450,
+        completed_at: '2026-07-29T10:00:00Z',
+        customer_invoice_id: 'inv-1',
+        invoice_number: 'INV-1',
+        invoice_status: 'paid',
+        zoho_sync_status: 'failed',
+      }],
+      paynowUnmatched: [],
+      openArInvoices: [],
+    });
+    const zoho = rows.find((r) => r.id === 'p2');
+    expect(zoho?.severity).toBe('amber');
+    expect(countUnmatchedCash(rows)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 4: Implement builders until green**
+
+```bash
+npx jest __tests__/lib/billing/recon-hub --ci --forceExit
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/billing/recon-hub __tests__/lib/billing/recon-hub
+git commit -m "feat(billing): pure recon-hub window and exception classifiers"
+```
+
+---
+
+### Task 2: Hub API route
+
+**Files:**
+- Create: `app/api/admin/billing/recon-hub/route.ts`
+- Optionally extract: `lib/billing/recon-hub/load-paynow-status.ts` from status route logic
+
+- [ ] **Step 1: Implement GET handler**
+
+```typescript
+// Sketch — fill with real Supabase selects matching Task 1 types
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) return authResult.response;
+
+  const windowParam = (new URL(request.url).searchParams.get('window') || 'yesterday') as ReconWindow;
+  const bounds = resolveReconWindow(windowParam, new Date());
+
+  // 1) payments in window (netcash)
+  // 2) paynow recon status
+  // 3) secondary stats
+  // 4) buildExceptionRows(...)
+  // 5) return ReconHubResponse
+}
+```
+
+Rules:
+- Use `createClient` from `@/lib/supabase/server` **or** same service-role pattern as `stats/route.ts` — **match the file you copy from**; do not invent a third client style in the same folder without reason. Prefer `stats/route.ts` service-role pattern for aggregations.
+- Join invoice fields: either second query `customer_invoices` by ids or select if FK embed exists.
+- Cap exceptions list at **100** rows (newest first).
+- Auth failures return existing admin 401 pattern.
+
+- [ ] **Step 2: Manual smoke (with env)**
+
+```bash
+set -a && source .env.local && set +a
+# From logged-in admin session cookie or bearer — if only cookie auth, use browser.
+# At minimum: type-check the route and unit tests still pass.
+npx jest __tests__/lib/billing/recon-hub --ci --forceExit
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/admin/billing/recon-hub lib/billing/recon-hub
+git commit -m "feat(billing): recon-hub API for admin cash-match dashboard"
+```
+
+---
+
+### Task 3: Presentational components
+
+**Files:**
+- Create: `components/admin/billing/recon/DayDoneBanner.tsx`
+- Create: `components/admin/billing/recon/CashMatchStrip.tsx`
+- Create: `components/admin/billing/recon/ExceptionTable.tsx`
+- Create: `components/admin/billing/recon/SecondaryKpis.tsx`
+- Create: `components/admin/billing/recon/DeepLinks.tsx`
+
+- [ ] **Step 1: Implement components against `ReconHubResponse` props**
+
+Follow wireframe hierarchy and existing patterns:
+
+```tsx
+// DayDoneBanner — use StatusBadge-like styling or plain Tailwind
+// dayDone true → green “Cash matched…”
+// dayDone false → red “N unmatched NetCash payments need a CT invoice”
+
+// CashMatchStrip — 4 StatCards or custom tiles
+// unmatched = primary red/green border
+// zoho lag = amber value
+
+// ExceptionTable — chips set filter client-side on props.exceptions
+// default chip: unmatched_cash (severity === 'red')
+// columns per wireframe; row link href to invoice when present
+// “Match…” for unmatched → Link to /admin/finance/reconciliation
+
+// SecondaryKpis — dashed compact strip from summary.secondary
+
+// DeepLinks — 4 outline buttons/cards
+// /admin/finance/reconciliation
+// /admin/integrations/zoho-books
+// /admin/payments/transactions
+// /admin/billing/invoices
+```
+
+Icons: Phosphor `react-icons/pi` only for UI chrome.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/admin/billing/recon
+git commit -m "feat(billing): recon hub presentational components"
+```
+
+---
+
+### Task 4: Rewrite `/admin/billing` page
+
+**Files:**
+- Modify: `app/admin/billing/page.tsx`
+
+- [ ] **Step 1: Replace dashboard fetch**
+
+```tsx
+// Fetch GET /api/admin/billing/recon-hub?window=${window}
+// State: window, data, loading, error
+// Header actions: window select, refresh, trigger recon (POST existing trigger), link invoices
+```
+
+Trigger recon: keep calling existing  
+`POST /api/admin/billing/reconciliation/trigger` (same as Finance page) then refresh hub.
+
+- [ ] **Step 2: Compose layout order**
+
+1. PageHeader  
+2. DayDoneBanner  
+3. CashMatchStrip  
+4. SecondaryKpis  
+5. ExceptionTable  
+6. DeepLinks  
+
+Remove as **hero**: old recent invoices / recent payments dual cards (optional: keep a small “Recent paid” link only — not required).
+
+- [ ] **Step 3: Loading / error**
+
+Reuse `LoadingState` / `ErrorState` from `@/components/backend`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/admin/billing/page.tsx
+git commit -m "feat(admin): billing home is daily cash-match recon hub"
+```
+
+---
+
+### Task 5: Header copy + smoke verification
+
+**Files:**
+- Modify if needed: `components/admin/layout/AdminHeader.tsx` (billing title/description)
+
+- [ ] **Step 1: Set billing header description** to something like “Daily cash match · NetCash → invoices → Zoho”
+
+- [ ] **Step 2: Verification**
+
+```bash
+npx jest __tests__/lib/billing/recon-hub --ci --forceExit
+# scoped type-check on touched files if pre-push requires it
+npm run type-check:memory   # or project scoped equivalent if too heavy
+```
+
+Manual (staging/prod admin session):
+
+| Check | Expect |
+|-------|--------|
+| Open `/admin/billing` | Day-done banner + strip + table visible |
+| Window = yesterday | Counts change vs today |
+| Unmatched > 0 | Banner red; primary tile red |
+| Unmatched = 0 | Banner green; dayDone true |
+| Zoho lag > 0, unmatched = 0 | Still green day-done; amber tile |
+| Match… / Finance link | Lands on recon queue |
+| Zoho Books link | Lands on integrations page |
+| Trigger recon | Does not 500; refresh updates last run if cron log exists |
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/admin/layout/AdminHeader.tsx
+git commit -m "chore(admin): billing header copy for cash-match hub"
+```
+
+---
+
+### Task 6: PR
+
+- [ ] **Step 1: Branch** `feat/admin-billing-recon-hub` from latest `origin/main` in a worktree (git-tree hygiene).
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "feat(admin): billing recon hub for NetCash cash-match" --body "$(cat <<'EOF'
+## Summary
+Replaces the generic /admin/billing dashboard with a daily cash-match recon hub (wayfinder map admin-billing-recon-workspace).
+
+- Day-done = zero unmatched NetCash→CT
+- Status strip + exception table (MVP)
+- Zoho lag secondary (yellow)
+- Deep-links to Finance queue, Zoho Books, Payments
+
+## Test plan
+- [ ] Unit: recon-hub window + exceptions
+- [ ] Admin smoke: banner red/green, filters, deep-links
+- [ ] Trigger recon + refresh
+
+## Spec / map
+- `.scratch/admin-billing-recon-workspace/map.md`
+- Wireframe: `.scratch/admin-billing-recon-workspace/assets/admin-billing-recon-hub-wireframe.html`
+- Plan: `docs/superpowers/plans/2026-07-30-admin-billing-recon-hub.md`
+EOF
+)"
+```
+
+---
+
+## Non-goals (do not implement in this plan)
+
+- In-page bulk match / bulk Zoho retry  
+- Full three-way side-by-side editor  
+- Debit-order batch recon UI  
+- CSV accountant export  
+- Unjani Connect rename filters  
+- Changing Finance or Zoho Books pages beyond deep-links  
+
+---
+
+## Self-review (plan writing time)
+
+| Wayfinder / wireframe requirement | Task |
+|-----------------------------------|------|
+| Daily cash match primary | 2, 4 |
+| Full hub on `/admin/billing` | 4 |
+| Status strip + exception table | 3, 4 |
+| Day-done unmatched NetCash→CT | 1, 2, 3 |
+| Zoho secondary yellow | 1, 2, 3 |
+| Deep-links | 3 |
+| Pure tests for classifiers | 1 |
+
+**Residual risks:**  
+- `completed_at` sparse on older payments → fall back to `updated_at` when status=completed.  
+- PayNow unmatched list may duplicate payment rows → de-dupe by netcashRef in builder.  
+- Empty historical queue does not block hub (unmatched can still come from payment rows + last run details).
+
+---
+
+## Execution handoff
+
+Plan saved to `docs/superpowers/plans/2026-07-30-admin-billing-recon-hub.md`.
+
+**Two execution options:**
+
+1. **Subagent-driven (recommended)** — fresh subagent per task, review between tasks  
+2. **Inline** — implement in this session with checkpoints  
+
+Say which approach (or simply **`implement`**) to start.

--- a/lib/billing/recon-hub/build-exceptions.ts
+++ b/lib/billing/recon-hub/build-exceptions.ts
@@ -1,0 +1,178 @@
+import type {
+  BuildExceptionRowsInput,
+  ExceptionFilter,
+  OpenArLike,
+  PaymentLike,
+  PaynowUnmatchedLike,
+  ReconExceptionRow,
+  ZohoStatus,
+} from './types';
+
+const INVOICE_HREF_PREFIX = '/admin/billing/invoices/';
+const UNMATCHED_HREF = '/admin/finance/reconciliation';
+
+const REASON_LABELS: Record<ReconExceptionRow['reasonCode'], string> = {
+  no_ct_invoice: 'Cash received — no CircleTel invoice',
+  paynow_unmatched: 'PayNow cash unmatched to invoice',
+  zoho_payment_pending: 'Zoho payment sync pending',
+  zoho_payment_failed: 'Zoho payment sync failed',
+  open_ar: 'Open accounts receivable',
+};
+
+function normalizeZohoStatus(raw: string | null | undefined): ZohoStatus {
+  switch (raw) {
+    case 'synced':
+    case 'pending':
+    case 'failed':
+    case 'skipped':
+      return raw;
+    default:
+      return 'n/a';
+  }
+}
+
+function invoiceHref(invoiceId: string | null): string | null {
+  return invoiceId ? `${INVOICE_HREF_PREFIX}${invoiceId}` : UNMATCHED_HREF;
+}
+
+function paymentDate(p: PaymentLike): string {
+  return p.completed_at ?? '';
+}
+
+function rowFromUnlinkedPayment(p: PaymentLike): ReconExceptionRow {
+  return {
+    id: p.id,
+    kind: 'payment',
+    date: paymentDate(p),
+    netcashRef: p.reference,
+    amount: p.amount,
+    invoiceId: null,
+    invoiceNumber: p.invoice_number ?? null,
+    invoiceStatus: p.invoice_status ?? null,
+    zohoStatus: normalizeZohoStatus(p.zoho_sync_status),
+    reasonCode: 'no_ct_invoice',
+    reasonLabel: REASON_LABELS.no_ct_invoice,
+    severity: 'red',
+    href: invoiceHref(null),
+  };
+}
+
+function rowFromZohoLagPayment(p: PaymentLike): ReconExceptionRow | null {
+  const zoho = normalizeZohoStatus(p.zoho_sync_status);
+  if (zoho !== 'pending' && zoho !== 'failed') {
+    return null;
+  }
+
+  const reasonCode = zoho === 'failed' ? 'zoho_payment_failed' : 'zoho_payment_pending';
+
+  return {
+    id: p.id,
+    kind: 'payment',
+    date: paymentDate(p),
+    netcashRef: p.reference,
+    amount: p.amount,
+    invoiceId: p.customer_invoice_id,
+    invoiceNumber: p.invoice_number ?? null,
+    invoiceStatus: p.invoice_status ?? null,
+    zohoStatus: zoho,
+    reasonCode,
+    reasonLabel: REASON_LABELS[reasonCode],
+    severity: 'amber',
+    href: invoiceHref(p.customer_invoice_id),
+  };
+}
+
+function rowFromPaynowUnmatched(u: PaynowUnmatchedLike): ReconExceptionRow {
+  return {
+    id: u.id,
+    kind: 'paynow_unmatched',
+    date: u.date,
+    netcashRef: u.netcashRef,
+    amount: u.amount,
+    invoiceId: null,
+    invoiceNumber: null,
+    invoiceStatus: null,
+    zohoStatus: 'n/a',
+    reasonCode: 'paynow_unmatched',
+    reasonLabel: REASON_LABELS.paynow_unmatched,
+    severity: 'red',
+    href: UNMATCHED_HREF,
+  };
+}
+
+function rowFromOpenAr(inv: OpenArLike): ReconExceptionRow {
+  return {
+    id: inv.id,
+    kind: 'invoice_ar',
+    date: inv.date,
+    netcashRef: null,
+    amount: inv.amount,
+    invoiceId: inv.id,
+    invoiceNumber: inv.invoice_number,
+    invoiceStatus: inv.status,
+    zohoStatus: 'n/a',
+    reasonCode: 'open_ar',
+    reasonLabel: REASON_LABELS.open_ar,
+    severity: 'neutral',
+    href: invoiceHref(inv.id),
+  };
+}
+
+/**
+ * Classify payments, unmatched PayNow cash, and open AR into exception rows.
+ *
+ * Red  = unmatched cash (day-done blocker)
+ * Amber = Zoho lag on linked payments (secondary)
+ * Neutral = open AR (optional queue)
+ */
+export function buildExceptionRows(input: BuildExceptionRowsInput): ReconExceptionRow[] {
+  const rows: ReconExceptionRow[] = [];
+
+  for (const payment of input.payments) {
+    if (payment.status !== 'completed') {
+      continue;
+    }
+
+    if (!payment.customer_invoice_id) {
+      rows.push(rowFromUnlinkedPayment(payment));
+      continue;
+    }
+
+    const zohoRow = rowFromZohoLagPayment(payment);
+    if (zohoRow) {
+      rows.push(zohoRow);
+    }
+  }
+
+  for (const unmatched of input.paynowUnmatched) {
+    rows.push(rowFromPaynowUnmatched(unmatched));
+  }
+
+  for (const inv of input.openArInvoices) {
+    rows.push(rowFromOpenAr(inv));
+  }
+
+  return rows;
+}
+
+/** Day-done metric: count of red (unmatched cash) exception rows. */
+export function countUnmatchedCash(rows: ReconExceptionRow[]): number {
+  return rows.filter((r) => r.severity === 'red').length;
+}
+
+export function filterExceptions(
+  rows: ReconExceptionRow[],
+  filter: ExceptionFilter
+): ReconExceptionRow[] {
+  switch (filter) {
+    case 'unmatched_cash':
+      return rows.filter((r) => r.severity === 'red');
+    case 'zoho_lag':
+      return rows.filter((r) => r.severity === 'amber');
+    case 'open_ar':
+      return rows.filter((r) => r.reasonCode === 'open_ar');
+    case 'all':
+    default:
+      return rows;
+  }
+}

--- a/lib/billing/recon-hub/types.ts
+++ b/lib/billing/recon-hub/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure types for the admin billing recon hub (cash-match day board).
+ * No runtime deps — safe for client or server imports.
+ */
+
+export type ReconWindow = 'today' | 'yesterday' | '48h';
+
+export type ExceptionFilter = 'unmatched_cash' | 'zoho_lag' | 'open_ar' | 'all';
+
+export type ExceptionReasonCode =
+  | 'no_ct_invoice'
+  | 'paynow_unmatched'
+  | 'zoho_payment_pending'
+  | 'zoho_payment_failed'
+  | 'open_ar';
+
+export type ExceptionSeverity = 'red' | 'amber' | 'neutral';
+
+export type ExceptionKind = 'payment' | 'paynow_unmatched' | 'invoice_ar';
+
+export type ZohoStatus = 'n/a' | 'synced' | 'pending' | 'failed' | 'skipped';
+
+export interface ReconExceptionRow {
+  id: string;
+  kind: ExceptionKind;
+  date: string;
+  netcashRef: string | null;
+  amount: number;
+  invoiceId: string | null;
+  invoiceNumber: string | null;
+  invoiceStatus: string | null;
+  zohoStatus: ZohoStatus;
+  reasonCode: ExceptionReasonCode;
+  reasonLabel: string;
+  severity: ExceptionSeverity;
+  href: string | null;
+}
+
+/** Payment-shaped input (subset of payment_transactions + optional invoice join). */
+export interface PaymentLike {
+  id: string;
+  status: string;
+  amount: number;
+  /** NetCash / provider reference */
+  reference: string | null;
+  completed_at: string | null;
+  customer_invoice_id: string | null;
+  invoice_number?: string | null;
+  invoice_status?: string | null;
+  zoho_sync_status?: string | null;
+}
+
+/** Unmatched PayNow / NetCash cash detail that never linked to a CT invoice. */
+export interface PaynowUnmatchedLike {
+  id: string;
+  amount: number;
+  date: string;
+  netcashRef: string | null;
+}
+
+/** Open accounts-receivable invoice (optional secondary queue). */
+export interface OpenArLike {
+  id: string;
+  invoice_number: string | null;
+  amount: number;
+  status: string | null;
+  date: string;
+}
+
+export interface BuildExceptionRowsInput {
+  payments: PaymentLike[];
+  paynowUnmatched: PaynowUnmatchedLike[];
+  openArInvoices: OpenArLike[];
+}
+
+export interface ReconWindowBounds {
+  from: string;
+  to: string;
+}

--- a/lib/billing/recon-hub/types.ts
+++ b/lib/billing/recon-hub/types.ts
@@ -77,3 +77,35 @@ export interface ReconWindowBounds {
   from: string;
   to: string;
 }
+
+/** Summary KPI block for GET /api/admin/billing/recon-hub */
+export interface ReconHubSummary {
+  window: ReconWindow;
+  windowFrom: string;
+  windowTo: string;
+  unmatchedNetcashToCt: number;
+  netcashCompletedInWindow: number;
+  netcashMatchedInWindow: number;
+  zohoPaymentLagCount: number;
+  dayDone: boolean;
+  paynowRecon: {
+    lastRunAt: string | null;
+    status: 'success' | 'partial' | 'failed' | null;
+    durationMs: number;
+    unmatchedFromLastRun: number;
+  };
+  zohoBooks: {
+    healthStatus: 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+    failedEntityCount: number;
+  };
+  secondary: {
+    openAr: number;
+    collectedLast30Days: number;
+    activeServices: number;
+  };
+}
+
+export interface ReconHubResponse {
+  summary: ReconHubSummary;
+  exceptions: ReconExceptionRow[];
+}

--- a/lib/billing/recon-hub/window.ts
+++ b/lib/billing/recon-hub/window.ts
@@ -1,0 +1,39 @@
+import type { ReconWindow, ReconWindowBounds } from './types';
+
+function utcMidnight(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+/**
+ * Resolve inclusive-start / exclusive-end ISO bounds for a recon window.
+ *
+ * - today: UTC calendar day of `now` [00:00, next midnight)
+ * - yesterday: UTC calendar day before today
+ * - 48h: [now - 48h, now] (inclusive end as exact `now` ISO)
+ */
+export function resolveReconWindow(window: ReconWindow, now: Date): ReconWindowBounds {
+  if (window === '48h') {
+    const from = new Date(now.getTime() - 48 * 3600 * 1000);
+    return {
+      from: from.toISOString(),
+      to: now.toISOString(),
+    };
+  }
+
+  const todayStart = utcMidnight(now);
+
+  if (window === 'today') {
+    const tomorrowStart = new Date(todayStart.getTime() + 24 * 3600 * 1000);
+    return {
+      from: todayStart.toISOString(),
+      to: tomorrowStart.toISOString(),
+    };
+  }
+
+  // yesterday
+  const yesterdayStart = new Date(todayStart.getTime() - 24 * 3600 * 1000);
+  return {
+    from: yesterdayStart.toISOString(),
+    to: todayStart.toISOString(),
+  };
+}

--- a/lib/inngest/functions/paynow-reconciliation.ts
+++ b/lib/inngest/functions/paynow-reconciliation.ts
@@ -106,7 +106,7 @@ export const paynowReconciliationFunction = inngest.createFunction(
           .from('cron_execution_log')
           .update({
             status: 'running',
-            started_at: new Date().toISOString(),
+            execution_start: new Date().toISOString(),
           })
           .eq('id', eventData.process_log_id);
 
@@ -129,8 +129,10 @@ export const paynowReconciliationFunction = inngest.createFunction(
         .insert({
           job_name: 'paynow-reconciliation',
           status: 'running',
-          started_at: new Date().toISOString(),
-          result: {
+          execution_start: new Date().toISOString(),
+          trigger_source: triggeredBy === 'manual' ? 'manual' : 'cron',
+          triggered_by: adminUserId || null,
+          execution_details: {
             triggered_by: triggeredBy,
             triggered_by_user_id: adminUserId || null,
             reconciliation_date: dateStr,
@@ -185,16 +187,18 @@ export const paynowReconciliationFunction = inngest.createFunction(
 
       await step.run('finalize-log-no-statement', async () => {
         const supabase = await createClient();
+        const durationMsNoStmt = Date.now() - startTime;
         await supabase
           .from('cron_execution_log')
           .update({
             status: 'completed_with_errors',
-            completed_at: new Date().toISOString(),
-            result: {
+            execution_end: new Date().toISOString(),
+            duration_seconds: Math.round(durationMsNoStmt / 1000),
+            execution_details: {
               reconciliation_date: dateStr,
               statement_fetched: false,
               errors: [errorMsg],
-              duration_ms: Date.now() - startTime,
+              duration_ms: durationMsNoStmt,
             },
           })
           .eq('id', processLogId);
@@ -472,13 +476,17 @@ export const paynowReconciliationFunction = inngest.createFunction(
         .from('cron_execution_log')
         .update({
           status: finalStatus,
-          completed_at: new Date().toISOString(),
-          result: {
+          execution_end: new Date().toISOString(),
+          duration_seconds: Math.round(duration / 1000),
+          records_processed: processingResult.total_transactions ?? null,
+          records_failed: processingResult.unmatched ?? null,
+          execution_details: {
             reconciliation_date: dateStr,
             statement_fetched: true,
             dry_run: dryRun,
             ...processingResult,
             duration_ms: duration,
+            unmatchedDetails: processingResult.unmatched_details ?? processingResult.unmatchedDetails ?? [],
           },
         })
         .eq('id', processLogId);
@@ -593,8 +601,9 @@ export const paynowReconciliationFailedFunction = inngest.createFunction(
         .from('cron_execution_log')
         .update({
           status: 'failed',
-          completed_at: new Date().toISOString(),
-          result: {
+          execution_end: new Date().toISOString(),
+          error_message: typeof error === 'string' ? error : String(error),
+          execution_details: {
             error,
             failed_attempt: attempt,
           },

--- a/lib/inngest/functions/paynow-reconciliation.ts
+++ b/lib/inngest/functions/paynow-reconciliation.ts
@@ -486,7 +486,12 @@ export const paynowReconciliationFunction = inngest.createFunction(
             dry_run: dryRun,
             ...processingResult,
             duration_ms: duration,
-            unmatchedDetails: processingResult.unmatched_details ?? processingResult.unmatchedDetails ?? [],
+            // unmatchedDetails may be present at runtime on processingResult extras
+            unmatchedDetails:
+              (processingResult as { unmatched_details?: unknown; unmatchedDetails?: unknown })
+                .unmatched_details ??
+              (processingResult as { unmatchedDetails?: unknown }).unmatchedDetails ??
+              [],
           },
         })
         .eq('id', processLogId);


### PR DESCRIPTION
## Summary

Replaces the generic `/admin/billing` dashboard with a **daily cash-match recon hub** (wayfinder map `admin-billing-recon-workspace`).

- **Day-done** = zero unmatched NetCash → CT invoice (red until clear)
- Status strip + exception table (MVP)
- Zoho lag secondary (amber)
- Deep-links to Finance queue, Zoho Books, Payments, Invoices
- `GET /api/admin/billing/recon-hub?window=today|yesterday|48h`

## Test plan

- [x] Unit: recon-hub window + exceptions (15 tests)
- [x] Scoped type-check on push (clean)
- [ ] Admin smoke: banner red/green, filters, deep-links
- [ ] Trigger PayNow recon + refresh

## Spec / plan

- `.scratch/admin-billing-recon-workspace/map.md` (local)
- Plan: `docs/superpowers/plans/2026-07-30-admin-billing-recon-hub.md`
- Wireframe: `.scratch/admin-billing-recon-workspace/assets/admin-billing-recon-hub-wireframe.html`

## Notes from implement

- Maps `invoice_id ?? customer_invoice_id` for live payment rows
- PayNow unmatched falls back to pending `reconciliation_queue` when cron log details empty
- Existing recon status route may still use older cron_execution_log column names — hub uses live schema