### PR TITLE
style(admin): billing + AR analytics onto network console look

### DIFF
--- a/app/admin/billing/page.tsx
+++ b/app/admin/billing/page.tsx
@@ -4,10 +4,12 @@ import React, { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
   PiArrowsClockwiseBold,
+  PiClockBold,
   PiFileTextBold,
   PiPlayBold,
 } from 'react-icons/pi';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
@@ -17,7 +19,6 @@ import {
 } from '@/components/ui/select';
 import {
   AdminPage,
-  PageHeader,
   LoadingState,
   ErrorState,
 } from '@/components/backend';
@@ -128,62 +129,70 @@ export default function BillingDashboard() {
 
   return (
     <AdminPage>
-      <PageHeader
-        title="Billing"
-        subtitle="Daily cash match — NetCash completed payments to CircleTel invoices"
-        actions={
-          <>
-            <Select
-              value={window}
-              onValueChange={(value) => setWindow(value as ReconWindow)}
-            >
-              <SelectTrigger className="w-[160px]" aria-label="Recon window">
-                <SelectValue placeholder="Window" />
-              </SelectTrigger>
-              <SelectContent>
-                {WINDOW_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Button
-              variant="outline"
-              onClick={fetchHub}
-              disabled={loading || triggerLoading}
-            >
-              <PiArrowsClockwiseBold
-                className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`}
-              />
-              Refresh
-            </Button>
-            <Button
-              variant="outline"
-              onClick={handleTriggerPayNow}
-              disabled={triggerLoading || loading}
-            >
-              <PiPlayBold className="h-4 w-4 mr-2" />
-              {triggerLoading ? 'Triggering…' : 'Trigger PayNow recon'}
-            </Button>
+      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+        <div>
+          <p className="text-xs text-slate-400 mb-1">Finance / Billing / Cash Match</p>
+          <h1 className="text-2xl font-semibold text-slate-900 tracking-tight">Billing</h1>
+          <p className="text-slate-500 mt-1 text-sm">
+            Daily cash match — NetCash completed payments to CircleTel invoices
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={window} onValueChange={(value) => setWindow(value as ReconWindow)}>
+            <SelectTrigger className="w-[160px] rounded-lg border-slate-200" aria-label="Recon window">
+              <SelectValue placeholder="Window" />
+            </SelectTrigger>
+            <SelectContent>
+              {WINDOW_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="sm" onClick={fetchHub} disabled={loading || triggerLoading}>
+            <PiArrowsClockwiseBold className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleTriggerPayNow}
+            disabled={triggerLoading || loading}
+          >
+            <PiPlayBold className="w-4 h-4 mr-2" />
+            {triggerLoading ? 'Triggering…' : 'Trigger PayNow recon'}
+          </Button>
+          <Button size="sm" className="bg-circleTel-orange hover:bg-circleTel-orange-dark" asChild>
             <Link href="/admin/billing/invoices">
-              <Button className="bg-circleTel-orange hover:bg-circleTel-orange-dark">
-                <PiFileTextBold className="h-4 w-4 mr-2" />
-                View All Invoices
-              </Button>
+              <PiFileTextBold className="w-4 h-4 mr-2" />
+              View All Invoices
             </Link>
-          </>
-        }
-      />
+          </Button>
+        </div>
+      </div>
 
       {error && data && (
         <div
           role="alert"
-          className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
+          className="rounded-xl border border-red-200/80 bg-red-50/80 shadow-sm px-4 py-3 text-sm text-red-800"
         >
           {error}
         </div>
       )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-600">
+          Supabase recon hub
+        </Badge>
+        <span className="text-xs text-slate-400">Window · {windowLabel(window)}</span>
+        {summary ? (
+          <span className="text-xs text-slate-500">
+            {summary.netcashCompletedInWindow} NetCash completed ·{' '}
+            {summary.netcashMatchedInWindow} matched
+          </span>
+        ) : null}
+      </div>
 
       {summary && (
         <>
@@ -212,6 +221,13 @@ export default function BillingDashboard() {
       <ExceptionTable exceptions={data?.exceptions ?? []} />
 
       <DeepLinks />
+
+      <div className="flex flex-wrap items-center justify-end gap-3 text-sm text-slate-500">
+        <span className="inline-flex items-center gap-2">
+          <PiClockBold className="w-4 h-4" aria-hidden="true" />
+          {loading ? 'Refreshing…' : `Recon window · ${windowLabel(window)}`}
+        </span>
+      </div>
     </AdminPage>
   );
 }

--- a/app/admin/billing/page.tsx
+++ b/app/admin/billing/page.tsx
@@ -172,15 +172,6 @@ export default function BillingDashboard() {
         </div>
       </div>
 
-      {error && data && (
-        <div
-          role="alert"
-          className="rounded-xl border border-red-200/80 bg-red-50/80 shadow-sm px-4 py-3 text-sm text-red-800"
-        >
-          {error}
-        </div>
-      )}
-
       <div className="flex flex-wrap items-center gap-2">
         <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-600">
           Supabase recon hub
@@ -193,6 +184,15 @@ export default function BillingDashboard() {
           </span>
         ) : null}
       </div>
+
+      {error && data && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-200/80 bg-red-50/80 shadow-sm px-4 py-3 text-sm text-red-800"
+        >
+          {error}
+        </div>
+      )}
 
       {summary && (
         <>

--- a/app/admin/finance/ar-analytics/page.tsx
+++ b/app/admin/finance/ar-analytics/page.tsx
@@ -3,10 +3,17 @@
 import { useEffect, useState } from 'react';
 import { PiArrowsClockwiseBold, PiClockBold, PiCurrencyDollarBold, PiPulseBold, PiTargetBold } from 'react-icons/pi';
 import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { AdminPage, PageHeader, LoadingState, ErrorState } from '@/components/backend';
+import {
+  AdminPage,
+  LoadingState,
+  ErrorState,
+  Tabs,
+  ConsoleTabsList,
+  ConsoleTabsContent,
+} from '@/components/backend';
 import {
   ArAgingPanel,
   DsoMetricsPanel,
@@ -76,28 +83,45 @@ export default function ARAnalyticsPage() {
 
   return (
     <AdminPage>
-      <PageHeader
-        title="AR Analytics & Collections"
-        subtitle="Accounts Receivable, DSO tracking, and notification effectiveness"
-        actions={
-          <div className="flex items-center gap-2">
-            <Select value={period} onValueChange={setPeriod}>
-              <SelectTrigger className="w-32">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="7">7 Days</SelectItem>
-                <SelectItem value="30">30 Days</SelectItem>
-                <SelectItem value="60">60 Days</SelectItem>
-                <SelectItem value="90">90 Days</SelectItem>
-              </SelectContent>
-            </Select>
-            <Button variant="outline" size="icon" onClick={handleRefresh} disabled={refreshing}>
-              <PiArrowsClockwiseBold className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
-            </Button>
-          </div>
-        }
-      />
+      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+        <div>
+          <p className="text-xs text-slate-400 mb-1">Finance / Receivables / AR Analytics</p>
+          <h1 className="text-2xl font-semibold text-slate-900 tracking-tight">
+            AR Analytics &amp; Collections
+          </h1>
+          <p className="text-slate-500 mt-1 text-sm">
+            Accounts Receivable, DSO tracking, and notification effectiveness
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={period} onValueChange={setPeriod}>
+            <SelectTrigger className="w-[140px] rounded-lg border-slate-200" aria-label="Reporting period">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="7">Last 7 days</SelectItem>
+              <SelectItem value="30">Last 30 days</SelectItem>
+              <SelectItem value="60">Last 60 days</SelectItem>
+              <SelectItem value="90">Last 90 days</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing}>
+            <PiArrowsClockwiseBold className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-600">
+          Supabase AR snapshot
+        </Badge>
+        <span className="text-xs text-slate-400">Last {period} days</span>
+        <span className="text-xs text-slate-500">
+          {data.ar_aging.total_outstanding_invoices} open invoices ·{' '}
+          {formatCurrency(data.ar_aging.total_outstanding_amount)} outstanding
+        </span>
+      </div>
 
       {/* KPI Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -175,28 +199,35 @@ export default function ARAnalyticsPage() {
         </Card>
       </div>
 
-      {/* Tabs */}
       <Tabs defaultValue="aging" className="space-y-4">
-        <TabsList>
-          <TabsTrigger value="aging">AR Aging</TabsTrigger>
-          <TabsTrigger value="dso">DSO &amp; Metrics</TabsTrigger>
-          <TabsTrigger value="notifications">Notifications</TabsTrigger>
-          <TabsTrigger value="history">History</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="aging" className="space-y-4">
+        <ConsoleTabsList
+          items={[
+            { value: 'aging', label: 'AR Aging' },
+            { value: 'dso', label: 'DSO & Metrics' },
+            { value: 'notifications', label: 'Notifications' },
+            { value: 'history', label: 'History' },
+          ]}
+        />
+        <ConsoleTabsContent value="aging">
           <ArAgingPanel data={data} />
-        </TabsContent>
-        <TabsContent value="dso" className="space-y-4">
+        </ConsoleTabsContent>
+        <ConsoleTabsContent value="dso">
           <DsoMetricsPanel data={data} />
-        </TabsContent>
-        <TabsContent value="notifications" className="space-y-4">
+        </ConsoleTabsContent>
+        <ConsoleTabsContent value="notifications">
           <NotificationsPanel data={data} />
-        </TabsContent>
-        <TabsContent value="history" className="space-y-4">
+        </ConsoleTabsContent>
+        <ConsoleTabsContent value="history">
           <HistoryPanel data={data} />
-        </TabsContent>
+        </ConsoleTabsContent>
       </Tabs>
+
+      <div className="flex flex-wrap items-center justify-end gap-3 text-sm text-slate-500">
+        <span className="inline-flex items-center gap-2">
+          <PiClockBold className="w-4 h-4" aria-hidden="true" />
+          {refreshing ? 'Refreshing…' : `AR snapshot · last ${period} days`}
+        </span>
+      </div>
     </AdminPage>
   );
 }

--- a/app/admin/finance/ar-analytics/page.tsx
+++ b/app/admin/finance/ar-analytics/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { PiArrowsClockwiseBold, PiClockBold, PiCurrencyDollarBold, PiPulseBold, PiTargetBold } from 'react-icons/pi';
-import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -10,6 +9,7 @@ import {
   AdminPage,
   LoadingState,
   ErrorState,
+  MetricCard,
   Tabs,
   ConsoleTabsList,
   ConsoleTabsContent,
@@ -124,79 +124,41 @@ export default function ARAnalyticsPage() {
       </div>
 
       {/* KPI Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        {/* Total Outstanding */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription className="flex items-center gap-2">
-              <PiCurrencyDollarBold className="h-4 w-4" />
-              Total Outstanding
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-primary">
-              {formatCurrency(data.ar_aging.total_outstanding_amount)}
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {data.ar_aging.total_outstanding_invoices} invoices
-            </p>
-          </CardContent>
-        </Card>
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <MetricCard
+          title="Total Outstanding"
+          value={formatCurrency(data.ar_aging.total_outstanding_amount)}
+          subtitle={`${data.ar_aging.total_outstanding_invoices} invoices`}
+        >
+          <PiCurrencyDollarBold className="w-5 h-5 text-amber-600" aria-hidden="true" />
+        </MetricCard>
 
-        {/* DSO */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription className="flex items-center gap-2">
-              <PiClockBold className="h-4 w-4" />
-              Days Sales Outstanding
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center gap-2">
-              <span className="text-2xl font-bold">{data.dso.dso_current.toFixed(1)}</span>
-              <TrendIcon trend={data.dso.dso_trend} />
-            </div>
-            <p className="text-sm text-muted-foreground">
-              30-day avg: {data.dso.dso_30_day_avg.toFixed(1)} days
-            </p>
-          </CardContent>
-        </Card>
+        <MetricCard
+          title="Days Sales Outstanding"
+          value={data.dso.dso_current.toFixed(1)}
+          subtitle={`30-day avg: ${data.dso.dso_30_day_avg.toFixed(1)} days`}
+        >
+          <span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+            <TrendIcon trend={data.dso.dso_trend} />
+            <span className="capitalize">{data.dso.dso_trend}</span>
+          </span>
+        </MetricCard>
 
-        {/* Collection Rate */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription className="flex items-center gap-2">
-              <PiTargetBold className="h-4 w-4" />
-              Collection Rate
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-green-600">
-              {data.collection.collection_rate.toFixed(1)}%
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {formatCurrency(data.collection.total_amount_collected)} collected
-            </p>
-          </CardContent>
-        </Card>
+        <MetricCard
+          title="Collection Rate"
+          value={`${data.collection.collection_rate.toFixed(1)}%`}
+          subtitle={`${formatCurrency(data.collection.total_amount_collected)} collected`}
+        >
+          <PiTargetBold className="w-5 h-5 text-emerald-600" aria-hidden="true" />
+        </MetricCard>
 
-        {/* Notifications Sent */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription className="flex items-center gap-2">
-              <PiPulseBold className="h-4 w-4" />
-              Notifications Sent
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">
-              {data.notifications.total_sms + data.notifications.total_email}
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {data.notifications.delivery_rate.toFixed(1)}% delivery rate
-            </p>
-          </CardContent>
-        </Card>
+        <MetricCard
+          title="Notifications Sent"
+          value={`${data.notifications.total_sms + data.notifications.total_email}`}
+          subtitle={`${data.notifications.delivery_rate.toFixed(1)}% delivery rate`}
+        >
+          <PiPulseBold className="w-5 h-5 text-blue-600" aria-hidden="true" />
+        </MetricCard>
       </div>
 
       <Tabs defaultValue="aging" className="space-y-4">

--- a/app/admin/finance/ar-analytics/page.tsx
+++ b/app/admin/finance/ar-analytics/page.tsx
@@ -124,7 +124,7 @@ export default function ARAnalyticsPage() {
       </div>
 
       {/* KPI Cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <MetricCard
           title="Total Outstanding"
           value={formatCurrency(data.ar_aging.total_outstanding_amount)}

--- a/app/admin/finance/ar-analytics/page.tsx
+++ b/app/admin/finance/ar-analytics/page.tsx
@@ -1,18 +1,21 @@
 'use client';
-import { PiArrowsClockwiseBold, PiCalendarBold, PiChatBold, PiCheckCircleBold, PiClockBold, PiCurrencyDollarBold, PiEnvelopeBold, PiMinusBold, PiPulseBold, PiTargetBold, PiTrendDownBold, PiTrendUpBold, PiWarningBold, PiXCircleBold } from 'react-icons/pi';
 
+import { useEffect, useState } from 'react';
+import { PiArrowsClockwiseBold, PiClockBold, PiCurrencyDollarBold, PiPulseBold, PiTargetBold } from 'react-icons/pi';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AdminPage, PageHeader, LoadingState, ErrorState } from '@/components/backend';
 import {
-  AdminPage,
-  PageHeader,
-  StatCard,
-  SectionCard,
-  StatusBadge,
-  LoadingState,
-  EmptyState,
-  ErrorState,
-  type StatusVariant,
-} from '@/components/backend';
-
+  ArAgingPanel,
+  DsoMetricsPanel,
+  HistoryPanel,
+  NotificationsPanel,
+  TrendIcon,
+  formatCurrency,
+  type ARAnalyticsData,
+} from '@/components/admin/finance/ar';
 
 /**
  * AR Analytics Dashboard
@@ -24,121 +27,6 @@ import {
  * - Notification tracking and effectiveness
  * - Collection performance
  */
-
-import { useEffect, useState } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
-  LineChart,
-  Line,
-  Legend,
-  AreaChart,
-  Area,
-} from 'recharts';
-
-// Types
-interface ARAnalyticsData {
-  ar_aging: {
-    total_outstanding_invoices: number;
-    total_outstanding_amount: number;
-    current_count: number;
-    current_amount: number;
-    overdue_1_30_count: number;
-    overdue_1_30_amount: number;
-    overdue_31_60_count: number;
-    overdue_31_60_amount: number;
-    overdue_61_90_count: number;
-    overdue_61_90_amount: number;
-    overdue_90_plus_count: number;
-    overdue_90_plus_amount: number;
-    avg_days_overdue: number;
-  };
-  dso: {
-    dso_current: number;
-    dso_30_day_avg: number;
-    dso_trend: 'improving' | 'stable' | 'worsening';
-    best_possible_dso: number;
-    collection_effectiveness_index: number;
-  };
-  collection: {
-    total_notifications_sent: number;
-    total_amount_collected: number;
-    collection_rate: number;
-    avg_days_to_payment: number;
-    response_rate: number;
-  };
-  notifications: {
-    total_sms: number;
-    total_email: number;
-    total_delivered: number;
-    total_failed: number;
-    delivery_rate: number;
-  };
-  daily_analytics: Array<{
-    date: string;
-    notification_type: string;
-    total_sent: number;
-    delivered: number;
-    failed: number;
-    total_amount_notified: number;
-  }>;
-  recent_notifications: Array<{
-    id: string;
-    invoice_number: string;
-    notification_type: string;
-    recipient: string;
-    status: string;
-    amount_due: number;
-    days_overdue: number;
-    created_at: string;
-  }>;
-  historical: Array<{
-    snapshot_date: string;
-    total_outstanding: number;
-    dso_current: number;
-    sms_sent_count: number;
-    email_sent_count: number;
-    payments_received_amount: number;
-  }> | null;
-}
-
-const COLORS = {
-  current: '#22c55e',
-  overdue_1_30: '#eab308',
-  overdue_31_60: '#f97316',
-  overdue_61_90: '#ef4444',
-  overdue_90_plus: '#991b1b',
-  sms: '#3b82f6',
-  email: '#8b5cf6',
-};
 
 export default function ARAnalyticsPage() {
   const [data, setData] = useState<ARAnalyticsData | null>(null);
@@ -170,49 +58,6 @@ export default function ARAnalyticsPage() {
     fetchData();
   };
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-ZA', {
-      style: 'currency',
-      currency: 'ZAR',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(amount);
-  };
-
-  const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString('en-ZA', {
-      month: 'short',
-      day: 'numeric',
-    });
-  };
-
-  const getTrendIcon = (trend: string) => {
-    switch (trend) {
-      case 'improving':
-        return <PiTrendDownBold className="h-4 w-4 text-green-500" />;
-      case 'worsening':
-        return <PiTrendUpBold className="h-4 w-4 text-red-500" />;
-      default:
-        return <PiMinusBold className="h-4 w-4 text-gray-500" />;
-    }
-  };
-
-  const NOTIF_STATUS_VARIANT: Record<string, StatusVariant> = {
-    sent: 'success',
-    delivered: 'success',
-    failed: 'error',
-    bounced: 'error',
-    opened: 'info',
-    clicked: 'info',
-  };
-  const getStatusBadge = (status: string) => {
-    const label =
-      status === 'sent' || status === 'delivered'
-        ? 'Delivered'
-        : status.charAt(0).toUpperCase() + status.slice(1);
-    return <StatusBadge status={label} variant={NOTIF_STATUS_VARIANT[status] ?? 'neutral'} />;
-  };
-
   if (loading) {
     return (
       <AdminPage>
@@ -228,20 +73,6 @@ export default function ARAnalyticsPage() {
       </AdminPage>
     );
   }
-
-  // Prepare chart data
-  const agingChartData = [
-    { name: 'Current', amount: data.ar_aging.current_amount, count: data.ar_aging.current_count, fill: COLORS.current },
-    { name: '1-30 Days', amount: data.ar_aging.overdue_1_30_amount, count: data.ar_aging.overdue_1_30_count, fill: COLORS.overdue_1_30 },
-    { name: '31-60 Days', amount: data.ar_aging.overdue_31_60_amount, count: data.ar_aging.overdue_31_60_count, fill: COLORS.overdue_31_60 },
-    { name: '61-90 Days', amount: data.ar_aging.overdue_61_90_amount, count: data.ar_aging.overdue_61_90_count, fill: COLORS.overdue_61_90 },
-    { name: '90+ Days', amount: data.ar_aging.overdue_90_plus_amount, count: data.ar_aging.overdue_90_plus_count, fill: COLORS.overdue_90_plus },
-  ];
-
-  const notificationPieData = [
-    { name: 'SMS', value: data.notifications.total_sms, fill: COLORS.sms },
-    { name: 'Email', value: data.notifications.total_email, fill: COLORS.email },
-  ];
 
   return (
     <AdminPage>
@@ -299,7 +130,7 @@ export default function ARAnalyticsPage() {
           <CardContent>
             <div className="flex items-center gap-2">
               <span className="text-2xl font-bold">{data.dso.dso_current.toFixed(1)}</span>
-              {getTrendIcon(data.dso.dso_trend)}
+              <TrendIcon trend={data.dso.dso_trend} />
             </div>
             <p className="text-sm text-muted-foreground">
               30-day avg: {data.dso.dso_30_day_avg.toFixed(1)} days
@@ -348,376 +179,22 @@ export default function ARAnalyticsPage() {
       <Tabs defaultValue="aging" className="space-y-4">
         <TabsList>
           <TabsTrigger value="aging">AR Aging</TabsTrigger>
-          <TabsTrigger value="dso">DSO & Metrics</TabsTrigger>
+          <TabsTrigger value="dso">DSO &amp; Metrics</TabsTrigger>
           <TabsTrigger value="notifications">Notifications</TabsTrigger>
           <TabsTrigger value="history">History</TabsTrigger>
         </TabsList>
 
-        {/* AR Aging Tab */}
         <TabsContent value="aging" className="space-y-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            {/* Aging Bar Chart */}
-            <Card>
-              <CardHeader>
-                <CardTitle>AR Aging Breakdown</CardTitle>
-                <CardDescription>Outstanding amounts by aging bucket</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <BarChart data={agingChartData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="name" />
-                    <YAxis tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`} />
-                    <Tooltip
-                      formatter={(value: number) => [formatCurrency(value), 'Amount']}
-                    />
-                    <Bar dataKey="amount" radius={[4, 4, 0, 0]}>
-                      {agingChartData.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.fill} />
-                      ))}
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
-
-            {/* Aging Table */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Aging Summary</CardTitle>
-                <CardDescription>Invoice counts and amounts by bucket</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Bucket</TableHead>
-                      <TableHead className="text-right">Invoices</TableHead>
-                      <TableHead className="text-right">Amount</TableHead>
-                      <TableHead className="text-right">%</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {agingChartData.map((bucket) => (
-                      <TableRow key={bucket.name}>
-                        <TableCell>
-                          <div className="flex items-center gap-2">
-                            <div
-                              className="w-3 h-3 rounded-full"
-                              style={{ backgroundColor: bucket.fill }}
-                            />
-                            {bucket.name}
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-right">{bucket.count}</TableCell>
-                        <TableCell className="text-right">{formatCurrency(bucket.amount)}</TableCell>
-                        <TableCell className="text-right">
-                          {data.ar_aging.total_outstanding_amount > 0
-                            ? ((bucket.amount / data.ar_aging.total_outstanding_amount) * 100).toFixed(1)
-                            : 0}%
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                    <TableRow className="font-bold">
-                      <TableCell>Total</TableCell>
-                      <TableCell className="text-right">{data.ar_aging.total_outstanding_invoices}</TableCell>
-                      <TableCell className="text-right">{formatCurrency(data.ar_aging.total_outstanding_amount)}</TableCell>
-                      <TableCell className="text-right">100%</TableCell>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-              </CardContent>
-            </Card>
-          </div>
+          <ArAgingPanel data={data} />
         </TabsContent>
-
-        {/* DSO & Metrics Tab */}
         <TabsContent value="dso" className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg">Current DSO</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-4xl font-bold">{data.dso.dso_current.toFixed(1)}</div>
-                <p className="text-muted-foreground">days</p>
-                <div className="mt-4 flex items-center gap-2">
-                  {getTrendIcon(data.dso.dso_trend)}
-                  <span className="text-sm capitalize">{data.dso.dso_trend}</span>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg">Best Possible DSO</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-4xl font-bold text-green-600">{data.dso.best_possible_dso.toFixed(1)}</div>
-                <p className="text-muted-foreground">days</p>
-                <p className="mt-4 text-sm text-muted-foreground">
-                  Gap: {(data.dso.dso_current - data.dso.best_possible_dso).toFixed(1)} days
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg">Collection Effectiveness</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-4xl font-bold text-blue-600">{data.dso.collection_effectiveness_index.toFixed(1)}%</div>
-                <p className="text-muted-foreground">CEI</p>
-                <p className="mt-4 text-sm text-muted-foreground">
-                  Target: 80%+
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Collection Performance</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="text-center p-4 bg-muted/50 rounded-lg">
-                  <div className="text-2xl font-bold">{data.collection.total_notifications_sent}</div>
-                  <p className="text-sm text-muted-foreground">Notifications Sent</p>
-                </div>
-                <div className="text-center p-4 bg-muted/50 rounded-lg">
-                  <div className="text-2xl font-bold">{formatCurrency(data.collection.total_amount_collected)}</div>
-                  <p className="text-sm text-muted-foreground">Amount Collected</p>
-                </div>
-                <div className="text-center p-4 bg-muted/50 rounded-lg">
-                  <div className="text-2xl font-bold">{data.collection.avg_days_to_payment.toFixed(1)}</div>
-                  <p className="text-sm text-muted-foreground">Avg Days to Payment</p>
-                </div>
-                <div className="text-center p-4 bg-muted/50 rounded-lg">
-                  <div className="text-2xl font-bold">{data.collection.response_rate.toFixed(1)}%</div>
-                  <p className="text-sm text-muted-foreground">Response Rate</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <DsoMetricsPanel data={data} />
         </TabsContent>
-
-        {/* Notifications Tab */}
         <TabsContent value="notifications" className="space-y-4">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-            {/* Notification Breakdown */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Notification Channels</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={200}>
-                  <PieChart>
-                    <Pie
-                      data={notificationPieData}
-                      cx="50%"
-                      cy="50%"
-                      innerRadius={40}
-                      outerRadius={80}
-                      dataKey="value"
-                      label={({ name, value }) => `${name}: ${value}`}
-                    >
-                      {notificationPieData.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.fill} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
-                <div className="flex justify-center gap-4 mt-4">
-                  <div className="flex items-center gap-2">
-                    <PiChatBold className="h-4 w-4 text-blue-500" />
-                    <span className="text-sm">SMS: {data.notifications.total_sms}</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <PiEnvelopeBold className="h-4 w-4 text-purple-500" />
-                    <span className="text-sm">Email: {data.notifications.total_email}</span>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Delivery Stats */}
-            <Card className="lg:col-span-2">
-              <CardHeader>
-                <CardTitle>Delivery Statistics</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  <div className="text-center p-4 bg-green-50 dark:bg-green-950/20 rounded-lg">
-                    <PiCheckCircleBold className="h-6 w-6 mx-auto text-green-500 mb-2" />
-                    <div className="text-xl font-bold">{data.notifications.total_delivered}</div>
-                    <p className="text-sm text-muted-foreground">Delivered</p>
-                  </div>
-                  <div className="text-center p-4 bg-red-50 dark:bg-red-950/20 rounded-lg">
-                    <PiXCircleBold className="h-6 w-6 mx-auto text-red-500 mb-2" />
-                    <div className="text-xl font-bold">{data.notifications.total_failed}</div>
-                    <p className="text-sm text-muted-foreground">Failed</p>
-                  </div>
-                  <div className="text-center p-4 bg-blue-50 dark:bg-blue-950/20 rounded-lg">
-                    <PiPulseBold className="h-6 w-6 mx-auto text-blue-500 mb-2" />
-                    <div className="text-xl font-bold">{data.notifications.delivery_rate.toFixed(1)}%</div>
-                    <p className="text-sm text-muted-foreground">Delivery Rate</p>
-                  </div>
-                  <div className="text-center p-4 bg-purple-50 dark:bg-purple-950/20 rounded-lg">
-                    <PiCalendarBold className="h-6 w-6 mx-auto text-purple-500 mb-2" />
-                    <div className="text-xl font-bold">{data.ar_aging.avg_days_overdue.toFixed(0)}</div>
-                    <p className="text-sm text-muted-foreground">Avg Days Overdue</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Recent Notifications Table */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Recent Notifications</CardTitle>
-              <CardDescription>Last 20 notifications sent</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Invoice</TableHead>
-                    <TableHead>Type</TableHead>
-                    <TableHead>Recipient</TableHead>
-                    <TableHead>Amount</TableHead>
-                    <TableHead>Days Overdue</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Sent</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {data.recent_notifications.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
-                        No notifications sent yet
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    data.recent_notifications.map((notif) => (
-                      <TableRow key={notif.id}>
-                        <TableCell className="font-medium">{notif.invoice_number}</TableCell>
-                        <TableCell>
-                          {notif.notification_type === 'sms' ? (
-                            <Badge variant="outline" className="gap-1">
-                              <PiChatBold className="h-3 w-3" /> SMS
-                            </Badge>
-                          ) : (
-                            <Badge variant="outline" className="gap-1">
-                              <PiEnvelopeBold className="h-3 w-3" /> Email
-                            </Badge>
-                          )}
-                        </TableCell>
-                        <TableCell className="max-w-[150px] truncate">{notif.recipient}</TableCell>
-                        <TableCell>{formatCurrency(notif.amount_due)}</TableCell>
-                        <TableCell>{notif.days_overdue} days</TableCell>
-                        <TableCell>{getStatusBadge(notif.status)}</TableCell>
-                        <TableCell className="text-muted-foreground">
-                          {new Date(notif.created_at).toLocaleString('en-ZA')}
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
+          <NotificationsPanel data={data} />
         </TabsContent>
-
-        {/* History Tab */}
         <TabsContent value="history" className="space-y-4">
-          {data.historical && data.historical.length > 0 ? (
-            <>
-              <Card>
-                <CardHeader>
-                  <CardTitle>AR & DSO Trend</CardTitle>
-                  <CardDescription>Historical outstanding amount and DSO</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ResponsiveContainer width="100%" height={300}>
-                    <AreaChart data={data.historical}>
-                      <CartesianGrid strokeDasharray="3 3" />
-                      <XAxis dataKey="snapshot_date" tickFormatter={formatDate} />
-                      <YAxis yAxisId="left" tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`} />
-                      <YAxis yAxisId="right" orientation="right" />
-                      <Tooltip
-                        formatter={(value: number, name: string) => [
-                          name === 'total_outstanding' ? formatCurrency(value) : value.toFixed(1),
-                          name === 'total_outstanding' ? 'Outstanding' : 'DSO',
-                        ]}
-                        labelFormatter={formatDate}
-                      />
-                      <Legend />
-                      <Area
-                        yAxisId="left"
-                        type="monotone"
-                        dataKey="total_outstanding"
-                        name="Outstanding"
-                        stroke="#F5831F"
-                        fill="#F5831F"
-                        fillOpacity={0.3}
-                      />
-                      <Line
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="dso_current"
-                        name="DSO"
-                        stroke="#3b82f6"
-                        strokeWidth={2}
-                        dot={false}
-                      />
-                    </AreaChart>
-                  </ResponsiveContainer>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader>
-                  <CardTitle>Notifications & Collections</CardTitle>
-                  <CardDescription>Daily notification activity and payments received</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ResponsiveContainer width="100%" height={300}>
-                    <BarChart data={data.historical}>
-                      <CartesianGrid strokeDasharray="3 3" />
-                      <XAxis dataKey="snapshot_date" tickFormatter={formatDate} />
-                      <YAxis yAxisId="left" />
-                      <YAxis yAxisId="right" orientation="right" tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`} />
-                      <Tooltip labelFormatter={formatDate} />
-                      <Legend />
-                      <Bar yAxisId="left" dataKey="sms_sent_count" name="SMS" fill={COLORS.sms} />
-                      <Bar yAxisId="left" dataKey="email_sent_count" name="Email" fill={COLORS.email} />
-                      <Line
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="payments_received_amount"
-                        name="Payments"
-                        stroke="#22c55e"
-                        strokeWidth={2}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </CardContent>
-              </Card>
-            </>
-          ) : (
-            <Card>
-              <CardContent className="py-10 text-center">
-                <PiCalendarBold className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-                <p className="text-muted-foreground">No historical data available yet</p>
-                <p className="text-sm text-muted-foreground mt-2">
-                  Historical snapshots are created daily by the system
-                </p>
-              </CardContent>
-            </Card>
-          )}
+          <HistoryPanel data={data} />
         </TabsContent>
       </Tabs>
     </AdminPage>

--- a/components/admin/billing/recon/CashMatchStrip.tsx
+++ b/components/admin/billing/recon/CashMatchStrip.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import {
   PiCheckCircleBold,
   PiClockBold,
@@ -5,7 +6,7 @@ import {
   PiWarningBold,
   PiXCircleBold,
 } from 'react-icons/pi';
-import { StatCard } from '@/components/admin/shared';
+import { MetricCard } from '@/components/backend';
 import type { ReconHubSummary } from '@/lib/billing/recon-hub/types';
 
 export interface CashMatchStripProps {
@@ -52,91 +53,74 @@ export function CashMatchStrip({
 
   const paynowIcon =
     paynowStatus === 'success' ? (
-      <PiCheckCircleBold className="h-5 w-5" />
+      <PiCheckCircleBold className="w-5 h-5" aria-hidden="true" />
     ) : paynowStatus === 'failed' ? (
-      <PiXCircleBold className="h-5 w-5" />
+      <PiXCircleBold className="w-5 h-5" aria-hidden="true" />
     ) : (
-      <PiClockBold className="h-5 w-5" />
+      <PiClockBold className="w-5 h-5" aria-hidden="true" />
     );
 
+  const paynowIconColor =
+    paynowStatus === 'success'
+      ? 'text-green-600'
+      : paynowStatus === 'failed'
+        ? 'text-red-600'
+        : paynowStatus === 'partial'
+          ? 'text-amber-600'
+          : 'text-slate-400';
+
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
-      <StatCard
-        label="Unmatched NetCash→CT"
-        value={unmatchedNetcashToCt}
-        icon={
-          unmatchedClear ? (
-            <PiCheckCircleBold className="h-5 w-5" />
-          ) : (
-            <PiWarningBold className="h-5 w-5" />
-          )
-        }
-        iconBgColor={unmatchedClear ? 'bg-green-100' : 'bg-red-100'}
-        iconColor={unmatchedClear ? 'text-green-700' : 'text-red-700'}
-        subtitle={
-          unmatchedClear
-            ? 'Day-done clear'
-            : 'Needs invoice match'
-        }
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <MetricCard
+        title="Unmatched NetCash→CT"
+        value={`${unmatchedNetcashToCt}`}
+        subtitle={unmatchedClear ? 'Day-done clear' : 'Needs invoice match'}
         className={
           unmatchedClear
-            ? 'border-green-200 bg-green-50/40'
-            : 'border-red-200 bg-red-50/40'
+            ? 'border-green-200/80 bg-green-50/40'
+            : 'border-red-200/80 bg-red-50/40'
         }
-      />
+      >
+        {unmatchedClear ? (
+          <PiCheckCircleBold className="w-5 h-5 text-green-600" aria-hidden="true" />
+        ) : (
+          <PiWarningBold className="w-5 h-5 text-red-600" aria-hidden="true" />
+        )}
+      </MetricCard>
 
-      <StatCard
-        label="NetCash completed"
-        value={netcashCompletedInWindow}
-        icon={<PiCurrencyCircleDollarBold className="h-5 w-5" />}
-        iconBgColor="bg-slate-100"
-        iconColor="text-slate-700"
+      <MetricCard
+        title="NetCash completed"
+        value={`${netcashCompletedInWindow}`}
         subtitle={`${netcashMatchedInWindow} matched in window`}
-      />
+      >
+        <PiCurrencyCircleDollarBold className="w-5 h-5 text-slate-500" aria-hidden="true" />
+      </MetricCard>
 
-      <StatCard
-        label="Zoho payment sync lag"
-        value={zohoPaymentLagCount}
-        icon={<PiWarningBold className="h-5 w-5" />}
-        iconBgColor={
-          zohoPaymentLagCount > 0 ? 'bg-amber-100' : 'bg-slate-100'
-        }
-        iconColor={
-          zohoPaymentLagCount > 0 ? 'text-amber-700' : 'text-slate-600'
-        }
-        subtitle="Pending or failed sync"
-        href="/admin/integrations/zoho-books"
-        className={
-          zohoPaymentLagCount > 0
-            ? 'border-amber-200 bg-amber-50/40'
-            : undefined
-        }
-      />
+      <Link href="/admin/integrations/zoho-books" className="block">
+        <MetricCard
+          title="Zoho payment sync lag"
+          value={`${zohoPaymentLagCount}`}
+          subtitle="Pending or failed sync"
+          className={
+            zohoPaymentLagCount > 0
+              ? 'border-amber-200/80 bg-amber-50/40 transition-shadow hover:shadow-md'
+              : 'transition-shadow hover:shadow-md'
+          }
+        >
+          <PiWarningBold
+            className={`w-5 h-5 ${zohoPaymentLagCount > 0 ? 'text-amber-600' : 'text-slate-400'}`}
+            aria-hidden="true"
+          />
+        </MetricCard>
+      </Link>
 
-      <StatCard
-        label="PayNow recon last run"
+      <MetricCard
+        title="PayNow recon last run"
         value={paynowLabel}
-        icon={paynowIcon}
-        iconBgColor={
-          paynowStatus === 'success'
-            ? 'bg-green-100'
-            : paynowStatus === 'failed'
-              ? 'bg-red-100'
-              : paynowStatus === 'partial'
-                ? 'bg-amber-100'
-                : 'bg-slate-100'
-        }
-        iconColor={
-          paynowStatus === 'success'
-            ? 'text-green-700'
-            : paynowStatus === 'failed'
-              ? 'text-red-700'
-              : paynowStatus === 'partial'
-                ? 'text-amber-700'
-                : 'text-slate-600'
-        }
         subtitle={formatLastRunAt(paynowRecon.lastRunAt)}
-      />
+      >
+        <span className={paynowIconColor}>{paynowIcon}</span>
+      </MetricCard>
     </div>
   );
 }

--- a/components/admin/billing/recon/DayDoneBanner.tsx
+++ b/components/admin/billing/recon/DayDoneBanner.tsx
@@ -22,7 +22,7 @@ export function DayDoneBanner({
     return (
       <div
         role="status"
-        className="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 px-4 py-3"
+        className="flex items-start gap-3 rounded-xl border border-green-200/80 bg-green-50/80 shadow-sm px-4 py-3"
       >
         <PiCheckCircleBold
           className="mt-0.5 h-5 w-5 shrink-0 text-green-600"
@@ -48,7 +48,7 @@ export function DayDoneBanner({
   return (
     <div
       role="alert"
-      className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3"
+      className="flex items-start gap-3 rounded-xl border border-red-200/80 bg-red-50/80 shadow-sm px-4 py-3"
     >
       <PiWarningCircleBold
         className="mt-0.5 h-5 w-5 shrink-0 text-red-600"

--- a/components/admin/billing/recon/DeepLinks.tsx
+++ b/components/admin/billing/recon/DeepLinks.tsx
@@ -39,12 +39,12 @@ const LINKS = [
  */
 export function DeepLinks() {
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
       {LINKS.map(({ href, title, description, icon: Icon }) => (
         <Link
           key={href}
           href={href}
-          className="group flex items-start gap-3 rounded-lg border border-slate-200 bg-white p-4 transition-colors hover:border-circleTel-orange/40 hover:bg-orange-50/40"
+          className="group flex items-start gap-3 rounded-xl border border-slate-200/80 bg-white p-4 shadow-sm transition-colors hover:border-circleTel-orange/40 hover:bg-orange-50/40"
         >
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-circleTel-orange/10 text-circleTel-orange">
             <Icon className="h-5 w-5" aria-hidden="true" />

--- a/components/admin/billing/recon/ExceptionTable.tsx
+++ b/components/admin/billing/recon/ExceptionTable.tsx
@@ -7,8 +7,9 @@ import {
   PiLinkBold,
   PiWarningBold,
 } from 'react-icons/pi';
-import { SectionCard, StatusBadge } from '@/components/admin/shared';
-import type { StatusVariant } from '@/components/admin/shared';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { StatusBadge } from '@/components/backend';
+import type { StatusVariant } from '@/components/backend';
 import { filterExceptions } from '@/lib/billing/recon-hub/build-exceptions';
 import type {
   ExceptionFilter,
@@ -104,15 +105,18 @@ export function ExceptionTable({ exceptions }: ExceptionTableProps) {
   }, [exceptions]);
 
   return (
-    <SectionCard
-      title="Exceptions"
-      action={
-        <span className="text-xs font-medium text-slate-500">
-          {rows.length} shown
-        </span>
-      }
-    >
-      <div className="space-y-4">
+    <Card className="border border-slate-200/80 shadow-sm rounded-xl bg-white">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div>
+          <CardTitle className="text-base font-semibold text-slate-900">Exceptions</CardTitle>
+          <p className="text-xs text-slate-500">
+            Unmatched cash, Zoho sync lag, and open AR needing action
+          </p>
+        </div>
+        <span className="text-xs font-medium text-slate-500">{rows.length} shown</span>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
         <div
           className="flex flex-wrap gap-2"
           role="tablist"
@@ -150,12 +154,12 @@ export function ExceptionTable({ exceptions }: ExceptionTableProps) {
         </div>
 
         {rows.length === 0 ? (
-          <div className="flex items-center gap-2 rounded-lg border border-slate-100 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+          <div className="flex items-center gap-2 rounded-xl border border-slate-100 bg-slate-50/50 px-4 py-6 text-sm text-slate-500">
             <PiWarningBold className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
             No exceptions for this filter.
           </div>
         ) : (
-          <div className="overflow-x-auto rounded-lg border border-slate-200">
+          <div className="overflow-x-auto rounded-xl border border-slate-200/80">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-slate-200 bg-slate-50">
@@ -280,7 +284,8 @@ export function ExceptionTable({ exceptions }: ExceptionTableProps) {
             </table>
           </div>
         )}
-      </div>
-    </SectionCard>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/components/admin/billing/recon/SecondaryKpis.tsx
+++ b/components/admin/billing/recon/SecondaryKpis.tsx
@@ -51,20 +51,18 @@ export function SecondaryKpis({
   ] as const;
 
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
       {items.map(({ label, value, icon: Icon }) => (
         <div
           key={label}
-          className="flex items-center gap-3 rounded-lg border border-dashed border-slate-300 bg-slate-50/60 px-4 py-3"
+          className="flex items-center gap-3 rounded-xl border border-slate-100 bg-slate-50/50 px-4 py-3"
         >
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-white text-slate-500 shadow-sm ring-1 ring-slate-200">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white text-slate-500 shadow-sm ring-1 ring-slate-200">
             <Icon className="h-4 w-4" aria-hidden="true" />
           </div>
           <div className="min-w-0">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-slate-500">
-              {label}
-            </p>
-            <p className="truncate text-base font-semibold tabular-nums text-slate-800">
+            <p className="text-xs font-medium text-slate-500">{label}</p>
+            <p className="truncate text-xl font-semibold tabular-nums text-slate-900 mt-0.5">
               {value}
             </p>
           </div>

--- a/components/admin/finance/ar/ArAgingPanel.tsx
+++ b/components/admin/finance/ar/ArAgingPanel.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { buildAgingBuckets, formatCurrency, type ARAnalyticsData } from './shared';
+
+export function ArAgingPanel({ data }: { data: ARAnalyticsData }) {
+  const agingChartData = buildAgingBuckets(data.ar_aging);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {/* Aging Bar Chart */}
+      <Card>
+        <CardHeader>
+          <CardTitle>AR Aging Breakdown</CardTitle>
+          <CardDescription>Outstanding amounts by aging bucket</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={agingChartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" />
+              <YAxis tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`} />
+              <Tooltip
+                formatter={(value: number) => [formatCurrency(value), 'Amount']}
+              />
+              <Bar dataKey="amount" radius={[4, 4, 0, 0]}>
+                {agingChartData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.fill} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      {/* Aging Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Aging Summary</CardTitle>
+          <CardDescription>Invoice counts and amounts by bucket</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Bucket</TableHead>
+                <TableHead className="text-right">Invoices</TableHead>
+                <TableHead className="text-right">Amount</TableHead>
+                <TableHead className="text-right">%</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {agingChartData.map((bucket) => (
+                <TableRow key={bucket.name}>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <div
+                        className="w-3 h-3 rounded-full"
+                        style={{ backgroundColor: bucket.fill }}
+                      />
+                      {bucket.name}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right">{bucket.count}</TableCell>
+                  <TableCell className="text-right">{formatCurrency(bucket.amount)}</TableCell>
+                  <TableCell className="text-right">
+                    {data.ar_aging.total_outstanding_amount > 0
+                      ? ((bucket.amount / data.ar_aging.total_outstanding_amount) * 100).toFixed(1)
+                      : 0}%
+                  </TableCell>
+                </TableRow>
+              ))}
+              <TableRow className="font-bold">
+                <TableCell>Total</TableCell>
+                <TableCell className="text-right">{data.ar_aging.total_outstanding_invoices}</TableCell>
+                <TableCell className="text-right">{formatCurrency(data.ar_aging.total_outstanding_amount)}</TableCell>
+                <TableCell className="text-right">100%</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/admin/finance/ar/ArAgingPanel.tsx
+++ b/components/admin/finance/ar/ArAgingPanel.tsx
@@ -1,85 +1,132 @@
 'use client';
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
 import { buildAgingBuckets, formatCurrency, type ARAnalyticsData } from './shared';
 
+const chartConfig = {
+  amount: { label: 'Outstanding' },
+} satisfies ChartConfig;
+
 export function ArAgingPanel({ data }: { data: ARAnalyticsData }) {
-  const agingChartData = buildAgingBuckets(data.ar_aging);
+  const buckets = buildAgingBuckets(data.ar_aging);
+  const total = data.ar_aging.total_outstanding_amount;
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-      {/* Aging Bar Chart */}
-      <Card>
-        <CardHeader>
-          <CardTitle>AR Aging Breakdown</CardTitle>
-          <CardDescription>Outstanding amounts by aging bucket</CardDescription>
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">
+            AR Aging Breakdown
+          </CardTitle>
+          <p className="text-xs text-slate-500">Outstanding amounts by aging bucket</p>
         </CardHeader>
         <CardContent>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={agingChartData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`} />
-              <Tooltip
-                formatter={(value: number) => [formatCurrency(value), 'Amount']}
+          <ChartContainer config={chartConfig} className="aspect-auto h-[300px] w-full">
+            <BarChart accessibilityLayer data={buckets} margin={{ left: 8, right: 8, top: 8, bottom: 0 }}>
+              <CartesianGrid vertical={false} strokeDasharray="3 3" />
+              <XAxis dataKey="name" tickLine={false} axisLine={false} tickMargin={8} />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={56}
+                tickFormatter={(v) => `R${(Number(v) / 1000).toFixed(0)}k`}
               />
-              <Bar dataKey="amount" radius={[4, 4, 0, 0]}>
-                {agingChartData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.fill} />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    indicator="dot"
+                    formatter={(value) => (
+                      <div className="flex w-full items-center justify-between gap-4">
+                        <span className="text-muted-foreground">Outstanding</span>
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {formatCurrency(Number(value))}
+                        </span>
+                      </div>
+                    )}
+                  />
+                }
+              />
+              <Bar dataKey="amount" radius={[6, 6, 0, 0]}>
+                {buckets.map((bucket) => (
+                  <Cell key={bucket.name} fill={bucket.fill} />
                 ))}
               </Bar>
             </BarChart>
-          </ResponsiveContainer>
+          </ChartContainer>
         </CardContent>
       </Card>
 
-      {/* Aging Table */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Aging Summary</CardTitle>
-          <CardDescription>Invoice counts and amounts by bucket</CardDescription>
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">Aging Summary</CardTitle>
+          <p className="text-xs text-slate-500">Invoice counts and amounts by bucket</p>
         </CardHeader>
         <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Bucket</TableHead>
-                <TableHead className="text-right">Invoices</TableHead>
-                <TableHead className="text-right">Amount</TableHead>
-                <TableHead className="text-right">%</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {agingChartData.map((bucket) => (
-                <TableRow key={bucket.name}>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <div
-                        className="w-3 h-3 rounded-full"
-                        style={{ backgroundColor: bucket.fill }}
-                      />
-                      {bucket.name}
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-right">{bucket.count}</TableCell>
-                  <TableCell className="text-right">{formatCurrency(bucket.amount)}</TableCell>
-                  <TableCell className="text-right">
-                    {data.ar_aging.total_outstanding_amount > 0
-                      ? ((bucket.amount / data.ar_aging.total_outstanding_amount) * 100).toFixed(1)
-                      : 0}%
-                  </TableCell>
-                </TableRow>
-              ))}
-              <TableRow className="font-bold">
-                <TableCell>Total</TableCell>
-                <TableCell className="text-right">{data.ar_aging.total_outstanding_invoices}</TableCell>
-                <TableCell className="text-right">{formatCurrency(data.ar_aging.total_outstanding_amount)}</TableCell>
-                <TableCell className="text-right">100%</TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
+          <div className="overflow-x-auto rounded-xl border border-slate-200/80">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 bg-slate-50">
+                  <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Bucket
+                  </th>
+                  <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Invoices
+                  </th>
+                  <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Amount
+                  </th>
+                  <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    %
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {buckets.map((bucket) => (
+                  <tr key={bucket.name} className="transition-colors hover:bg-slate-50">
+                    <td className="whitespace-nowrap px-3 py-2.5">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="h-2.5 w-2.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: bucket.fill }}
+                        />
+                        <span className="text-slate-700">{bucket.name}</span>
+                      </div>
+                    </td>
+                    <td className="px-3 py-2.5 text-right tabular-nums text-slate-700">
+                      {bucket.count}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                      {formatCurrency(bucket.amount)}
+                    </td>
+                    <td className="px-3 py-2.5 text-right tabular-nums text-slate-600">
+                      {total > 0 ? ((bucket.amount / total) * 100).toFixed(1) : '0.0'}%
+                    </td>
+                  </tr>
+                ))}
+                <tr className="border-t border-slate-200 bg-slate-50/60">
+                  <td className="px-3 py-2.5 font-semibold text-slate-900">Total</td>
+                  <td className="px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                    {data.ar_aging.total_outstanding_invoices}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                    {formatCurrency(total)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                    100%
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/components/admin/finance/ar/DsoMetricsPanel.tsx
+++ b/components/admin/finance/ar/DsoMetricsPanel.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatCurrency, TrendIcon, type ARAnalyticsData } from './shared';
+
+export function DsoMetricsPanel({ data }: { data: ARAnalyticsData }) {
+  return (
+    <>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Current DSO</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-4xl font-bold">{data.dso.dso_current.toFixed(1)}</div>
+            <p className="text-muted-foreground">days</p>
+            <div className="mt-4 flex items-center gap-2">
+              <TrendIcon trend={data.dso.dso_trend} />
+              <span className="text-sm capitalize">{data.dso.dso_trend}</span>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Best Possible DSO</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-4xl font-bold text-green-600">{data.dso.best_possible_dso.toFixed(1)}</div>
+            <p className="text-muted-foreground">days</p>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Gap: {(data.dso.dso_current - data.dso.best_possible_dso).toFixed(1)} days
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Collection Effectiveness</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-4xl font-bold text-blue-600">{data.dso.collection_effectiveness_index.toFixed(1)}%</div>
+            <p className="text-muted-foreground">CEI</p>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Target: 80%+
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Collection Performance</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="text-center p-4 bg-muted/50 rounded-lg">
+              <div className="text-2xl font-bold">{data.collection.total_notifications_sent}</div>
+              <p className="text-sm text-muted-foreground">Notifications Sent</p>
+            </div>
+            <div className="text-center p-4 bg-muted/50 rounded-lg">
+              <div className="text-2xl font-bold">{formatCurrency(data.collection.total_amount_collected)}</div>
+              <p className="text-sm text-muted-foreground">Amount Collected</p>
+            </div>
+            <div className="text-center p-4 bg-muted/50 rounded-lg">
+              <div className="text-2xl font-bold">{data.collection.avg_days_to_payment.toFixed(1)}</div>
+              <p className="text-sm text-muted-foreground">Avg Days to Payment</p>
+            </div>
+            <div className="text-center p-4 bg-muted/50 rounded-lg">
+              <div className="text-2xl font-bold">{data.collection.response_rate.toFixed(1)}%</div>
+              <p className="text-sm text-muted-foreground">Response Rate</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/components/admin/finance/ar/DsoMetricsPanel.tsx
+++ b/components/admin/finance/ar/DsoMetricsPanel.tsx
@@ -1,78 +1,66 @@
 'use client';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { formatCurrency, TrendIcon, type ARAnalyticsData } from './shared';
+import { MetricCard } from '@/components/backend';
+import { TrendIcon, formatCurrency, type ARAnalyticsData } from './shared';
 
 export function DsoMetricsPanel({ data }: { data: ARAnalyticsData }) {
+  const gap = data.dso.dso_current - data.dso.best_possible_dso;
+
+  const performance = [
+    { label: 'Notifications sent', value: `${data.collection.total_notifications_sent}` },
+    { label: 'Amount collected', value: formatCurrency(data.collection.total_amount_collected) },
+    { label: 'Avg days to payment', value: data.collection.avg_days_to_payment.toFixed(1) },
+    { label: 'Response rate', value: `${data.collection.response_rate.toFixed(1)}%` },
+  ];
+
   return (
-    <>
+    <div className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Current DSO</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-4xl font-bold">{data.dso.dso_current.toFixed(1)}</div>
-            <p className="text-muted-foreground">days</p>
-            <div className="mt-4 flex items-center gap-2">
-              <TrendIcon trend={data.dso.dso_trend} />
-              <span className="text-sm capitalize">{data.dso.dso_trend}</span>
-            </div>
-          </CardContent>
-        </Card>
+        <MetricCard
+          title="Current DSO"
+          value={data.dso.dso_current.toFixed(1)}
+          subtitle="days"
+        >
+          <span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+            <TrendIcon trend={data.dso.dso_trend} />
+            <span className="capitalize">{data.dso.dso_trend}</span>
+          </span>
+        </MetricCard>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Best Possible DSO</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-4xl font-bold text-green-600">{data.dso.best_possible_dso.toFixed(1)}</div>
-            <p className="text-muted-foreground">days</p>
-            <p className="mt-4 text-sm text-muted-foreground">
-              Gap: {(data.dso.dso_current - data.dso.best_possible_dso).toFixed(1)} days
-            </p>
-          </CardContent>
-        </Card>
+        <MetricCard
+          title="Best Possible DSO"
+          value={data.dso.best_possible_dso.toFixed(1)}
+          subtitle="days"
+          delta={`Gap: ${gap.toFixed(1)} days`}
+          deltaPositive={gap <= 0}
+        />
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Collection Effectiveness</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-4xl font-bold text-blue-600">{data.dso.collection_effectiveness_index.toFixed(1)}%</div>
-            <p className="text-muted-foreground">CEI</p>
-            <p className="mt-4 text-sm text-muted-foreground">
-              Target: 80%+
-            </p>
-          </CardContent>
-        </Card>
+        <MetricCard
+          title="Collection Effectiveness"
+          value={`${data.dso.collection_effectiveness_index.toFixed(1)}%`}
+          subtitle="CEI"
+          delta="Target: 80%+"
+          deltaPositive={data.dso.collection_effectiveness_index >= 80}
+        />
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Collection Performance</CardTitle>
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">
+            Collection Performance
+          </CardTitle>
+          <p className="text-xs text-slate-500">Notification volume and payment response</p>
         </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <div className="text-center p-4 bg-muted/50 rounded-lg">
-              <div className="text-2xl font-bold">{data.collection.total_notifications_sent}</div>
-              <p className="text-sm text-muted-foreground">Notifications Sent</p>
+        <CardContent className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {performance.map(({ label, value }) => (
+            <div key={label} className="rounded-xl border border-slate-100 bg-slate-50/50 p-3">
+              <p className="text-xs text-slate-500">{label}</p>
+              <p className="text-xl font-semibold tabular-nums text-slate-900 mt-1">{value}</p>
             </div>
-            <div className="text-center p-4 bg-muted/50 rounded-lg">
-              <div className="text-2xl font-bold">{formatCurrency(data.collection.total_amount_collected)}</div>
-              <p className="text-sm text-muted-foreground">Amount Collected</p>
-            </div>
-            <div className="text-center p-4 bg-muted/50 rounded-lg">
-              <div className="text-2xl font-bold">{data.collection.avg_days_to_payment.toFixed(1)}</div>
-              <p className="text-sm text-muted-foreground">Avg Days to Payment</p>
-            </div>
-            <div className="text-center p-4 bg-muted/50 rounded-lg">
-              <div className="text-2xl font-bold">{data.collection.response_rate.toFixed(1)}%</div>
-              <p className="text-sm text-muted-foreground">Response Rate</p>
-            </div>
-          </div>
+          ))}
         </CardContent>
       </Card>
-    </>
+    </div>
   );
 }

--- a/components/admin/finance/ar/HistoryPanel.tsx
+++ b/components/admin/finance/ar/HistoryPanel.tsx
@@ -107,7 +107,7 @@ export function HistoryPanel({ data }: { data: ARAnalyticsData }) {
               <Area
                 yAxisId="left"
                 dataKey="total_outstanding"
-                type="natural"
+                type="monotone"
                 fill="url(#fillOutstanding)"
                 stroke="var(--color-total_outstanding)"
                 strokeWidth={1.5}
@@ -115,7 +115,7 @@ export function HistoryPanel({ data }: { data: ARAnalyticsData }) {
               <Line
                 yAxisId="right"
                 dataKey="dso_current"
-                type="natural"
+                type="monotone"
                 stroke="var(--color-dso_current)"
                 strokeWidth={2}
                 dot={false}
@@ -171,7 +171,7 @@ export function HistoryPanel({ data }: { data: ARAnalyticsData }) {
               <Line
                 yAxisId="right"
                 dataKey="payments_received_amount"
-                type="natural"
+                type="monotone"
                 stroke="var(--color-payments_received_amount)"
                 strokeWidth={2}
                 dot={false}

--- a/components/admin/finance/ar/HistoryPanel.tsx
+++ b/components/admin/finance/ar/HistoryPanel.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { PiCalendarBold } from 'react-icons/pi';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  Legend,
+} from 'recharts';
+import { CHANNEL_COLORS, formatCurrency, formatShortDate, type ARAnalyticsData } from './shared';
+
+export function HistoryPanel({ data }: { data: ARAnalyticsData }) {
+  return data.historical && data.historical.length > 0 ? (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>AR & DSO Trend</CardTitle>
+          <CardDescription>Historical outstanding amount and DSO</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={300}>
+            <AreaChart data={data.historical}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="snapshot_date" tickFormatter={formatShortDate} />
+              <YAxis yAxisId="left" tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`} />
+              <YAxis yAxisId="right" orientation="right" />
+              <Tooltip
+                formatter={(value: number, name: string) => [
+                  name === 'total_outstanding' ? formatCurrency(value) : value.toFixed(1),
+                  name === 'total_outstanding' ? 'Outstanding' : 'DSO',
+                ]}
+                labelFormatter={formatShortDate}
+              />
+              <Legend />
+              <Area
+                yAxisId="left"
+                type="monotone"
+                dataKey="total_outstanding"
+                name="Outstanding"
+                stroke="#F5831F"
+                fill="#F5831F"
+                fillOpacity={0.3}
+              />
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="dso_current"
+                name="DSO"
+                stroke="#3b82f6"
+                strokeWidth={2}
+                dot={false}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Notifications & Collections</CardTitle>
+          <CardDescription>Daily notification activity and payments received</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={data.historical}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="snapshot_date" tickFormatter={formatShortDate} />
+              <YAxis yAxisId="left" />
+              <YAxis yAxisId="right" orientation="right" tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`} />
+              <Tooltip labelFormatter={formatShortDate} />
+              <Legend />
+              <Bar yAxisId="left" dataKey="sms_sent_count" name="SMS" fill={CHANNEL_COLORS.sms} />
+              <Bar yAxisId="left" dataKey="email_sent_count" name="Email" fill={CHANNEL_COLORS.email} />
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="payments_received_amount"
+                name="Payments"
+                stroke="#22c55e"
+                strokeWidth={2}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </>
+  ) : (
+    <Card>
+      <CardContent className="py-10 text-center">
+        <PiCalendarBold className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+        <p className="text-muted-foreground">No historical data available yet</p>
+        <p className="text-sm text-muted-foreground mt-2">
+          Historical snapshots are created daily by the system
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/finance/ar/HistoryPanel.tsx
+++ b/components/admin/finance/ar/HistoryPanel.tsx
@@ -1,107 +1,185 @@
 'use client';
 
+import { Area, Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from 'recharts';
 import { PiCalendarBold } from 'react-icons/pi';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
-  AreaChart,
-  Area,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  LineChart,
-  Line,
-  Legend,
-} from 'recharts';
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
 import { CHANNEL_COLORS, formatCurrency, formatShortDate, type ARAnalyticsData } from './shared';
 
+const trendConfig = {
+  total_outstanding: { label: 'Outstanding', color: 'var(--chart-1)' },
+  dso_current: { label: 'DSO', color: 'var(--chart-3)' },
+} satisfies ChartConfig;
+
+const activityConfig = {
+  sms_sent_count: { label: 'SMS', color: CHANNEL_COLORS.sms },
+  email_sent_count: { label: 'Email', color: CHANNEL_COLORS.email },
+  payments_received_amount: { label: 'Payments', color: '#22c55e' },
+} satisfies ChartConfig;
+
 export function HistoryPanel({ data }: { data: ARAnalyticsData }) {
-  return data.historical && data.historical.length > 0 ? (
-    <>
-      <Card>
-        <CardHeader>
-          <CardTitle>AR & DSO Trend</CardTitle>
-          <CardDescription>Historical outstanding amount and DSO</CardDescription>
+  const history = data.historical;
+
+  if (!history || history.length === 0) {
+    return (
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardContent className="py-12 text-center">
+          <PiCalendarBold className="mx-auto mb-4 h-12 w-12 text-slate-300" aria-hidden="true" />
+          <p className="text-slate-600">No historical data available yet</p>
+          <p className="mt-1 text-sm text-slate-500">
+            Historical snapshots are created daily by the system
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">AR &amp; DSO Trend</CardTitle>
+          <p className="text-xs text-slate-500">Historical outstanding amount and DSO</p>
         </CardHeader>
         <CardContent>
-          <ResponsiveContainer width="100%" height={300}>
-            <AreaChart data={data.historical}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="snapshot_date" tickFormatter={formatShortDate} />
-              <YAxis yAxisId="left" tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`} />
-              <YAxis yAxisId="right" orientation="right" />
-              <Tooltip
-                formatter={(value: number, name: string) => [
-                  name === 'total_outstanding' ? formatCurrency(value) : value.toFixed(1),
-                  name === 'total_outstanding' ? 'Outstanding' : 'DSO',
-                ]}
-                labelFormatter={formatShortDate}
+          <ChartContainer config={trendConfig} className="aspect-auto h-[300px] w-full">
+            <ComposedChart accessibilityLayer data={history} margin={{ left: 8, right: 8, top: 8, bottom: 0 }}>
+              <CartesianGrid vertical={false} strokeDasharray="3 3" />
+              <XAxis
+                dataKey="snapshot_date"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={28}
+                tickFormatter={formatShortDate}
               />
-              <Legend />
+              <YAxis
+                yAxisId="left"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={56}
+                tickFormatter={(v) => `R${(Number(v) / 1000).toFixed(0)}k`}
+              />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={40}
+              />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    indicator="dot"
+                    labelFormatter={(value) => formatShortDate(String(value))}
+                    formatter={(value, name) => (
+                      <div className="flex w-full items-center justify-between gap-4">
+                        <span className="text-muted-foreground">
+                          {trendConfig[name as keyof typeof trendConfig]?.label ?? name}
+                        </span>
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {name === 'total_outstanding'
+                            ? formatCurrency(Number(value))
+                            : Number(value).toFixed(1)}
+                        </span>
+                      </div>
+                    )}
+                  />
+                }
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <defs>
+                <linearGradient id="fillOutstanding" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--color-total_outstanding)" stopOpacity={0.85} />
+                  <stop offset="95%" stopColor="var(--color-total_outstanding)" stopOpacity={0.08} />
+                </linearGradient>
+              </defs>
               <Area
                 yAxisId="left"
-                type="monotone"
                 dataKey="total_outstanding"
-                name="Outstanding"
-                stroke="#F5831F"
-                fill="#F5831F"
-                fillOpacity={0.3}
+                type="natural"
+                fill="url(#fillOutstanding)"
+                stroke="var(--color-total_outstanding)"
+                strokeWidth={1.5}
               />
               <Line
                 yAxisId="right"
-                type="monotone"
                 dataKey="dso_current"
-                name="DSO"
-                stroke="#3b82f6"
+                type="natural"
+                stroke="var(--color-dso_current)"
                 strokeWidth={2}
                 dot={false}
               />
-            </AreaChart>
-          </ResponsiveContainer>
+            </ComposedChart>
+          </ChartContainer>
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Notifications & Collections</CardTitle>
-          <CardDescription>Daily notification activity and payments received</CardDescription>
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">
+            Notifications &amp; Collections
+          </CardTitle>
+          <p className="text-xs text-slate-500">
+            Daily notification activity and payments received
+          </p>
         </CardHeader>
         <CardContent>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={data.historical}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="snapshot_date" tickFormatter={formatShortDate} />
-              <YAxis yAxisId="left" />
-              <YAxis yAxisId="right" orientation="right" tickFormatter={(v) => `R${(v / 1000).toFixed(0)}k`} />
-              <Tooltip labelFormatter={formatShortDate} />
-              <Legend />
-              <Bar yAxisId="left" dataKey="sms_sent_count" name="SMS" fill={CHANNEL_COLORS.sms} />
-              <Bar yAxisId="left" dataKey="email_sent_count" name="Email" fill={CHANNEL_COLORS.email} />
+          <ChartContainer config={activityConfig} className="aspect-auto h-[300px] w-full">
+            <ComposedChart accessibilityLayer data={history} margin={{ left: 8, right: 8, top: 8, bottom: 0 }}>
+              <CartesianGrid vertical={false} strokeDasharray="3 3" />
+              <XAxis
+                dataKey="snapshot_date"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={28}
+                tickFormatter={formatShortDate}
+              />
+              <YAxis yAxisId="left" tickLine={false} axisLine={false} tickMargin={8} width={40} />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={56}
+                tickFormatter={(v) => `R${(Number(v) / 1000).toFixed(0)}k`}
+              />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    indicator="dot"
+                    labelFormatter={(value) => formatShortDate(String(value))}
+                  />
+                }
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Bar yAxisId="left" dataKey="sms_sent_count" fill="var(--color-sms_sent_count)" radius={[4, 4, 0, 0]} />
+              <Bar yAxisId="left" dataKey="email_sent_count" fill="var(--color-email_sent_count)" radius={[4, 4, 0, 0]} />
               <Line
                 yAxisId="right"
-                type="monotone"
                 dataKey="payments_received_amount"
-                name="Payments"
-                stroke="#22c55e"
+                type="natural"
+                stroke="var(--color-payments_received_amount)"
                 strokeWidth={2}
+                dot={false}
               />
-            </BarChart>
-          </ResponsiveContainer>
+            </ComposedChart>
+          </ChartContainer>
         </CardContent>
       </Card>
-    </>
-  ) : (
-    <Card>
-      <CardContent className="py-10 text-center">
-        <PiCalendarBold className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-        <p className="text-muted-foreground">No historical data available yet</p>
-        <p className="text-sm text-muted-foreground mt-2">
-          Historical snapshots are created daily by the system
-        </p>
-      </CardContent>
-    </Card>
+    </div>
   );
 }

--- a/components/admin/finance/ar/NotificationsPanel.tsx
+++ b/components/admin/finance/ar/NotificationsPanel.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { PiCalendarBold, PiChatBold, PiCheckCircleBold, PiEnvelopeBold, PiPulseBold, PiXCircleBold } from 'react-icons/pi';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+import { StatusBadge, type StatusVariant } from '@/components/backend';
+import { CHANNEL_COLORS, formatCurrency, type ARAnalyticsData } from './shared';
+
+export function NotificationsPanel({ data }: { data: ARAnalyticsData }) {
+  const notificationPieData = [
+    { name: 'SMS', value: data.notifications.total_sms, fill: CHANNEL_COLORS.sms },
+    { name: 'Email', value: data.notifications.total_email, fill: CHANNEL_COLORS.email },
+  ];
+
+  const NOTIF_STATUS_VARIANT: Record<string, StatusVariant> = {
+    sent: 'success',
+    delivered: 'success',
+    failed: 'error',
+    bounced: 'error',
+    opened: 'info',
+    clicked: 'info',
+  };
+
+  const getStatusBadge = (status: string) => {
+    const label =
+      status === 'sent' || status === 'delivered'
+        ? 'Delivered'
+        : status.charAt(0).toUpperCase() + status.slice(1);
+    return <StatusBadge status={label} variant={NOTIF_STATUS_VARIANT[status] ?? 'neutral'} />;
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* Notification Breakdown */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Notification Channels</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={200}>
+              <PieChart>
+                <Pie
+                  data={notificationPieData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={40}
+                  outerRadius={80}
+                  dataKey="value"
+                  label={({ name, value }) => `${name}: ${value}`}
+                >
+                  {notificationPieData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.fill} />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+            <div className="flex justify-center gap-4 mt-4">
+              <div className="flex items-center gap-2">
+                <PiChatBold className="h-4 w-4 text-blue-500" />
+                <span className="text-sm">SMS: {data.notifications.total_sms}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <PiEnvelopeBold className="h-4 w-4 text-purple-500" />
+                <span className="text-sm">Email: {data.notifications.total_email}</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Delivery Stats */}
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle>Delivery Statistics</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="text-center p-4 bg-green-50 dark:bg-green-950/20 rounded-lg">
+                <PiCheckCircleBold className="h-6 w-6 mx-auto text-green-500 mb-2" />
+                <div className="text-xl font-bold">{data.notifications.total_delivered}</div>
+                <p className="text-sm text-muted-foreground">Delivered</p>
+              </div>
+              <div className="text-center p-4 bg-red-50 dark:bg-red-950/20 rounded-lg">
+                <PiXCircleBold className="h-6 w-6 mx-auto text-red-500 mb-2" />
+                <div className="text-xl font-bold">{data.notifications.total_failed}</div>
+                <p className="text-sm text-muted-foreground">Failed</p>
+              </div>
+              <div className="text-center p-4 bg-blue-50 dark:bg-blue-950/20 rounded-lg">
+                <PiPulseBold className="h-6 w-6 mx-auto text-blue-500 mb-2" />
+                <div className="text-xl font-bold">{data.notifications.delivery_rate.toFixed(1)}%</div>
+                <p className="text-sm text-muted-foreground">Delivery Rate</p>
+              </div>
+              <div className="text-center p-4 bg-purple-50 dark:bg-purple-950/20 rounded-lg">
+                <PiCalendarBold className="h-6 w-6 mx-auto text-purple-500 mb-2" />
+                <div className="text-xl font-bold">{data.ar_aging.avg_days_overdue.toFixed(0)}</div>
+                <p className="text-sm text-muted-foreground">Avg Days Overdue</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Recent Notifications Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Notifications</CardTitle>
+          <CardDescription>Last 20 notifications sent</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Invoice</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Recipient</TableHead>
+                <TableHead>Amount</TableHead>
+                <TableHead>Days Overdue</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Sent</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.recent_notifications.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
+                    No notifications sent yet
+                  </TableCell>
+                </TableRow>
+              ) : (
+                data.recent_notifications.map((notif) => (
+                  <TableRow key={notif.id}>
+                    <TableCell className="font-medium">{notif.invoice_number}</TableCell>
+                    <TableCell>
+                      {notif.notification_type === 'sms' ? (
+                        <Badge variant="outline" className="gap-1">
+                          <PiChatBold className="h-3 w-3" /> SMS
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="gap-1">
+                          <PiEnvelopeBold className="h-3 w-3" /> Email
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="max-w-[150px] truncate">{notif.recipient}</TableCell>
+                    <TableCell>{formatCurrency(notif.amount_due)}</TableCell>
+                    <TableCell>{notif.days_overdue} days</TableCell>
+                    <TableCell>{getStatusBadge(notif.status)}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {new Date(notif.created_at).toLocaleString('en-ZA')}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/components/admin/finance/ar/NotificationsPanel.tsx
+++ b/components/admin/finance/ar/NotificationsPanel.tsx
@@ -1,163 +1,198 @@
 'use client';
 
+import { Cell, Pie, PieChart } from 'recharts';
 import { PiCalendarBold, PiChatBold, PiCheckCircleBold, PiEnvelopeBold, PiPulseBold, PiXCircleBold } from 'react-icons/pi';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
 import { StatusBadge, type StatusVariant } from '@/components/backend';
 import { CHANNEL_COLORS, formatCurrency, type ARAnalyticsData } from './shared';
 
+const chartConfig = {
+  value: { label: 'Sent' },
+  SMS: { label: 'SMS', color: CHANNEL_COLORS.sms },
+  Email: { label: 'Email', color: CHANNEL_COLORS.email },
+} satisfies ChartConfig;
+
+const NOTIF_STATUS_VARIANT: Record<string, StatusVariant> = {
+  sent: 'success',
+  delivered: 'success',
+  failed: 'error',
+  bounced: 'error',
+  opened: 'info',
+  clicked: 'info',
+};
+
+function notifStatusBadge(status: string) {
+  const label =
+    status === 'sent' || status === 'delivered'
+      ? 'Delivered'
+      : status.charAt(0).toUpperCase() + status.slice(1);
+  return <StatusBadge status={label} variant={NOTIF_STATUS_VARIANT[status] ?? 'neutral'} />;
+}
+
 export function NotificationsPanel({ data }: { data: ARAnalyticsData }) {
-  const notificationPieData = [
+  const channelData = [
     { name: 'SMS', value: data.notifications.total_sms, fill: CHANNEL_COLORS.sms },
     { name: 'Email', value: data.notifications.total_email, fill: CHANNEL_COLORS.email },
   ];
 
-  const NOTIF_STATUS_VARIANT: Record<string, StatusVariant> = {
-    sent: 'success',
-    delivered: 'success',
-    failed: 'error',
-    bounced: 'error',
-    opened: 'info',
-    clicked: 'info',
-  };
-
-  const getStatusBadge = (status: string) => {
-    const label =
-      status === 'sent' || status === 'delivered'
-        ? 'Delivered'
-        : status.charAt(0).toUpperCase() + status.slice(1);
-    return <StatusBadge status={label} variant={NOTIF_STATUS_VARIANT[status] ?? 'neutral'} />;
-  };
+  const deliveryTiles = [
+    {
+      label: 'Delivered',
+      value: `${data.notifications.total_delivered}`,
+      icon: <PiCheckCircleBold className="h-5 w-5 text-emerald-600" aria-hidden="true" />,
+    },
+    {
+      label: 'Failed',
+      value: `${data.notifications.total_failed}`,
+      icon: <PiXCircleBold className="h-5 w-5 text-red-600" aria-hidden="true" />,
+    },
+    {
+      label: 'Delivery rate',
+      value: `${data.notifications.delivery_rate.toFixed(1)}%`,
+      icon: <PiPulseBold className="h-5 w-5 text-blue-600" aria-hidden="true" />,
+    },
+    {
+      label: 'Avg days overdue',
+      value: data.ar_aging.avg_days_overdue.toFixed(0),
+      icon: <PiCalendarBold className="h-5 w-5 text-amber-600" aria-hidden="true" />,
+    },
+  ];
 
   return (
-    <>
+    <div className="space-y-4">
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        {/* Notification Breakdown */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Notification Channels</CardTitle>
+        <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base font-semibold text-slate-900">
+              Notification Channels
+            </CardTitle>
+            <p className="text-xs text-slate-500">Share of sends by channel</p>
           </CardHeader>
           <CardContent>
-            <ResponsiveContainer width="100%" height={200}>
+            <ChartContainer config={chartConfig} className="aspect-auto h-[200px] w-full">
               <PieChart>
-                <Pie
-                  data={notificationPieData}
-                  cx="50%"
-                  cy="50%"
-                  innerRadius={40}
-                  outerRadius={80}
-                  dataKey="value"
-                  label={({ name, value }) => `${name}: ${value}`}
-                >
-                  {notificationPieData.map((entry, index) => (
-                    <Cell key={`cell-${index}`} fill={entry.fill} />
+                <ChartTooltip cursor={false} content={<ChartTooltipContent indicator="dot" />} />
+                <Pie data={channelData} dataKey="value" nameKey="name" innerRadius={45} outerRadius={80} strokeWidth={2}>
+                  {channelData.map((entry) => (
+                    <Cell key={entry.name} fill={entry.fill} />
                   ))}
                 </Pie>
-                <Tooltip />
               </PieChart>
-            </ResponsiveContainer>
-            <div className="flex justify-center gap-4 mt-4">
-              <div className="flex items-center gap-2">
-                <PiChatBold className="h-4 w-4 text-blue-500" />
-                <span className="text-sm">SMS: {data.notifications.total_sms}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <PiEnvelopeBold className="h-4 w-4 text-purple-500" />
-                <span className="text-sm">Email: {data.notifications.total_email}</span>
-              </div>
+            </ChartContainer>
+            <div className="mt-3 flex justify-center gap-4 text-sm">
+              <span className="inline-flex items-center gap-2 text-slate-600">
+                <PiChatBold className="h-4 w-4" style={{ color: CHANNEL_COLORS.sms }} aria-hidden="true" />
+                SMS: <span className="tabular-nums font-medium text-slate-900">{data.notifications.total_sms}</span>
+              </span>
+              <span className="inline-flex items-center gap-2 text-slate-600">
+                <PiEnvelopeBold className="h-4 w-4" style={{ color: CHANNEL_COLORS.email }} aria-hidden="true" />
+                Email: <span className="tabular-nums font-medium text-slate-900">{data.notifications.total_email}</span>
+              </span>
             </div>
           </CardContent>
         </Card>
 
-        {/* Delivery Stats */}
-        <Card className="lg:col-span-2">
-          <CardHeader>
-            <CardTitle>Delivery Statistics</CardTitle>
+        <Card className="lg:col-span-2 rounded-xl border-slate-200/80 shadow-sm bg-white">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base font-semibold text-slate-900">
+              Delivery Statistics
+            </CardTitle>
+            <p className="text-xs text-slate-500">Outcome of sends in the selected window</p>
           </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <div className="text-center p-4 bg-green-50 dark:bg-green-950/20 rounded-lg">
-                <PiCheckCircleBold className="h-6 w-6 mx-auto text-green-500 mb-2" />
-                <div className="text-xl font-bold">{data.notifications.total_delivered}</div>
-                <p className="text-sm text-muted-foreground">Delivered</p>
+          <CardContent className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {deliveryTiles.map(({ label, value, icon }) => (
+              <div key={label} className="rounded-xl border border-slate-100 bg-slate-50/50 p-3">
+                {icon}
+                <p className="text-xs text-slate-500 mt-2">{label}</p>
+                <p className="text-xl font-semibold tabular-nums text-slate-900 mt-0.5">{value}</p>
               </div>
-              <div className="text-center p-4 bg-red-50 dark:bg-red-950/20 rounded-lg">
-                <PiXCircleBold className="h-6 w-6 mx-auto text-red-500 mb-2" />
-                <div className="text-xl font-bold">{data.notifications.total_failed}</div>
-                <p className="text-sm text-muted-foreground">Failed</p>
-              </div>
-              <div className="text-center p-4 bg-blue-50 dark:bg-blue-950/20 rounded-lg">
-                <PiPulseBold className="h-6 w-6 mx-auto text-blue-500 mb-2" />
-                <div className="text-xl font-bold">{data.notifications.delivery_rate.toFixed(1)}%</div>
-                <p className="text-sm text-muted-foreground">Delivery Rate</p>
-              </div>
-              <div className="text-center p-4 bg-purple-50 dark:bg-purple-950/20 rounded-lg">
-                <PiCalendarBold className="h-6 w-6 mx-auto text-purple-500 mb-2" />
-                <div className="text-xl font-bold">{data.ar_aging.avg_days_overdue.toFixed(0)}</div>
-                <p className="text-sm text-muted-foreground">Avg Days Overdue</p>
-              </div>
-            </div>
+            ))}
           </CardContent>
         </Card>
       </div>
 
-      {/* Recent Notifications Table */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Recent Notifications</CardTitle>
-          <CardDescription>Last 20 notifications sent</CardDescription>
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <div>
+            <CardTitle className="text-base font-semibold text-slate-900">
+              Recent Notifications
+            </CardTitle>
+            <p className="text-xs text-slate-500">Last 20 notifications sent</p>
+          </div>
+          <span className="text-xs font-medium text-slate-500">
+            {data.recent_notifications.length} shown
+          </span>
         </CardHeader>
         <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Invoice</TableHead>
-                <TableHead>Type</TableHead>
-                <TableHead>Recipient</TableHead>
-                <TableHead>Amount</TableHead>
-                <TableHead>Days Overdue</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Sent</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {data.recent_notifications.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
-                    No notifications sent yet
-                  </TableCell>
-                </TableRow>
-              ) : (
-                data.recent_notifications.map((notif) => (
-                  <TableRow key={notif.id}>
-                    <TableCell className="font-medium">{notif.invoice_number}</TableCell>
-                    <TableCell>
-                      {notif.notification_type === 'sms' ? (
-                        <Badge variant="outline" className="gap-1">
-                          <PiChatBold className="h-3 w-3" /> SMS
-                        </Badge>
-                      ) : (
-                        <Badge variant="outline" className="gap-1">
-                          <PiEnvelopeBold className="h-3 w-3" /> Email
-                        </Badge>
-                      )}
-                    </TableCell>
-                    <TableCell className="max-w-[150px] truncate">{notif.recipient}</TableCell>
-                    <TableCell>{formatCurrency(notif.amount_due)}</TableCell>
-                    <TableCell>{notif.days_overdue} days</TableCell>
-                    <TableCell>{getStatusBadge(notif.status)}</TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {new Date(notif.created_at).toLocaleString('en-ZA')}
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
+          {data.recent_notifications.length === 0 ? (
+            <div className="flex items-center justify-center rounded-xl border border-dashed border-slate-200 py-10 text-sm text-slate-400">
+              No notifications sent yet
+            </div>
+          ) : (
+            <div className="overflow-x-auto rounded-xl border border-slate-200/80">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 bg-slate-50">
+                    {['Invoice', 'Type', 'Recipient', 'Amount', 'Days overdue', 'Status', 'Sent'].map((h, i) => (
+                      <th
+                        key={h}
+                        className={`px-3 py-2.5 text-xs font-semibold uppercase tracking-wider text-slate-500 ${
+                          i === 3 || i === 4 ? 'text-right' : 'text-left'
+                        }`}
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {data.recent_notifications.map((notif) => (
+                    <tr key={notif.id} className="transition-colors hover:bg-slate-50">
+                      <td className="whitespace-nowrap px-3 py-2.5 font-medium text-slate-900">
+                        {notif.invoice_number}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5">
+                        <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs font-medium text-slate-600">
+                          {notif.notification_type === 'sms' ? (
+                            <>
+                              <PiChatBold className="h-3 w-3" style={{ color: CHANNEL_COLORS.sms }} aria-hidden="true" />
+                              SMS
+                            </>
+                          ) : (
+                            <>
+                              <PiEnvelopeBold className="h-3 w-3" style={{ color: CHANNEL_COLORS.email }} aria-hidden="true" />
+                              Email
+                            </>
+                          )}
+                        </span>
+                      </td>
+                      <td className="max-w-[180px] truncate px-3 py-2.5 text-slate-700">
+                        {notif.recipient}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                        {formatCurrency(notif.amount_due)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-right tabular-nums text-slate-600">
+                        {notif.days_overdue}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5">{notifStatusBadge(notif.status)}</td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-xs text-slate-500">
+                        {new Date(notif.created_at).toLocaleString('en-ZA')}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </CardContent>
       </Card>
-    </>
+    </div>
   );
 }

--- a/components/admin/finance/ar/index.ts
+++ b/components/admin/finance/ar/index.ts
@@ -1,0 +1,13 @@
+export { ArAgingPanel } from './ArAgingPanel';
+export { DsoMetricsPanel } from './DsoMetricsPanel';
+export { NotificationsPanel } from './NotificationsPanel';
+export { HistoryPanel } from './HistoryPanel';
+export {
+  AGING_COLORS,
+  CHANNEL_COLORS,
+  buildAgingBuckets,
+  formatCurrency,
+  formatShortDate,
+  TrendIcon,
+} from './shared';
+export type { ARAnalyticsData, AgingBucket } from './shared';

--- a/components/admin/finance/ar/shared.tsx
+++ b/components/admin/finance/ar/shared.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { PiMinusBold, PiTrendDownBold, PiTrendUpBold } from 'react-icons/pi';
+
+/** Response shape of GET /api/admin/finance/ar-analytics — moved from the page. */
+export interface ARAnalyticsData {
+  ar_aging: {
+    total_outstanding_invoices: number;
+    total_outstanding_amount: number;
+    current_count: number;
+    current_amount: number;
+    overdue_1_30_count: number;
+    overdue_1_30_amount: number;
+    overdue_31_60_count: number;
+    overdue_31_60_amount: number;
+    overdue_61_90_count: number;
+    overdue_61_90_amount: number;
+    overdue_90_plus_count: number;
+    overdue_90_plus_amount: number;
+    avg_days_overdue: number;
+  };
+  dso: {
+    dso_current: number;
+    dso_30_day_avg: number;
+    dso_trend: 'improving' | 'stable' | 'worsening';
+    best_possible_dso: number;
+    collection_effectiveness_index: number;
+  };
+  collection: {
+    total_notifications_sent: number;
+    total_amount_collected: number;
+    collection_rate: number;
+    avg_days_to_payment: number;
+    response_rate: number;
+  };
+  notifications: {
+    total_sms: number;
+    total_email: number;
+    total_delivered: number;
+    total_failed: number;
+    delivery_rate: number;
+  };
+  daily_analytics: Array<{
+    date: string;
+    notification_type: string;
+    total_sent: number;
+    delivered: number;
+    failed: number;
+    total_amount_notified: number;
+  }>;
+  recent_notifications: Array<{
+    id: string;
+    invoice_number: string;
+    notification_type: string;
+    recipient: string;
+    status: string;
+    amount_due: number;
+    days_overdue: number;
+    created_at: string;
+  }>;
+  historical: Array<{
+    snapshot_date: string;
+    total_outstanding: number;
+    dso_current: number;
+    sms_sent_count: number;
+    email_sent_count: number;
+    payments_received_amount: number;
+  }> | null;
+}
+
+/**
+ * Aging severity ramp — green to dark red by age. Semantic, NOT the chart palette.
+ * Do not replace with --chart-* vars; the hue is the "how overdue" signal.
+ */
+export const AGING_COLORS = {
+  current: '#22c55e',
+  overdue_1_30: '#eab308',
+  overdue_31_60: '#f97316',
+  overdue_61_90: '#ef4444',
+  overdue_90_plus: '#991b1b',
+} as const;
+
+/** Notification channel identity — used in chart, legend, and table badges. */
+export const CHANNEL_COLORS = {
+  sms: '#3b82f6',
+  email: '#8b5cf6',
+} as const;
+
+export function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-ZA', {
+    style: 'currency',
+    currency: 'ZAR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export function formatShortDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-ZA', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/** Down = improving for DSO (fewer days is better), so the arrow is inverted on purpose. */
+export function TrendIcon({ trend }: { trend: string }) {
+  if (trend === 'improving') {
+    return <PiTrendDownBold className="h-4 w-4 text-green-600" aria-hidden="true" />;
+  }
+  if (trend === 'worsening') {
+    return <PiTrendUpBold className="h-4 w-4 text-red-600" aria-hidden="true" />;
+  }
+  return <PiMinusBold className="h-4 w-4 text-slate-400" aria-hidden="true" />;
+}
+
+export interface AgingBucket {
+  name: string;
+  amount: number;
+  count: number;
+  fill: string;
+}
+
+export function buildAgingBuckets(aging: ARAnalyticsData['ar_aging']): AgingBucket[] {
+  return [
+    { name: 'Current', amount: aging.current_amount, count: aging.current_count, fill: AGING_COLORS.current },
+    { name: '1-30 Days', amount: aging.overdue_1_30_amount, count: aging.overdue_1_30_count, fill: AGING_COLORS.overdue_1_30 },
+    { name: '31-60 Days', amount: aging.overdue_31_60_amount, count: aging.overdue_31_60_count, fill: AGING_COLORS.overdue_31_60 },
+    { name: '61-90 Days', amount: aging.overdue_61_90_amount, count: aging.overdue_61_90_count, fill: AGING_COLORS.overdue_61_90 },
+    { name: '90+ Days', amount: aging.overdue_90_plus_amount, count: aging.overdue_90_plus_count, fill: AGING_COLORS.overdue_90_plus },
+  ];
+}

--- a/components/admin/network/performance/MetricCard.tsx
+++ b/components/admin/network/performance/MetricCard.tsx
@@ -1,52 +1,7 @@
-'use client';
-
-import { ReactNode } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { cn } from '@/lib/utils';
-
-type MetricCardProps = {
-  title: string;
-  value: string;
-  subtitle?: string;
-  delta?: string | null;
-  deltaPositive?: boolean | null;
-  children?: ReactNode;
-  className?: string;
-};
-
-export function MetricCard({
-  title,
-  value,
-  subtitle,
-  delta,
-  deltaPositive,
-  children,
-  className,
-}: MetricCardProps) {
-  return (
-    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
-      <CardHeader className="pb-2 space-y-0">
-        <CardTitle className="text-sm font-medium text-slate-500">{title}</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <div>
-          <p className="text-3xl font-semibold tracking-tight text-slate-900">{value}</p>
-          {subtitle ? <p className="text-xs text-slate-500 mt-1">{subtitle}</p> : null}
-          {delta ? (
-            <p
-              className={cn(
-                'text-xs mt-1 font-medium',
-                deltaPositive === true && 'text-blue-600',
-                deltaPositive === false && 'text-amber-600',
-                deltaPositive == null && 'text-slate-500'
-              )}
-            >
-              {delta}
-            </p>
-          ) : null}
-        </div>
-        {children}
-      </CardContent>
-    </Card>
-  );
-}
+/**
+ * Back-compat shim. MetricCard was promoted to the shared backend kit —
+ * see components/backend/MetricCard.tsx and docs/design/BACKEND_UI_KIT.md.
+ * Imports the file directly (not the @/components/backend barrel) to avoid a cycle.
+ */
+export { MetricCard } from '@/components/backend/MetricCard';
+export type { MetricCardProps } from '@/components/backend/MetricCard';

--- a/components/backend/MetricCard.tsx
+++ b/components/backend/MetricCard.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * Canonical metric card for backend UIs — the network console look.
+ * Promoted from components/admin/network/performance/MetricCard.tsx, which is
+ * now a re-export shim so the network pages render identically.
+ *
+ * Use this (not StatCard) for new/migrated pages. `children` renders below the
+ * value block — pass a small icon or an inline chart.
+ */
+export type MetricCardProps = {
+  title: string;
+  value: string;
+  subtitle?: string;
+  delta?: string | null;
+  deltaPositive?: boolean | null;
+  children?: ReactNode;
+  className?: string;
+};
+
+export function MetricCard({
+  title,
+  value,
+  subtitle,
+  delta,
+  deltaPositive,
+  children,
+  className,
+}: MetricCardProps) {
+  return (
+    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+      <CardHeader className="pb-2 space-y-0">
+        <CardTitle className="text-sm font-medium text-slate-500">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <p className="text-3xl font-semibold tracking-tight text-slate-900">{value}</p>
+          {subtitle ? <p className="text-xs text-slate-500 mt-1">{subtitle}</p> : null}
+          {delta ? (
+            <p
+              className={cn(
+                'text-xs mt-1 font-medium',
+                deltaPositive === true && 'text-blue-600',
+                deltaPositive === false && 'text-amber-600',
+                deltaPositive == null && 'text-slate-500'
+              )}
+            >
+              {delta}
+            </p>
+          ) : null}
+        </div>
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/backend/index.ts
+++ b/components/backend/index.ts
@@ -5,6 +5,8 @@
  */
 export { StatCard } from './StatCard';
 export type { StatCardProps } from './StatCard';
+export { MetricCard } from './MetricCard';
+export type { MetricCardProps } from './MetricCard';
 export { StatusBadge, getStatusVariant } from './StatusBadge';
 export type { StatusVariant } from './StatusBadge';
 export { PageHeader } from './PageHeader';

--- a/docs/design/BACKEND_UI_KIT.md
+++ b/docs/design/BACKEND_UI_KIT.md
@@ -3,7 +3,7 @@
 Shared component primitives for the **admin** (`/admin/*`) and **consumer** (`/dashboard/*`) dashboards. One kit, one look — so both surfaces feel like the same product.
 
 - **Home:** `components/backend/` — import from `@/components/backend`.
-- **Reference look:** the consumer billing dashboard (`app/dashboard/billing/page.tsx`) and the migrated admin billing hub (`app/admin/billing/*`). — functional minimalism: white surfaces, soft gray borders, restrained orange accent, generous spacing, `tabular-nums` numbers.
+- **Reference look:** the network console (`app/admin/network/analytics`, `app/admin/network/devices`) — functional minimalism on `slate`: white surfaces, `border-slate-200/80`, `rounded-xl`, `shadow-sm`, breadcrumb eyebrow above the H1, outline `size="sm"` action rows, source/freshness meta strips, `tabular-nums` numbers, restrained orange accent.
 - **Tokens:** reuse `tailwind.config.ts` (`circleTel.*`), `app/globals.css`, `DESIGN.md`, `lib/design-system.ts`. Do not invent new tokens.
 
 ## Principles
@@ -20,7 +20,8 @@ Shared component primitives for the **admin** (`/admin/*`) and **consumer** (`/d
 | `AdminPage` | Page body shell (`space-y-6`). No extra padding/min-h-screen — AdminLayout already shells. |
 | `PageHeader` | List/index page title + subtitle + actions. (Detail pages → `DetailPageHeader`.) |
 | `DetailPageHeader` | Detail title + optional breadcrumbs/status. Type scale matches `PageHeader`. |
-| `StatCard` | Metric cards. Replaces inline stat `<div>`s, admin `StatCard`, and `ModernStatCard`. |
+| `MetricCard` | **Preferred** metric card — network console look. Label above, big `font-semibold` value, optional `children` (icon or inline chart) below. |
+| `StatCard` | Legacy metric card (gray, three layout variants). Retained for unmigrated pages — prefer `MetricCard` for new work. |
 | `StatusBadge` + `getStatusVariant` | Every status pill. Map raw DB strings with `getStatusVariant()`. |
 | `SectionCard` | Card with a header for grouped content. |
 | `InfoRow` | Key/value rows in detail panels. |
@@ -69,6 +70,14 @@ import { PiFileTextBold } from 'react-icons/pi';
 5. Loading/empty/error blocks → `LoadingState` / `EmptyState` / `ErrorState`.
 6. Tabs → `ConsoleTabsList` / `ConsoleTabsContent` (where tabs exist).
 7. `npm run type-check:memory`; visual-diff against the billing hub / consumer billing reference.
+
+## Colour that carries meaning
+
+Status colour comes only from `StatusBadge`/`getStatusVariant`. Beyond that, some
+surfaces use colour as *data* — AR aging buckets (green→dark-red by age), notification
+channels (SMS blue / Email purple), cash-match day-done state (green/red), and exception
+severity (red/amber). Preserve those hues when restyling; do not flatten them into the
+chart palette. Consistency of *chrome* (grid, axes, tooltips, card shells), not of hue.
 
 ## Back-compat
 

--- a/docs/superpowers/plans/2026-07-30-billing-ar-network-console-look.md
+++ b/docs/superpowers/plans/2026-07-30-billing-ar-network-console-look.md
@@ -117,7 +117,17 @@ Then browse `http://localhost:3000/admin/...`. Without the env var you get redir
 | `components/admin/finance/ar/NotificationsPanel.tsx` | CREATE. Channel donut, delivery stats, recent notifications table. |
 | `components/admin/finance/ar/HistoryPanel.tsx` | CREATE. AR/DSO trend + notifications/collections charts. |
 
-**Total: 16 files.** The spec estimated 15; `shared.tsx` is the addition — the four panels need the formatters and the `ARAnalyticsData` type that currently live inside `page.tsx`, and duplicating them across four files would violate DRY.
+**Total: 17 files changed** — 16 under `app/`/`components/` plus `docs/design/BACKEND_UI_KIT.md`.
+
+Count reconciliation against the spec's estimate of 15:
+
+| | Files |
+|---|---|
+| Spec estimate | 15 |
+| `+ components/admin/finance/ar/shared.tsx` | 16 |
+| `+ components/admin/finance/ar/index.ts` | 17 |
+
+Both additions are new files inside the already-approved `components/admin/finance/ar/` directory. `shared.tsx` holds the `ARAnalyticsData` type, the aging/channel colour constants, and the formatters that currently live inside `page.tsx` — all four panels need them, and duplicating them four times would violate DRY. `index.ts` is the barrel, matching the `performance/index.ts` convention.
 
 ---
 
@@ -1114,7 +1124,7 @@ export {
 export type { ARAnalyticsData, AgingBucket } from './shared';
 ```
 
-This makes 17 files total, not 16 — the barrel matches the convention of `components/admin/network/performance/index.ts` and keeps `page.tsx`'s import to one line.
+The barrel matches the convention of `components/admin/network/performance/index.ts` and keeps `page.tsx`'s import to one line. It is the 17th changed file — see the count reconciliation under File Structure.
 
 - [ ] **Step 4: Rewrite `page.tsx` to fetch + header + tabs wiring only**
 
@@ -2268,7 +2278,7 @@ git diff --stat origin/main...HEAD
 git diff --name-only origin/main...HEAD | grep -E "^(app|components|lib)/" | sort
 ```
 
-Expected exactly these 17 paths, and nothing else — in particular **no `app/admin/network/*` and no `lib/*`**:
+Expected exactly these 16 code paths, and nothing else — in particular **no `app/admin/network/*` and no `lib/*`**. (`docs/design/BACKEND_UI_KIT.md` is the 17th changed file but is filtered out by the `grep`.)
 
 ```
 app/admin/billing/page.tsx
@@ -2423,7 +2433,7 @@ EOF
 
 **Deviations from the spec, and why**
 
-1. **File count 15 → 17.** `shared.tsx` (types, colours, formatters needed by all four panels — duplicating across four files would violate DRY) and `index.ts` (barrel, matching the `performance/index.ts` convention). Both are new files in the already-approved `components/admin/finance/ar/` directory.
+1. **File count 15 → 17** (16 code + 1 doc). Additions: `shared.tsx` (types, colours, formatters needed by all four panels — duplicating across four files would violate DRY) and `index.ts` (barrel, matching the `performance/index.ts` convention). Both are new files in the already-approved `components/admin/finance/ar/` directory. Reconciliation table under File Structure.
 2. **Success criterion 3 verification method strengthened.** The spec called for screenshot-diffing the three network pages. Task 1 instead proves the `MetricCard` render body is byte-identical via `diff`, which is deterministic and cheaper; the visual check in Task 13 Step 6 is retained as confirmation. Screenshot diffing would also have needed image tooling the repo does not have.
 3. **No component tests, and none written.** The spec assumed nothing here, but the plan states it explicitly: there is no working component-test infrastructure and a restyle adds no logic, so tests would be fake (Rule 11) and would need 4 new dev deps (Rule 12).
 4. **`ComposedChart` in Task 12.** The current code nests `<Line>` inside `<AreaChart>`/`<BarChart>`; Recharts needs `ComposedChart` for mixed marks. This is a correctness fix inside a file already being rewritten, not scope creep — and without it the restyled history charts would silently drop a series.

--- a/docs/superpowers/plans/2026-07-30-billing-ar-network-console-look.md
+++ b/docs/superpowers/plans/2026-07-30-billing-ar-network-console-look.md
@@ -1,0 +1,2434 @@
+# Billing + AR Analytics Network Console Look — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restyle `/admin/billing` and `/admin/finance/ar-analytics` to match the visual language of `/admin/network/analytics` and `/admin/network/devices`, with zero visual change to any other page.
+
+**Architecture:** Promote `MetricCard` from `components/admin/network/performance/` into the shared `components/backend/` kit, leaving a re-export shim so the three network pages are untouched. Then restyle the two target pages onto the promoted card plus the network card/table/banner class conventions. Presentation only — no data, API, or logic changes.
+
+**Tech Stack:** Next.js 15 (App Router, client components), TypeScript, Tailwind, shadcn/ui (`Card`, `Select`, `Badge`, `Tabs`, `chart`), Recharts 2.15, `react-icons/pi` (Phosphor), Jest 30 (node env).
+
+**Spec:** `docs/superpowers/specs/2026-07-30-billing-ar-network-console-look-design.md`
+
+---
+
+## Global Constraints
+
+- **Working directory is the worktree:** `/home/circletel/.worktrees/billing-console` on branch `feat/billing-network-console-look`. Never edit `/home/circletel` directly.
+- **Presentation only.** Do not change data fetching, API routes, SQL, types under `lib/billing/recon-hub/`, `filterExceptions`, or any `/api/*` handler. If a restyle appears to need a data change, stop and report.
+- **No new dependencies.** Do not `npm install` anything. There is no React component test infrastructure (see "Verification model" below) and adding it is out of scope.
+- **`MetricCardProps` shape is frozen.** No prop renames, removals, or default changes. Adding the `export` keyword is the only permitted edit.
+- **Palette:** `slate-*`, not `gray-*`. Metric values `font-semibold`, not `font-bold`. Grid gaps `gap-4`.
+- **Icons:** Phosphor via `react-icons/pi` only. Decorative icons get `aria-hidden="true"`.
+- **Preserve semantic colour.** These encode data, not decoration — keep their current hex/classes and restyle only the surrounding chrome:
+  - AR aging buckets: `current #22c55e`, `1-30 #eab308`, `31-60 #f97316`, `61-90 #ef4444`, `90+ #991b1b`
+  - Channels: `sms #3b82f6`, `email #8b5cf6`
+  - `CashMatchStrip` day-done green/red tint; `DayDoneBanner` green/red
+  - `ExceptionTable` red/amber severity text
+  - All `StatusBadge` variants
+- **Orange is an accent only:** one primary CTA on billing, filter chips, links. Never body text.
+- **No dark mode.** Neither reference page implements it. `dark:` classes removed with the tinted tiles are not replaced.
+- **Commit after every task.** Never `git commit --no-verify`.
+
+### Verification model (read before Task 1)
+
+This repo has **no working React component test infrastructure**, verified at plan time:
+
+- `jest.config.js` sets `testEnvironment: 'jest-environment-node'` — no DOM.
+- `vitest`, `@testing-library/react`, `@testing-library/jest-dom`, `jest-environment-jsdom` are all **not installed**.
+- The only `.test.tsx` in the repo (`components/admin/compliance/__tests__/compliance-queue.test.tsx`) imports from `vitest` and cannot execute. It is dead code. Do not use it as a pattern.
+
+A restyle introduces **no new logic**, so there is nothing meaningful to unit test. Writing tests that assert Tailwind class strings would be the fake-test anti-pattern (`.claude/rules/anti-patterns.md`, Rule 11) and adding four dev dependencies would violate Rule 12. **Do not write component tests for this work.**
+
+Verification for every task is therefore:
+
+1. **Type-check delta** — the repo carries pre-existing `tsc` errors, so "zero errors" is not the bar. Compare against the Task 0 baseline; your touched files must contribute **no new** errors.
+
+   Measured at plan time on `origin/main` (`8b481677`): **211 errors** — note this is lower than the "~295" figure in `.claude/rules/pre-push-hook.md`, which is stale. Capture your own baseline in Task 0 rather than trusting either number.
+
+   **Crucially, all 16 files this plan touches are currently type-clean, as are the three network consumer pages.** Verified:
+
+   ```
+   grep -E "app/admin/billing/page|ar-analytics|recon/|components/backend/|network/performance/MetricCard" → NONE
+   grep -E "app/admin/network/(analytics|devices|health)"                                                   → NONE
+   ```
+
+   This is why each task's verification can simply grep the baseline output for its own filenames and expect nothing: any hit is a regression you just introduced, not pre-existing noise.
+2. **Build** — `npm run build:memory` must succeed (run once in Task 14, not per task; it takes 10–18 min).
+3. **Existing Jest suites stay green** — the recon-hub and network aggregate suites.
+4. **Content-identity proof** for the `MetricCard` move (Task 1) — deterministic, and a stronger guarantee than a screenshot that the three network pages are unchanged.
+5. **Visual inspection** against a local dev server (Task 14).
+
+### Two environment traps (both verified at plan time)
+
+**Trap 1 — Jest finds zero tests inside a worktree.** `jest.config.js` sets:
+
+```js
+modulePathIgnorePatterns: ['/.worktrees/', '/.claude/worktrees/'],
+testPathIgnorePatterns: ['/node_modules/', '/.next/', '/coverage/', '/dist/', '/.worktrees/', '/.claude/worktrees/'],
+```
+
+Because the worktree's absolute path contains `/.worktrees/`, a bare `npx jest <path>` reports `0 matches` and **exits 1** — which reads like "no tests" rather than "tests were skipped". Always override on the CLI:
+
+```bash
+npx jest <paths> --modulePathIgnorePatterns=/node_modules/ --testPathIgnorePatterns=/node_modules/
+```
+
+**Trap 2 — `/admin/*` requires auth locally.** `middleware/admin-auth.ts` has an opt-in dev bypass requiring **all** of: `ALLOW_DEV_ADMIN_BYPASS=true`, `NODE_ENV=development`, and a `localhost`/`127.0.0.1` Host header. Start the dev server as:
+
+```bash
+ALLOW_DEV_ADMIN_BYPASS=true npm run dev:memory
+```
+
+Then browse `http://localhost:3000/admin/...`. Without the env var you get redirected to login.
+
+---
+
+## File Structure
+
+**Unit 1 — promote the card (4 files)**
+
+| File | Responsibility |
+|---|---|
+| `components/backend/MetricCard.tsx` | CREATE. Canonical metric card. Content identical to the network original + `export` on the type. |
+| `components/backend/index.ts` | MODIFY. Export `MetricCard`, `MetricCardProps`. |
+| `components/admin/network/performance/MetricCard.tsx` | MODIFY. Two-line re-export shim. |
+| `docs/design/BACKEND_UI_KIT.md` | MODIFY. Network console becomes the documented reference; add `MetricCard` row. |
+
+**Unit 2 — `/admin/billing` (6 files)**
+
+| File | Responsibility |
+|---|---|
+| `app/admin/billing/page.tsx` | MODIFY. Header, eyebrow, `size="sm"` actions, meta strip, footer meta. |
+| `components/admin/billing/recon/CashMatchStrip.tsx` | MODIFY. `StatCard` → `MetricCard`. |
+| `components/admin/billing/recon/SecondaryKpis.tsx` | MODIFY. Tile shell → network tile. |
+| `components/admin/billing/recon/DayDoneBanner.tsx` | MODIFY. Banner shell → network banner. |
+| `components/admin/billing/recon/ExceptionTable.tsx` | MODIFY. `SectionCard` → network `Card`. Table markup untouched. |
+| `components/admin/billing/recon/DeepLinks.tsx` | MODIFY. Card shell radius/border. |
+
+**Unit 3 — `/admin/finance/ar-analytics` (6 files)**
+
+| File | Responsibility |
+|---|---|
+| `app/admin/finance/ar-analytics/page.tsx` | MODIFY. Shrinks to fetch + state + header + tabs wiring (~170 lines). |
+| `components/admin/finance/ar/shared.tsx` | CREATE. `ARAnalyticsData` type, panel prop types, `AGING_COLORS`, `CHANNEL_COLORS`, `formatCurrency`, `formatShortDate`, `TrendIcon`. |
+| `components/admin/finance/ar/ArAgingPanel.tsx` | CREATE. Aging bar chart + aging summary table. |
+| `components/admin/finance/ar/DsoMetricsPanel.tsx` | CREATE. 3 DSO cards + collection performance tiles. |
+| `components/admin/finance/ar/NotificationsPanel.tsx` | CREATE. Channel donut, delivery stats, recent notifications table. |
+| `components/admin/finance/ar/HistoryPanel.tsx` | CREATE. AR/DSO trend + notifications/collections charts. |
+
+**Total: 16 files.** The spec estimated 15; `shared.tsx` is the addition — the four panels need the formatters and the `ARAnalyticsData` type that currently live inside `page.tsx`, and duplicating them across four files would violate DRY.
+
+---
+
+## Task 0: Prepare the worktree and capture baselines
+
+The worktree has no `node_modules`, and every later task's "no new type errors" check needs a baseline to diff against.
+
+**Files:**
+- Create: `.scratch/baseline-typecheck.txt` (gitignored — do not commit)
+- Create: `.scratch/baseline-jest.txt` (gitignored — do not commit)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `.scratch/baseline-typecheck.txt` — the pre-change `tsc --noEmit` output, used by every subsequent task's verification step.
+
+- [ ] **Step 1: Confirm you are in the worktree on the right branch**
+
+```bash
+cd /home/circletel/.worktrees/billing-console
+git status -sb
+```
+
+Expected: `## feat/billing-network-console-look...origin/feat/billing-network-console-look`
+
+- [ ] **Step 2: Install dependencies**
+
+```bash
+npm ci
+```
+
+This also runs the `prepare` script (`git config core.hooksPath .githooks`), which the pre-push hook needs. Takes several minutes.
+
+- [ ] **Step 3: Capture the type-check baseline**
+
+```bash
+mkdir -p .scratch
+npm run type-check:memory 2>&1 | tee .scratch/baseline-typecheck.txt | tail -5
+grep -c "error TS" .scratch/baseline-typecheck.txt || true
+```
+
+Expected: **211** `error TS` lines on `origin/main` `8b481677`; a different base commit will differ. Record the count — this is the number to compare against in Task 13. A non-zero exit is expected and correct.
+
+Then confirm your touched files start clean, so later per-task greps are trustworthy:
+
+```bash
+grep -E "app/admin/billing/page|ar-analytics|recon/|components/backend/|network/performance/MetricCard|finance/ar/" .scratch/baseline-typecheck.txt \
+  || echo "ALL TARGET FILES CLEAN — per-task greps are meaningful"
+```
+
+Expected: `ALL TARGET FILES CLEAN — per-task greps are meaningful`. If a target file already has errors, note them — that file's per-task check must then diff rather than expect zero hits.
+
+- [ ] **Step 4: Capture the Jest baseline (note the worktree override)**
+
+```bash
+npx jest __tests__/lib/billing __tests__/lib/network \
+  --modulePathIgnorePatterns=/node_modules/ \
+  --testPathIgnorePatterns=/node_modules/ 2>&1 | tee .scratch/baseline-jest.txt | tail -8
+```
+
+Expected, measured at plan time: `Test Suites: 2 skipped, 17 passed, 17 of 19 total` and `Tests: 12 skipped, 142 passed, 154 total`. The 2 skipped suites are pre-existing and not your concern.
+
+If you see `0 matches` and exit 1, you omitted the override flags — see Trap 1.
+
+- [ ] **Step 5: Verify `.scratch/` is gitignored**
+
+```bash
+git check-ignore -v .scratch/baseline-typecheck.txt && echo "IGNORED — good"
+git status --porcelain
+```
+
+Expected: `IGNORED — good`, and `git status --porcelain` shows nothing. If `.scratch/` is NOT ignored, add it to `.gitignore` and commit that one-line change:
+
+```bash
+echo ".scratch/" >> .gitignore
+git add .gitignore && git commit -m "chore: gitignore .scratch baseline dir"
+```
+
+---
+
+## Task 1: Promote MetricCard into the backend kit
+
+The whole restyle depends on this card, and the three network pages must not move a pixel.
+
+**Files:**
+- Create: `components/backend/MetricCard.tsx`
+- Modify: `components/backend/index.ts`
+- Modify: `components/admin/network/performance/MetricCard.tsx` (all 52 lines replaced)
+- Modify: `docs/design/BACKEND_UI_KIT.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `MetricCard` and `MetricCardProps` from `@/components/backend`. Signature — all props except `title` and `value` are optional:
+  ```ts
+  export type MetricCardProps = {
+    title: string;
+    value: string;
+    subtitle?: string;
+    delta?: string | null;
+    deltaPositive?: boolean | null;
+    children?: ReactNode;
+    className?: string;
+  };
+  ```
+  Note `value` is `string` — numeric callers must template it (`` `${n}` ``). `children` renders **below** the value/subtitle/delta block.
+
+- [ ] **Step 1: Snapshot the original for the identity proof**
+
+```bash
+cp components/admin/network/performance/MetricCard.tsx /tmp/metriccard-original.tsx
+wc -l /tmp/metriccard-original.tsx
+```
+
+Expected: `52`.
+
+- [ ] **Step 2: Create `components/backend/MetricCard.tsx`**
+
+This is the original file verbatim, with `export` added to the type declaration and the doc comment updated.
+
+```tsx
+'use client';
+
+import { ReactNode } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * Canonical metric card for backend UIs — the network console look.
+ * Promoted from components/admin/network/performance/MetricCard.tsx, which is
+ * now a re-export shim so the network pages render identically.
+ *
+ * Use this (not StatCard) for new/migrated pages. `children` renders below the
+ * value block — pass a small icon or an inline chart.
+ */
+export type MetricCardProps = {
+  title: string;
+  value: string;
+  subtitle?: string;
+  delta?: string | null;
+  deltaPositive?: boolean | null;
+  children?: ReactNode;
+  className?: string;
+};
+
+export function MetricCard({
+  title,
+  value,
+  subtitle,
+  delta,
+  deltaPositive,
+  children,
+  className,
+}: MetricCardProps) {
+  return (
+    <Card className={cn('border border-slate-200/80 shadow-sm rounded-xl bg-white', className)}>
+      <CardHeader className="pb-2 space-y-0">
+        <CardTitle className="text-sm font-medium text-slate-500">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <p className="text-3xl font-semibold tracking-tight text-slate-900">{value}</p>
+          {subtitle ? <p className="text-xs text-slate-500 mt-1">{subtitle}</p> : null}
+          {delta ? (
+            <p
+              className={cn(
+                'text-xs mt-1 font-medium',
+                deltaPositive === true && 'text-blue-600',
+                deltaPositive === false && 'text-amber-600',
+                deltaPositive == null && 'text-slate-500'
+              )}
+            >
+              {delta}
+            </p>
+          ) : null}
+        </div>
+        {children}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 3: Prove the render body is byte-identical to the original**
+
+This is the regression proof for the three network pages. It compares everything from `export function MetricCard` onward.
+
+```bash
+diff <(sed -n '/^export function MetricCard/,$p' /tmp/metriccard-original.tsx) \
+     <(sed -n '/^export function MetricCard/,$p' components/backend/MetricCard.tsx) \
+  && echo "IDENTICAL RENDER BODY — network pages cannot change"
+```
+
+Expected: `IDENTICAL RENDER BODY — network pages cannot change`. If `diff` prints anything, you altered the JSX or classes — revert to the original text and retry.
+
+- [ ] **Step 4: Prove the prop shape is unchanged**
+
+```bash
+diff <(sed -n '/MetricCardProps = {/,/^};\?$/p' /tmp/metriccard-original.tsx | sed 's/^export //') \
+     <(sed -n '/MetricCardProps = {/,/^};\?$/p' components/backend/MetricCard.tsx | sed 's/^export //') \
+  && echo "PROP SHAPE UNCHANGED"
+```
+
+Expected: `PROP SHAPE UNCHANGED`.
+
+- [ ] **Step 5: Replace the network file with a re-export shim**
+
+Overwrite all 52 lines of `components/admin/network/performance/MetricCard.tsx` with exactly:
+
+```tsx
+/**
+ * Back-compat shim. MetricCard was promoted to the shared backend kit —
+ * see components/backend/MetricCard.tsx and docs/design/BACKEND_UI_KIT.md.
+ * Imports the file directly (not the @/components/backend barrel) to avoid a cycle.
+ */
+export { MetricCard } from '@/components/backend/MetricCard';
+export type { MetricCardProps } from '@/components/backend/MetricCard';
+```
+
+- [ ] **Step 6: Export from the kit barrel**
+
+In `components/backend/index.ts`, insert immediately after the `StatCard` export lines:
+
+```ts
+export { MetricCard } from './MetricCard';
+export type { MetricCardProps } from './MetricCard';
+```
+
+- [ ] **Step 7: Confirm the network barrel still resolves and no cycle was introduced**
+
+```bash
+grep -n "MetricCard" components/admin/network/performance/index.ts
+grep -rn "from '@/components/backend'" components/backend/MetricCard.tsx || echo "no barrel self-import — good"
+```
+
+Expected: the barrel still has `export { MetricCard } from './MetricCard';` (unchanged), and `no barrel self-import — good`.
+
+- [ ] **Step 8: Confirm the three network pages were not edited**
+
+```bash
+git status --porcelain app/admin/network/
+```
+
+Expected: **empty output.** If any network page shows as modified, revert it — this task must not touch them.
+
+- [ ] **Step 9: Type-check the moved module and its consumers**
+
+```bash
+npm run type-check:memory 2>&1 | grep -E "components/backend/MetricCard|performance/MetricCard|app/admin/network/(analytics|devices|health)" || echo "NO ERRORS in moved module or network consumers"
+```
+
+Expected: `NO ERRORS in moved module or network consumers`.
+
+- [ ] **Step 10: Update the kit doc**
+
+In `docs/design/BACKEND_UI_KIT.md`:
+
+Replace the `**Reference look:**` bullet with:
+
+```markdown
+- **Reference look:** the network console (`app/admin/network/analytics`, `app/admin/network/devices`) — functional minimalism on `slate`: white surfaces, `border-slate-200/80`, `rounded-xl`, `shadow-sm`, breadcrumb eyebrow above the H1, outline `size="sm"` action rows, source/freshness meta strips, `tabular-nums` numbers, restrained orange accent.
+```
+
+Add to the Components table, directly after the `StatCard` row:
+
+```markdown
+| `MetricCard` | **Preferred** metric card — network console look. Label above, big `font-semibold` value, optional `children` (icon or inline chart) below. |
+```
+
+Change the existing `StatCard` row's description to:
+
+```markdown
+| `StatCard` | Legacy metric card (gray, three layout variants). Retained for unmigrated pages — prefer `MetricCard` for new work. |
+```
+
+Add this paragraph immediately above the `## Back-compat` heading:
+
+```markdown
+## Colour that carries meaning
+
+Status colour comes only from `StatusBadge`/`getStatusVariant`. Beyond that, some
+surfaces use colour as *data* — AR aging buckets (green→dark-red by age), notification
+channels (SMS blue / Email purple), cash-match day-done state (green/red), and exception
+severity (red/amber). Preserve those hues when restyling; do not flatten them into the
+chart palette. Consistency of *chrome* (grid, axes, tooltips, card shells), not of hue.
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add components/backend/MetricCard.tsx components/backend/index.ts \
+        components/admin/network/performance/MetricCard.tsx \
+        docs/design/BACKEND_UI_KIT.md
+git commit -m "refactor(backend-kit): promote MetricCard to shared kit
+
+Network console becomes the kit's documented reference look. The network
+copy is now a re-export shim, so analytics/devices/health render identically
+(render body verified byte-identical). Adds a note that semantic colour
+(aging buckets, channels, day-done, severity) survives restyles."
+```
+
+---
+
+## Task 2: Billing page header and chrome
+
+**Files:**
+- Modify: `app/admin/billing/page.tsx`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: nothing consumed by later tasks. `PageHeader` is no longer imported by this file.
+
+- [ ] **Step 1: Swap the imports**
+
+Remove `PageHeader` from the `@/components/backend` import (keep `AdminPage`, `LoadingState`, `ErrorState`). Add `Badge`, and add `PiClockBold` to the existing `react-icons/pi` import.
+
+```tsx
+import { PiArrowsClockwiseBold, PiClockBold, PiFileTextBold, PiPlayBold } from 'react-icons/pi';
+import { Badge } from '@/components/ui/badge';
+import { AdminPage, LoadingState, ErrorState } from '@/components/backend';
+```
+
+- [ ] **Step 2: Replace the `<PageHeader …/>` block (currently lines 131–177) with the network header**
+
+```tsx
+      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+        <div>
+          <p className="text-xs text-slate-400 mb-1">Finance / Billing / Cash Match</p>
+          <h1 className="text-2xl font-semibold text-slate-900 tracking-tight">Billing</h1>
+          <p className="text-slate-500 mt-1 text-sm">
+            Daily cash match — NetCash completed payments to CircleTel invoices
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={window} onValueChange={(value) => setWindow(value as ReconWindow)}>
+            <SelectTrigger className="w-[160px] rounded-lg border-slate-200" aria-label="Recon window">
+              <SelectValue placeholder="Window" />
+            </SelectTrigger>
+            <SelectContent>
+              {WINDOW_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="sm" onClick={fetchHub} disabled={loading || triggerLoading}>
+            <PiArrowsClockwiseBold className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleTriggerPayNow}
+            disabled={triggerLoading || loading}
+          >
+            <PiPlayBold className="w-4 h-4 mr-2" />
+            {triggerLoading ? 'Triggering…' : 'Trigger PayNow recon'}
+          </Button>
+          <Button size="sm" className="bg-circleTel-orange hover:bg-circleTel-orange-dark" asChild>
+            <Link href="/admin/billing/invoices">
+              <PiFileTextBold className="w-4 h-4 mr-2" />
+              View All Invoices
+            </Link>
+          </Button>
+        </div>
+      </div>
+```
+
+Note the CTA changed from `<Link><Button>` to `<Button asChild><Link>` — that is the pattern the network pages use and it avoids nesting a button inside an anchor.
+
+- [ ] **Step 3: Restyle the inline error to the network banner**
+
+Replace the existing `{error && data && (…)}` block with:
+
+```tsx
+      {error && data && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-200/80 bg-red-50/80 shadow-sm px-4 py-3 text-sm text-red-800"
+        >
+          {error}
+        </div>
+      )}
+```
+
+- [ ] **Step 4: Add the meta strip directly below the header**
+
+Insert immediately after the header `</div>`, before the error block:
+
+```tsx
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-600">
+          Supabase recon hub
+        </Badge>
+        <span className="text-xs text-slate-400">Window · {windowLabel(window)}</span>
+        {summary ? (
+          <span className="text-xs text-slate-500">
+            {summary.netcashCompletedInWindow} NetCash completed ·{' '}
+            {summary.netcashMatchedInWindow} matched
+          </span>
+        ) : null}
+      </div>
+```
+
+`summary` is declared at line 127 (`const summary = data?.summary;`) — move that declaration above this JSX if it is not already before the `return`. It is: it sits just before `return (`, so no move is needed.
+
+- [ ] **Step 5: Add the footer meta line as the last child of `<AdminPage>`**
+
+Insert immediately after `<DeepLinks />`:
+
+```tsx
+      <div className="flex flex-wrap items-center justify-end gap-3 text-sm text-slate-500">
+        <span className="inline-flex items-center gap-2">
+          <PiClockBold className="w-4 h-4" aria-hidden="true" />
+          {loading ? 'Refreshing…' : `Recon window · ${windowLabel(window)}`}
+        </span>
+      </div>
+```
+
+- [ ] **Step 6: Verify no new type errors**
+
+```bash
+npm run type-check:memory 2>&1 | grep "app/admin/billing/page.tsx" || echo "NO ERRORS in billing page"
+```
+
+Expected: `NO ERRORS in billing page`.
+
+- [ ] **Step 7: Confirm `PageHeader` is genuinely unused here now**
+
+```bash
+grep -n "PageHeader" app/admin/billing/page.tsx || echo "PageHeader removed — good"
+```
+
+Expected: `PageHeader removed — good`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/admin/billing/page.tsx
+git commit -m "style(billing): network console header, meta strip, sm action row"
+```
+
+---
+
+## Task 3: CashMatchStrip onto MetricCard
+
+**Files:**
+- Modify: `components/admin/billing/recon/CashMatchStrip.tsx`
+
+**Interfaces:**
+- Consumes: `MetricCard`, from `@/components/backend` (Task 1).
+- Produces: nothing. `CashMatchStripProps` is unchanged — `page.tsx` needs no edit.
+
+- [ ] **Step 1: Swap the import**
+
+Replace `import { StatCard } from '@/components/admin/shared';` with:
+
+```tsx
+import { MetricCard } from '@/components/backend';
+```
+
+- [ ] **Step 2: Replace the four cards in the returned grid**
+
+`MetricCard` has no `icon`/`iconBgColor`/`iconColor` props — the icon becomes a child, and `value` must be a string. The semantic green/red/amber tint moves to `className`.
+
+```tsx
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <MetricCard
+        title="Unmatched NetCash→CT"
+        value={`${unmatchedNetcashToCt}`}
+        subtitle={unmatchedClear ? 'Day-done clear' : 'Needs invoice match'}
+        className={
+          unmatchedClear
+            ? 'border-green-200/80 bg-green-50/40'
+            : 'border-red-200/80 bg-red-50/40'
+        }
+      >
+        {unmatchedClear ? (
+          <PiCheckCircleBold className="w-5 h-5 text-green-600" aria-hidden="true" />
+        ) : (
+          <PiWarningBold className="w-5 h-5 text-red-600" aria-hidden="true" />
+        )}
+      </MetricCard>
+
+      <MetricCard
+        title="NetCash completed"
+        value={`${netcashCompletedInWindow}`}
+        subtitle={`${netcashMatchedInWindow} matched in window`}
+      >
+        <PiCurrencyCircleDollarBold className="w-5 h-5 text-slate-500" aria-hidden="true" />
+      </MetricCard>
+
+      <MetricCard
+        title="Zoho payment sync lag"
+        value={`${zohoPaymentLagCount}`}
+        subtitle="Pending or failed sync"
+        className={zohoPaymentLagCount > 0 ? 'border-amber-200/80 bg-amber-50/40' : undefined}
+      >
+        <PiWarningBold
+          className={`w-5 h-5 ${zohoPaymentLagCount > 0 ? 'text-amber-600' : 'text-slate-400'}`}
+          aria-hidden="true"
+        />
+      </MetricCard>
+
+      <MetricCard
+        title="PayNow recon last run"
+        value={paynowLabel}
+        subtitle={formatLastRunAt(paynowRecon.lastRunAt)}
+      >
+        <span className={paynowIconColor}>{paynowIcon}</span>
+      </MetricCard>
+    </div>
+  );
+```
+
+- [ ] **Step 3: Replace the `paynowIcon` block with icon + colour**
+
+The old code derived `iconBgColor`/`iconColor` in the JSX. Replace the existing `const paynowIcon = …` declaration with both of these:
+
+```tsx
+  const paynowIcon =
+    paynowStatus === 'success' ? (
+      <PiCheckCircleBold className="w-5 h-5" aria-hidden="true" />
+    ) : paynowStatus === 'failed' ? (
+      <PiXCircleBold className="w-5 h-5" aria-hidden="true" />
+    ) : (
+      <PiClockBold className="w-5 h-5" aria-hidden="true" />
+    );
+
+  const paynowIconColor =
+    paynowStatus === 'success'
+      ? 'text-green-600'
+      : paynowStatus === 'failed'
+        ? 'text-red-600'
+        : paynowStatus === 'partial'
+          ? 'text-amber-600'
+          : 'text-slate-400';
+```
+
+- [ ] **Step 4: Confirm the `href` drop is intentional and restore navigation**
+
+The old Zoho card passed `href="/admin/integrations/zoho-books"`; `MetricCard` has no `href`. Wrap only that card in a `Link` so the navigation is not silently lost. Add `import Link from 'next/link';` at the top and wrap:
+
+```tsx
+      <Link href="/admin/integrations/zoho-books" className="block">
+        <MetricCard
+          title="Zoho payment sync lag"
+          value={`${zohoPaymentLagCount}`}
+          subtitle="Pending or failed sync"
+          className={
+            zohoPaymentLagCount > 0
+              ? 'border-amber-200/80 bg-amber-50/40 transition-shadow hover:shadow-md'
+              : 'transition-shadow hover:shadow-md'
+          }
+        >
+          <PiWarningBold
+            className={`w-5 h-5 ${zohoPaymentLagCount > 0 ? 'text-amber-600' : 'text-slate-400'}`}
+            aria-hidden="true"
+          />
+        </MetricCard>
+      </Link>
+```
+
+Use this wrapped version in place of the bare Zoho `MetricCard` from Step 2.
+
+- [ ] **Step 5: Verify no new type errors**
+
+```bash
+npm run type-check:memory 2>&1 | grep "CashMatchStrip" || echo "NO ERRORS in CashMatchStrip"
+```
+
+Expected: `NO ERRORS in CashMatchStrip`. A `Type 'number' is not assignable to type 'string'` here means you missed a `` `${…}` `` on a `value`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/admin/billing/recon/CashMatchStrip.tsx
+git commit -m "style(billing): CashMatchStrip onto MetricCard, keep day-done tint"
+```
+
+---
+
+## Task 4: Billing tiles, banner, and deep links
+
+Three small shell changes. A reviewer would accept or reject them together.
+
+**Files:**
+- Modify: `components/admin/billing/recon/SecondaryKpis.tsx`
+- Modify: `components/admin/billing/recon/DayDoneBanner.tsx`
+- Modify: `components/admin/billing/recon/DeepLinks.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing. All three prop interfaces unchanged.
+
+- [ ] **Step 1: `SecondaryKpis` — tile shell to the network tile**
+
+Change the grid gap and the tile wrapper. Replace the `<div key={label} …>` className with the `GroupTrafficCards` tile treatment, and the label/value classes:
+
+```tsx
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      {items.map(({ label, value, icon: Icon }) => (
+        <div
+          key={label}
+          className="flex items-center gap-3 rounded-xl border border-slate-100 bg-slate-50/50 px-4 py-3"
+        >
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white text-slate-500 shadow-sm ring-1 ring-slate-200">
+            <Icon className="h-4 w-4" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-slate-500">{label}</p>
+            <p className="truncate text-xl font-semibold tabular-nums text-slate-900 mt-0.5">
+              {value}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+```
+
+The uppercase `text-[11px] … uppercase tracking-wide` label is dropped: the network tiles use plain sentence-case `text-xs text-slate-500`.
+
+- [ ] **Step 2: `DayDoneBanner` — both branches to the network banner shell**
+
+Change only the two wrapper classNames. Day-done branch:
+
+```tsx
+        className="flex items-start gap-3 rounded-xl border border-green-200/80 bg-green-50/80 shadow-sm px-4 py-3"
+```
+
+Unmatched branch:
+
+```tsx
+        className="flex items-start gap-3 rounded-xl border border-red-200/80 bg-red-50/80 shadow-sm px-4 py-3"
+```
+
+Leave the icons, `role="status"` / `role="alert"`, and all text classes exactly as they are — the green/red is semantic state.
+
+- [ ] **Step 3: `DeepLinks` — card shell radius and border**
+
+Change the grid gap and the `<Link>` className:
+
+```tsx
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {LINKS.map(({ href, title, description, icon: Icon }) => (
+        <Link
+          key={href}
+          href={href}
+          className="group flex items-start gap-3 rounded-xl border border-slate-200/80 bg-white p-4 shadow-sm transition-colors hover:border-circleTel-orange/40 hover:bg-orange-50/40"
+        >
+```
+
+Leave the orange icon chip and hover-orange title — orange as accent is the kit rule.
+
+- [ ] **Step 4: Verify no new type errors (these are class-only edits, so expect none)**
+
+```bash
+npm run type-check:memory 2>&1 | grep -E "SecondaryKpis|DayDoneBanner|DeepLinks" || echo "NO ERRORS in the three shells"
+```
+
+Expected: `NO ERRORS in the three shells`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/admin/billing/recon/SecondaryKpis.tsx \
+        components/admin/billing/recon/DayDoneBanner.tsx \
+        components/admin/billing/recon/DeepLinks.tsx
+git commit -m "style(billing): rounded-xl slate shells for KPI tiles, banner, deep links"
+```
+
+---
+
+## Task 5: ExceptionTable card shell
+
+The table markup already matches the network treatment. Only the wrapper changes.
+
+**Files:**
+- Modify: `components/admin/billing/recon/ExceptionTable.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing. `ExceptionTableProps` unchanged.
+
+- [ ] **Step 1: Swap the imports**
+
+Replace:
+
+```tsx
+import { SectionCard, StatusBadge } from '@/components/admin/shared';
+import type { StatusVariant } from '@/components/admin/shared';
+```
+
+with:
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { StatusBadge } from '@/components/backend';
+import type { StatusVariant } from '@/components/backend';
+```
+
+- [ ] **Step 2: Replace the `<SectionCard>` wrapper with the network `Card`**
+
+The opening becomes:
+
+```tsx
+    <Card className="border border-slate-200/80 shadow-sm rounded-xl bg-white">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div>
+          <CardTitle className="text-base font-semibold text-slate-900">Exceptions</CardTitle>
+          <p className="text-xs text-slate-500">
+            Unmatched cash, Zoho sync lag, and open AR needing action
+          </p>
+        </div>
+        <span className="text-xs font-medium text-slate-500">{rows.length} shown</span>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+```
+
+and the closing `</SectionCard>` becomes:
+
+```tsx
+        </div>
+      </CardContent>
+    </Card>
+```
+
+Keep the filter-chip block, the empty state, and the entire `<table>` exactly as they are.
+
+- [ ] **Step 3: Round the empty state and table container to match**
+
+Two class-only changes inside the body. Empty state:
+
+```tsx
+          <div className="flex items-center gap-2 rounded-xl border border-slate-100 bg-slate-50/50 px-4 py-6 text-sm text-slate-500">
+```
+
+Table container:
+
+```tsx
+          <div className="overflow-x-auto rounded-xl border border-slate-200/80">
+```
+
+- [ ] **Step 4: Confirm the table markup was not touched**
+
+```bash
+git diff components/admin/billing/recon/ExceptionTable.tsx | grep -E "^[-+].*(uppercase tracking-wider|divide-slate-100|hover:bg-slate-50|<th |<td )" || echo "TABLE MARKUP UNTOUCHED — good"
+```
+
+Expected: `TABLE MARKUP UNTOUCHED — good`.
+
+- [ ] **Step 5: Verify no new type errors**
+
+```bash
+npm run type-check:memory 2>&1 | grep "ExceptionTable" || echo "NO ERRORS in ExceptionTable"
+```
+
+Expected: `NO ERRORS in ExceptionTable`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/admin/billing/recon/ExceptionTable.tsx
+git commit -m "style(billing): ExceptionTable onto network Card shell
+
+Table markup untouched — it already matched the network treatment."
+```
+
+---
+
+## Task 6: Extract the four AR panels as a pure move
+
+**No restyling in this task.** Move the markup unchanged so that if the page breaks, it is a move bug and not a style bug. Restyling happens in Tasks 8–12.
+
+**Files:**
+- Create: `components/admin/finance/ar/shared.tsx`
+- Create: `components/admin/finance/ar/ArAgingPanel.tsx`
+- Create: `components/admin/finance/ar/DsoMetricsPanel.tsx`
+- Create: `components/admin/finance/ar/NotificationsPanel.tsx`
+- Create: `components/admin/finance/ar/HistoryPanel.tsx`
+- Modify: `app/admin/finance/ar-analytics/page.tsx`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces, all from `@/components/admin/finance/ar/shared`:
+  ```ts
+  export interface ARAnalyticsData { /* moved verbatim from page.tsx lines 68-131 */ }
+  export const AGING_COLORS: { current: string; overdue_1_30: string; overdue_31_60: string; overdue_61_90: string; overdue_90_plus: string };
+  export const CHANNEL_COLORS: { sms: string; email: string };
+  export function formatCurrency(amount: number): string;
+  export function formatShortDate(dateStr: string): string;
+  export function TrendIcon({ trend }: { trend: string }): React.ReactElement;
+  export interface AgingBucket { name: string; amount: number; count: number; fill: string }
+  export function buildAgingBuckets(aging: ARAnalyticsData['ar_aging']): AgingBucket[];
+  ```
+  And each panel takes exactly one prop, `data: ARAnalyticsData`:
+  ```ts
+  export function ArAgingPanel({ data }: { data: ARAnalyticsData }): React.ReactElement;
+  export function DsoMetricsPanel({ data }: { data: ARAnalyticsData }): React.ReactElement;
+  export function NotificationsPanel({ data }: { data: ARAnalyticsData }): React.ReactElement;
+  export function HistoryPanel({ data }: { data: ARAnalyticsData }): React.ReactElement;
+  ```
+
+- [ ] **Step 1: Create `components/admin/finance/ar/shared.tsx`**
+
+```tsx
+'use client';
+
+import { PiMinusBold, PiTrendDownBold, PiTrendUpBold } from 'react-icons/pi';
+
+/** Response shape of GET /api/admin/finance/ar-analytics — moved from the page. */
+export interface ARAnalyticsData {
+  ar_aging: {
+    total_outstanding_invoices: number;
+    total_outstanding_amount: number;
+    current_count: number;
+    current_amount: number;
+    overdue_1_30_count: number;
+    overdue_1_30_amount: number;
+    overdue_31_60_count: number;
+    overdue_31_60_amount: number;
+    overdue_61_90_count: number;
+    overdue_61_90_amount: number;
+    overdue_90_plus_count: number;
+    overdue_90_plus_amount: number;
+    avg_days_overdue: number;
+  };
+  dso: {
+    dso_current: number;
+    dso_30_day_avg: number;
+    dso_trend: 'improving' | 'stable' | 'worsening';
+    best_possible_dso: number;
+    collection_effectiveness_index: number;
+  };
+  collection: {
+    total_notifications_sent: number;
+    total_amount_collected: number;
+    collection_rate: number;
+    avg_days_to_payment: number;
+    response_rate: number;
+  };
+  notifications: {
+    total_sms: number;
+    total_email: number;
+    total_delivered: number;
+    total_failed: number;
+    delivery_rate: number;
+  };
+  daily_analytics: Array<{
+    date: string;
+    notification_type: string;
+    total_sent: number;
+    delivered: number;
+    failed: number;
+    total_amount_notified: number;
+  }>;
+  recent_notifications: Array<{
+    id: string;
+    invoice_number: string;
+    notification_type: string;
+    recipient: string;
+    status: string;
+    amount_due: number;
+    days_overdue: number;
+    created_at: string;
+  }>;
+  historical: Array<{
+    snapshot_date: string;
+    total_outstanding: number;
+    dso_current: number;
+    sms_sent_count: number;
+    email_sent_count: number;
+    payments_received_amount: number;
+  }> | null;
+}
+
+/**
+ * Aging severity ramp — green to dark red by age. Semantic, NOT the chart palette.
+ * Do not replace with --chart-* vars; the hue is the "how overdue" signal.
+ */
+export const AGING_COLORS = {
+  current: '#22c55e',
+  overdue_1_30: '#eab308',
+  overdue_31_60: '#f97316',
+  overdue_61_90: '#ef4444',
+  overdue_90_plus: '#991b1b',
+} as const;
+
+/** Notification channel identity — used in chart, legend, and table badges. */
+export const CHANNEL_COLORS = {
+  sms: '#3b82f6',
+  email: '#8b5cf6',
+} as const;
+
+export function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-ZA', {
+    style: 'currency',
+    currency: 'ZAR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export function formatShortDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-ZA', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/** Down = improving for DSO (fewer days is better), so the arrow is inverted on purpose. */
+export function TrendIcon({ trend }: { trend: string }) {
+  if (trend === 'improving') {
+    return <PiTrendDownBold className="h-4 w-4 text-green-600" aria-hidden="true" />;
+  }
+  if (trend === 'worsening') {
+    return <PiTrendUpBold className="h-4 w-4 text-red-600" aria-hidden="true" />;
+  }
+  return <PiMinusBold className="h-4 w-4 text-slate-400" aria-hidden="true" />;
+}
+
+export interface AgingBucket {
+  name: string;
+  amount: number;
+  count: number;
+  fill: string;
+}
+
+export function buildAgingBuckets(aging: ARAnalyticsData['ar_aging']): AgingBucket[] {
+  return [
+    { name: 'Current', amount: aging.current_amount, count: aging.current_count, fill: AGING_COLORS.current },
+    { name: '1-30 Days', amount: aging.overdue_1_30_amount, count: aging.overdue_1_30_count, fill: AGING_COLORS.overdue_1_30 },
+    { name: '31-60 Days', amount: aging.overdue_31_60_amount, count: aging.overdue_31_60_count, fill: AGING_COLORS.overdue_31_60 },
+    { name: '61-90 Days', amount: aging.overdue_61_90_amount, count: aging.overdue_61_90_count, fill: AGING_COLORS.overdue_61_90 },
+    { name: '90+ Days', amount: aging.overdue_90_plus_amount, count: aging.overdue_90_plus_count, fill: AGING_COLORS.overdue_90_plus },
+  ];
+}
+```
+
+- [ ] **Step 2: Create the four panel files by moving markup verbatim**
+
+For each panel, create the file with this skeleton and paste the **exact current JSX** from the matching `<TabsContent>` body in `page.tsx` — inner content only, without the `<TabsContent>` wrapper. Replace local references: `formatCurrency` → imported, `formatDate` → `formatShortDate`, `getTrendIcon(x)` → `<TrendIcon trend={x} />`, `agingChartData` → `buildAgingBuckets(data.ar_aging)`, `COLORS.sms` → `CHANNEL_COLORS.sms`, `COLORS.email` → `CHANNEL_COLORS.email`.
+
+Source ranges in the current `page.tsx`:
+
+| Panel | `<TabsContent>` | Body lines |
+|---|---|---|
+| `ArAgingPanel` | `value="aging"` | 358–431 |
+| `DsoMetricsPanel` | `value="dso"` | 436–502 |
+| `NotificationsPanel` | `value="notifications"` | 507–631 |
+| `HistoryPanel` | `value="history"` | 636–720 |
+
+Skeleton (shown for `ArAgingPanel`; the other three follow the same shape with their own imports):
+
+```tsx
+'use client';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { buildAgingBuckets, formatCurrency, type ARAnalyticsData } from './shared';
+
+export function ArAgingPanel({ data }: { data: ARAnalyticsData }) {
+  const agingChartData = buildAgingBuckets(data.ar_aging);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {/* paste lines 359-430 verbatim here */}
+    </div>
+  );
+}
+```
+
+Each panel keeps the outer wrapper that its `<TabsContent>` currently has. `HistoryPanel` must keep its `data.historical && data.historical.length > 0` conditional and the no-data `<Card>` branch.
+
+- [ ] **Step 3: Create a barrel for the panels**
+
+`components/admin/finance/ar/index.ts`:
+
+```ts
+export { ArAgingPanel } from './ArAgingPanel';
+export { DsoMetricsPanel } from './DsoMetricsPanel';
+export { NotificationsPanel } from './NotificationsPanel';
+export { HistoryPanel } from './HistoryPanel';
+export {
+  AGING_COLORS,
+  CHANNEL_COLORS,
+  buildAgingBuckets,
+  formatCurrency,
+  formatShortDate,
+  TrendIcon,
+} from './shared';
+export type { ARAnalyticsData, AgingBucket } from './shared';
+```
+
+This makes 17 files total, not 16 — the barrel matches the convention of `components/admin/network/performance/index.ts` and keeps `page.tsx`'s import to one line.
+
+- [ ] **Step 4: Rewrite `page.tsx` to fetch + header + tabs wiring only**
+
+Delete the moved `ARAnalyticsData` interface, `COLORS`, `formatCurrency`, `formatDate`, `getTrendIcon`, `agingChartData`, `notificationPieData`, all recharts imports, and all four `<TabsContent>` bodies. Keep the KPI card grid inline for now — Task 8 restyles it.
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { PiArrowsClockwiseBold, PiClockBold, PiCurrencyDollarBold, PiPulseBold, PiTargetBold } from 'react-icons/pi';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AdminPage, PageHeader, LoadingState, ErrorState } from '@/components/backend';
+import {
+  ArAgingPanel,
+  DsoMetricsPanel,
+  HistoryPanel,
+  NotificationsPanel,
+  TrendIcon,
+  formatCurrency,
+  type ARAnalyticsData,
+} from '@/components/admin/finance/ar';
+
+export default function ARAnalyticsPage() {
+  const [data, setData] = useState<ARAnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [period, setPeriod] = useState('30');
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchData = async () => {
+    try {
+      const response = await fetch(`/api/admin/finance/ar-analytics?days=${period}&history=true`);
+      const result = await response.json();
+      if (result.success) {
+        setData(result.data);
+      }
+    } catch (error) {
+      console.error('Failed to fetch AR analytics:', error);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [period]);
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    fetchData();
+  };
+
+  if (loading) {
+    return (
+      <AdminPage>
+        <LoadingState message="Loading AR analytics..." />
+      </AdminPage>
+    );
+  }
+
+  if (!data) {
+    return (
+      <AdminPage>
+        <ErrorState title="Failed to load AR analytics" onRetry={handleRefresh} />
+      </AdminPage>
+    );
+  }
+
+  return (
+    <AdminPage>
+      <PageHeader
+        title="AR Analytics & Collections"
+        subtitle="Accounts Receivable, DSO tracking, and notification effectiveness"
+        actions={
+          <div className="flex items-center gap-2">
+            <Select value={period} onValueChange={setPeriod}>
+              <SelectTrigger className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="7">7 Days</SelectItem>
+                <SelectItem value="30">30 Days</SelectItem>
+                <SelectItem value="60">60 Days</SelectItem>
+                <SelectItem value="90">90 Days</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button variant="outline" size="icon" onClick={handleRefresh} disabled={refreshing}>
+              <PiArrowsClockwiseBold className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+            </Button>
+          </div>
+        }
+      />
+
+      {/* KPI cards — restyled in Task 8. Paste the current lines 272-345 grid here verbatim. */}
+
+      <Tabs defaultValue="aging" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="aging">AR Aging</TabsTrigger>
+          <TabsTrigger value="dso">DSO &amp; Metrics</TabsTrigger>
+          <TabsTrigger value="notifications">Notifications</TabsTrigger>
+          <TabsTrigger value="history">History</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="aging" className="space-y-4">
+          <ArAgingPanel data={data} />
+        </TabsContent>
+        <TabsContent value="dso" className="space-y-4">
+          <DsoMetricsPanel data={data} />
+        </TabsContent>
+        <TabsContent value="notifications" className="space-y-4">
+          <NotificationsPanel data={data} />
+        </TabsContent>
+        <TabsContent value="history" className="space-y-4">
+          <HistoryPanel data={data} />
+        </TabsContent>
+      </Tabs>
+    </AdminPage>
+  );
+}
+```
+
+- [ ] **Step 5: Verify no new type errors**
+
+```bash
+npm run type-check:memory 2>&1 | grep -E "finance/ar|ar-analytics" || echo "NO ERRORS in AR page or panels"
+```
+
+Expected: `NO ERRORS in AR page or panels`. Unused-import errors here mean you left an import behind after moving markup out.
+
+- [ ] **Step 6: Confirm this was a pure move — no class changes**
+
+```bash
+git diff --stat
+git diff app/admin/finance/ar-analytics/page.tsx | grep -cE "^\+.*(slate-|rounded-xl|MetricCard|ConsoleTabs)" \
+  && echo "WARNING: restyle leaked into the move task — revert those" \
+  || echo "PURE MOVE — good"
+```
+
+Expected: `PURE MOVE — good`.
+
+- [ ] **Step 7: Visually confirm the page still works before restyling**
+
+```bash
+ALLOW_DEV_ADMIN_BYPASS=true npm run dev:memory
+```
+
+Open `http://localhost:3000/admin/finance/ar-analytics`, click all four tabs. Every chart, table, and number must render exactly as before. Stop the server when done.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add components/admin/finance/ar app/admin/finance/ar-analytics/page.tsx
+git commit -m "refactor(ar-analytics): extract 4 tab panels, no visual change
+
+Pure move ahead of the restyle so move bugs and style bugs stay separable.
+Shared types, aging/channel colours, and formatters go to ar/shared.tsx."
+```
+
+---
+
+## Task 7: AR page header, tabs, and chrome
+
+**Files:**
+- Modify: `app/admin/finance/ar-analytics/page.tsx`
+
+**Interfaces:**
+- Consumes: the four panels from Task 6.
+- Produces: nothing.
+
+- [ ] **Step 1: Swap `PageHeader` and raw tabs for the network header and kit pill tabs**
+
+Change the `@/components/backend` import to bring in the kit tabs and drop `PageHeader`:
+
+```tsx
+import { Badge } from '@/components/ui/badge';
+import {
+  AdminPage,
+  LoadingState,
+  ErrorState,
+  Tabs,
+  ConsoleTabsList,
+  ConsoleTabsContent,
+} from '@/components/backend';
+```
+
+Remove `Tabs, TabsContent, TabsList, TabsTrigger` from the `@/components/ui/tabs` import (delete the line entirely — `Tabs` now comes from the kit).
+
+- [ ] **Step 2: Replace `<PageHeader …/>` with the network header**
+
+```tsx
+      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+        <div>
+          <p className="text-xs text-slate-400 mb-1">Finance / Receivables / AR Analytics</p>
+          <h1 className="text-2xl font-semibold text-slate-900 tracking-tight">
+            AR Analytics &amp; Collections
+          </h1>
+          <p className="text-slate-500 mt-1 text-sm">
+            Accounts Receivable, DSO tracking, and notification effectiveness
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={period} onValueChange={setPeriod}>
+            <SelectTrigger className="w-[140px] rounded-lg border-slate-200" aria-label="Reporting period">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="7">Last 7 days</SelectItem>
+              <SelectItem value="30">Last 30 days</SelectItem>
+              <SelectItem value="60">Last 60 days</SelectItem>
+              <SelectItem value="90">Last 90 days</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing}>
+            <PiArrowsClockwiseBold className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+```
+
+The icon-only refresh button becomes a labelled `size="sm"` button to match the network action rows.
+
+- [ ] **Step 3: Add the meta strip below the header**
+
+```tsx
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-600">
+          Supabase AR snapshot
+        </Badge>
+        <span className="text-xs text-slate-400">Last {period} days</span>
+        <span className="text-xs text-slate-500">
+          {data.ar_aging.total_outstanding_invoices} open invoices ·{' '}
+          {formatCurrency(data.ar_aging.total_outstanding_amount)} outstanding
+        </span>
+      </div>
+```
+
+- [ ] **Step 4: Replace the tabs block with kit pill tabs**
+
+```tsx
+      <Tabs defaultValue="aging" className="space-y-4">
+        <ConsoleTabsList
+          items={[
+            { value: 'aging', label: 'AR Aging' },
+            { value: 'dso', label: 'DSO & Metrics' },
+            { value: 'notifications', label: 'Notifications' },
+            { value: 'history', label: 'History' },
+          ]}
+        />
+        <ConsoleTabsContent value="aging">
+          <ArAgingPanel data={data} />
+        </ConsoleTabsContent>
+        <ConsoleTabsContent value="dso">
+          <DsoMetricsPanel data={data} />
+        </ConsoleTabsContent>
+        <ConsoleTabsContent value="notifications">
+          <NotificationsPanel data={data} />
+        </ConsoleTabsContent>
+        <ConsoleTabsContent value="history">
+          <HistoryPanel data={data} />
+        </ConsoleTabsContent>
+      </Tabs>
+```
+
+`ConsoleTabsList` styles a 4-item list as `grid-cols-2 sm:grid-cols-4`, and `ConsoleTabsContent` already applies `mt-6` — so drop the per-content `className="space-y-4"`.
+
+- [ ] **Step 5: Add the footer meta line as the last child of `<AdminPage>`**
+
+```tsx
+      <div className="flex flex-wrap items-center justify-end gap-3 text-sm text-slate-500">
+        <span className="inline-flex items-center gap-2">
+          <PiClockBold className="w-4 h-4" aria-hidden="true" />
+          {refreshing ? 'Refreshing…' : `AR snapshot · last ${period} days`}
+        </span>
+      </div>
+```
+
+- [ ] **Step 6: Verify no new type errors**
+
+```bash
+npm run type-check:memory 2>&1 | grep "ar-analytics/page.tsx" || echo "NO ERRORS in AR page"
+```
+
+Expected: `NO ERRORS in AR page`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/admin/finance/ar-analytics/page.tsx
+git commit -m "style(ar-analytics): network console header, pill tabs, meta strip"
+```
+
+---
+
+## Task 8: AR KPI cards onto MetricCard
+
+**Files:**
+- Modify: `app/admin/finance/ar-analytics/page.tsx`
+
+**Interfaces:**
+- Consumes: `MetricCard` from `@/components/backend` (Task 1); `TrendIcon`, `formatCurrency` from the AR barrel (Task 6).
+- Produces: nothing.
+
+- [ ] **Step 1: Add `MetricCard` to the kit import and drop the now-unused card imports**
+
+Add `MetricCard` to the `@/components/backend` import. Delete the `@/components/ui/card` import line entirely — after this step the page no longer renders a raw `Card`.
+
+- [ ] **Step 2: Replace the whole four-card KPI grid**
+
+These four cards currently use `text-primary` and `text-muted-foreground`, which resolve through the global `:root` oklch variables. Moving to literal slate classes also removes that dependency.
+
+```tsx
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <MetricCard
+          title="Total Outstanding"
+          value={formatCurrency(data.ar_aging.total_outstanding_amount)}
+          subtitle={`${data.ar_aging.total_outstanding_invoices} invoices`}
+        >
+          <PiCurrencyDollarBold className="w-5 h-5 text-amber-600" aria-hidden="true" />
+        </MetricCard>
+
+        <MetricCard
+          title="Days Sales Outstanding"
+          value={data.dso.dso_current.toFixed(1)}
+          subtitle={`30-day avg: ${data.dso.dso_30_day_avg.toFixed(1)} days`}
+        >
+          <span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+            <TrendIcon trend={data.dso.dso_trend} />
+            <span className="capitalize">{data.dso.dso_trend}</span>
+          </span>
+        </MetricCard>
+
+        <MetricCard
+          title="Collection Rate"
+          value={`${data.collection.collection_rate.toFixed(1)}%`}
+          subtitle={`${formatCurrency(data.collection.total_amount_collected)} collected`}
+        >
+          <PiTargetBold className="w-5 h-5 text-emerald-600" aria-hidden="true" />
+        </MetricCard>
+
+        <MetricCard
+          title="Notifications Sent"
+          value={`${data.notifications.total_sms + data.notifications.total_email}`}
+          subtitle={`${data.notifications.delivery_rate.toFixed(1)}% delivery rate`}
+        >
+          <PiPulseBold className="w-5 h-5 text-blue-600" aria-hidden="true" />
+        </MetricCard>
+      </div>
+```
+
+The DSO trend arrow moves from beside the value into the `children` slot, where `MetricCard` renders it below — the trend keeps its green/red meaning via `TrendIcon`.
+
+- [ ] **Step 3: Verify no new type errors and no leftover raw Card usage**
+
+```bash
+npm run type-check:memory 2>&1 | grep "ar-analytics/page.tsx" || echo "NO ERRORS in AR page"
+grep -n "components/ui/card" app/admin/finance/ar-analytics/page.tsx || echo "no raw Card import — good"
+```
+
+Expected: `NO ERRORS in AR page` and `no raw Card import — good`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/admin/finance/ar-analytics/page.tsx
+git commit -m "style(ar-analytics): KPI cards onto MetricCard, drop theme-token colours"
+```
+
+---
+
+## Task 9: ArAgingPanel — chart chrome and table
+
+**Files:**
+- Modify: `components/admin/finance/ar/ArAgingPanel.tsx`
+
+**Interfaces:**
+- Consumes: `buildAgingBuckets`, `formatCurrency`, `ARAnalyticsData` from `./shared`.
+- Produces: nothing.
+
+- [ ] **Step 1: Replace the file entirely**
+
+```tsx
+'use client';
+
+import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
+import { buildAgingBuckets, formatCurrency, type ARAnalyticsData } from './shared';
+
+const chartConfig = {
+  amount: { label: 'Outstanding' },
+} satisfies ChartConfig;
+
+export function ArAgingPanel({ data }: { data: ARAnalyticsData }) {
+  const buckets = buildAgingBuckets(data.ar_aging);
+  const total = data.ar_aging.total_outstanding_amount;
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">
+            AR Aging Breakdown
+          </CardTitle>
+          <p className="text-xs text-slate-500">Outstanding amounts by aging bucket</p>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={chartConfig} className="aspect-auto h-[300px] w-full">
+            <BarChart accessibilityLayer data={buckets} margin={{ left: 8, right: 8, top: 8, bottom: 0 }}>
+              <CartesianGrid vertical={false} strokeDasharray="3 3" />
+              <XAxis dataKey="name" tickLine={false} axisLine={false} tickMargin={8} />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={56}
+                tickFormatter={(v) => `R${(Number(v) / 1000).toFixed(0)}k`}
+              />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    indicator="dot"
+                    formatter={(value) => (
+                      <div className="flex w-full items-center justify-between gap-4">
+                        <span className="text-muted-foreground">Outstanding</span>
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {formatCurrency(Number(value))}
+                        </span>
+                      </div>
+                    )}
+                  />
+                }
+              />
+              <Bar dataKey="amount" radius={[6, 6, 0, 0]}>
+                {buckets.map((bucket) => (
+                  <Cell key={bucket.name} fill={bucket.fill} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">Aging Summary</CardTitle>
+          <p className="text-xs text-slate-500">Invoice counts and amounts by bucket</p>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto rounded-xl border border-slate-200/80">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 bg-slate-50">
+                  <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Bucket
+                  </th>
+                  <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Invoices
+                  </th>
+                  <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    Amount
+                  </th>
+                  <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    %
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {buckets.map((bucket) => (
+                  <tr key={bucket.name} className="transition-colors hover:bg-slate-50">
+                    <td className="whitespace-nowrap px-3 py-2.5">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="h-2.5 w-2.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: bucket.fill }}
+                        />
+                        <span className="text-slate-700">{bucket.name}</span>
+                      </div>
+                    </td>
+                    <td className="px-3 py-2.5 text-right tabular-nums text-slate-700">
+                      {bucket.count}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                      {formatCurrency(bucket.amount)}
+                    </td>
+                    <td className="px-3 py-2.5 text-right tabular-nums text-slate-600">
+                      {total > 0 ? ((bucket.amount / total) * 100).toFixed(1) : '0.0'}%
+                    </td>
+                  </tr>
+                ))}
+                <tr className="border-t border-slate-200 bg-slate-50/60">
+                  <td className="px-3 py-2.5 font-semibold text-slate-900">Total</td>
+                  <td className="px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                    {data.ar_aging.total_outstanding_invoices}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                    {formatCurrency(total)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                    100%
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+The `shadcn` `Table` primitive is replaced with the same raw `<table>` markup `ExceptionTable` and `DeviceTable` use — that is what produces the network table look. The `0` in the percent cell became `'0.0'` so the column stays aligned when a bucket is empty.
+
+- [ ] **Step 2: Verify no new type errors**
+
+```bash
+npm run type-check:memory 2>&1 | grep "ArAgingPanel" || echo "NO ERRORS in ArAgingPanel"
+```
+
+Expected: `NO ERRORS in ArAgingPanel`.
+
+- [ ] **Step 3: Confirm the semantic colours survived**
+
+```bash
+grep -c "bucket.fill" components/admin/finance/ar/ArAgingPanel.tsx
+grep -n "chart-1\|chart-2\|chart-3" components/admin/finance/ar/ArAgingPanel.tsx || echo "no chart-palette leak — good"
+```
+
+Expected: `2` (chart `Cell` + table dot) and `no chart-palette leak — good`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/admin/finance/ar/ArAgingPanel.tsx
+git commit -m "style(ar-analytics): aging chart + table onto network chrome
+
+Keeps the green-to-dark-red bucket ramp; only grid, axes, tooltip, and
+table treatment change."
+```
+
+---
+
+## Task 10: DsoMetricsPanel
+
+**Files:**
+- Modify: `components/admin/finance/ar/DsoMetricsPanel.tsx`
+
+**Interfaces:**
+- Consumes: `formatCurrency`, `TrendIcon`, `ARAnalyticsData` from `./shared`; `MetricCard` from `@/components/backend`.
+- Produces: nothing.
+
+- [ ] **Step 1: Replace the file entirely**
+
+```tsx
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { MetricCard } from '@/components/backend';
+import { TrendIcon, formatCurrency, type ARAnalyticsData } from './shared';
+
+export function DsoMetricsPanel({ data }: { data: ARAnalyticsData }) {
+  const gap = data.dso.dso_current - data.dso.best_possible_dso;
+
+  const performance = [
+    { label: 'Notifications sent', value: `${data.collection.total_notifications_sent}` },
+    { label: 'Amount collected', value: formatCurrency(data.collection.total_amount_collected) },
+    { label: 'Avg days to payment', value: data.collection.avg_days_to_payment.toFixed(1) },
+    { label: 'Response rate', value: `${data.collection.response_rate.toFixed(1)}%` },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <MetricCard
+          title="Current DSO"
+          value={data.dso.dso_current.toFixed(1)}
+          subtitle="days"
+        >
+          <span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+            <TrendIcon trend={data.dso.dso_trend} />
+            <span className="capitalize">{data.dso.dso_trend}</span>
+          </span>
+        </MetricCard>
+
+        <MetricCard
+          title="Best Possible DSO"
+          value={data.dso.best_possible_dso.toFixed(1)}
+          subtitle="days"
+          delta={`Gap: ${gap.toFixed(1)} days`}
+          deltaPositive={gap <= 0}
+        />
+
+        <MetricCard
+          title="Collection Effectiveness"
+          value={`${data.dso.collection_effectiveness_index.toFixed(1)}%`}
+          subtitle="CEI"
+          delta="Target: 80%+"
+          deltaPositive={data.dso.collection_effectiveness_index >= 80}
+        />
+      </div>
+
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">
+            Collection Performance
+          </CardTitle>
+          <p className="text-xs text-slate-500">Notification volume and payment response</p>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {performance.map(({ label, value }) => (
+            <div key={label} className="rounded-xl border border-slate-100 bg-slate-50/50 p-3">
+              <p className="text-xs text-slate-500">{label}</p>
+              <p className="text-xl font-semibold tabular-nums text-slate-900 mt-1">{value}</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+The `text-4xl font-bold` DSO numbers become `MetricCard`'s `text-3xl font-semibold`. `deltaPositive` drives blue (good) vs amber (attention) via `MetricCard`'s existing logic — note it is deliberately *not* green/red, because these are targets rather than states.
+
+- [ ] **Step 2: Verify no new type errors**
+
+```bash
+npm run type-check:memory 2>&1 | grep "DsoMetricsPanel" || echo "NO ERRORS in DsoMetricsPanel"
+```
+
+Expected: `NO ERRORS in DsoMetricsPanel`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/admin/finance/ar/DsoMetricsPanel.tsx
+git commit -m "style(ar-analytics): DSO panel onto MetricCard + slate tiles"
+```
+
+---
+
+## Task 11: NotificationsPanel
+
+**Files:**
+- Modify: `components/admin/finance/ar/NotificationsPanel.tsx`
+
+**Interfaces:**
+- Consumes: `CHANNEL_COLORS`, `formatCurrency`, `ARAnalyticsData` from `./shared`; `StatusBadge`, `StatusVariant` from `@/components/backend`.
+- Produces: nothing.
+
+- [ ] **Step 1: Replace the file entirely**
+
+```tsx
+'use client';
+
+import { Cell, Pie, PieChart } from 'recharts';
+import { PiCalendarBold, PiChatBold, PiCheckCircleBold, PiEnvelopeBold, PiPulseBold, PiXCircleBold } from 'react-icons/pi';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
+import { StatusBadge, type StatusVariant } from '@/components/backend';
+import { CHANNEL_COLORS, formatCurrency, type ARAnalyticsData } from './shared';
+
+const chartConfig = {
+  value: { label: 'Sent' },
+  SMS: { label: 'SMS', color: CHANNEL_COLORS.sms },
+  Email: { label: 'Email', color: CHANNEL_COLORS.email },
+} satisfies ChartConfig;
+
+const NOTIF_STATUS_VARIANT: Record<string, StatusVariant> = {
+  sent: 'success',
+  delivered: 'success',
+  failed: 'error',
+  bounced: 'error',
+  opened: 'info',
+  clicked: 'info',
+};
+
+function notifStatusBadge(status: string) {
+  const label =
+    status === 'sent' || status === 'delivered'
+      ? 'Delivered'
+      : status.charAt(0).toUpperCase() + status.slice(1);
+  return <StatusBadge status={label} variant={NOTIF_STATUS_VARIANT[status] ?? 'neutral'} />;
+}
+
+export function NotificationsPanel({ data }: { data: ARAnalyticsData }) {
+  const channelData = [
+    { name: 'SMS', value: data.notifications.total_sms, fill: CHANNEL_COLORS.sms },
+    { name: 'Email', value: data.notifications.total_email, fill: CHANNEL_COLORS.email },
+  ];
+
+  const deliveryTiles = [
+    {
+      label: 'Delivered',
+      value: `${data.notifications.total_delivered}`,
+      icon: <PiCheckCircleBold className="h-5 w-5 text-emerald-600" aria-hidden="true" />,
+    },
+    {
+      label: 'Failed',
+      value: `${data.notifications.total_failed}`,
+      icon: <PiXCircleBold className="h-5 w-5 text-red-600" aria-hidden="true" />,
+    },
+    {
+      label: 'Delivery rate',
+      value: `${data.notifications.delivery_rate.toFixed(1)}%`,
+      icon: <PiPulseBold className="h-5 w-5 text-blue-600" aria-hidden="true" />,
+    },
+    {
+      label: 'Avg days overdue',
+      value: data.ar_aging.avg_days_overdue.toFixed(0),
+      icon: <PiCalendarBold className="h-5 w-5 text-amber-600" aria-hidden="true" />,
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base font-semibold text-slate-900">
+              Notification Channels
+            </CardTitle>
+            <p className="text-xs text-slate-500">Share of sends by channel</p>
+          </CardHeader>
+          <CardContent>
+            <ChartContainer config={chartConfig} className="aspect-auto h-[200px] w-full">
+              <PieChart>
+                <ChartTooltip cursor={false} content={<ChartTooltipContent indicator="dot" />} />
+                <Pie data={channelData} dataKey="value" nameKey="name" innerRadius={45} outerRadius={80} strokeWidth={2}>
+                  {channelData.map((entry) => (
+                    <Cell key={entry.name} fill={entry.fill} />
+                  ))}
+                </Pie>
+              </PieChart>
+            </ChartContainer>
+            <div className="mt-3 flex justify-center gap-4 text-sm">
+              <span className="inline-flex items-center gap-2 text-slate-600">
+                <PiChatBold className="h-4 w-4" style={{ color: CHANNEL_COLORS.sms }} aria-hidden="true" />
+                SMS: <span className="tabular-nums font-medium text-slate-900">{data.notifications.total_sms}</span>
+              </span>
+              <span className="inline-flex items-center gap-2 text-slate-600">
+                <PiEnvelopeBold className="h-4 w-4" style={{ color: CHANNEL_COLORS.email }} aria-hidden="true" />
+                Email: <span className="tabular-nums font-medium text-slate-900">{data.notifications.total_email}</span>
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="lg:col-span-2 rounded-xl border-slate-200/80 shadow-sm bg-white">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base font-semibold text-slate-900">
+              Delivery Statistics
+            </CardTitle>
+            <p className="text-xs text-slate-500">Outcome of sends in the selected window</p>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {deliveryTiles.map(({ label, value, icon }) => (
+              <div key={label} className="rounded-xl border border-slate-100 bg-slate-50/50 p-3">
+                {icon}
+                <p className="text-xs text-slate-500 mt-2">{label}</p>
+                <p className="text-xl font-semibold tabular-nums text-slate-900 mt-0.5">{value}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <div>
+            <CardTitle className="text-base font-semibold text-slate-900">
+              Recent Notifications
+            </CardTitle>
+            <p className="text-xs text-slate-500">Last 20 notifications sent</p>
+          </div>
+          <span className="text-xs font-medium text-slate-500">
+            {data.recent_notifications.length} shown
+          </span>
+        </CardHeader>
+        <CardContent>
+          {data.recent_notifications.length === 0 ? (
+            <div className="flex items-center justify-center rounded-xl border border-dashed border-slate-200 py-10 text-sm text-slate-400">
+              No notifications sent yet
+            </div>
+          ) : (
+            <div className="overflow-x-auto rounded-xl border border-slate-200/80">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 bg-slate-50">
+                    {['Invoice', 'Type', 'Recipient', 'Amount', 'Days overdue', 'Status', 'Sent'].map((h, i) => (
+                      <th
+                        key={h}
+                        className={`px-3 py-2.5 text-xs font-semibold uppercase tracking-wider text-slate-500 ${
+                          i === 3 || i === 4 ? 'text-right' : 'text-left'
+                        }`}
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {data.recent_notifications.map((notif) => (
+                    <tr key={notif.id} className="transition-colors hover:bg-slate-50">
+                      <td className="whitespace-nowrap px-3 py-2.5 font-medium text-slate-900">
+                        {notif.invoice_number}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5">
+                        <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs font-medium text-slate-600">
+                          {notif.notification_type === 'sms' ? (
+                            <>
+                              <PiChatBold className="h-3 w-3" style={{ color: CHANNEL_COLORS.sms }} aria-hidden="true" />
+                              SMS
+                            </>
+                          ) : (
+                            <>
+                              <PiEnvelopeBold className="h-3 w-3" style={{ color: CHANNEL_COLORS.email }} aria-hidden="true" />
+                              Email
+                            </>
+                          )}
+                        </span>
+                      </td>
+                      <td className="max-w-[180px] truncate px-3 py-2.5 text-slate-700">
+                        {notif.recipient}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-right font-semibold tabular-nums text-slate-900">
+                        {formatCurrency(notif.amount_due)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-right tabular-nums text-slate-600">
+                        {notif.days_overdue}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2.5">{notifStatusBadge(notif.status)}</td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-xs text-slate-500">
+                        {new Date(notif.created_at).toLocaleString('en-ZA')}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+The four tinted tiles (`bg-green-50`, `bg-red-50`, `bg-blue-50`, `bg-purple-50` and their `dark:` variants) become slate tiles with the icon carrying the colour. The "Days Overdue" `days` suffix moved into the column header so the cell stays numeric and right-aligned.
+
+- [ ] **Step 2: Verify no new type errors**
+
+```bash
+npm run type-check:memory 2>&1 | grep "NotificationsPanel" || echo "NO ERRORS in NotificationsPanel"
+```
+
+Expected: `NO ERRORS in NotificationsPanel`.
+
+- [ ] **Step 3: Confirm channel colours were not flattened**
+
+```bash
+grep -c "CHANNEL_COLORS" components/admin/finance/ar/NotificationsPanel.tsx
+```
+
+Expected: `8` or more (chart config ×2, chart data ×2, legend ×2, table badge ×2).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/admin/finance/ar/NotificationsPanel.tsx
+git commit -m "style(ar-analytics): notifications panel onto network chrome
+
+Channel blue/purple preserved; tinted tiles become slate with coloured icons."
+```
+
+---
+
+## Task 12: HistoryPanel
+
+Two composed charts (`Area` + `Line`, and `Bar` + `Line`). Recharts requires `ComposedChart` for mixed marks — the current code nests `<Line>` inside `<AreaChart>`/`<BarChart>`, which Recharts tolerates inconsistently. Switching to `ComposedChart` is required for the mixed series to render reliably.
+
+**Files:**
+- Modify: `components/admin/finance/ar/HistoryPanel.tsx`
+
+**Interfaces:**
+- Consumes: `CHANNEL_COLORS`, `formatCurrency`, `formatShortDate`, `ARAnalyticsData` from `./shared`.
+- Produces: nothing.
+
+- [ ] **Step 1: Replace the file entirely**
+
+```tsx
+'use client';
+
+import { Area, Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from 'recharts';
+import { PiCalendarBold } from 'react-icons/pi';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
+import { CHANNEL_COLORS, formatCurrency, formatShortDate, type ARAnalyticsData } from './shared';
+
+const trendConfig = {
+  total_outstanding: { label: 'Outstanding', color: 'var(--chart-1)' },
+  dso_current: { label: 'DSO', color: 'var(--chart-3)' },
+} satisfies ChartConfig;
+
+const activityConfig = {
+  sms_sent_count: { label: 'SMS', color: CHANNEL_COLORS.sms },
+  email_sent_count: { label: 'Email', color: CHANNEL_COLORS.email },
+  payments_received_amount: { label: 'Payments', color: '#22c55e' },
+} satisfies ChartConfig;
+
+export function HistoryPanel({ data }: { data: ARAnalyticsData }) {
+  const history = data.historical;
+
+  if (!history || history.length === 0) {
+    return (
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardContent className="py-12 text-center">
+          <PiCalendarBold className="mx-auto mb-4 h-12 w-12 text-slate-300" aria-hidden="true" />
+          <p className="text-slate-600">No historical data available yet</p>
+          <p className="mt-1 text-sm text-slate-500">
+            Historical snapshots are created daily by the system
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">AR &amp; DSO Trend</CardTitle>
+          <p className="text-xs text-slate-500">Historical outstanding amount and DSO</p>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={trendConfig} className="aspect-auto h-[300px] w-full">
+            <ComposedChart accessibilityLayer data={history} margin={{ left: 8, right: 8, top: 8, bottom: 0 }}>
+              <CartesianGrid vertical={false} strokeDasharray="3 3" />
+              <XAxis
+                dataKey="snapshot_date"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={28}
+                tickFormatter={formatShortDate}
+              />
+              <YAxis
+                yAxisId="left"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={56}
+                tickFormatter={(v) => `R${(Number(v) / 1000).toFixed(0)}k`}
+              />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={40}
+              />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    indicator="dot"
+                    labelFormatter={(value) => formatShortDate(String(value))}
+                    formatter={(value, name) => (
+                      <div className="flex w-full items-center justify-between gap-4">
+                        <span className="text-muted-foreground">
+                          {trendConfig[name as keyof typeof trendConfig]?.label ?? name}
+                        </span>
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {name === 'total_outstanding'
+                            ? formatCurrency(Number(value))
+                            : Number(value).toFixed(1)}
+                        </span>
+                      </div>
+                    )}
+                  />
+                }
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <defs>
+                <linearGradient id="fillOutstanding" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--color-total_outstanding)" stopOpacity={0.85} />
+                  <stop offset="95%" stopColor="var(--color-total_outstanding)" stopOpacity={0.08} />
+                </linearGradient>
+              </defs>
+              <Area
+                yAxisId="left"
+                dataKey="total_outstanding"
+                type="natural"
+                fill="url(#fillOutstanding)"
+                stroke="var(--color-total_outstanding)"
+                strokeWidth={1.5}
+              />
+              <Line
+                yAxisId="right"
+                dataKey="dso_current"
+                type="natural"
+                stroke="var(--color-dso_current)"
+                strokeWidth={2}
+                dot={false}
+              />
+            </ComposedChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-xl border-slate-200/80 shadow-sm bg-white">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold text-slate-900">
+            Notifications &amp; Collections
+          </CardTitle>
+          <p className="text-xs text-slate-500">
+            Daily notification activity and payments received
+          </p>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={activityConfig} className="aspect-auto h-[300px] w-full">
+            <ComposedChart accessibilityLayer data={history} margin={{ left: 8, right: 8, top: 8, bottom: 0 }}>
+              <CartesianGrid vertical={false} strokeDasharray="3 3" />
+              <XAxis
+                dataKey="snapshot_date"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={28}
+                tickFormatter={formatShortDate}
+              />
+              <YAxis yAxisId="left" tickLine={false} axisLine={false} tickMargin={8} width={40} />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={56}
+                tickFormatter={(v) => `R${(Number(v) / 1000).toFixed(0)}k`}
+              />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    indicator="dot"
+                    labelFormatter={(value) => formatShortDate(String(value))}
+                  />
+                }
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Bar yAxisId="left" dataKey="sms_sent_count" fill="var(--color-sms_sent_count)" radius={[4, 4, 0, 0]} />
+              <Bar yAxisId="left" dataKey="email_sent_count" fill="var(--color-email_sent_count)" radius={[4, 4, 0, 0]} />
+              <Line
+                yAxisId="right"
+                dataKey="payments_received_amount"
+                type="natural"
+                stroke="var(--color-payments_received_amount)"
+                strokeWidth={2}
+                dot={false}
+              />
+            </ComposedChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+The AR/DSO trend is the one chart that legitimately adopts the warm `--chart-*` palette: outstanding-over-time is a plain quantity with no severity meaning, so it should look like the network traffic charts. The hardcoded `#F5831F` it used before is replaced by `var(--chart-1)`.
+
+- [ ] **Step 2: Verify no new type errors**
+
+```bash
+npm run type-check:memory 2>&1 | grep "HistoryPanel" || echo "NO ERRORS in HistoryPanel"
+```
+
+Expected: `NO ERRORS in HistoryPanel`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/admin/finance/ar/HistoryPanel.tsx
+git commit -m "style(ar-analytics): history charts onto ComposedChart + network chrome
+
+ComposedChart is required for the mixed Area+Line / Bar+Line series;
+nesting Line inside AreaChart/BarChart renders inconsistently."
+```
+
+---
+
+## Task 13: Full verification pass
+
+**Files:** none modified unless a defect is found.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–12, and `.scratch/baseline-typecheck.txt` from Task 0.
+- Produces: a green build and a visual sign-off.
+
+- [ ] **Step 1: Confirm no new type errors against the Task 0 baseline**
+
+```bash
+npm run type-check:memory 2>&1 | tee .scratch/after-typecheck.txt | tail -3
+echo "baseline: $(grep -c 'error TS' .scratch/baseline-typecheck.txt)"
+echo "after:    $(grep -c 'error TS' .scratch/after-typecheck.txt)"
+diff <(grep "error TS" .scratch/baseline-typecheck.txt | sort) \
+     <(grep "error TS" .scratch/after-typecheck.txt | sort) \
+  && echo "IDENTICAL ERROR SET — no regressions"
+```
+
+Expected: the after-count is `<=` baseline, and either `IDENTICAL ERROR SET` or a diff showing only **removed** lines (the AR page dropped theme-token usage, so some errors may disappear). **Any added `+` line is a regression — fix it before continuing.**
+
+- [ ] **Step 2: Confirm the existing Jest suites are still green**
+
+```bash
+npx jest __tests__/lib/billing __tests__/lib/network \
+  --modulePathIgnorePatterns=/node_modules/ \
+  --testPathIgnorePatterns=/node_modules/ 2>&1 | tail -8
+```
+
+Expected: same pass count as `.scratch/baseline-jest.txt`. These cover `filterExceptions` and the network aggregates, which this work must not have touched.
+
+- [ ] **Step 3: Confirm no unintended files were changed**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --name-only origin/main...HEAD | grep -E "^(app|components|lib)/" | sort
+```
+
+Expected exactly these 17 paths, and nothing else — in particular **no `app/admin/network/*` and no `lib/*`**:
+
+```
+app/admin/billing/page.tsx
+app/admin/finance/ar-analytics/page.tsx
+components/admin/billing/recon/CashMatchStrip.tsx
+components/admin/billing/recon/DayDoneBanner.tsx
+components/admin/billing/recon/DeepLinks.tsx
+components/admin/billing/recon/ExceptionTable.tsx
+components/admin/billing/recon/SecondaryKpis.tsx
+components/admin/finance/ar/ArAgingPanel.tsx
+components/admin/finance/ar/DsoMetricsPanel.tsx
+components/admin/finance/ar/HistoryPanel.tsx
+components/admin/finance/ar/NotificationsPanel.tsx
+components/admin/finance/ar/index.ts
+components/admin/finance/ar/shared.tsx
+components/admin/network/performance/MetricCard.tsx
+components/backend/MetricCard.tsx
+components/backend/index.ts
+```
+
+- [ ] **Step 4: Run the production build**
+
+```bash
+npm run build:memory 2>&1 | tail -30
+```
+
+Expected: `✓ Compiled successfully`, no errors on `/admin/billing` or `/admin/finance/ar-analytics`. Takes 10–18 minutes. Per `.claude/rules/vps-devops.md`, do not run this while another heavy CircleTel build is running on the VPS.
+
+- [ ] **Step 5: Visual pass — the two restyled pages**
+
+```bash
+ALLOW_DEV_ADMIN_BYPASS=true npm run dev:memory
+```
+
+At **1440px** then **1280px**, check `http://localhost:3000/admin/billing`:
+
+- [ ] Eyebrow `Finance / Billing / Cash Match` above a `text-2xl font-semibold` slate H1
+- [ ] Action row is all `size="sm"`, one orange CTA
+- [ ] Meta strip badge + window text below the header
+- [ ] Four `MetricCard`s, `rounded-xl`, value `font-semibold`, icon **below** the value
+- [ ] Day-done banner still green when clear / red when not
+- [ ] Exceptions card is `rounded-xl` slate; filter chips still orange when active; table unchanged
+- [ ] Footer meta line, right-aligned with clock icon
+- [ ] No horizontal scrollbar on `<body>`
+
+And `http://localhost:3000/admin/finance/ar-analytics`:
+
+- [ ] Eyebrow `Finance / Receivables / AR Analytics`, same H1 treatment
+- [ ] Four `MetricCard` KPIs; DSO trend arrow renders below the value
+- [ ] Pill tabs (white active pill), all four switch correctly
+- [ ] **AR Aging** — bars still green→dark-red, soft grid, no axis lines, tooltip shows ZAR
+- [ ] **DSO & Metrics** — three `MetricCard`s + four slate tiles
+- [ ] **Notifications** — donut still blue/purple, four slate tiles, table has slate uppercase headers
+- [ ] **History** — both composed charts render *both* series (area **and** line; bars **and** line)
+- [ ] No console errors, and no React key or unknown-prop warnings
+
+- [ ] **Step 6: Visual regression check — the three network pages**
+
+Task 1 proved the `MetricCard` render body is byte-identical, so this is a confirmation, not a discovery. With the dev server still running, load each and confirm the metric cards look unchanged:
+
+- [ ] `http://localhost:3000/admin/network/analytics` — four metric cards with coloured arrow/lightning/database icons below the values
+- [ ] `http://localhost:3000/admin/network/devices` — Online Devices / Telemetry Coverage cards with their `delta` lines
+- [ ] `http://localhost:3000/admin/network/health` — three metric cards with their inline `DotMatrixChart` / `SegmentedBar` / `BandwidthChart` children
+
+Stop the dev server.
+
+- [ ] **Step 7: Clean up the scratch baselines**
+
+```bash
+rm -rf .scratch/baseline-typecheck.txt .scratch/baseline-jest.txt .scratch/after-typecheck.txt
+git status --porcelain
+```
+
+Expected: empty output.
+
+- [ ] **Step 8: Rebase onto latest main and push**
+
+`/admin/billing` changed under this branch once already (PR #644 landed the recon hub mid-design), so re-check before opening the PR.
+
+```bash
+git fetch origin
+git log --oneline origin/main -3
+git rebase origin/main
+npm run type-check:memory 2>&1 | grep -cE "error TS"
+git push --force-with-lease
+```
+
+If the rebase conflicts in `app/admin/billing/page.tsx` or any `recon/` file, resolve in favour of **their** data/logic changes plus **your** styling, then re-run Steps 1–5 before pushing.
+
+- [ ] **Step 9: Open the PR**
+
+```bash
+gh pr create --base main \
+  --title "style(admin): billing + AR analytics onto network console look" \
+  --body "$(cat <<'EOF'
+## What
+
+Restyles `/admin/billing` and `/admin/finance/ar-analytics` to match
+`/admin/network/analytics` and `/admin/network/devices`.
+
+Promotes `MetricCard` into `components/backend/` as the canonical metric card and
+makes the network console the documented reference look in `BACKEND_UI_KIT.md`,
+resolving a conflict where the doc named `/admin/billing` (gray `StatCard`) as the
+reference while the network pages had moved to slate and bypassed the kit's card.
+
+## Verification
+
+- No new `tsc` errors vs. the pre-change baseline (repo carries ~295 pre-existing)
+- `npm run build:memory` compiles
+- `__tests__/lib/billing` + `__tests__/lib/network` green
+- `MetricCard` render body byte-identical to the original — the three network
+  pages (analytics, devices, health) cannot change; visually confirmed
+- Both restyled pages checked at 1280px and 1440px, all four AR tabs
+
+## Deliberately preserved
+
+Colour that encodes data rather than decoration: AR aging buckets
+(green→dark-red), SMS blue / Email purple, cash-match day-done green/red,
+exception severity red/amber, all `StatusBadge` variants.
+
+## Not included
+
+No data, API, or logic changes. No other admin or consumer page changes
+appearance. No dark mode (neither reference page implements it).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Plan Self-Review
+
+**Spec coverage**
+
+| Spec section | Task |
+|---|---|
+| Unit 1 — Promote MetricCard (4 files) | Task 1 |
+| Unit 2 — `/admin/billing` (6 files) | Tasks 2, 3, 4, 5 |
+| Unit 3 — `/admin/finance/ar-analytics` | Tasks 6, 7, 8, 9, 10, 11, 12 |
+| Colour that carries meaning | Global Constraints; verified in Tasks 9 Step 3, 11 Step 3 |
+| Success criteria 1 (type-check) | Task 0 Step 3 baseline → Task 13 Step 1 diff |
+| Success criteria 2 (build) | Task 13 Step 4 |
+| Success criteria 3 (network unchanged) | Task 1 Steps 3–4, 8 (deterministic) + Task 13 Step 6 (visual) |
+| Success criteria 4 (target pages) | Task 13 Step 5 |
+| Success criteria 5 (all four AR tabs) | Task 6 Step 7, Task 13 Step 5 |
+| Success criteria 6 (semantic colour) | Tasks 9/11 verification steps + Task 13 Step 5 |
+| Success criteria 7 (no h-scroll) | Task 13 Step 5 |
+| Success criteria 8 (no console errors) | Task 13 Step 5 |
+| Risk: billing diverges mid-work | Task 13 Step 8 |
+
+**Deviations from the spec, and why**
+
+1. **File count 15 → 17.** `shared.tsx` (types, colours, formatters needed by all four panels — duplicating across four files would violate DRY) and `index.ts` (barrel, matching the `performance/index.ts` convention). Both are new files in the already-approved `components/admin/finance/ar/` directory.
+2. **Success criterion 3 verification method strengthened.** The spec called for screenshot-diffing the three network pages. Task 1 instead proves the `MetricCard` render body is byte-identical via `diff`, which is deterministic and cheaper; the visual check in Task 13 Step 6 is retained as confirmation. Screenshot diffing would also have needed image tooling the repo does not have.
+3. **No component tests, and none written.** The spec assumed nothing here, but the plan states it explicitly: there is no working component-test infrastructure and a restyle adds no logic, so tests would be fake (Rule 11) and would need 4 new dev deps (Rule 12).
+4. **`ComposedChart` in Task 12.** The current code nests `<Line>` inside `<AreaChart>`/`<BarChart>`; Recharts needs `ComposedChart` for mixed marks. This is a correctness fix inside a file already being rewritten, not scope creep — and without it the restyled history charts would silently drop a series.
+5. **`CashMatchStrip` Zoho card wrapped in `Link` (Task 3 Step 4).** `StatCard` had an `href` prop; `MetricCard` does not. Wrapping preserves navigation that would otherwise be silently lost.
+
+**Placeholder scan:** No `TBD`/`TODO`/"similar to Task N". Two steps intentionally reference exact source line ranges rather than restating ~200 lines of markup (Task 6 Step 2, Step 4's KPI-grid comment) — those are *pure moves* of existing code, immediately restyled with full code given in Tasks 8–12, and Task 6 Step 6 asserts the move introduced no class changes.
+
+**Type consistency:** `MetricCardProps` fields match Task 1's declaration everywhere. `value` is `string` at every call site (`` `${n}` `` for numerics, `.toFixed(1)` for floats, `formatCurrency(...)` for money). `formatShortDate` is used consistently — the old name `formatDate` appears nowhere after Task 6. `TrendIcon` is a component (`<TrendIcon trend={…} />`), never the old `getTrendIcon(…)` call form. `buildAgingBuckets` returns `AgingBucket[]` with `fill`, consumed as `bucket.fill` in Task 9. `CHANNEL_COLORS`/`AGING_COLORS` replace the old flat `COLORS` object everywhere.

--- a/docs/superpowers/specs/2026-07-30-billing-ar-network-console-look-design.md
+++ b/docs/superpowers/specs/2026-07-30-billing-ar-network-console-look-design.md
@@ -1,0 +1,157 @@
+# Billing + AR Analytics — Network Console Look
+
+**Date:** 2026-07-30
+**Branch:** `feat/billing-network-console-look`
+**Status:** Design approved, ready for implementation plan
+
+## Goal
+
+Bring `/admin/billing` and `/admin/finance/ar-analytics` onto the same visual language as `/admin/network/analytics` and `/admin/network/devices`, so the admin reads as one product.
+
+Presentation only. No data, API, query, or business-logic changes.
+
+## Problem
+
+Two design languages coexist in the admin, and a checked-in spec makes billing the wrong one.
+
+`docs/design/BACKEND_UI_KIT.md` names `app/admin/billing/*` and `app/dashboard/billing` as the kit's **reference look**: `border-gray-200`, `p-6`, `StatCard`, `SectionCard`, orange accent.
+
+The network console pages evolved a newer language and deliberately do not use the kit's `StatCard`/`SectionCard` for their metric cards: `border-slate-200/80`, `rounded-xl`, breadcrumb eyebrows, `MetricCard`, outline-only action rows, source/freshness meta strips.
+
+Restyling the two billing pages without resolving this would hard-code a third variant of the same card while the spec still declares gray canonical — a blend, which `.claude/rules/` Rule 7 forbids. So the network console becomes the documented reference, and the metric card it uses moves into the shared kit.
+
+## Approach
+
+Promote `MetricCard` into `components/backend/` as the canonical metric card. Restyle only the two target pages onto it. Leave every other admin page visually untouched.
+
+Rejected alternatives:
+
+- **Retheme `StatCard`/`SectionCard` to slate.** One edit, instant consistency — but silently restyles every `/admin/*` and `/dashboard/*` page using them. Blast radius far beyond the request.
+- **Copy slate classes into the two pages.** Fastest, but creates a third card variant and leaves the kit doc contradicting reality.
+
+## The look, codified
+
+Extracted from `app/admin/network/analytics/page.tsx` and `app/admin/network/devices/page.tsx` — measured, not invented.
+
+| Element | Value |
+|---|---|
+| Page shell | `AdminPage` → `space-y-6` |
+| Eyebrow breadcrumb | `text-xs text-slate-400 mb-1` |
+| H1 | `text-2xl font-semibold text-slate-900 tracking-tight` |
+| Subtitle | `text-sm text-slate-500 mt-1` |
+| Action row | `variant="outline" size="sm"`; Selects `rounded-lg border-slate-200` |
+| Meta strip | `<Badge variant="outline">` + `text-xs text-slate-400/500` |
+| Card shell | `rounded-xl border-slate-200/80 shadow-sm bg-white` |
+| Card header | `CardHeader pb-2`; title `text-base font-semibold text-slate-900`; desc `text-xs text-slate-500` |
+| Inner tile | `rounded-xl border border-slate-100 bg-slate-50/50 p-3` |
+| Metric value | `text-3xl font-semibold tracking-tight text-slate-900` |
+| Metric label | `text-sm font-medium text-slate-500` |
+| Grid gap | `gap-4` |
+| Banner | `rounded-xl border-{color}-200/80 bg-{color}-50/80 shadow-sm` + `CardContent py-3` |
+| Table header | `bg-slate-50`, `text-xs font-semibold uppercase tracking-wider text-slate-500` |
+| Table body | `divide-y divide-slate-100`, row `hover:bg-slate-50` |
+| Footer meta | right-aligned `text-sm text-slate-500` + `PiClockBold` |
+
+Two shifts to note: the palette moves `gray-*` → `slate-*`, and metric values move `font-bold` → `font-semibold`. `MetricCard` also renders its icon as a **child below the value**, where `StatCard` puts it inline top-left — so converting moves the icon. Intended.
+
+## Colour that carries meaning is preserved
+
+The network palette is a warm amber ramp (`--chart-1..5` in `app/globals.css`). Several things on these two pages use colour as *data*, not decoration, and flattening them into that ramp would look consistent while destroying the signal. These keep their current values and adopt only the surrounding chrome:
+
+- **AR aging buckets** — green → yellow → orange → red → dark-red encodes how overdue.
+- **SMS blue / Email purple** — channel identity, used in chart, legend, and table badges.
+- **`CashMatchStrip` green/red tint** and **`DayDoneBanner` green/red** — encodes whether cash is matched.
+- **`ExceptionTable` red/amber severity text** — encodes exception severity.
+- **`StatusBadge` variants** — the kit already owns status colour; no per-page status hex.
+
+Orange stays an accent per the kit rule: one primary CTA, filter chips, links.
+
+## Unit 1 — Promote MetricCard
+
+| File | Change |
+|---|---|
+| `components/backend/MetricCard.tsx` | NEW — content moved verbatim from the network copy, plus `export` added to the existing `type MetricCardProps` (currently file-local) |
+| `components/backend/index.ts` | Export `MetricCard` + `MetricCardProps` |
+| `components/admin/network/performance/MetricCard.tsx` | Becomes a re-export shim |
+| `docs/design/BACKEND_UI_KIT.md` | Reference look → network console; add `MetricCard` row; note `StatCard` is retained for unmigrated pages |
+
+`components/admin/network/performance/index.ts` keeps re-exporting `MetricCard`, so `analytics`, `devices`, and `health` need **zero edits and render identically**. This is the same back-compat shim pattern the kit doc already uses for `components/admin/shared/*`.
+
+No import cycle: the shim imports `@/components/backend/MetricCard` (the file) rather than the barrel.
+
+Existing `MetricCard` consumers that must stay pixel-identical:
+
+- `app/admin/network/analytics/page.tsx` (4 cards, all with icon children)
+- `app/admin/network/devices/page.tsx` (2 cards, using `delta` / `deltaPositive`)
+- `app/admin/network/health/page.tsx` (4+ cards with children)
+
+The `MetricCardProps` **shape** is therefore frozen — no prop renames, removals, or default changes. Adding the `export` keyword is the only permitted edit to it.
+
+## Unit 2 — `/admin/billing`
+
+PR #644 rewrote this page into a cash-match recon hub. It is already substantially slate; only the shells are off-look.
+
+| File | Change |
+|---|---|
+| `app/admin/billing/page.tsx` | Eyebrow `Finance / Billing / Cash Match`; network header markup replacing bare `PageHeader`; all actions `size="sm"`; one orange CTA at `size="sm"`; window Select `rounded-lg border-slate-200`; source/window meta strip; footer meta line with `PiClockBold` |
+| `recon/CashMatchStrip.tsx` | `StatCard` boxed-icon variant → `MetricCard`; icon becomes a child; keep semantic green/red tint via `className` |
+| `recon/SecondaryKpis.tsx` | `rounded-lg` → `rounded-xl`; dashed `border-slate-300` → `border-slate-100 bg-slate-50/50` matching `GroupTrafficCards` tiles |
+| `recon/DayDoneBanner.tsx` | `rounded-lg` → `rounded-xl` `border-{c}-200/80 bg-{c}-50/80 shadow-sm`, matching the devices-page banner |
+| `recon/ExceptionTable.tsx` | `SectionCard` wrapper → network `Card` + `CardHeader pb-2` + `text-base font-semibold` title. **Table markup untouched** — it already matches |
+| `recon/DeepLinks.tsx` | `rounded-lg` → `rounded-xl`; `border-slate-200` → `border-slate-200/80` |
+
+Where an import line is already being edited, switch `@/components/admin/shared` → `@/components/backend` (the kit doc's stated preference for migrated code). Not a separate sweep.
+
+The `/admin/billing` API (`/api/admin/billing/recon-hub`), `ReconHubResponse` types, and `filterExceptions` logic are untouched.
+
+## Unit 3 — `/admin/finance/ar-analytics`
+
+Currently 725 lines. Restyling in place would push it past ~800, so the four tab bodies are extracted first — the restyle then lands as four readable diffs instead of one large one.
+
+| File | Change |
+|---|---|
+| `app/admin/finance/ar-analytics/page.tsx` | Reduce to ~150 lines: fetch, state, formatters, header, tabs wiring. Eyebrow `Finance / Receivables / AR Analytics`; period Select + refresh at `size="sm"`; meta strip; footer meta |
+| `components/admin/finance/ar/ArAgingPanel.tsx` | NEW — aging bar chart + aging summary table |
+| `components/admin/finance/ar/DsoMetricsPanel.tsx` | NEW — 3 DSO cards + collection performance tiles |
+| `components/admin/finance/ar/NotificationsPanel.tsx` | NEW — channel pie, delivery stats, recent notifications table |
+| `components/admin/finance/ar/HistoryPanel.tsx` | NEW — AR/DSO trend + notifications/collections charts |
+
+Restyle within those panels:
+
+- 4 KPI cards: raw shadcn `Card` with `text-primary` / `text-muted-foreground` → `MetricCard`. This also sidesteps the known latent bug where global `:root` oklch values break `hsl(var())` consumers — slate classes are literal, not token-derived.
+- Tabs: raw shadcn `TabsList` → kit `ConsoleTabsList` pill tabs. Same 4 tabs, same content, no reordering.
+- Charts: onto shadcn chart primitives — `ChartContainer` + `ChartConfig`, `CartesianGrid vertical={false}`, `tickLine={false} axisLine={false}`, `linearGradient` fills, `ChartTooltip`/`ChartTooltipContent`. Bucket and channel colours preserved per the section above.
+- Tinted stat tiles (`bg-green-50`, `bg-red-50`, `bg-blue-50`, `bg-purple-50`) → slate tiles, icon colour as the only signal.
+- `text-4xl font-bold` DSO numbers → `text-3xl font-semibold tracking-tight text-slate-900`.
+- The 4 tables keep the `ExceptionTable`/`DeviceTable` header + divider treatment.
+
+Data contract is unchanged: `ARAnalyticsData` moves to a shared type import for the panels; `/api/admin/finance/ar-analytics` is untouched.
+
+## Success criteria
+
+1. `npm run type-check:memory` introduces no new errors in touched files (repo carries ~295 pre-existing; the pre-push hook only blocks on files in the push).
+2. `npm run build:memory` succeeds.
+3. `/admin/network/analytics`, `/admin/network/devices`, `/admin/network/health` are visually unchanged — verified by screenshot diff, since they share the promoted `MetricCard`.
+4. `/admin/billing` and `/admin/finance/ar-analytics` render with: eyebrow, `text-2xl font-semibold text-slate-900` H1, outline `size="sm"` action row, `rounded-xl border-slate-200/80` cards, `gap-4` grids, footer meta line.
+5. All four AR tabs render with data and with the empty state (History has a no-data branch).
+6. Semantic colours still legible: aging buckets green→dark-red, SMS blue / Email purple, day-done green/red, severity red/amber.
+7. No page grew a horizontal scrollbar at 1280px or 1440px.
+8. No new console errors or React key/prop warnings.
+
+## Out of scope
+
+- Any other admin or consumer dashboard page.
+- `StatCard`, `SectionCard`, `ConsoleTabsList` internals — used as-is.
+- API routes, SQL, types under `lib/billing/recon-hub/`, `filterExceptions`.
+- Consolidating the `components/admin/shared` shims.
+- Dark mode. Neither reference page implements it; the `dark:` classes currently in ar-analytics' tinted tiles disappear with those tiles and are not replaced.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `MetricCard` move regresses 3 network pages | Shim + unchanged barrel export; screenshot-diff all three |
+| AR chart migration breaks a chart silently | Migrate and verify one chart at a time; both empty and populated states |
+| Extracting 4 panels drops a prop or state hook | Extract first as a pure move, verify, then restyle — two steps, not one |
+| Semantic colour lost to "consistency" | Enumerated explicitly above; success criterion 6 checks it |
+| `/admin/billing` diverges further mid-work | #644 landed today; rebase on `origin/main` before PR |


### PR DESCRIPTION
## What

Restyles `/admin/billing` and `/admin/finance/ar-analytics` to match `/admin/network/analytics` and `/admin/network/devices`, so the admin reads as one product.

Also promotes `MetricCard` from `components/admin/network/performance/` into the shared `components/backend/` kit and makes the network console the documented reference look in `BACKEND_UI_KIT.md`.

### Why the kit doc changed too

`docs/design/BACKEND_UI_KIT.md` named `/admin/billing` (gray `border-gray-200` + `StatCard`) as the kit's reference look, while the network pages had moved to slate `border-slate-200/80` + `rounded-xl` and bypassed the kit's metric card entirely. Restyling billing without resolving that would have hard-coded a third card variant while the spec still declared gray canonical. The network console is now the documented reference.

`StatCard` is retained — it is still referenced by ~111 files, so retheming it was rejected as far too wide a blast radius. `MetricCard` sits alongside it as the preferred card for new work.

## Approach

`MetricCard` moved to `components/backend/`; the old path became a re-export shim, so `analytics`, `devices`, and `health` needed **zero edits**. Their render is provably unchanged: the moved file's render body was verified byte-identical to the original via `diff`.

The AR page (725 lines) had its four tab bodies extracted into `components/admin/finance/ar/` as a **pure move first**, verified, and only then restyled — so move bugs and style bugs stayed separable.

## Verification

| Check | Result |
|---|---|
| Type-check delta | 211 pre-existing errors before and after; sorted error sets identical both directions — zero new |
| Pre-push hook | "No type errors in the files you're pushing" (16 changed TS files) |
| `npm run build:memory` | Succeeds; both routes and all three network routes present in `.next` |
| Jest (`__tests__/lib/billing`, `__tests__/lib/network`) | 17 suites / 142 tests passing — identical to baseline |
| File scope | No `app/admin/network/*` page and no `lib/*` file touched |
| Horizontal scroll @ 1280px / 1440px | None on any affected page |

## Deliberately preserved

Colour that encodes data rather than decoration: AR aging buckets (`#22c55e` → `#991b1b` by age), SMS blue `#3b82f6` / Email purple `#8b5cf6`, cash-match day-done green/red, exception severity red/amber, all `StatusBadge` variants. Only one chart deliberately adopts the warm `--chart-*` palette — the AR/DSO trend, where outstanding-over-time is a plain quantity with no severity meaning.

## Known gap — please check this in staging

**Populated appearance was not visually verified.** `middleware/admin-auth.ts`'s `ALLOW_DEV_ADMIN_BYPASS` covers page routes only; `/api/admin/*` uses `authenticateAdmin()`, which has no dev bypass. Every data fetch returned 401 locally and each page rendered its `ErrorState` — including the untouched network pages, so this is an environment limitation rather than a regression. The two restyled pages were verified from code and by build/type-check, not from a rendered screen with real data.

A hydration warning appears on `/admin/billing`, but it also appears on `/admin/network/health` (untouched by this branch) and not on `/admin/dashboard` — pre-existing, not introduced here.

## Also fixed

`HistoryPanel` nested `<Line>` inside `<AreaChart>` / `<BarChart>`. Recharts needs `<ComposedChart>` for mixed marks; without it the DSO and Payments lines can silently fail to render. Fixed as part of that file's rewrite.

## Not included

No data, API, SQL, or logic changes. No other admin or consumer page changes appearance. No dark mode (neither reference page implements it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)