### PR TITLE
feat(billing): service↔invoice coverage script (revenue leakage)

### DIFF
--- a/__tests__/lib/billing/service-invoice-coverage.test.ts
+++ b/__tests__/lib/billing/service-invoice-coverage.test.ts
@@ -1,0 +1,153 @@
+import {
+  buildCoverageReport,
+  invoiceCoversPeriod,
+  isDeferredForPeriod,
+  periodBounds,
+} from '@/lib/billing/service-invoice-coverage';
+
+describe('periodBounds', () => {
+  it('returns July 2026 bounds', () => {
+    const b = periodBounds('2026-07');
+    expect(b.start).toBe('2026-07-01');
+    expect(b.end).toBe('2026-07-31');
+  });
+});
+
+describe('invoiceCoversPeriod', () => {
+  it('matches full-month range overlap', () => {
+    const r = invoiceCoversPeriod(
+      {
+        id: '1',
+        invoice_number: 'INV-1',
+        service_id: 's1',
+        status: 'sent',
+        period_start: '2026-07-01',
+        period_end: '2026-07-31',
+        invoice_date: '2026-07-01',
+        total_amount: 450,
+      },
+      '2026-07'
+    );
+    expect(r.covers).toBe(true);
+    expect(r.how).toBe('range_overlap');
+  });
+
+  it('rejects voided', () => {
+    const r = invoiceCoversPeriod(
+      {
+        id: '1',
+        invoice_number: 'INV-1',
+        service_id: 's1',
+        status: 'voided',
+        period_start: '2026-07-01',
+        period_end: '2026-07-31',
+        invoice_date: '2026-07-01',
+        total_amount: 450,
+      },
+      '2026-07'
+    );
+    expect(r.covers).toBe(false);
+  });
+
+  it('matches pro-rata overlapping July', () => {
+    const r = invoiceCoversPeriod(
+      {
+        id: '1',
+        invoice_number: 'INV-1',
+        service_id: 's1',
+        status: 'paid',
+        period_start: '2026-06-15',
+        period_end: '2026-07-14',
+        invoice_date: '2026-06-19',
+        total_amount: 276,
+      },
+      '2026-07'
+    );
+    expect(r.covers).toBe(true);
+  });
+});
+
+describe('isDeferredForPeriod', () => {
+  it('defers Chloorkop for July 2026', () => {
+    expect(isDeferredForPeriod('Unjani Clinic - Chloorkop', '2026-07')).toBe(
+      true
+    );
+  });
+
+  it('does not defer Chloorkop for August 2026', () => {
+    expect(isDeferredForPeriod('Unjani Clinic - Chloorkop', '2026-08')).toBe(
+      false
+    );
+  });
+});
+
+describe('buildCoverageReport', () => {
+  it('classifies covered, deferred, and gap', () => {
+    const report = buildCoverageReport(
+      [
+        {
+          id: 's1',
+          customer_id: 'c1',
+          package_name: 'Unjani Managed Connectivity',
+          monthly_price: 450,
+          status: 'active',
+          active: true,
+          billing_day: 1,
+          last_invoice_date: '2026-07-01',
+          activation_date: '2026-06-01',
+          billing_start_date: null,
+          product_category: 'corporate',
+          customer_business_name: 'Unjani Clinic - Sky City',
+        },
+        {
+          id: 's2',
+          customer_id: 'c2',
+          package_name: 'Unjani Managed Connectivity',
+          monthly_price: 450,
+          status: 'active',
+          active: true,
+          billing_day: 1,
+          last_invoice_date: '2026-07-01',
+          activation_date: '2026-06-01',
+          billing_start_date: null,
+          product_category: 'corporate',
+          customer_business_name: 'Unjani Clinic - Chloorkop',
+        },
+        {
+          id: 's3',
+          customer_id: 'c3',
+          package_name: 'Unjani Managed Connectivity',
+          monthly_price: 450,
+          status: 'active',
+          active: true,
+          billing_day: 1,
+          last_invoice_date: null,
+          activation_date: '2026-07-01',
+          billing_start_date: null,
+          product_category: 'corporate',
+          customer_business_name: 'Unjani Clinic - Sweetwaters',
+        },
+      ],
+      [
+        {
+          id: 'i1',
+          invoice_number: 'INV-1',
+          service_id: 's1',
+          status: 'sent',
+          period_start: '2026-07-01',
+          period_end: '2026-07-31',
+          invoice_date: '2026-07-01',
+          total_amount: 450,
+        },
+      ],
+      '2026-07'
+    );
+
+    expect(report.summary.covered).toBe(1);
+    expect(report.summary.deferred).toBe(1);
+    expect(report.summary.gaps).toBe(1);
+    expect(report.lines.find((l) => l.serviceId === 's3')?.reason).toBe(
+      'no_invoice'
+    );
+  });
+});

--- a/lib/billing/service-invoice-coverage.ts
+++ b/lib/billing/service-invoice-coverage.ts
@@ -1,0 +1,401 @@
+/**
+ * Service ↔ invoice coverage (entitlement leakage).
+ * Wayfinder: .scratch/revenue-leakage-service-invoice/
+ *
+ * Ticket 03: billable = active + past start + clinic delay; voided-only ≠ covered.
+ * Ticket 04: period hybrid range-first; SAST calendar months.
+ * Deferrals: five Unjani sites first bill 2026-08-01.
+ */
+
+import { isBeforeBillingStart } from '@/lib/billing/billing-eligibility';
+import {
+  isClinicBillingCategory,
+  shouldEmitRecurringInvoice,
+} from '@/lib/billing/new-clinic-billing-helper';
+
+export const QUALIFYING_INVOICE_STATUSES = [
+  'sent',
+  'partial',
+  'paid',
+  'overdue',
+] as const;
+
+export type QualifyingInvoiceStatus = (typeof QUALIFYING_INVOICE_STATUSES)[number];
+
+/** Sites whose first bill is deferred to this ISO date (inclusive). */
+export const BILLING_EFFECTIVE_FROM: Array<{
+  businessNameIncludes: string;
+  effectiveFrom: string; // YYYY-MM-DD
+}> = [
+  { businessNameIncludes: 'Alexandra', effectiveFrom: '2026-08-01' },
+  { businessNameIncludes: 'Chloorkop', effectiveFrom: '2026-08-01' },
+  { businessNameIncludes: 'Oukasie', effectiveFrom: '2026-08-01' },
+  { businessNameIncludes: 'Phoenix', effectiveFrom: '2026-08-01' },
+  { businessNameIncludes: 'Sicelo', effectiveFrom: '2026-08-01' },
+];
+
+export type GapReason =
+  | 'covered'
+  | 'deferred_effective_date'
+  | 'not_yet_due_billing_start'
+  | 'not_yet_due_clinic_delay'
+  | 'void_only'
+  | 'no_invoice'
+  | 'excluded_inactive';
+
+export interface ServiceRow {
+  id: string;
+  customer_id: string;
+  package_name: string | null;
+  monthly_price: number | null;
+  status: string | null;
+  active: boolean | null;
+  billing_day: number | null;
+  last_invoice_date: string | null;
+  activation_date: string | null;
+  billing_start_date: string | null;
+  product_category: string | null;
+  customer_name?: string | null;
+  customer_business_name?: string | null;
+}
+
+export interface InvoiceRow {
+  id: string;
+  invoice_number: string | null;
+  service_id: string | null;
+  status: string | null;
+  period_start: string | null;
+  period_end: string | null;
+  invoice_date: string | null;
+  total_amount: number | null;
+}
+
+export interface CoverageLine {
+  serviceId: string;
+  customerId: string;
+  customerName: string;
+  packageName: string | null;
+  monthlyPrice: number;
+  billingDay: number | null;
+  activationDate: string | null;
+  lastInvoiceDate: string | null;
+  reason: GapReason;
+  invoiceNumber: string | null;
+  invoiceStatus: string | null;
+  matchHow: string | null;
+}
+
+export interface CoverageReport {
+  period: string; // YYYY-MM
+  periodStart: string;
+  periodEnd: string;
+  generatedAt: string;
+  summary: {
+    activeServices: number;
+    billable: number;
+    covered: number;
+    deferred: number;
+    notYetDue: number;
+    gaps: number;
+    gapCatalogMrr: number;
+    coveredCatalogMrr: number;
+  };
+  lines: CoverageLine[];
+}
+
+function parseDateOnly(s: string | null | undefined): Date | null {
+  if (!s) return null;
+  const d = s.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) return null;
+  return new Date(`${d}T00:00:00.000Z`);
+}
+
+/** First/last calendar day of YYYY-MM as UTC date-only anchors (SAST business months stored as dates). */
+export function periodBounds(period: string): { start: string; end: string; y: number; m: number } {
+  const m = /^(\d{4})-(\d{2})$/.exec(period);
+  if (!m) throw new Error(`Invalid period ${period}; expected YYYY-MM`);
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  if (mo < 1 || mo > 12) throw new Error(`Invalid month in period ${period}`);
+  const lastDay = new Date(Date.UTC(y, mo, 0)).getUTCDate();
+  const start = `${y}-${String(mo).padStart(2, '0')}-01`;
+  const end = `${y}-${String(mo).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+  return { start, end, y, m: mo };
+}
+
+/**
+ * Ticket 04: invoice covers period month if range overlaps, else period_start month,
+ * else invoice_date month (flagged).
+ */
+export function invoiceCoversPeriod(
+  inv: InvoiceRow,
+  period: string
+): { covers: boolean; how: string | null } {
+  const status = (inv.status || '').toLowerCase();
+  if (!QUALIFYING_INVOICE_STATUSES.includes(status as QualifyingInvoiceStatus)) {
+    return { covers: false, how: null };
+  }
+
+  const { start, end } = periodBounds(period);
+  const ps = inv.period_start?.slice(0, 10) ?? null;
+  const pe = inv.period_end?.slice(0, 10) ?? null;
+
+  if (ps && pe) {
+    // overlap: ps <= periodEnd && pe >= periodStart
+    if (ps <= end && pe >= start) {
+      return { covers: true, how: 'range_overlap' };
+    }
+    return { covers: false, how: null };
+  }
+
+  if (ps) {
+    if (ps.slice(0, 7) === period) {
+      return { covers: true, how: 'period_start_month' };
+    }
+    return { covers: false, how: null };
+  }
+
+  const idt = inv.invoice_date?.slice(0, 10) ?? null;
+  if (idt && idt.slice(0, 7) === period) {
+    return { covers: true, how: 'invoice_date_fallback' };
+  }
+  return { covers: false, how: null };
+}
+
+export function isDeferredForPeriod(
+  customerBusinessName: string | null | undefined,
+  period: string
+): boolean {
+  const name = customerBusinessName || '';
+  const { end } = periodBounds(period);
+  for (const rule of BILLING_EFFECTIVE_FROM) {
+    if (!name.includes(rule.businessNameIncludes)) continue;
+    // Period is before effective month if period end < effectiveFrom
+    if (end < rule.effectiveFrom) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether the service is expected to have a bill for period M (ticket 03).
+ * Returns reason when not due yet; null when billable for coverage check.
+ */
+export function notYetDueReason(
+  service: ServiceRow,
+  period: string
+): 'not_yet_due_billing_start' | 'not_yet_due_clinic_delay' | null {
+  const { end, start } = periodBounds(period);
+  const endDate = new Date(`${end}T12:00:00.000Z`);
+  const startDate = new Date(`${start}T12:00:00.000Z`);
+
+  if (isBeforeBillingStart(service.billing_start_date, endDate)) {
+    return 'not_yet_due_billing_start';
+  }
+
+  // Effective start: billing_start else activation — if activation after period end, not due
+  const act = service.activation_date?.slice(0, 10);
+  if (act && act > end) {
+    return 'not_yet_due_billing_start';
+  }
+
+  // New-clinic recurring delay: only suppresses full recurring when NOT first invoice.
+  // First invoice path: no last_invoice_date → still billable (pro-rata).
+  const isFirst = !service.last_invoice_date;
+  if (
+    !isFirst &&
+    !shouldEmitRecurringInvoice(service.activation_date, startDate, service.product_category)
+  ) {
+    // For period M, also check end of month as run date
+    if (!shouldEmitRecurringInvoice(service.activation_date, endDate, service.product_category)) {
+      return 'not_yet_due_clinic_delay';
+    }
+  }
+
+  return null;
+}
+
+function displayName(s: ServiceRow): string {
+  return (
+    s.customer_business_name ||
+    s.customer_name ||
+    s.customer_id.slice(0, 8)
+  );
+}
+
+export function classifyService(
+  service: ServiceRow,
+  invoices: InvoiceRow[],
+  period: string
+): CoverageLine {
+  const base = {
+    serviceId: service.id,
+    customerId: service.customer_id,
+    customerName: displayName(service),
+    packageName: service.package_name,
+    monthlyPrice: Number(service.monthly_price || 0),
+    billingDay: service.billing_day,
+    activationDate: service.activation_date,
+    lastInvoiceDate: service.last_invoice_date,
+  };
+
+  if (service.active !== true || service.status !== 'active') {
+    return {
+      ...base,
+      reason: 'excluded_inactive',
+      invoiceNumber: null,
+      invoiceStatus: null,
+      matchHow: null,
+    };
+  }
+
+  if (isDeferredForPeriod(service.customer_business_name, period)) {
+    return {
+      ...base,
+      reason: 'deferred_effective_date',
+      invoiceNumber: null,
+      invoiceStatus: null,
+      matchHow: null,
+    };
+  }
+
+  const due = notYetDueReason(service, period);
+  if (due) {
+    return {
+      ...base,
+      reason: due,
+      invoiceNumber: null,
+      invoiceStatus: null,
+      matchHow: null,
+    };
+  }
+
+  const forService = invoices.filter((i) => i.service_id === service.id);
+  for (const inv of forService) {
+    const { covers, how } = invoiceCoversPeriod(inv, period);
+    if (covers) {
+      return {
+        ...base,
+        reason: 'covered',
+        invoiceNumber: inv.invoice_number,
+        invoiceStatus: inv.status,
+        matchHow: how,
+      };
+    }
+  }
+
+  const voidOnly = forService.some((inv) => {
+    if ((inv.status || '').toLowerCase() !== 'voided') return false;
+    const ps = inv.period_start?.slice(0, 7);
+    const idt = inv.invoice_date?.slice(0, 7);
+    return ps === period || idt === period;
+  });
+
+  return {
+    ...base,
+    reason: voidOnly ? 'void_only' : 'no_invoice',
+    invoiceNumber: null,
+    invoiceStatus: null,
+    matchHow: null,
+  };
+}
+
+export function buildCoverageReport(
+  services: ServiceRow[],
+  invoices: InvoiceRow[],
+  period: string,
+  generatedAt = new Date().toISOString()
+): CoverageReport {
+  const { start, end } = periodBounds(period);
+  const lines = services.map((s) => classifyService(s, invoices, period));
+
+  const billable = lines.filter(
+    (l) =>
+      l.reason !== 'excluded_inactive' &&
+      l.reason !== 'deferred_effective_date' &&
+      l.reason !== 'not_yet_due_billing_start' &&
+      l.reason !== 'not_yet_due_clinic_delay'
+  );
+  const covered = lines.filter((l) => l.reason === 'covered');
+  const deferred = lines.filter((l) => l.reason === 'deferred_effective_date');
+  const notYetDue = lines.filter(
+    (l) =>
+      l.reason === 'not_yet_due_billing_start' ||
+      l.reason === 'not_yet_due_clinic_delay'
+  );
+  const gaps = lines.filter(
+    (l) => l.reason === 'void_only' || l.reason === 'no_invoice'
+  );
+
+  return {
+    period,
+    periodStart: start,
+    periodEnd: end,
+    generatedAt,
+    summary: {
+      activeServices: services.filter((s) => s.active && s.status === 'active')
+        .length,
+      billable: billable.length,
+      covered: covered.length,
+      deferred: deferred.length,
+      notYetDue: notYetDue.length,
+      gaps: gaps.length,
+      gapCatalogMrr: gaps.reduce((s, l) => s + l.monthlyPrice, 0),
+      coveredCatalogMrr: covered.reduce((s, l) => s + l.monthlyPrice, 0),
+    },
+    lines: lines.sort((a, b) => {
+      const order = (r: GapReason) =>
+        r === 'no_invoice' || r === 'void_only'
+          ? 0
+          : r === 'deferred_effective_date'
+            ? 1
+            : r === 'covered'
+              ? 3
+              : 2;
+      return order(a.reason) - order(b.reason) || a.customerName.localeCompare(b.customerName);
+    }),
+  };
+}
+
+export function reportToCsv(report: CoverageReport): string {
+  const headers = [
+    'reason',
+    'customer_name',
+    'package_name',
+    'monthly_price',
+    'billing_day',
+    'activation_date',
+    'last_invoice_date',
+    'invoice_number',
+    'invoice_status',
+    'match_how',
+    'service_id',
+    'customer_id',
+  ];
+  const esc = (v: string | number | null | undefined) => {
+    const s = v == null ? '' : String(v);
+    if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+    return s;
+  };
+  const rows = report.lines.map((l) =>
+    [
+      l.reason,
+      l.customerName,
+      l.packageName,
+      l.monthlyPrice,
+      l.billingDay,
+      l.activationDate,
+      l.lastInvoiceDate,
+      l.invoiceNumber,
+      l.invoiceStatus,
+      l.matchHow,
+      l.serviceId,
+      l.customerId,
+    ]
+      .map(esc)
+      .join(',')
+  );
+  return [headers.join(','), ...rows].join('\n') + '\n';
+}
+
+// re-export for scripts that want clinic category check
+export { isClinicBillingCategory };

--- a/scripts/billing/service-invoice-coverage.ts
+++ b/scripts/billing/service-invoice-coverage.ts
@@ -1,0 +1,187 @@
+/**
+ * Post-generate service ↔ invoice coverage (entitlement leakage).
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a && npx tsx scripts/billing/service-invoice-coverage.ts --period=2026-07
+ *   ... --format=csv --out=/tmp/coverage-2026-07.csv
+ *
+ * Rules: wayfinder revenue-leakage-service-invoice (tickets 03–06).
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync } from 'fs';
+import {
+  buildCoverageReport,
+  reportToCsv,
+  type InvoiceRow,
+  type ServiceRow,
+} from '../../lib/billing/service-invoice-coverage';
+
+function parseArgs(argv: string[]) {
+  let period = '';
+  let format: 'json' | 'csv' = 'json';
+  let out: string | null = null;
+  for (const a of argv) {
+    if (a.startsWith('--period=')) period = a.slice('--period='.length);
+    else if (a.startsWith('--format=')) {
+      const f = a.slice('--format='.length);
+      if (f === 'json' || f === 'csv') format = f;
+      else throw new Error(`Invalid --format=${f}`);
+    } else if (a.startsWith('--out=')) out = a.slice('--out='.length);
+    else if (a === '--help' || a === '-h') {
+      console.log(`Usage: npx tsx scripts/billing/service-invoice-coverage.ts --period=YYYY-MM [--format=json|csv] [--out=path]
+Env: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (source .env.local)`);
+      process.exit(0);
+    }
+  }
+  if (!period) {
+    // default: previous calendar month UTC (document; finance often runs after month)
+    const d = new Date();
+    d.setUTCDate(1);
+    d.setUTCMonth(d.getUTCMonth() - 1);
+    period = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+  }
+  return { period, format, out };
+}
+
+async function main() {
+  const { period, format, out } = parseArgs(process.argv.slice(2));
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY. Run: set -a && source .env.local && set +a'
+    );
+    process.exit(1);
+  }
+
+  const supabase = createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data: servicesRaw, error: svcErr } = await supabase
+    .from('customer_services')
+    .select(
+      'id, customer_id, package_name, monthly_price, status, active, billing_day, last_invoice_date, activation_date, billing_start_date, product_category'
+    )
+    .eq('active', true)
+    .eq('status', 'active');
+
+  if (svcErr) throw new Error(`customer_services: ${svcErr.message}`);
+
+  const services = servicesRaw ?? [];
+  const customerIds = [...new Set(services.map((s) => s.customer_id as string))];
+
+  const customers = new Map<
+    string,
+    { business_name: string | null; first_name: string | null; last_name: string | null; email: string | null }
+  >();
+
+  // batch customers
+  for (let i = 0; i < customerIds.length; i += 50) {
+    const batch = customerIds.slice(i, i + 50);
+    const { data, error } = await supabase
+      .from('customers')
+      .select('id, business_name, first_name, last_name, email')
+      .in('id', batch);
+    if (error) throw new Error(`customers: ${error.message}`);
+    for (const c of data ?? []) {
+      customers.set(c.id as string, {
+        business_name: (c.business_name as string | null) ?? null,
+        first_name: (c.first_name as string | null) ?? null,
+        last_name: (c.last_name as string | null) ?? null,
+        email: (c.email as string | null) ?? null,
+      });
+    }
+  }
+
+  const serviceRows: ServiceRow[] = services.map((s) => {
+    const c = customers.get(s.customer_id as string);
+    const name =
+      c?.business_name ||
+      [c?.first_name, c?.last_name].filter(Boolean).join(' ') ||
+      c?.email ||
+      null;
+    return {
+      id: s.id as string,
+      customer_id: s.customer_id as string,
+      package_name: (s.package_name as string | null) ?? null,
+      monthly_price: s.monthly_price != null ? Number(s.monthly_price) : null,
+      status: (s.status as string | null) ?? null,
+      active: s.active as boolean | null,
+      billing_day: s.billing_day != null ? Number(s.billing_day) : null,
+      last_invoice_date: (s.last_invoice_date as string | null) ?? null,
+      activation_date: (s.activation_date as string | null) ?? null,
+      billing_start_date: (s.billing_start_date as string | null) ?? null,
+      product_category: (s.product_category as string | null) ?? null,
+      customer_business_name: c?.business_name ?? name,
+      customer_name: name,
+    };
+  });
+
+  // Invoices: load from ~6 months before period start for safety
+  const [py, pm] = period.split('-').map(Number);
+  const fromDate = new Date(Date.UTC(py, pm - 4, 1)); // 3 months before period month
+  const fromIso = fromDate.toISOString();
+
+  const { data: invRaw, error: invErr } = await supabase
+    .from('customer_invoices')
+    .select(
+      'id, invoice_number, service_id, status, period_start, period_end, invoice_date, total_amount'
+    )
+    .gte('created_at', fromIso)
+    .limit(5000);
+
+  if (invErr) throw new Error(`customer_invoices: ${invErr.message}`);
+
+  const invoices: InvoiceRow[] = (invRaw ?? []).map((i) => ({
+    id: i.id as string,
+    invoice_number: (i.invoice_number as string | null) ?? null,
+    service_id: (i.service_id as string | null) ?? null,
+    status: (i.status as string | null) ?? null,
+    period_start: (i.period_start as string | null) ?? null,
+    period_end: (i.period_end as string | null) ?? null,
+    invoice_date: (i.invoice_date as string | null) ?? null,
+    total_amount: i.total_amount != null ? Number(i.total_amount) : null,
+  }));
+
+  const report = buildCoverageReport(serviceRows, invoices, period);
+
+  // Human summary on stderr so JSON stdout is clean when piping
+  const s = report.summary;
+  console.error(`Service↔invoice coverage ${period}`);
+  console.error(
+    `  active=${s.activeServices} billable=${s.billable} covered=${s.covered} deferred=${s.deferred} notYetDue=${s.notYetDue} gaps=${s.gaps}`
+  );
+  console.error(
+    `  coveredCatalogMrr=R${s.coveredCatalogMrr.toFixed(2)} gapCatalogMrr=R${s.gapCatalogMrr.toFixed(2)}`
+  );
+  if (s.gaps > 0) {
+    console.error('  GAPS:');
+    for (const l of report.lines.filter(
+      (x) => x.reason === 'no_invoice' || x.reason === 'void_only'
+    )) {
+      console.error(
+        `    [${l.reason}] day=${l.billingDay} R${l.monthlyPrice} | ${l.customerName} | ${l.packageName}`
+      );
+    }
+  }
+
+  const body =
+    format === 'csv' ? reportToCsv(report) : JSON.stringify(report, null, 2);
+
+  if (out) {
+    writeFileSync(out, body, 'utf8');
+    console.error(`Wrote ${out}`);
+  } else {
+    process.stdout.write(body.endsWith('\n') ? body : body + '\n');
+  }
+
+  // Exit 1 if gaps (useful in CI after generate) — still write full report
+  if (s.gaps > 0) process.exitCode = 1;
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Post-generate **entitlement** check: active billable services vs qualifying invoices for a period (wayfinder `revenue-leakage-service-invoice`).

- Pure helpers: `lib/billing/service-invoice-coverage.ts`
- CLI: `scripts/billing/service-invoice-coverage.ts`
- Rules: active + start + clinic delay; void ≠ covered; range-first period match; Alexandra/Chloorkop/Oukasie/Phoenix/Sicelo deferred until **2026-08-01**
- Delmas is inactive in prod (separate data fix) and drops out of the active set

## Usage

```bash
set -a && source .env.local && set +a
npx tsx scripts/billing/service-invoice-coverage.ts --period=2026-07
npx tsx scripts/billing/service-invoice-coverage.ts --period=2026-07 --format=csv --out=/tmp/c.csv
```

Exit code **1** if gaps remain (useful after generate).

## Live run (2026-07)

| Metric | Count |
|--------|------:|
| Active | 24 |
| Covered | 15 |
| Deferred (Aug effective) | 5 |
| **Gaps** | **4** — Sweetwaters, Nokaneng, Cosmo City, Bhekilanga |

## Test plan

- [x] Unit tests (7)
- [x] Live script run for 2026-07
- [x] Scoped type-check on push

## Spec

`.scratch/revenue-leakage-service-invoice/map.md` (tickets 03–06)