### PR TITLE
feat: near-term F1 + admin lead follow-up + ops floor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -305,3 +305,11 @@ RUIJIE_APP_ID=your_ruijie_app_id
 RUIJIE_SECRET=your_ruijie_secret
 RUIJIE_BASE_URL=https://cloud-eu.ruijienetworks.com/service/api
 RUIJIE_MOCK_MODE=false
+
+# =============================================================================
+# WhatsApp Cloud API / Flows
+# =============================================================================
+# Existing WA vars (phone number, access token, WABA, webhook) live in Coolify/.env.local
+# Meta Flow id for F1 lead qualification (from Flow Builder after create/publish)
+WHATSAPP_FLOW_LEAD_QUALIFICATION_ID=
+

--- a/__tests__/lib/leads/first-response-sla.test.ts
+++ b/__tests__/lib/leads/first-response-sla.test.ts
@@ -1,0 +1,133 @@
+/**
+ * First-response SLA business-hours helper tests
+ *
+ * Business window: Mon–Fri 08:00–17:00 Africa/Johannesburg (SAST, UTC+2, no DST)
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  addBusinessHours,
+  computeFirstResponseDueAt,
+} from '@/lib/leads/first-response-sla';
+
+/** Parse a SAST wall-clock ISO without offset as Africa/Johannesburg */
+function sast(isoLocal: string): Date {
+  // Accept "YYYY-MM-DDTHH:mm:ss" as SAST
+  return new Date(`${isoLocal}+02:00`);
+}
+
+function expectSast(actual: Date, isoLocal: string): void {
+  expect(actual.toISOString()).toBe(sast(isoLocal).toISOString());
+}
+
+describe('addBusinessHours', () => {
+  describe('mid-day within same business day', () => {
+    it('Wednesday 10:00 SAST + 2h → Wednesday 12:00 SAST', () => {
+      // 2026-06-10 is a Wednesday
+      const result = addBusinessHours(sast('2026-06-10T10:00:00'), 2);
+      expectSast(result, '2026-06-10T12:00:00');
+    });
+
+    it('Monday 08:00 SAST + 1h → Monday 09:00 SAST', () => {
+      const result = addBusinessHours(sast('2026-06-08T08:00:00'), 1);
+      expectSast(result, '2026-06-08T09:00:00');
+    });
+
+    it('Thursday 09:15 SAST + 0.5h → Thursday 09:45 SAST', () => {
+      const result = addBusinessHours(sast('2026-06-11T09:15:00'), 0.5);
+      expectSast(result, '2026-06-11T09:45:00');
+    });
+  });
+
+  describe('cross end-of-day into next business day', () => {
+    it('Wednesday 16:00 SAST + 2h → Thursday 09:00 SAST', () => {
+      // 1h remaining Wed (16:00–17:00), then 1h from Thu 08:00 → 09:00
+      const result = addBusinessHours(sast('2026-06-10T16:00:00'), 2);
+      expectSast(result, '2026-06-11T09:00:00');
+    });
+
+    it('Wednesday 16:30 SAST + 2h → Thursday 09:30 SAST', () => {
+      // 0.5h Wed + 1.5h Thu from 08:00
+      const result = addBusinessHours(sast('2026-06-10T16:30:00'), 2);
+      expectSast(result, '2026-06-11T09:30:00');
+    });
+  });
+
+  describe('cross weekend', () => {
+    it('Friday 16:30 SAST + 2h → Monday 09:30 SAST', () => {
+      // 0.5h Fri remaining, then Mon 08:00 + 1.5h
+      const result = addBusinessHours(sast('2026-06-12T16:30:00'), 2);
+      expectSast(result, '2026-06-15T09:30:00');
+    });
+
+    it('Friday 15:00 SAST + 4h → Monday 10:00 SAST', () => {
+      // 2h Fri remaining (15–17), then Mon 08:00 + 2h → 10:00
+      const result = addBusinessHours(sast('2026-06-12T15:00:00'), 4);
+      expectSast(result, '2026-06-15T10:00:00');
+    });
+  });
+
+  describe('after hours and weekends snap to next open', () => {
+    it('Saturday morning + 2h → Monday 10:00 SAST', () => {
+      const result = addBusinessHours(sast('2026-06-13T09:00:00'), 2);
+      expectSast(result, '2026-06-15T10:00:00');
+    });
+
+    it('Sunday evening + 2h → Monday 10:00 SAST', () => {
+      const result = addBusinessHours(sast('2026-06-14T20:00:00'), 2);
+      expectSast(result, '2026-06-15T10:00:00');
+    });
+
+    it('Wednesday 18:00 SAST + 2h → Thursday 10:00 SAST', () => {
+      const result = addBusinessHours(sast('2026-06-10T18:00:00'), 2);
+      expectSast(result, '2026-06-11T10:00:00');
+    });
+
+    it('Wednesday before open 07:00 SAST + 2h → Wednesday 10:00 SAST', () => {
+      const result = addBusinessHours(sast('2026-06-10T07:00:00'), 2);
+      expectSast(result, '2026-06-10T10:00:00');
+    });
+
+    it('exactly at close 17:00 SAST + 2h → next business day 10:00 SAST', () => {
+      const result = addBusinessHours(sast('2026-06-10T17:00:00'), 2);
+      expectSast(result, '2026-06-11T10:00:00');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('adds 0 hours and returns the same instant when already in business hours', () => {
+      const start = sast('2026-06-10T11:00:00');
+      const result = addBusinessHours(start, 0);
+      expect(result.toISOString()).toBe(start.toISOString());
+    });
+
+    it('returns an invalid date for invalid input', () => {
+      const invalid = new Date('invalid');
+      const result = addBusinessHours(invalid, 2);
+      expect(Number.isNaN(result.getTime())).toBe(true);
+    });
+
+    it('uses Africa/Johannesburg by default (UTC input mid-day SAST)', () => {
+      // 08:00 UTC = 10:00 SAST Wednesday
+      const start = new Date('2026-06-10T08:00:00.000Z');
+      const result = addBusinessHours(start, 2);
+      // 12:00 SAST = 10:00 UTC
+      expect(result.toISOString()).toBe('2026-06-10T10:00:00.000Z');
+    });
+  });
+});
+
+describe('computeFirstResponseDueAt', () => {
+  it('is a convenience for addBusinessHours(createdAt, 2)', () => {
+    const createdAt = sast('2026-06-10T10:00:00');
+    expect(computeFirstResponseDueAt(createdAt).toISOString()).toBe(
+      addBusinessHours(createdAt, 2).toISOString()
+    );
+  });
+
+  it('sets due 2 business hours after after-hours create', () => {
+    // Friday 18:00 SAST → Monday 10:00 SAST
+    const result = computeFirstResponseDueAt(sast('2026-06-12T18:00:00'));
+    expectSast(result, '2026-06-15T10:00:00');
+  });
+});

--- a/app/admin/leads/[id]/page.tsx
+++ b/app/admin/leads/[id]/page.tsx
@@ -1,0 +1,551 @@
+'use client';
+
+import {
+  PiArrowsClockwiseBold,
+  PiEnvelopeBold,
+  PiMapPinBold,
+  PiPhoneBold,
+  PiUserBold,
+} from 'react-icons/pi';
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { formatDistanceToNow, format } from 'date-fns';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  AdminPage,
+  DetailPageHeader,
+  SectionCard,
+  StatusBadge,
+  LoadingState,
+  ErrorState,
+  type StatusVariant,
+} from '@/components/backend';
+import { createClient } from '@/lib/supabase/client';
+import { getLeadSlaBadge } from '@/lib/leads/sla-badge';
+
+interface AssignedAdmin {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+}
+
+interface AdminOption {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+}
+
+interface CoverageLead {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  phone: string | null;
+  company_name: string | null;
+  customer_type: string | null;
+  status: string | null;
+  lead_source: string | null;
+  source_campaign: string | null;
+  assigned_admin_id: string | null;
+  assigned_admin?: AssignedAdmin | null;
+  follow_up_notes: string | null;
+  last_contacted_at: string | null;
+  next_follow_up_at: string | null;
+  follow_up_count: number | null;
+  first_response_due_at: string | null;
+  first_responded_at: string | null;
+  zoho_lead_id: string | null;
+  zoho_sync_status: string | null;
+  zoho_sync_error: string | null;
+  zoho_synced_at: string | null;
+  address: string | null;
+  suburb: string | null;
+  city: string | null;
+  province: string | null;
+  created_at: string;
+  updated_at: string;
+  [key: string]: unknown;
+}
+
+const LEAD_STATUSES = [
+  'new',
+  'contacted',
+  'interested',
+  'not_interested',
+  'coverage_available',
+  'converted_to_order',
+  'lost',
+  'follow_up_scheduled',
+] as const;
+
+function formatStatusLabel(status: string | null | undefined): string {
+  if (!status) return '—';
+  return status.replace(/_/g, ' ');
+}
+
+function getLeadStatusVariant(status: string | null): StatusVariant {
+  const s = (status || '').toLowerCase();
+  if (s === 'new') return 'info';
+  if (s === 'contacted' || s === 'follow_up_scheduled' || s === 'interested') return 'warning';
+  if (s === 'converted_to_order' || s === 'coverage_available') return 'success';
+  if (s === 'lost' || s === 'not_interested') return 'error';
+  return 'neutral';
+}
+
+function getZohoVariant(status: string | null): StatusVariant {
+  const s = (status || '').toLowerCase();
+  if (s === 'synced' || s === 'success') return 'success';
+  if (s === 'pending' || s === 'queued') return 'warning';
+  if (s === 'error' || s === 'failed') return 'error';
+  if (!s) return 'neutral';
+  return 'info';
+}
+
+function displayName(lead: CoverageLead): string {
+  const name = [lead.first_name, lead.last_name].filter(Boolean).join(' ').trim();
+  if (name) return name;
+  if (lead.company_name) return lead.company_name;
+  if (lead.email) return lead.email;
+  return 'Lead';
+}
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return '—';
+  try {
+    return format(new Date(value), 'dd MMM yyyy HH:mm');
+  } catch {
+    return value;
+  }
+}
+
+function toDatetimeLocalValue(iso: string | null | undefined): string {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  } catch {
+    return '';
+  }
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <dt className="text-xs font-medium text-gray-500">{label}</dt>
+      <dd className="text-sm text-gray-900 break-words">{value ?? '—'}</dd>
+    </div>
+  );
+}
+
+export default function AdminLeadDetailPage() {
+  const params = useParams();
+  const leadId = Array.isArray(params.id) ? params.id[0] : params.id;
+
+  const [lead, setLead] = useState<CoverageLead | null>(null);
+  const [admins, setAdmins] = useState<AdminOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Editable fields
+  const [notes, setNotes] = useState('');
+  const [status, setStatus] = useState('new');
+  const [assignedAdminId, setAssignedAdminId] = useState<string>('unassigned');
+  const [nextFollowUp, setNextFollowUp] = useState('');
+
+  const fetchLead = useCallback(async () => {
+    if (!leadId) {
+      setError('Invalid lead id');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await fetch(`/api/admin/leads/${leadId}`, {
+        credentials: 'include',
+      });
+      const result = await response.json();
+
+      if (!response.ok || !result.success) {
+        throw new Error(result.error || 'Failed to fetch lead');
+      }
+
+      const data = result.lead as CoverageLead;
+      setLead(data);
+      setNotes(data.follow_up_notes || '');
+      setStatus(data.status || 'new');
+      setAssignedAdminId(data.assigned_admin_id || 'unassigned');
+      setNextFollowUp(toDatetimeLocalValue(data.next_follow_up_at));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load lead');
+      setLead(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [leadId]);
+
+  const fetchAdmins = useCallback(async () => {
+    try {
+      const supabase = createClient();
+      const { data, error: adminsError } = await supabase
+        .from('admin_users')
+        .select('id, full_name, email')
+        .eq('is_active', true)
+        .order('full_name', { ascending: true });
+
+      if (adminsError) {
+        console.warn('[Lead detail] Failed to load admin_users:', adminsError.message);
+        return;
+      }
+
+      setAdmins(
+        (data || []).map((a) => ({
+          id: a.id,
+          full_name: a.full_name,
+          email: a.email,
+        }))
+      );
+    } catch (err) {
+      console.warn('[Lead detail] admin_users fetch error', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLead();
+    fetchAdmins();
+  }, [fetchLead, fetchAdmins]);
+
+  const handleSave = async () => {
+    if (!leadId) return;
+
+    setSaving(true);
+    try {
+      const body: Record<string, unknown> = {
+        follow_up_notes: notes,
+        status,
+        assigned_admin_id: assignedAdminId === 'unassigned' ? null : assignedAdminId,
+        next_follow_up_at: nextFollowUp
+          ? new Date(nextFollowUp).toISOString()
+          : null,
+      };
+
+      const response = await fetch(`/api/admin/leads/${leadId}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const result = await response.json();
+
+      if (!response.ok || !result.success) {
+        throw new Error(result.error || 'Failed to save lead');
+      }
+
+      const data = result.lead as CoverageLead;
+      setLead(data);
+      setNotes(data.follow_up_notes || '');
+      setStatus(data.status || 'new');
+      setAssignedAdminId(data.assigned_admin_id || 'unassigned');
+      setNextFollowUp(toDatetimeLocalValue(data.next_follow_up_at));
+      toast.success('Lead updated');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Save failed';
+      toast.error(message);
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <AdminPage>
+        <LoadingState message="Loading lead…" />
+      </AdminPage>
+    );
+  }
+
+  if (error && !lead) {
+    return (
+      <AdminPage>
+        <ErrorState title="Could not load lead" message={error} onRetry={fetchLead} />
+      </AdminPage>
+    );
+  }
+
+  if (!lead) {
+    return (
+      <AdminPage>
+        <ErrorState title="Lead not found" message="This lead does not exist or was removed." />
+      </AdminPage>
+    );
+  }
+
+  const sla = getLeadSlaBadge(lead);
+  const title = displayName(lead);
+  const addressParts = [lead.address, lead.suburb, lead.city, lead.province]
+    .filter(Boolean)
+    .join(', ');
+
+  return (
+    <AdminPage>
+      <DetailPageHeader
+        breadcrumbs={[
+          { label: 'Leads', href: '/admin/leads' },
+          { label: title },
+        ]}
+        title={title}
+        subtitle={lead.company_name && title !== lead.company_name ? lead.company_name : undefined}
+        status={{
+          label: formatStatusLabel(lead.status),
+          variant: getLeadStatusVariant(lead.status),
+        }}
+        actions={
+          <div className="flex items-center gap-2">
+            <StatusBadge status={sla.status} variant={sla.variant} showDot />
+            <Button variant="outline" size="sm" onClick={fetchLead} disabled={loading || saving}>
+              <PiArrowsClockwiseBold className="h-4 w-4 mr-1.5" aria-hidden="true" />
+              Refresh
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        }
+      />
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Main column */}
+        <div className="lg:col-span-2 space-y-6">
+          <SectionCard title="Contact" icon={PiUserBold}>
+            <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Field label="First name" value={lead.first_name || '—'} />
+              <Field label="Last name" value={lead.last_name || '—'} />
+              <Field
+                label="Email"
+                value={
+                  lead.email ? (
+                    <a
+                      href={`mailto:${lead.email}`}
+                      className="inline-flex items-center gap-1 text-circleTel-orange hover:underline"
+                    >
+                      <PiEnvelopeBold className="h-3.5 w-3.5" aria-hidden="true" />
+                      {lead.email}
+                    </a>
+                  ) : (
+                    '—'
+                  )
+                }
+              />
+              <Field
+                label="Phone"
+                value={
+                  lead.phone ? (
+                    <a
+                      href={`tel:${lead.phone}`}
+                      className="inline-flex items-center gap-1 text-circleTel-orange hover:underline"
+                    >
+                      <PiPhoneBold className="h-3.5 w-3.5" aria-hidden="true" />
+                      {lead.phone}
+                    </a>
+                  ) : (
+                    '—'
+                  )
+                }
+              />
+              <Field label="Company" value={lead.company_name || '—'} />
+              <Field label="Customer type" value={lead.customer_type || '—'} />
+              <Field
+                label="Address"
+                value={
+                  addressParts ? (
+                    <span className="inline-flex items-start gap-1">
+                      <PiMapPinBold className="h-3.5 w-3.5 text-gray-400 mt-0.5 shrink-0" aria-hidden="true" />
+                      {addressParts}
+                    </span>
+                  ) : (
+                    '—'
+                  )
+                }
+              />
+            </dl>
+          </SectionCard>
+
+          <SectionCard title="Follow-up">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="follow_up_notes">Notes</Label>
+                <Textarea
+                  id="follow_up_notes"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  rows={6}
+                  placeholder="Log contact attempts, interest, next steps…"
+                  className="resize-y"
+                />
+                <p className="text-xs text-gray-500">
+                  Saving notes while status is new stamps first response and increments follow-up
+                  count.
+                </p>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="status">Status</Label>
+                  <Select value={status} onValueChange={setStatus}>
+                    <SelectTrigger id="status">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {LEAD_STATUSES.map((s) => (
+                        <SelectItem key={s} value={s}>
+                          {formatStatusLabel(s)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="assigned_admin">Assigned owner</Label>
+                  <Select value={assignedAdminId} onValueChange={setAssignedAdminId}>
+                    <SelectTrigger id="assigned_admin">
+                      <SelectValue placeholder="Unassigned" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="unassigned">Unassigned</SelectItem>
+                      {admins.map((a) => (
+                        <SelectItem key={a.id} value={a.id}>
+                          {a.full_name || a.email || a.id}
+                        </SelectItem>
+                      ))}
+                      {/* Keep current assignee visible if not in active list */}
+                      {assignedAdminId !== 'unassigned' &&
+                        !admins.some((a) => a.id === assignedAdminId) && (
+                          <SelectItem value={assignedAdminId}>
+                            {lead.assigned_admin?.full_name ||
+                              lead.assigned_admin?.email ||
+                              assignedAdminId}
+                          </SelectItem>
+                        )}
+                    </SelectContent>
+                  </Select>
+                  {admins.length === 0 && (
+                    <p className="text-xs text-amber-700">
+                      Could not load admin list (RLS). You can still save status/notes; reassign may
+                      need elevated access.
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2 sm:col-span-2">
+                  <Label htmlFor="next_follow_up_at">Next follow-up</Label>
+                  <Input
+                    id="next_follow_up_at"
+                    type="datetime-local"
+                    value={nextFollowUp}
+                    onChange={(e) => setNextFollowUp(e.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="flex justify-end">
+                <Button onClick={handleSave} disabled={saving}>
+                  {saving ? 'Saving…' : 'Save changes'}
+                </Button>
+              </div>
+            </div>
+          </SectionCard>
+        </div>
+
+        {/* Side column */}
+        <div className="space-y-6">
+          <SectionCard title="SLA & activity" compact>
+            <dl className="space-y-3">
+              <Field
+                label="SLA"
+                value={<StatusBadge status={sla.status} variant={sla.variant} showDot />}
+              />
+              <Field label="First response due" value={formatDateTime(lead.first_response_due_at)} />
+              <Field label="First responded" value={formatDateTime(lead.first_responded_at)} />
+              <Field label="Last contacted" value={formatDateTime(lead.last_contacted_at)} />
+              <Field label="Follow-up count" value={lead.follow_up_count ?? 0} />
+              <Field
+                label="Created"
+                value={
+                  lead.created_at
+                    ? `${formatDateTime(lead.created_at)} (${formatDistanceToNow(new Date(lead.created_at), { addSuffix: true })})`
+                    : '—'
+                }
+              />
+              <Field label="Updated" value={formatDateTime(lead.updated_at)} />
+            </dl>
+          </SectionCard>
+
+          <SectionCard title="Source" compact>
+            <dl className="space-y-3">
+              <Field
+                label="Lead source"
+                value={lead.lead_source?.replace(/_/g, ' ') || '—'}
+              />
+              <Field label="Campaign" value={lead.source_campaign || '—'} />
+            </dl>
+          </SectionCard>
+
+          <SectionCard title="Zoho (read-only)" compact>
+            <dl className="space-y-3">
+              <Field
+                label="Sync status"
+                value={
+                  <StatusBadge
+                    status={lead.zoho_sync_status || 'none'}
+                    variant={getZohoVariant(lead.zoho_sync_status)}
+                  />
+                }
+              />
+              <Field label="Zoho lead id" value={lead.zoho_lead_id || '—'} />
+              <Field label="Synced at" value={formatDateTime(lead.zoho_synced_at)} />
+              {lead.zoho_sync_error && (
+                <Field
+                  label="Sync error"
+                  value={<span className="text-red-700 text-xs">{lead.zoho_sync_error}</span>}
+                />
+              )}
+            </dl>
+          </SectionCard>
+
+          <SectionCard title="System" compact>
+            <dl className="space-y-3">
+              <Field
+                label="Lead id"
+                value={<code className="text-xs break-all">{lead.id}</code>}
+              />
+            </dl>
+          </SectionCard>
+        </div>
+      </div>
+    </AdminPage>
+  );
+}

--- a/app/admin/leads/page.tsx
+++ b/app/admin/leads/page.tsx
@@ -1,0 +1,437 @@
+'use client';
+
+import {
+  PiArrowsClockwiseBold,
+  PiMagnifyingGlassBold,
+  PiPhoneBold,
+  PiUserBold,
+  PiWarningCircleBold,
+} from 'react-icons/pi';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { formatDistanceToNow } from 'date-fns';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AdminPage,
+  PageHeader,
+  StatusBadge,
+  LoadingState,
+  EmptyState,
+  type StatusVariant,
+} from '@/components/backend';
+import { useAdminAuth } from '@/hooks/useAdminAuth';
+import { getLeadSlaBadge } from '@/lib/leads/sla-badge';
+
+interface AssignedAdmin {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+}
+
+interface CoverageLead {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  phone: string | null;
+  company_name: string | null;
+  status: string | null;
+  lead_source: string | null;
+  assigned_admin_id: string | null;
+  assigned_admin?: AssignedAdmin | AssignedAdmin[] | null;
+  first_response_due_at: string | null;
+  first_responded_at: string | null;
+  zoho_sync_status: string | null;
+  created_at: string;
+}
+
+const LEAD_STATUSES = [
+  'new',
+  'contacted',
+  'interested',
+  'not_interested',
+  'coverage_available',
+  'converted_to_order',
+  'lost',
+  'follow_up_scheduled',
+] as const;
+
+function ownerName(lead: CoverageLead): string {
+  const admin = Array.isArray(lead.assigned_admin)
+    ? lead.assigned_admin[0]
+    : lead.assigned_admin;
+  if (admin?.full_name) return admin.full_name;
+  if (admin?.email) return admin.email;
+  return lead.assigned_admin_id ? 'Assigned' : 'Unassigned';
+}
+
+function leadDisplayName(lead: CoverageLead): string {
+  const name = [lead.first_name, lead.last_name].filter(Boolean).join(' ').trim();
+  if (name) return name;
+  if (lead.company_name) return lead.company_name;
+  if (lead.email) return lead.email;
+  return 'Unknown';
+}
+
+function formatStatusLabel(status: string | null): string {
+  if (!status) return '—';
+  return status.replace(/_/g, ' ');
+}
+
+function getLeadStatusVariant(status: string | null): StatusVariant {
+  const s = (status || '').toLowerCase();
+  if (s === 'new') return 'info';
+  if (s === 'contacted' || s === 'follow_up_scheduled' || s === 'interested') return 'warning';
+  if (s === 'converted_to_order' || s === 'coverage_available') return 'success';
+  if (s === 'lost' || s === 'not_interested') return 'error';
+  return 'neutral';
+}
+
+function getZohoVariant(status: string | null): StatusVariant {
+  const s = (status || '').toLowerCase();
+  if (s === 'synced' || s === 'success') return 'success';
+  if (s === 'pending' || s === 'queued') return 'warning';
+  if (s === 'error' || s === 'failed') return 'error';
+  if (!s) return 'neutral';
+  return 'info';
+}
+
+export default function AdminLeadsQueuePage() {
+  const router = useRouter();
+  const { user } = useAdminAuth();
+
+  const [leads, setLeads] = useState<CoverageLead[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [ownerFilter, setOwnerFilter] = useState<string>('all');
+  const [overdueOnly, setOverdueOnly] = useState(false);
+  const [offset, setOffset] = useState(0);
+  const limit = 50;
+
+  const fetchLeads = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const params = new URLSearchParams();
+      params.set('limit', String(limit));
+      params.set('offset', String(offset));
+
+      if (search) params.set('q', search);
+      if (overdueOnly) {
+        params.set('overdue', 'true');
+      } else if (statusFilter !== 'all') {
+        params.set('status', statusFilter);
+      }
+
+      if (ownerFilter === 'unassigned') {
+        params.set('assigned_admin_id', 'unassigned');
+      } else if (ownerFilter === 'mine' && user?.id) {
+        params.set('assigned_admin_id', user.id);
+      }
+
+      const response = await fetch(`/api/admin/leads?${params.toString()}`, {
+        credentials: 'include',
+      });
+      const result = await response.json();
+
+      if (!response.ok || !result.success) {
+        throw new Error(result.error || 'Failed to fetch leads');
+      }
+
+      setLeads(Array.isArray(result.leads) ? result.leads : []);
+      setTotalCount(typeof result.total_count === 'number' ? result.total_count : 0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load leads');
+      setLeads([]);
+      setTotalCount(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [offset, search, statusFilter, ownerFilter, overdueOnly, user?.id]);
+
+  useEffect(() => {
+    fetchLeads();
+  }, [fetchLeads]);
+
+  const overdueCount = useMemo(
+    () =>
+      leads.filter((l) => getLeadSlaBadge(l).status === 'Overdue').length,
+    [leads]
+  );
+
+  const handleSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setOffset(0);
+    setSearch(searchInput.trim());
+  };
+
+  const pageStart = totalCount === 0 ? 0 : offset + 1;
+  const pageEnd = Math.min(offset + limit, totalCount);
+  const hasPrev = offset > 0;
+  const hasNext = offset + limit < totalCount;
+
+  return (
+    <AdminPage>
+      <PageHeader
+        title="Leads"
+        subtitle="Coverage lead follow-up queue — first-response SLA (not Zoho Desk support)"
+        actions={
+          <Button onClick={fetchLeads} disabled={loading} variant="outline" size="sm">
+            <PiArrowsClockwiseBold
+              className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`}
+              aria-hidden="true"
+            />
+            Refresh
+          </Button>
+        }
+      />
+
+      {/* Filters */}
+      <div className="bg-white border border-gray-200 rounded-xl p-4 shadow-sm space-y-3">
+        <form onSubmit={handleSearchSubmit} className="flex flex-wrap gap-3 items-end">
+          <div className="flex-1 min-w-[200px]">
+            <label className="block text-xs font-medium text-gray-500 mb-1">Search</label>
+            <div className="relative">
+              <PiMagnifyingGlassBold
+                className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400"
+                aria-hidden="true"
+              />
+              <Input
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="Name, phone, email…"
+                className="pl-9"
+              />
+            </div>
+          </div>
+
+          <div className="w-[160px]">
+            <label className="block text-xs font-medium text-gray-500 mb-1">Status</label>
+            <Select
+              value={statusFilter}
+              onValueChange={(v) => {
+                setStatusFilter(v);
+                setOffset(0);
+                if (v !== 'all') setOverdueOnly(false);
+              }}
+              disabled={overdueOnly}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="All statuses" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All statuses</SelectItem>
+                {LEAD_STATUSES.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {formatStatusLabel(s)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="w-[160px]">
+            <label className="block text-xs font-medium text-gray-500 mb-1">Owner</label>
+            <Select
+              value={ownerFilter}
+              onValueChange={(v) => {
+                setOwnerFilter(v);
+                setOffset(0);
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="All owners" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All owners</SelectItem>
+                <SelectItem value="unassigned">Unassigned</SelectItem>
+                <SelectItem value="mine" disabled={!user?.id}>
+                  Mine
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Button type="submit" size="sm">
+            Search
+          </Button>
+
+          <Button
+            type="button"
+            size="sm"
+            variant={overdueOnly ? 'default' : 'outline'}
+            onClick={() => {
+              setOverdueOnly((v) => !v);
+              setOffset(0);
+              if (!overdueOnly) setStatusFilter('all');
+            }}
+            className={overdueOnly ? 'bg-red-600 hover:bg-red-700' : ''}
+          >
+            <PiWarningCircleBold className="h-4 w-4 mr-1.5" aria-hidden="true" />
+            Overdue only
+            {overdueCount > 0 && !overdueOnly ? (
+              <span className="ml-1.5 text-xs opacity-80">({overdueCount} on page)</span>
+            ) : null}
+          </Button>
+        </form>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-100 flex items-center justify-between">
+          <p className="text-sm text-gray-600">
+            {loading
+              ? 'Loading…'
+              : totalCount === 0
+                ? 'No leads'
+                : `Showing ${pageStart}–${pageEnd} of ${totalCount}`}
+          </p>
+        </div>
+
+        {loading ? (
+          <LoadingState message="Loading leads…" />
+        ) : leads.length === 0 ? (
+          <EmptyState
+            icon={<PiUserBold />}
+            title="No leads found"
+            description="Try clearing filters or waiting for new coverage / WhatsApp leads."
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Phone</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Age</TableHead>
+                  <TableHead>Owner</TableHead>
+                  <TableHead>Zoho</TableHead>
+                  <TableHead>SLA</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {leads.map((lead) => {
+                  const sla = getLeadSlaBadge(lead);
+                  return (
+                    <TableRow
+                      key={lead.id}
+                      className="cursor-pointer hover:bg-gray-50"
+                      onClick={() => router.push(`/admin/leads/${lead.id}`)}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-2 min-w-[140px]">
+                          <PiUserBold className="h-4 w-4 text-gray-400 shrink-0" aria-hidden="true" />
+                          <div>
+                            <p className="font-medium text-gray-900 text-sm">
+                              {leadDisplayName(lead)}
+                            </p>
+                            {lead.email && (
+                              <p className="text-xs text-gray-500 truncate max-w-[180px]">
+                                {lead.email}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {lead.phone ? (
+                          <span className="inline-flex items-center gap-1 text-sm text-gray-700">
+                            <PiPhoneBold className="h-3.5 w-3.5 text-gray-400" aria-hidden="true" />
+                            {lead.phone}
+                          </span>
+                        ) : (
+                          <span className="text-gray-400 text-sm">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <span className="text-sm text-gray-700">
+                          {lead.lead_source?.replace(/_/g, ' ') || '—'}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        <StatusBadge
+                          status={formatStatusLabel(lead.status)}
+                          variant={getLeadStatusVariant(lead.status)}
+                        />
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-600 whitespace-nowrap">
+                        {lead.created_at
+                          ? formatDistanceToNow(new Date(lead.created_at), { addSuffix: true })
+                          : '—'}
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-700">
+                        {ownerName(lead)}
+                      </TableCell>
+                      <TableCell>
+                        <StatusBadge
+                          status={lead.zoho_sync_status || 'none'}
+                          variant={getZohoVariant(lead.zoho_sync_status)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <StatusBadge status={sla.status} variant={sla.variant} showDot />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {totalCount > limit && (
+          <div className="px-4 py-3 border-t border-gray-100 flex items-center justify-between">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasPrev || loading}
+              onClick={() => setOffset(Math.max(0, offset - limit))}
+            >
+              Previous
+            </Button>
+            <span className="text-xs text-gray-500">
+              Page {Math.floor(offset / limit) + 1} of {Math.ceil(totalCount / limit)}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasNext || loading}
+              onClick={() => setOffset(offset + limit)}
+            >
+              Next
+            </Button>
+          </div>
+        )}
+      </div>
+    </AdminPage>
+  );
+}

--- a/app/admin/network/devices/page.tsx
+++ b/app/admin/network/devices/page.tsx
@@ -1,5 +1,20 @@
 'use client';
 
+/**
+ * Network Devices list — Ruijie fleet ops.
+ *
+ * Customer link path (Task C3):
+ * - Filter Customer link → Unlinked only
+ * - Per-row Link opens LinkCustomerDialog → POST /api/ruijie/devices/[sn]/link
+ * - Detail page also has Customer Assignment panel
+ *
+ * Link body: { type: "consumer"|"corporate", customer_order_id? | corporate_site_id? }
+ * Search: GET /api/admin/search/customers?q=
+ * Verify: ruijie_device_cache.customer_order_id or corporate_site_id set after link.
+ *
+ * Ops: do not mass-link with invented IDs — search real orders/sites from the picker.
+ */
+
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -20,6 +35,8 @@ import {
   DeviceFilters,
   DeviceTable,
   DeviceCard,
+  LinkCustomerDialog,
+  type RuijieListDevice,
 } from '@/components/admin/network';
 import {
   MetricCard,
@@ -31,33 +48,12 @@ import { computeNetworkInventory } from '@/lib/network/performance-aggregates';
 import {
   AdminPage,
   PageHeader,
-  StatCard,
-  SectionCard,
-  StatusBadge,
   LoadingState,
-  EmptyState,
-  ErrorState,
-  type StatusVariant,
 } from '@/components/backend';
 
 
-interface RuijieDevice {
-  sn: string;
-  device_name: string;
-  model: string | null;
-  group_name: string | null;
-  management_ip: string | null;
-  online_clients: number;
-  cpu_usage?: number | null;
-  memory_usage?: number | null;
-  status: string;
-  config_status: string | null;
-  synced_at: string;
-  mock_data: boolean;
-}
-
 interface DevicesResponse {
-  devices: RuijieDevice[];
+  devices: RuijieListDevice[];
   total: number;
   lastSynced: string | null;
   filters: {
@@ -93,9 +89,11 @@ export default function RuijieDevicesPage() {
   const [statusFilter, setStatusFilter] = useState(searchParams.get('status') || '');
   const [groupFilter, setGroupFilter] = useState(searchParams.get('group') || '');
   const [modelFilter, setModelFilter] = useState(searchParams.get('model') || '');
+  const [linkedFilter, setLinkedFilter] = useState(searchParams.get('linked') || '');
 
-  const [rebootDevice, setRebootDevice] = useState<RuijieDevice | null>(null);
+  const [rebootDevice, setRebootDevice] = useState<RuijieListDevice | null>(null);
   const [rebooting, setRebooting] = useState(false);
+  const [linkDevice, setLinkDevice] = useState<RuijieListDevice | null>(null);
 
   const [tunnelCount] = useState(0);
   const TUNNEL_LIMIT = 10;
@@ -109,6 +107,7 @@ export default function RuijieDevicesPage() {
         if (statusFilter) params.set('status', statusFilter);
         if (groupFilter) params.set('group', groupFilter);
         if (modelFilter) params.set('model', modelFilter);
+        if (linkedFilter) params.set('linked', linkedFilter);
 
         const response = await fetch(`/api/ruijie/devices?${params.toString()}`, {
           credentials: 'include',
@@ -126,7 +125,7 @@ export default function RuijieDevicesPage() {
         setRefreshing(false);
       }
     },
-    [search, statusFilter, groupFilter, modelFilter]
+    [search, statusFilter, groupFilter, modelFilter, linkedFilter]
   );
 
   useEffect(() => {
@@ -141,10 +140,11 @@ export default function RuijieDevicesPage() {
     if (statusFilter) params.set('status', statusFilter);
     if (groupFilter) params.set('group', groupFilter);
     if (modelFilter) params.set('model', modelFilter);
+    if (linkedFilter) params.set('linked', linkedFilter);
 
     const newUrl = params.toString() ? `?${params.toString()}` : '/admin/network/devices';
     router.replace(newUrl, { scroll: false });
-  }, [search, statusFilter, groupFilter, modelFilter, router]);
+  }, [search, statusFilter, groupFilter, modelFilter, linkedFilter, router]);
 
   const handleRefresh = async () => {
     setRefreshing(true);
@@ -190,6 +190,9 @@ export default function RuijieDevicesPage() {
       'CPU %',
       'Mem %',
       'Clients',
+      'Customer',
+      'Customer Order ID',
+      'Corporate Site ID',
       'Last Synced',
     ];
     const rows = data.devices.map((d) => [
@@ -203,6 +206,9 @@ export default function RuijieDevicesPage() {
       d.cpu_usage == null ? '' : String(Math.round(d.cpu_usage)),
       d.memory_usage == null ? '' : String(Math.round(d.memory_usage)),
       d.online_clients.toString(),
+      d.customer_name || '',
+      d.customer_order_id || '',
+      d.corporate_site_id || '',
       d.synced_at,
     ]);
 
@@ -252,6 +258,9 @@ export default function RuijieDevicesPage() {
   const devices = data?.devices || [];
   const onlineCount = devices.filter((d) => d.status === 'online').length;
   const offlineCount = devices.filter((d) => d.status === 'offline').length;
+  const unlinkedCount = devices.filter(
+    (d) => !d.customer_order_id && !d.corporate_site_id
+  ).length;
   const totalClients = devices.reduce((sum, d) => sum + (d.online_clients || 0), 0);
   const withCpu = devices.filter((d) => d.cpu_usage != null).length;
   const isMockData = devices.length > 0 && devices.every((d) => d.mock_data);
@@ -266,6 +275,18 @@ export default function RuijieDevicesPage() {
           <PageHeader title="Network Devices" subtitle="Manage CPE and network devices" />
         </div>
         <div className="flex items-center gap-2">
+          <Button
+            variant={linkedFilter === 'unlinked' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() =>
+              setLinkedFilter((prev) => (prev === 'unlinked' ? '' : 'unlinked'))
+            }
+          >
+            Unlinked
+            {linkedFilter !== 'linked' && devices.length > 0
+              ? ` (${unlinkedCount})`
+              : ''}
+          </Button>
           <Button variant="outline" size="sm" asChild>
             <Link href="/admin/network/health">System Health</Link>
           </Button>
@@ -334,10 +355,14 @@ export default function RuijieDevicesPage() {
           deltaPositive={offlineCount === 0}
         />
         <MetricCard
-          title="Telemetry Coverage"
-          value={`${withCpu}`}
-          subtitle="Devices with live CPU/mem"
-          delta={`${totalClients} clients online`}
+          title="Unlinked devices"
+          value={`${unlinkedCount}`}
+          subtitle={
+            linkedFilter === 'unlinked'
+              ? 'Filter: unlinked only'
+              : 'No customer / site assignment'
+          }
+          delta={`${withCpu} with CPU · ${totalClients} clients`}
         />
       </div>
 
@@ -350,6 +375,8 @@ export default function RuijieDevicesPage() {
         onGroupChange={setGroupFilter}
         modelFilter={modelFilter}
         onModelChange={setModelFilter}
+        linkedFilter={linkedFilter}
+        onLinkedChange={setLinkedFilter}
         groups={data?.filters.groups || []}
         models={data?.filters.models || []}
         onExport={handleExportCSV}
@@ -360,6 +387,7 @@ export default function RuijieDevicesPage() {
           devices={devices}
           tunnelLimitReached={tunnelCount >= TUNNEL_LIMIT}
           onReboot={setRebootDevice}
+          onLinkCustomer={setLinkDevice}
           formatRelativeTime={formatRelativeTime}
         />
       </div>
@@ -370,6 +398,7 @@ export default function RuijieDevicesPage() {
             device={device}
             tunnelLimitReached={tunnelCount >= TUNNEL_LIMIT}
             onReboot={setRebootDevice}
+            onLinkCustomer={setLinkDevice}
             formatRelativeTime={formatRelativeTime}
           />
         ))}
@@ -385,6 +414,7 @@ export default function RuijieDevicesPage() {
       <div className="flex items-center justify-between text-xs text-slate-500">
         <span>
           Showing {devices.length} of {data?.total || 0} devices
+          {linkedFilter ? ` · customer filter: ${linkedFilter}` : ''}
         </span>
         <span>
           Active tunnels: {tunnelCount}/{TUNNEL_LIMIT}
@@ -412,6 +442,19 @@ export default function RuijieDevicesPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <LinkCustomerDialog
+        open={!!linkDevice}
+        onOpenChange={(open) => {
+          if (!open) setLinkDevice(null);
+        }}
+        sn={linkDevice?.sn || ''}
+        deviceName={linkDevice?.device_name}
+        onLinked={() => {
+          setLinkDevice(null);
+          fetchDevices(true);
+        }}
+      />
     </AdminPage>
   );
 }

--- a/app/api/admin/leads/[id]/route.ts
+++ b/app/api/admin/leads/[id]/route.ts
@@ -1,0 +1,294 @@
+/**
+ * Admin Lead Detail API
+ * GET   /api/admin/leads/[id] — single coverage_lead
+ * PATCH /api/admin/leads/[id] — update notes, status, assignment, next follow-up
+ *
+ * First-response SLA: when status moves new → non-new OR follow_up_notes is
+ * updated while first_responded_at is null, stamp first_responded_at and
+ * last_contacted_at.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { apiLogger } from '@/lib/logging/logger';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ALLOWED_STATUSES = new Set([
+  'new',
+  'contacted',
+  'interested',
+  'not_interested',
+  'coverage_available',
+  'converted_to_order',
+  'lost',
+  'follow_up_scheduled',
+]);
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+interface LeadPatchBody {
+  follow_up_notes?: string | null;
+  /** Alias for follow_up_notes */
+  notes?: string | null;
+  status?: string;
+  assigned_admin_id?: string | null;
+  next_follow_up_at?: string | null;
+}
+
+async function attachAssignedAdmin(
+  supabase: SupabaseClient,
+  lead: Record<string, unknown> | null
+): Promise<Record<string, unknown> | null> {
+  if (!lead) return lead;
+  const assignedId = lead.assigned_admin_id as string | null | undefined;
+  if (!assignedId) {
+    return { ...lead, assigned_admin: null };
+  }
+
+  const { data: admin } = await supabase
+    .from('admin_users')
+    .select('id, full_name, email')
+    .eq('id', assignedId)
+    .maybeSingle();
+
+  return { ...lead, assigned_admin: admin ?? null };
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) {
+    return authResult.response;
+  }
+
+  try {
+    const { id } = await context.params;
+    if (!id) {
+      return NextResponse.json(
+        { success: false, error: 'Lead id is required' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await createClient();
+
+    const { data: row, error } = await supabase
+      .from('coverage_leads')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return NextResponse.json(
+          { success: false, error: 'Lead not found' },
+          { status: 404 }
+        );
+      }
+      apiLogger.error('[Admin Leads] GET one failed', { error, id });
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 500 }
+      );
+    }
+
+    const lead = await attachAssignedAdmin(supabase, row);
+
+    return NextResponse.json({ success: true, lead });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    apiLogger.error('[Admin Leads] GET one error', { error: message });
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) {
+    return authResult.response;
+  }
+
+  try {
+    const { id } = await context.params;
+    if (!id) {
+      return NextResponse.json(
+        { success: false, error: 'Lead id is required' },
+        { status: 400 }
+      );
+    }
+
+    const body = (await request.json()) as LeadPatchBody;
+    const supabase = await createClient();
+
+    // Load current row for first-response + follow_up_count logic
+    const { data: current, error: fetchError } = await supabase
+      .from('coverage_leads')
+      .select(
+        'id, status, follow_up_notes, follow_up_count, first_responded_at, last_contacted_at'
+      )
+      .eq('id', id)
+      .single();
+
+    if (fetchError) {
+      if (fetchError.code === 'PGRST116') {
+        return NextResponse.json(
+          { success: false, error: 'Lead not found' },
+          { status: 404 }
+        );
+      }
+      apiLogger.error('[Admin Leads] PATCH fetch failed', {
+        error: fetchError.message,
+        id,
+      });
+      return NextResponse.json(
+        { success: false, error: fetchError.message },
+        { status: 500 }
+      );
+    }
+
+    if (!current) {
+      return NextResponse.json(
+        { success: false, error: 'Lead not found' },
+        { status: 404 }
+      );
+    }
+
+    const updates: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    };
+
+    const notesValue =
+      body.follow_up_notes !== undefined
+        ? body.follow_up_notes
+        : body.notes !== undefined
+          ? body.notes
+          : undefined;
+
+    const notesProvided = notesValue !== undefined;
+    const statusProvided = body.status !== undefined;
+    const assignmentProvided = body.assigned_admin_id !== undefined;
+    const nextFollowUpProvided = body.next_follow_up_at !== undefined;
+
+    if (
+      !notesProvided &&
+      !statusProvided &&
+      !assignmentProvided &&
+      !nextFollowUpProvided
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            'No updatable fields provided. Allowed: follow_up_notes|notes, status, assigned_admin_id, next_follow_up_at',
+        },
+        { status: 400 }
+      );
+    }
+
+    if (statusProvided) {
+      if (typeof body.status !== 'string' || !ALLOWED_STATUSES.has(body.status)) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: `Invalid status. Allowed: ${Array.from(ALLOWED_STATUSES).join(', ')}`,
+          },
+          { status: 400 }
+        );
+      }
+      updates.status = body.status;
+    }
+
+    if (assignmentProvided) {
+      // null / empty clears assignment
+      if (body.assigned_admin_id !== null && body.assigned_admin_id !== '') {
+        if (typeof body.assigned_admin_id !== 'string') {
+          return NextResponse.json(
+            {
+              success: false,
+              error: 'assigned_admin_id must be a uuid or null',
+            },
+            { status: 400 }
+          );
+        }
+        updates.assigned_admin_id = body.assigned_admin_id;
+      } else {
+        updates.assigned_admin_id = null;
+      }
+    }
+
+    if (nextFollowUpProvided) {
+      updates.next_follow_up_at = body.next_follow_up_at || null;
+    }
+
+    if (notesProvided) {
+      updates.follow_up_notes = notesValue;
+      const prevNotes = current.follow_up_notes ?? '';
+      const nextNotes = notesValue ?? '';
+      if (prevNotes !== nextNotes) {
+        const nowIso = new Date().toISOString();
+        updates.last_contacted_at = nowIso;
+        updates.follow_up_count = (current.follow_up_count ?? 0) + 1;
+      }
+    }
+
+    // First-response stamp: status new→non-new OR notes updated, when still null
+    const statusLeavingNew =
+      statusProvided && current.status === 'new' && body.status !== 'new';
+
+    const notesUpdated =
+      notesProvided &&
+      (current.follow_up_notes ?? '') !== (notesValue ?? '');
+
+    if (
+      current.first_responded_at == null &&
+      (statusLeavingNew || notesUpdated)
+    ) {
+      const nowIso = new Date().toISOString();
+      updates.first_responded_at = nowIso;
+      if (!updates.last_contacted_at) {
+        updates.last_contacted_at = nowIso;
+      }
+    }
+
+    const { data: row, error: updateError } = await supabase
+      .from('coverage_leads')
+      .update(updates)
+      .eq('id', id)
+      .select('*')
+      .single();
+
+    if (updateError) {
+      apiLogger.error('[Admin Leads] PATCH update failed', {
+        error: updateError,
+        id,
+      });
+      return NextResponse.json(
+        { success: false, error: updateError.message },
+        { status: 500 }
+      );
+    }
+
+    const lead = await attachAssignedAdmin(supabase, row);
+
+    apiLogger.info('[Admin Leads] Lead updated', {
+      id,
+      fields: Object.keys(updates),
+      adminId: authResult.adminUser.id,
+    });
+
+    return NextResponse.json({ success: true, lead });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    apiLogger.error('[Admin Leads] PATCH error', { error: message });
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/leads/route.ts
+++ b/app/api/admin/leads/route.ts
@@ -1,0 +1,225 @@
+/**
+ * Admin Leads Queue API
+ * GET /api/admin/leads — list coverage_leads for follow-up queue
+ *
+ * Query params:
+ * - status
+ * - assigned_admin_id (uuid | "unassigned")
+ * - overdue ("true" | "1") — first_response_due_at < now AND first_responded_at is null AND status=new
+ * - q — search first_name, last_name, phone, email
+ * - lead_source
+ * - limit (default 50, max 100)
+ * - offset (default 0)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { apiLogger } from '@/lib/logging/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const LIST_SELECT = [
+  'id',
+  'first_name',
+  'last_name',
+  'email',
+  'phone',
+  'company_name',
+  'customer_type',
+  'status',
+  'lead_source',
+  'source_campaign',
+  'assigned_admin_id',
+  'follow_up_notes',
+  'last_contacted_at',
+  'next_follow_up_at',
+  'follow_up_count',
+  'first_response_due_at',
+  'first_responded_at',
+  'zoho_lead_id',
+  'zoho_sync_status',
+  'zoho_sync_error',
+  'zoho_synced_at',
+  'address',
+  'suburb',
+  'city',
+  'province',
+  'created_at',
+  'updated_at',
+  'assigned_admin:admin_users!coverage_leads_assigned_admin_id_fkey(id,full_name,email)',
+].join(',');
+
+/** Strip PostgREST filter metacharacters from free-text search. */
+function sanitizeSearch(q: string): string {
+  return q.replace(/[%_,.()]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+type ListFilters = {
+  status: string | null;
+  assignedAdminId: string | null;
+  isOverdue: boolean;
+  leadSource: string | null;
+  q: string | null;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function applyLeadFilters(query: any, filters: ListFilters) {
+  let q = query;
+
+  if (filters.isOverdue) {
+    // SLA breach: still new, never responded, past first-response due
+    q = q
+      .eq('status', 'new')
+      .is('first_responded_at', null)
+      .lt('first_response_due_at', new Date().toISOString());
+  } else if (filters.status) {
+    q = q.eq('status', filters.status);
+  }
+
+  if (filters.assignedAdminId) {
+    if (
+      filters.assignedAdminId === 'unassigned' ||
+      filters.assignedAdminId === 'null'
+    ) {
+      q = q.is('assigned_admin_id', null);
+    } else {
+      q = q.eq('assigned_admin_id', filters.assignedAdminId);
+    }
+  }
+
+  if (filters.leadSource) {
+    q = q.eq('lead_source', filters.leadSource);
+  }
+
+  if (filters.q) {
+    const term = sanitizeSearch(filters.q);
+    if (term) {
+      q = q.or(
+        `first_name.ilike.%${term}%,last_name.ilike.%${term}%,email.ilike.%${term}%,phone.ilike.%${term}%`
+      );
+    }
+  }
+
+  return q;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function applyLeadOrder(query: any, isOverdue: boolean) {
+  if (isOverdue) {
+    return query
+      .order('first_response_due_at', { ascending: true })
+      .order('created_at', { ascending: false });
+  }
+  return query.order('created_at', { ascending: false });
+}
+
+function isRelationshipError(error: {
+  code?: string;
+  message?: string;
+}): boolean {
+  return (
+    error.code === 'PGRST200' ||
+    !!error.message?.includes('coverage_leads_assigned_admin_id_fkey') ||
+    !!error.message?.includes('Could not find a relationship')
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) {
+    return authResult.response;
+  }
+
+  try {
+    const supabase = await createClient();
+    const { searchParams } = new URL(request.url);
+
+    const filters: ListFilters = {
+      status: searchParams.get('status'),
+      assignedAdminId: searchParams.get('assigned_admin_id'),
+      isOverdue: ['true', '1', 'yes'].includes(
+        (searchParams.get('overdue') || '').toLowerCase()
+      ),
+      leadSource: searchParams.get('lead_source'),
+      q: searchParams.get('q'),
+    };
+
+    const limit = Math.min(
+      Math.max(parseInt(searchParams.get('limit') || '50', 10) || 50, 1),
+      100
+    );
+    const offset = Math.max(
+      parseInt(searchParams.get('offset') || '0', 10) || 0,
+      0
+    );
+
+    const base = applyLeadOrder(
+      applyLeadFilters(
+        supabase.from('coverage_leads').select(LIST_SELECT, { count: 'exact' }),
+        filters
+      ),
+      filters.isOverdue
+    ).range(offset, offset + limit - 1);
+
+    const { data: leads, error, count } = await base;
+
+    if (error) {
+      if (isRelationshipError(error)) {
+        apiLogger.warn(
+          '[Admin Leads] FK embed failed; falling back to flat select',
+          { error: error.message }
+        );
+
+        const fallback = applyLeadOrder(
+          applyLeadFilters(
+            supabase.from('coverage_leads').select('*', { count: 'exact' }),
+            filters
+          ),
+          filters.isOverdue
+        ).range(offset, offset + limit - 1);
+
+        const retry = await fallback;
+        if (retry.error) {
+          apiLogger.error('[Admin Leads] List query failed', {
+            error: retry.error,
+          });
+          return NextResponse.json(
+            { success: false, error: retry.error.message },
+            { status: 500 }
+          );
+        }
+
+        return NextResponse.json({
+          success: true,
+          leads: retry.data ?? [],
+          total_count: retry.count ?? 0,
+          limit,
+          offset,
+        });
+      }
+
+      apiLogger.error('[Admin Leads] List query failed', { error });
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      leads: leads ?? [],
+      total_count: count ?? 0,
+      limit,
+      offset,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    apiLogger.error('[Admin Leads] GET list error', { error: message });
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/whatsapp/flows/send/route.ts
+++ b/app/api/admin/whatsapp/flows/send/route.ts
@@ -1,0 +1,133 @@
+/**
+ * Admin WhatsApp Flow Send API
+ *
+ * POST /api/admin/whatsapp/flows/send
+ * Manually sends the F1 lead-qualification flow to a phone number.
+ * Requires admin authentication (same pattern as billing/whatsapp/send).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { sendFlow } from '@/lib/integrations/whatsapp';
+import { apiLogger } from '@/lib/logging';
+
+const VALID_ENTRY_SOURCES = [
+  'website',
+  'qr',
+  'admin',
+  'ctwa_ad',
+  'manual',
+  'followup',
+] as const;
+
+type EntrySource = (typeof VALID_ENTRY_SOURCES)[number];
+
+export async function POST(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response;
+
+    const body = await request.json();
+    const {
+      phone,
+      entry_source = 'admin',
+      source_campaign,
+      draft = false,
+    } = body as {
+      phone?: string;
+      entry_source?: string;
+      source_campaign?: string;
+      draft?: boolean;
+    };
+
+    if (!phone || typeof phone !== 'string' || !phone.trim()) {
+      return NextResponse.json(
+        { success: false, error: 'phone is required' },
+        { status: 400 }
+      );
+    }
+
+    if (
+      !VALID_ENTRY_SOURCES.includes(entry_source as EntrySource)
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Invalid entry_source. Must be one of: ${VALID_ENTRY_SOURCES.join(', ')}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    apiLogger.info('[Admin Flow Send] Sending F1 flow', {
+      phone: phone.trim(),
+      entrySource: entry_source,
+      sourceCampaign: source_campaign ?? null,
+      draft: Boolean(draft),
+      adminId: authResult.adminUser.id,
+    });
+
+    const result = await sendFlow({
+      to: phone.trim(),
+      entrySource: entry_source,
+      sourceCampaign: source_campaign ?? null,
+      draft: Boolean(draft),
+    });
+
+    if (result.success) {
+      apiLogger.info('[Admin Flow Send] Sent successfully', {
+        messageId: result.messageId,
+        flowToken: result.flowToken,
+        sessionId: result.sessionId,
+        adminId: authResult.adminUser.id,
+      });
+
+      return NextResponse.json({
+        success: true,
+        message_id: result.messageId,
+        wa_id: result.waId,
+        flow_token: result.flowToken,
+        session_id: result.sessionId,
+      });
+    }
+
+    apiLogger.error('[Admin Flow Send] Send failed', {
+      error: result.error,
+      errorCode: result.errorCode,
+      flowToken: result.flowToken,
+      sessionId: result.sessionId,
+    });
+
+    // Missing flow id / WhatsApp config / invalid phone → 400; API/network → 502
+    const clientErrors = [
+      'WHATSAPP_FLOW_LEAD_QUALIFICATION_ID not configured',
+      'WhatsApp API not configured',
+      'Invalid phone number',
+      'Supabase service role credentials not configured',
+      'Supabase not configured',
+    ];
+    const isClientError =
+      result.error &&
+      (clientErrors.some((msg) => result.error!.includes(msg)) ||
+        result.error.startsWith('Failed to create flow session'));
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: result.error || 'Failed to send WhatsApp flow',
+        error_code: result.errorCode,
+        flow_token: result.flowToken,
+        session_id: result.sessionId,
+      },
+      { status: isClientError ? 400 : 502 }
+    );
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+    apiLogger.error('[Admin Flow Send] Error', { error: errorMsg });
+
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/cron/lead-followup-sla/route.ts
+++ b/app/api/cron/lead-followup-sla/route.ts
@@ -1,0 +1,360 @@
+/**
+ * Lead first-response SLA escalation cron
+ *
+ * Finds coverage_leads past first_response_due_at that are still `new` and
+ * unanswered, emails the sales inbox, and stamps metadata.sla_escalated_at
+ * so we do not re-spam every tick (re-alert only after 24h).
+ *
+ * Schedule: every 30 minutes (vercel.json + host crontab from generator)
+ *
+ * Auth: Authorization: Bearer $CRON_SECRET
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { EmailChannel } from '@/lib/notifications/channels/email-channel';
+import { cronLogger } from '@/lib/logging';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const SALES_TEAM_EMAIL = process.env.SALES_TEAM_EMAIL || 'sales@circletel.co.za';
+const APP_BASE =
+  process.env.NEXT_PUBLIC_APP_URL ||
+  process.env.NEXT_PUBLIC_BASE_URL ||
+  'https://www.circletel.co.za';
+
+/** Minimum gap between escalation emails for the same lead */
+const REALERT_AFTER_MS = 24 * 60 * 60 * 1000;
+/** Safety cap per cron run */
+const MAX_LEADS_PER_RUN = 50;
+
+type LeadRow = {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  phone: string | null;
+  company_name: string | null;
+  customer_type: string | null;
+  lead_source: string | null;
+  source_campaign: string | null;
+  address: string | null;
+  suburb: string | null;
+  city: string | null;
+  first_response_due_at: string;
+  created_at: string | null;
+  assigned_admin_id: string | null;
+  metadata: Record<string, unknown> | null;
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatSast(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString('en-ZA', {
+    timeZone: 'Africa/Johannesburg',
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function hoursOverdue(dueAtIso: string, now: Date): number {
+  const due = new Date(dueAtIso).getTime();
+  if (Number.isNaN(due)) return 0;
+  return Math.max(0, (now.getTime() - due) / (60 * 60 * 1000));
+}
+
+function shouldEscalate(
+  metadata: Record<string, unknown> | null | undefined,
+  now: Date
+): boolean {
+  const raw = metadata?.sla_escalated_at;
+  if (typeof raw !== 'string' || !raw) return true;
+  const last = new Date(raw).getTime();
+  if (Number.isNaN(last)) return true;
+  return now.getTime() - last >= REALERT_AFTER_MS;
+}
+
+function buildEscalationHtml(lead: LeadRow, now: Date): string {
+  const name = [lead.first_name, lead.last_name].filter(Boolean).join(' ') || 'Unknown';
+  const location = [lead.suburb, lead.city].filter(Boolean).join(', ') || lead.address || '—';
+  const adminUrl = `${APP_BASE.replace(/\/$/, '')}/admin/leads/${lead.id}`;
+  const overdueH = hoursOverdue(lead.first_response_due_at, now).toFixed(1);
+
+  return `
+<!DOCTYPE html>
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1B2A4A; line-height: 1.5;">
+  <div style="max-width: 560px; margin: 0 auto; padding: 24px;">
+    <h1 style="color: #B91C1C; font-size: 20px; margin: 0 0 8px;">First-response SLA breached</h1>
+    <p style="margin: 0 0 16px; color: #4B5563;">
+      This lead is still <strong>new</strong> with no first response past the due time
+      (${escapeHtml(overdueH)}h overdue as of ${escapeHtml(formatSast(now.toISOString()))} SAST).
+    </p>
+    <table style="width: 100%; border-collapse: collapse; margin-bottom: 20px;">
+      <tr>
+        <td style="padding: 8px 0; color: #6B7280; width: 140px;">Lead</td>
+        <td style="padding: 8px 0;"><strong>${escapeHtml(name)}</strong></td>
+      </tr>
+      ${
+        lead.company_name
+          ? `<tr><td style="padding: 8px 0; color: #6B7280;">Company</td><td style="padding: 8px 0;">${escapeHtml(lead.company_name)}</td></tr>`
+          : ''
+      }
+      <tr>
+        <td style="padding: 8px 0; color: #6B7280;">Phone</td>
+        <td style="padding: 8px 0;"><a href="tel:${escapeHtml(lead.phone || '')}">${escapeHtml(lead.phone || '—')}</a></td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 0; color: #6B7280;">Email</td>
+        <td style="padding: 8px 0;"><a href="mailto:${escapeHtml(lead.email || '')}">${escapeHtml(lead.email || '—')}</a></td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 0; color: #6B7280;">Location</td>
+        <td style="padding: 8px 0;">${escapeHtml(location)}</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 0; color: #6B7280;">Customer type</td>
+        <td style="padding: 8px 0;">${escapeHtml(lead.customer_type || '—')}</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 0; color: #6B7280;">Source</td>
+        <td style="padding: 8px 0;">${escapeHtml(lead.lead_source || '—')}${
+          lead.source_campaign ? ` / ${escapeHtml(lead.source_campaign)}` : ''
+        }</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 0; color: #6B7280;">Created</td>
+        <td style="padding: 8px 0;">${escapeHtml(formatSast(lead.created_at))}</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 0; color: #6B7280;">Response due</td>
+        <td style="padding: 8px 0; color: #B91C1C;"><strong>${escapeHtml(formatSast(lead.first_response_due_at))}</strong></td>
+      </tr>
+    </table>
+    <a href="${escapeHtml(adminUrl)}"
+       style="display: inline-block; background: #E87A1E; color: #fff; text-decoration: none; padding: 12px 20px; border-radius: 6px; font-weight: 600;">
+      Open lead in admin
+    </a>
+    <p style="margin-top: 24px; font-size: 12px; color: #9CA3AF;">
+      CircleTel SLA escalation · re-alerts at most once per 24 hours while still overdue
+    </p>
+  </div>
+</body>
+</html>`.trim();
+}
+
+function authorize(request: NextRequest): NextResponse | null {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    cronLogger.error('[LeadFollowupSla] CRON_SECRET not configured');
+    return NextResponse.json({ error: 'Cron secret not configured' }, { status: 500 });
+  }
+
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    cronLogger.error('[LeadFollowupSla] Unauthorized request');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  return null;
+}
+
+async function runEscalation(): Promise<NextResponse> {
+  const startTime = Date.now();
+  const now = new Date();
+  const nowIso = now.toISOString();
+
+  cronLogger.info('[LeadFollowupSla] Starting SLA escalation run', { at: nowIso });
+
+  const supabase = await createClient();
+
+  const { data: rows, error: fetchError } = await supabase
+    .from('coverage_leads')
+    .select(
+      [
+        'id',
+        'first_name',
+        'last_name',
+        'email',
+        'phone',
+        'company_name',
+        'customer_type',
+        'lead_source',
+        'source_campaign',
+        'address',
+        'suburb',
+        'city',
+        'first_response_due_at',
+        'created_at',
+        'assigned_admin_id',
+        'metadata',
+      ].join(',')
+    )
+    .eq('status', 'new')
+    .is('first_responded_at', null)
+    .not('first_response_due_at', 'is', null)
+    .lt('first_response_due_at', nowIso)
+    .order('first_response_due_at', { ascending: true })
+    .limit(MAX_LEADS_PER_RUN);
+
+  if (fetchError) {
+    cronLogger.error('[LeadFollowupSla] Failed to query overdue leads', {
+      error: fetchError.message,
+    });
+    return NextResponse.json(
+      { success: false, error: 'Failed to query overdue leads', details: fetchError.message },
+      { status: 500 }
+    );
+  }
+
+  const leads = (rows || []) as LeadRow[];
+  const candidates = leads.filter((lead) => shouldEscalate(lead.metadata, now));
+
+  if (candidates.length === 0) {
+    cronLogger.info('[LeadFollowupSla] No leads needing escalation', {
+      overdueFetched: leads.length,
+      durationMs: Date.now() - startTime,
+    });
+    return NextResponse.json({
+      success: true,
+      message: 'No leads needing SLA escalation',
+      overdue_fetched: leads.length,
+      escalated: 0,
+      skipped_recent: leads.length,
+      duration_ms: Date.now() - startTime,
+    });
+  }
+
+  let escalated = 0;
+  let emailFailed = 0;
+  let updateFailed = 0;
+  const escalatedIds: string[] = [];
+  const errors: string[] = [];
+
+  for (const lead of candidates) {
+    const name = [lead.first_name, lead.last_name].filter(Boolean).join(' ') || 'Unknown';
+    const overdueH = hoursOverdue(lead.first_response_due_at, now).toFixed(1);
+
+    try {
+      const emailResult = await EmailChannel.send({
+        to: SALES_TEAM_EMAIL,
+        subject: `[SLA Breach] First response overdue — ${name} (${overdueH}h)`,
+        html: buildEscalationHtml(lead, now),
+        from: 'CircleTel Alerts <devadmin@notifications.circletelsa.co.za>',
+      });
+
+      if (!emailResult.success) {
+        emailFailed += 1;
+        errors.push(`${lead.id}: email ${emailResult.error || 'failed'}`);
+        cronLogger.warn('[LeadFollowupSla] Email failed', {
+          leadId: lead.id,
+          error: emailResult.error,
+        });
+        // Still stamp escalation if email service is misconfigured? Prefer not —
+        // leave unstamped so next run retries.
+        continue;
+      }
+
+      const prevMeta =
+        lead.metadata && typeof lead.metadata === 'object' && !Array.isArray(lead.metadata)
+          ? { ...lead.metadata }
+          : {};
+
+      const nextMeta = {
+        ...prevMeta,
+        sla_escalated_at: nowIso,
+        sla_escalation_count:
+          typeof prevMeta.sla_escalation_count === 'number'
+            ? prevMeta.sla_escalation_count + 1
+            : 1,
+      };
+
+      const { error: updateError } = await supabase
+        .from('coverage_leads')
+        .update({
+          metadata: nextMeta,
+          updated_at: nowIso,
+        })
+        .eq('id', lead.id);
+
+      if (updateError) {
+        updateFailed += 1;
+        errors.push(`${lead.id}: metadata update ${updateError.message}`);
+        cronLogger.error('[LeadFollowupSla] Failed to stamp sla_escalated_at', {
+          leadId: lead.id,
+          error: updateError.message,
+        });
+        // Email already sent — count as escalated to avoid double-count confusion
+      }
+
+      escalated += 1;
+      escalatedIds.push(lead.id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      emailFailed += 1;
+      errors.push(`${lead.id}: ${message}`);
+      cronLogger.error('[LeadFollowupSla] Lead escalation exception', {
+        leadId: lead.id,
+        error: message,
+      });
+    }
+  }
+
+  const durationMs = Date.now() - startTime;
+  cronLogger.info('[LeadFollowupSla] Run complete', {
+    overdueFetched: leads.length,
+    candidates: candidates.length,
+    escalated,
+    emailFailed,
+    updateFailed,
+    durationMs,
+  });
+
+  return NextResponse.json({
+    success: emailFailed === 0 && updateFailed === 0,
+    message: `Escalated ${escalated} of ${candidates.length} overdue lead(s)`,
+    overdue_fetched: leads.length,
+    candidates: candidates.length,
+    escalated,
+    email_failed: emailFailed,
+    update_failed: updateFailed,
+    escalated_ids: escalatedIds,
+    errors: errors.length ? errors : undefined,
+    duration_ms: durationMs,
+  });
+}
+
+/**
+ * GET /api/cron/lead-followup-sla
+ * Host crontab / Vercel Cron entrypoint.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const denied = authorize(request);
+  if (denied) return denied;
+
+  try {
+    return await runEscalation();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    cronLogger.error('[LeadFollowupSla] Fatal error', { error: message });
+    return NextResponse.json(
+      { success: false, error: 'Internal server error', details: message },
+      { status: 500 }
+    );
+  }
+}
+
+/** POST — same as GET (manual trigger) */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return GET(request);
+}

--- a/app/api/cron/lead-followup-sla/route.ts
+++ b/app/api/cron/lead-followup-sla/route.ts
@@ -217,7 +217,7 @@ async function runEscalation(): Promise<NextResponse> {
     );
   }
 
-  const leads = (rows || []) as LeadRow[];
+  const leads = (rows || []) as unknown as LeadRow[];
   const candidates = leads.filter((lead) => shouldEscalate(lead.metadata, now));
 
   if (candidates.length === 0) {

--- a/app/api/ruijie/devices/[sn]/link/route.ts
+++ b/app/api/ruijie/devices/[sn]/link/route.ts
@@ -1,7 +1,34 @@
 /**
- * Link/Unlink Device to Customer
- * POST /api/ruijie/devices/[sn]/link - Link device to customer
- * DELETE /api/ruijie/devices/[sn]/link - Unlink device
+ * Link / unlink a Ruijie device (`ruijie_device_cache`) to a customer.
+ *
+ * ## POST `/api/ruijie/devices/[sn]/link`
+ * Auth: admin session (cookie) + active `admin_users` row.
+ *
+ * Request body:
+ * | Field               | Type                    | Required when        |
+ * |---------------------|-------------------------|----------------------|
+ * | `type`              | `"consumer"\|"corporate"` | always             |
+ * | `customer_order_id` | UUID                    | `type === "consumer"`  |
+ * | `corporate_site_id` | UUID                    | `type === "corporate"` |
+ *
+ * Effects on `ruijie_device_cache` (by `sn`):
+ * - Sets one of `customer_order_id` / `corporate_site_id` (clears the other)
+ * - Denormalizes `customer_name`, `customer_email`, `customer_phone` from
+ *   `consumer_orders` or `corporate_sites`
+ *
+ * Success (200):
+ * ```json
+ * { "success": true, "customer_name": "...", "customer_email": "...", "customer_phone": "..." }
+ * ```
+ *
+ * Errors: 400 validation, 401/403 auth, 404 device or order/site missing, 500 update failure.
+ *
+ * ## DELETE `/api/ruijie/devices/[sn]/link`
+ * Clears `customer_order_id`, `corporate_site_id`, and denormalized customer fields.
+ * Success (200): `{ "success": true }`
+ *
+ * Ops UI: `/admin/network/devices` (list + filter Unlinked) and device detail
+ * Customer Assignment panel. Customer picker uses `GET /api/admin/search/customers?q=`.
  */
 
 import { NextRequest, NextResponse } from 'next/server';

--- a/app/api/ruijie/devices/route.ts
+++ b/app/api/ruijie/devices/route.ts
@@ -39,6 +39,8 @@ export async function GET(request: NextRequest) {
     const status = searchParams.get('status') || '';
     const group = searchParams.get('group') || '';
     const model = searchParams.get('model') || '';
+    // linked=unlinked | linked — filter by customer assignment on ruijie_device_cache
+    const linked = searchParams.get('linked') || '';
 
     // Build query (use admin client to bypass RLS)
     let query = supabaseAdmin
@@ -50,7 +52,7 @@ export async function GET(request: NextRequest) {
     // Apply filters
     if (search) {
       query = query.or(
-        `sn.ilike.%${search}%,device_name.ilike.%${search}%,management_ip.ilike.%${search}%`
+        `sn.ilike.%${search}%,device_name.ilike.%${search}%,management_ip.ilike.%${search}%,customer_name.ilike.%${search}%`
       );
     }
     if (status) {
@@ -61,6 +63,12 @@ export async function GET(request: NextRequest) {
     }
     if (model) {
       query = query.eq('model', model);
+    }
+    if (linked === 'unlinked') {
+      // Both FKs null = not linked to consumer order or corporate site
+      query = query.is('customer_order_id', null).is('corporate_site_id', null);
+    } else if (linked === 'linked') {
+      query = query.or('customer_order_id.not.is.null,corporate_site_id.not.is.null');
     }
 
     const { data: devices, error } = await query;

--- a/app/api/webhooks/whatsapp/route.ts
+++ b/app/api/webhooks/whatsapp/route.ts
@@ -4,16 +4,21 @@
  * Handles incoming webhooks from Meta Cloud API:
  * - Webhook verification (GET)
  * - Message status updates (POST)
+ * - Flow completions (interactive nfm_reply)
  *
  * @see https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { whatsAppService } from '@/lib/integrations/whatsapp';
+import {
+  whatsAppService,
+  handleFlowCompletion,
+} from '@/lib/integrations/whatsapp';
 import type {
   WebhookPayload,
   WebhookStatusUpdate,
+  WebhookMessage,
 } from '@/lib/integrations/whatsapp/types';
 
 // =============================================================================
@@ -83,21 +88,86 @@ export async function POST(request: NextRequest) {
           await processStatusUpdates(value.statuses);
         }
 
-        // Process incoming messages (optional - for future use)
+        // Process incoming messages (flow completions + log others)
         if (value.messages && value.messages.length > 0) {
-          // Could be used for customer replies
-          console.log('[WhatsApp Webhook] Received messages:', value.messages.length);
+          await processInboundMessages(value.messages);
         }
       }
     }
 
+    // Always 200 — Meta retries non-2xx and can amplify poison payloads
     return NextResponse.json({ received: true });
   } catch (error) {
+    // Still 200 so Meta does not retry endlessly; log for ops
     console.error('[WhatsApp Webhook] Error processing webhook:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return NextResponse.json({ received: true });
+  }
+}
+
+// =============================================================================
+// INBOUND MESSAGES (incl. Flow nfm_reply)
+// =============================================================================
+
+/**
+ * Detect Meta Flow completion: interactive.type === 'nfm_reply'.
+ * WebhookMessage.interactive is typed for button/list only — check raw shape.
+ */
+function isNfmReplyMessage(message: WebhookMessage): boolean {
+  if (message.type !== 'interactive') return false;
+  const interactive = message.interactive as
+    | { type?: string; nfm_reply?: { response_json?: string } }
+    | undefined;
+  return (
+    interactive?.type === 'nfm_reply' &&
+    typeof interactive.nfm_reply?.response_json === 'string'
+  );
+}
+
+/**
+ * Route inbound messages: nfm_reply → flow completion handler; others log only.
+ * Never throws — failures are logged so the webhook can still return 200.
+ */
+async function processInboundMessages(messages: WebhookMessage[]): Promise<void> {
+  console.log('[WhatsApp Webhook] Received messages:', messages.length);
+
+  for (const message of messages) {
+    if (!isNfmReplyMessage(message)) {
+      console.log('[WhatsApp Webhook] Inbound non-flow message', {
+        type: message.type,
+        from: message.from,
+        id: message.id,
+      });
+      continue;
+    }
+
+    try {
+      const supabase = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.SUPABASE_SERVICE_ROLE_KEY!,
+        {
+          auth: {
+            autoRefreshToken: false,
+            persistSession: false,
+          },
+        }
+      );
+
+      const result = await handleFlowCompletion(message, { supabase });
+      console.log('[WhatsApp Webhook] Flow completion handled', {
+        messageId: message.id,
+        from: message.from,
+        success: result.success,
+        reason: result.reason,
+        coverageLeadId: result.coverageLeadId,
+        sessionId: result.sessionId,
+      });
+    } catch (error) {
+      console.error('[WhatsApp Webhook] Flow completion handler failed', {
+        messageId: message.id,
+        from: message.from,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 }
 

--- a/app/api/webhooks/whatsapp/route.ts
+++ b/app/api/webhooks/whatsapp/route.ts
@@ -15,6 +15,7 @@ import {
   whatsAppService,
   handleFlowCompletion,
 } from '@/lib/integrations/whatsapp';
+import { onF1LeadCreated } from '@/lib/integrations/whatsapp/flows/f1-lead-notifications';
 import type {
   WebhookPayload,
   WebhookStatusUpdate,
@@ -152,7 +153,10 @@ async function processInboundMessages(messages: WebhookMessage[]): Promise<void>
         }
       );
 
-      const result = await handleFlowCompletion(message, { supabase });
+      const result = await handleFlowCompletion(message, {
+        supabase,
+        onLeadCreated: onF1LeadCreated,
+      });
       console.log('[WhatsApp Webhook] Flow completion handled', {
         messageId: message.id,
         from: message.from,

--- a/components/admin/layout/AdminHeader.tsx
+++ b/components/admin/layout/AdminHeader.tsx
@@ -110,6 +110,14 @@ const getPageInfo = (pathname: string): { title: string; description: string } =
     return { title: 'CMS Management', description: 'Manage website content' };
   }
 
+  // Leads follow-up queue
+  if (pathname.startsWith('/admin/leads')) {
+    if (pathname !== '/admin/leads' && pathname !== '/admin/leads/') {
+      return { title: 'Lead detail', description: 'Follow-up notes, owner, and first-response SLA' };
+    }
+    return { title: 'Leads', description: 'Coverage lead follow-up queue' };
+  }
+
   // Coverage
   if (pathname.startsWith('/admin/coverage')) {
     if (pathname.includes('/analytics')) {

--- a/components/admin/network/DeviceActionsMenu.tsx
+++ b/components/admin/network/DeviceActionsMenu.tsx
@@ -7,6 +7,7 @@ import {
   PiEyeBold,
   PiLinkBold,
   PiPowerBold,
+  PiUserPlusBold,
 } from 'react-icons/pi';
 import {
   DropdownMenu,
@@ -23,7 +24,10 @@ interface DeviceActionsMenuProps {
   deviceName: string;
   isOnline: boolean;
   tunnelLimitReached: boolean;
+  /** When true, show Link Customer action */
+  isUnlinked?: boolean;
   onReboot: () => void;
+  onLinkCustomer?: () => void;
 }
 
 export function DeviceActionsMenu({
@@ -31,7 +35,9 @@ export function DeviceActionsMenu({
   deviceName,
   isOnline,
   tunnelLimitReached,
+  isUnlinked = false,
   onReboot,
+  onLinkCustomer,
 }: DeviceActionsMenuProps) {
   const router = useRouter();
 
@@ -61,6 +67,12 @@ export function DeviceActionsMenu({
           <PiEyeBold className="mr-2 h-4 w-4" />
           View Details
         </DropdownMenuItem>
+        {isUnlinked && onLinkCustomer && (
+          <DropdownMenuItem onClick={onLinkCustomer}>
+            <PiUserPlusBold className="mr-2 h-4 w-4" />
+            Link Customer
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem
           onClick={handleLaunchEweb}
           disabled={tunnelLimitReached}

--- a/components/admin/network/DeviceCard.tsx
+++ b/components/admin/network/DeviceCard.tsx
@@ -1,25 +1,12 @@
 'use client';
 
 import Link from 'next/link';
-import { PiWifiHighBold, PiWifiSlashBold } from 'react-icons/pi';
+import { PiWifiHighBold, PiWifiSlashBold, PiUserPlusBold } from 'react-icons/pi';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { DeviceActionsMenu } from './DeviceActionsMenu';
-
-interface RuijieDevice {
-  sn: string;
-  device_name: string;
-  model: string | null;
-  group_name: string | null;
-  management_ip: string | null;
-  online_clients: number;
-  cpu_usage?: number | null;
-  memory_usage?: number | null;
-  status: string;
-  config_status: string | null;
-  synced_at: string;
-  mock_data: boolean;
-}
+import type { RuijieListDevice } from './DeviceTable';
 
 function formatPct(value: number | null | undefined): string {
   if (value == null || Number.isNaN(value)) return '—';
@@ -27,9 +14,10 @@ function formatPct(value: number | null | undefined): string {
 }
 
 interface DeviceCardProps {
-  device: RuijieDevice;
+  device: RuijieListDevice;
   tunnelLimitReached: boolean;
-  onReboot: (device: RuijieDevice) => void;
+  onReboot: (device: RuijieListDevice) => void;
+  onLinkCustomer?: (device: RuijieListDevice) => void;
   formatRelativeTime: (date: string) => string;
 }
 
@@ -37,10 +25,12 @@ export function DeviceCard({
   device,
   tunnelLimitReached,
   onReboot,
+  onLinkCustomer,
   formatRelativeTime,
 }: DeviceCardProps) {
   const isOnline = device.status === 'online';
   const StatusIcon = isOnline ? PiWifiHighBold : PiWifiSlashBold;
+  const unlinked = !device.customer_order_id && !device.corporate_site_id;
 
   return (
     <div
@@ -75,11 +65,40 @@ export function DeviceCard({
           deviceName={device.device_name}
           isOnline={isOnline}
           tunnelLimitReached={tunnelLimitReached}
+          isUnlinked={unlinked}
           onReboot={() => onReboot(device)}
+          onLinkCustomer={onLinkCustomer ? () => onLinkCustomer(device) : undefined}
         />
       </div>
       <div className="mt-2 text-sm text-slate-500">
         {device.model || 'Unknown'} · {device.group_name || 'No group'}
+      </div>
+      <div className="mt-1 flex items-center gap-2 flex-wrap">
+        {unlinked ? (
+          <>
+            <Badge
+              variant="outline"
+              className="bg-amber-50 text-amber-800 border-amber-200 text-xs"
+            >
+              Unlinked
+            </Badge>
+            {onLinkCustomer && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={() => onLinkCustomer(device)}
+              >
+                <PiUserPlusBold className="w-3.5 h-3.5 mr-1" />
+                Link
+              </Button>
+            )}
+          </>
+        ) : (
+          <span className="text-sm text-slate-600 truncate">
+            {device.customer_name || 'Linked customer'}
+          </span>
+        )}
       </div>
       <div className="mt-1 text-sm text-slate-500">
         CPU {formatPct(device.cpu_usage)} · Mem {formatPct(device.memory_usage)} ·{' '}

--- a/components/admin/network/DeviceFilters.tsx
+++ b/components/admin/network/DeviceFilters.tsx
@@ -33,6 +33,9 @@ interface DeviceFiltersProps {
   onGroupChange: (value: string) => void;
   modelFilter: string;
   onModelChange: (value: string) => void;
+  /** "" | "linked" | "unlinked" */
+  linkedFilter: string;
+  onLinkedChange: (value: string) => void;
   groups: string[];
   models: string[];
   onExport: () => void;
@@ -47,20 +50,32 @@ export function DeviceFilters({
   onGroupChange,
   modelFilter,
   onModelChange,
+  linkedFilter,
+  onLinkedChange,
   groups,
   models,
   onExport,
 }: DeviceFiltersProps) {
   const [filtersOpen, setFiltersOpen] = useState(false);
 
-  const hasFilters = statusFilter || groupFilter || modelFilter;
-  const activeFilterCount = [statusFilter, groupFilter, modelFilter].filter(Boolean).length;
+  const hasFilters = statusFilter || groupFilter || modelFilter || linkedFilter;
+  const activeFilterCount = [statusFilter, groupFilter, modelFilter, linkedFilter].filter(
+    Boolean
+  ).length;
 
   const clearAllFilters = () => {
     onStatusChange('');
     onGroupChange('');
     onModelChange('');
+    onLinkedChange('');
   };
+
+  const linkedLabel =
+    linkedFilter === 'unlinked'
+      ? 'Unlinked'
+      : linkedFilter === 'linked'
+        ? 'Linked'
+        : linkedFilter;
 
   return (
     <Card className="border border-slate-200/80 shadow-sm rounded-xl bg-white">
@@ -70,7 +85,7 @@ export function DeviceFilters({
             <div className="relative flex-1 min-w-[200px]">
               <PiMagnifyingGlassBold className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
               <Input
-                placeholder="Search by SN, name, or IP..."
+                placeholder="Search by SN, name, IP, or customer..."
                 value={search}
                 onChange={(e) => onSearchChange(e.target.value)}
                 className="pl-9 border-slate-200"
@@ -101,6 +116,14 @@ export function DeviceFilters({
                 <Badge variant="secondary" className="gap-1 bg-slate-100 text-slate-700">
                   Status: {statusFilter}
                   <button onClick={() => onStatusChange('')} className="ml-1 hover:text-red-500">
+                    <PiXBold className="h-3 w-3" />
+                  </button>
+                </Badge>
+              )}
+              {linkedFilter && (
+                <Badge variant="secondary" className="gap-1 bg-amber-50 text-amber-800">
+                  Customer: {linkedLabel}
+                  <button onClick={() => onLinkedChange('')} className="ml-1 hover:text-red-500">
                     <PiXBold className="h-3 w-3" />
                   </button>
                 </Badge>
@@ -139,6 +162,24 @@ export function DeviceFilters({
                     <SelectItem value="all">All</SelectItem>
                     <SelectItem value="online">Online</SelectItem>
                     <SelectItem value="offline">Offline</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="w-44">
+                <label className="text-xs font-medium text-slate-500 mb-1 block">
+                  Customer link
+                </label>
+                <Select
+                  value={linkedFilter || 'all'}
+                  onValueChange={(v) => onLinkedChange(v === 'all' ? '' : v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="All" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All</SelectItem>
+                    <SelectItem value="unlinked">Unlinked only</SelectItem>
+                    <SelectItem value="linked">Linked only</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/components/admin/network/DeviceTable.tsx
+++ b/components/admin/network/DeviceTable.tsx
@@ -3,12 +3,13 @@
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
-import { PiWifiHighBold } from 'react-icons/pi';
+import { PiWifiHighBold, PiUserPlusBold, PiBuildingsBold, PiUserCircleBold } from 'react-icons/pi';
 import { DeviceActionsMenu } from './DeviceActionsMenu';
 
-interface RuijieDevice {
+export interface RuijieListDevice {
   sn: string;
   device_name: string;
   model: string | null;
@@ -21,11 +22,18 @@ interface RuijieDevice {
   config_status: string | null;
   synced_at: string;
   mock_data: boolean;
+  customer_name?: string | null;
+  customer_order_id?: string | null;
+  corporate_site_id?: string | null;
 }
 
 function formatPct(value: number | null | undefined): string {
   if (value == null || Number.isNaN(value)) return '—';
   return `${Math.round(value)}%`;
+}
+
+function isDeviceUnlinked(device: RuijieListDevice): boolean {
+  return !device.customer_order_id && !device.corporate_site_id;
 }
 
 function statusBadge(status: string): { label: string; className: string } {
@@ -48,9 +56,10 @@ function statusBadge(status: string): { label: string; className: string } {
 }
 
 interface DeviceTableProps {
-  devices: RuijieDevice[];
+  devices: RuijieListDevice[];
   tunnelLimitReached: boolean;
-  onReboot: (device: RuijieDevice) => void;
+  onReboot: (device: RuijieListDevice) => void;
+  onLinkCustomer?: (device: RuijieListDevice) => void;
   formatRelativeTime: (date: string) => string;
 }
 
@@ -58,6 +67,7 @@ export function DeviceTable({
   devices,
   tunnelLimitReached,
   onReboot,
+  onLinkCustomer,
   formatRelativeTime,
 }: DeviceTableProps) {
   const router = useRouter();
@@ -69,7 +79,7 @@ export function DeviceTable({
           Devices Monitoring
         </CardTitle>
         <p className="text-xs text-slate-500">
-          Ruijie Wi-Fi fleet from Supabase cache · CPU / memory from live sync
+          Ruijie Wi-Fi fleet from Supabase cache · Link unlinked SNs to customer / site
         </p>
       </CardHeader>
       <CardContent className="p-0">
@@ -79,6 +89,7 @@ export function DeviceTable({
               <tr className="border-y border-slate-100 text-left text-xs uppercase tracking-wide text-slate-400">
                 <th className="px-4 py-3 font-medium">Device</th>
                 <th className="px-4 py-3 font-medium hidden md:table-cell">Model</th>
+                <th className="px-4 py-3 font-medium">Customer</th>
                 <th className="px-4 py-3 font-medium hidden lg:table-cell">Group</th>
                 <th className="px-4 py-3 font-medium hidden lg:table-cell">IP</th>
                 <th className="px-4 py-3 font-medium text-center">CPU</th>
@@ -92,7 +103,7 @@ export function DeviceTable({
             <tbody>
               {devices.length === 0 ? (
                 <tr>
-                  <td colSpan={10} className="px-4 py-10 text-center text-slate-400">
+                  <td colSpan={11} className="px-4 py-10 text-center text-slate-400">
                     No devices found
                   </td>
                 </tr>
@@ -100,6 +111,7 @@ export function DeviceTable({
                 devices.map((device) => {
                   const isOnline = device.status === 'online';
                   const status = statusBadge(device.status);
+                  const unlinked = isDeviceUnlinked(device);
 
                   return (
                     <tr
@@ -122,7 +134,7 @@ export function DeviceTable({
                               isOnline ? 'text-blue-500' : 'text-slate-400'
                             )}
                           />
-                          <span className="truncate max-w-[180px]">{device.device_name}</span>
+                          <span className="truncate max-w-[160px]">{device.device_name}</span>
                           {device.mock_data && (
                             <Badge
                               variant="outline"
@@ -132,9 +144,46 @@ export function DeviceTable({
                             </Badge>
                           )}
                         </Link>
+                        <p className="text-[11px] font-mono text-slate-400 mt-0.5 ml-6">
+                          {device.sn}
+                        </p>
                       </td>
                       <td className="px-4 py-3 text-slate-600 hidden md:table-cell">
                         {device.model || '—'}
+                      </td>
+                      <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                        {unlinked ? (
+                          <div className="flex items-center gap-2">
+                            <Badge
+                              variant="outline"
+                              className="bg-amber-50 text-amber-800 border-amber-200 font-medium"
+                            >
+                              Unlinked
+                            </Badge>
+                            {onLinkCustomer && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
+                                onClick={() => onLinkCustomer(device)}
+                              >
+                                <PiUserPlusBold className="w-3.5 h-3.5 mr-1" />
+                                Link
+                              </Button>
+                            )}
+                          </div>
+                        ) : (
+                          <div className="flex items-center gap-1.5 min-w-0">
+                            {device.corporate_site_id ? (
+                              <PiBuildingsBold className="w-3.5 h-3.5 text-blue-500 flex-shrink-0" />
+                            ) : (
+                              <PiUserCircleBold className="w-3.5 h-3.5 text-purple-500 flex-shrink-0" />
+                            )}
+                            <span className="truncate max-w-[140px] text-slate-700">
+                              {device.customer_name || 'Linked'}
+                            </span>
+                          </div>
+                        )}
                       </td>
                       <td className="px-4 py-3 text-slate-600 hidden lg:table-cell">
                         {device.group_name || '—'}
@@ -167,7 +216,11 @@ export function DeviceTable({
                           deviceName={device.device_name}
                           isOnline={isOnline}
                           tunnelLimitReached={tunnelLimitReached}
+                          isUnlinked={unlinked}
                           onReboot={() => onReboot(device)}
+                          onLinkCustomer={
+                            onLinkCustomer ? () => onLinkCustomer(device) : undefined
+                          }
                         />
                       </td>
                     </tr>

--- a/components/admin/network/LinkCustomerDialog.tsx
+++ b/components/admin/network/LinkCustomerDialog.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+/**
+ * Shared dialog for linking a Ruijie device SN → consumer order or corporate site.
+ *
+ * API contract (POST /api/ruijie/devices/[sn]/link):
+ * - body: { type: "consumer"|"corporate", customer_order_id? | corporate_site_id? }
+ * - search: GET /api/admin/search/customers?q= (min 2 chars)
+ */
+
+import { useState, useCallback } from 'react';
+import {
+  PiMagnifyingGlassBold,
+  PiUserCircleBold,
+  PiBuildingsBold,
+  PiMapPinBold,
+  PiSpinnerBold,
+} from 'react-icons/pi';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+
+export interface CustomerSearchResult {
+  id: string;
+  type: 'consumer' | 'corporate';
+  name: string;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+}
+
+interface LinkCustomerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Device serial number to link */
+  sn: string;
+  deviceName?: string | null;
+  onLinked?: () => void;
+}
+
+export function LinkCustomerDialog({
+  open,
+  onOpenChange,
+  sn,
+  deviceName,
+  onLinked,
+}: LinkCustomerDialogProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<CustomerSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [linking, setLinking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setSearchQuery('');
+    setSearchResults([]);
+    setError(null);
+    setSearching(false);
+    setLinking(false);
+  }, []);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleSearch = useCallback(async () => {
+    if (!searchQuery.trim() || searchQuery.trim().length < 2) {
+      setError('Enter at least 2 characters to search');
+      return;
+    }
+
+    setSearching(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/admin/search/customers?q=${encodeURIComponent(searchQuery)}`,
+        { credentials: 'include' }
+      );
+
+      if (!response.ok) {
+        const data = await response.json();
+        setError(data.error || 'Search failed');
+        setSearchResults([]);
+        return;
+      }
+
+      const data = await response.json();
+      setSearchResults(data.results || []);
+
+      if ((data.results || []).length === 0) {
+        setError('No customers found matching your search');
+      }
+    } catch (err) {
+      console.error('Search failed:', err);
+      setError('Search failed. Please try again.');
+      setSearchResults([]);
+    } finally {
+      setSearching(false);
+    }
+  }, [searchQuery]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  const handleLink = async (result: CustomerSearchResult) => {
+    setLinking(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/ruijie/devices/${encodeURIComponent(sn)}/link`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: result.type,
+          customer_order_id: result.type === 'consumer' ? result.id : undefined,
+          corporate_site_id: result.type === 'corporate' ? result.id : undefined,
+        }),
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        setError(data.error || 'Failed to link customer');
+        return;
+      }
+
+      handleOpenChange(false);
+      onLinked?.();
+    } catch (err) {
+      console.error('Link failed:', err);
+      setError('Failed to link customer. Please try again.');
+    } finally {
+      setLinking(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Link Device to Customer</DialogTitle>
+          <DialogDescription>
+            Search for a consumer order or corporate site to link{' '}
+            <span className="font-medium text-slate-700">
+              {deviceName || sn}
+            </span>
+            {deviceName ? (
+              <span className="font-mono text-xs text-slate-500"> ({sn})</span>
+            ) : null}
+            .
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <PiMagnifyingGlassBold className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+              <Input
+                placeholder="Search by name, email, or phone..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="pl-9"
+                autoFocus
+              />
+            </div>
+            <Button onClick={handleSearch} disabled={searching}>
+              {searching ? (
+                <PiSpinnerBold className="w-4 h-4 animate-spin" />
+              ) : (
+                'Search'
+              )}
+            </Button>
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-600 text-center py-2">{error}</p>
+          )}
+
+          {searchResults.length > 0 && (
+            <div className="border border-slate-200 rounded-lg divide-y divide-slate-100 max-h-80 overflow-y-auto">
+              {searchResults.map((result) => (
+                <button
+                  key={`${result.type}-${result.id}`}
+                  type="button"
+                  className="w-full p-3 text-left hover:bg-slate-50 transition-colors disabled:opacity-50"
+                  onClick={() => handleLink(result)}
+                  disabled={linking}
+                >
+                  <div className="flex items-start gap-3">
+                    <div
+                      className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
+                        result.type === 'corporate' ? 'bg-blue-100' : 'bg-purple-100'
+                      }`}
+                    >
+                      {result.type === 'corporate' ? (
+                        <PiBuildingsBold className="w-4 h-4 text-blue-600" />
+                      ) : (
+                        <PiUserCircleBold className="w-4 h-4 text-purple-600" />
+                      )}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium text-slate-900 truncate">{result.name}</p>
+                        <Badge
+                          variant="outline"
+                          className={
+                            result.type === 'corporate'
+                              ? 'text-blue-600 border-blue-200'
+                              : 'text-purple-600 border-purple-200'
+                          }
+                        >
+                          {result.type === 'corporate' ? 'Corporate' : 'Consumer'}
+                        </Badge>
+                      </div>
+                      {result.email && (
+                        <p className="text-xs text-slate-500 truncate mt-0.5">{result.email}</p>
+                      )}
+                      {result.address && (
+                        <p className="text-xs text-slate-400 truncate flex items-center gap-1 mt-0.5">
+                          <PiMapPinBold className="w-3 h-3 flex-shrink-0" />
+                          {result.address}
+                        </p>
+                      )}
+                    </div>
+                    {linking && (
+                      <PiSpinnerBold className="w-4 h-4 text-slate-400 animate-spin" />
+                    )}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {!searching && searchQuery && searchResults.length === 0 && !error && (
+            <div className="text-center py-8 text-slate-500">
+              <PiMagnifyingGlassBold className="w-8 h-8 mx-auto mb-2 text-slate-300" />
+              <p>No results found</p>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/admin/network/detail/DeviceCustomerLink.tsx
+++ b/components/admin/network/detail/DeviceCustomerLink.tsx
@@ -1,33 +1,24 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import {
   PiUserBold,
   PiLinkBold,
   PiLinkBreakBold,
-  PiMagnifyingGlassBold,
   PiUserCircleBold,
   PiBuildingsBold,
   PiEnvelopeBold,
   PiPhoneBold,
-  PiMapPinBold,
-  PiCheckCircleBold,
   PiSpinnerBold,
 } from 'react-icons/pi';
 import { Button } from '@/components/ui/button';
 import { SectionCard } from '@/components/admin/shared';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
+import { LinkCustomerDialog } from '@/components/admin/network/LinkCustomerDialog';
 
 interface Device {
   sn: string;
+  device_name?: string | null;
   customer_name: string | null;
   customer_email: string | null;
   customer_phone: string | null;
@@ -35,115 +26,36 @@ interface Device {
   corporate_site_id: string | null;
 }
 
-interface SearchResult {
-  id: string;
-  type: 'consumer' | 'corporate';
-  name: string;
-  email: string | null;
-  phone: string | null;
-  address: string | null;
-}
-
 interface DeviceCustomerLinkProps {
   device: Device;
   onUpdate: () => void;
 }
 
+/**
+ * Customer Assignment panel on device detail.
+ * Link API: POST/DELETE `/api/ruijie/devices/[sn]/link` — see route JSDoc.
+ */
 export function DeviceCustomerLink({ device, onUpdate }: DeviceCustomerLinkProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-  const [searching, setSearching] = useState(false);
-  const [linking, setLinking] = useState(false);
   const [unlinking, setUnlinking] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const isLinked = device.customer_name !== null;
-  const linkType = device.customer_order_id ? 'consumer' : device.corporate_site_id ? 'corporate' : null;
-
-  const handleSearch = useCallback(async () => {
-    if (!searchQuery.trim() || searchQuery.trim().length < 2) {
-      setError('Enter at least 2 characters to search');
-      return;
-    }
-
-    setSearching(true);
-    setError(null);
-
-    try {
-      const response = await fetch(
-        `/api/admin/search/customers?q=${encodeURIComponent(searchQuery)}`,
-        { credentials: 'include' }
-      );
-
-      if (!response.ok) {
-        const data = await response.json();
-        setError(data.error || 'Search failed');
-        setSearchResults([]);
-        return;
-      }
-
-      const data = await response.json();
-      setSearchResults(data.results || []);
-
-      if (data.results.length === 0) {
-        setError('No customers found matching your search');
-      }
-    } catch (err) {
-      console.error('Search failed:', err);
-      setError('Search failed. Please try again.');
-      setSearchResults([]);
-    } finally {
-      setSearching(false);
-    }
-  }, [searchQuery]);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      handleSearch();
-    }
-  };
-
-  const handleLink = async (result: SearchResult) => {
-    setLinking(true);
-    setError(null);
-
-    try {
-      const response = await fetch(`/api/ruijie/devices/${device.sn}/link`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          type: result.type,
-          customer_order_id: result.type === 'consumer' ? result.id : undefined,
-          corporate_site_id: result.type === 'corporate' ? result.id : undefined,
-        }),
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        setError(data.error || 'Failed to link customer');
-        return;
-      }
-
-      setDialogOpen(false);
-      setSearchQuery('');
-      setSearchResults([]);
-      onUpdate();
-    } catch (err) {
-      console.error('Link failed:', err);
-      setError('Failed to link customer. Please try again.');
-    } finally {
-      setLinking(false);
-    }
-  };
+  const isLinked =
+    device.customer_name !== null ||
+    device.customer_order_id !== null ||
+    device.corporate_site_id !== null;
+  const linkType = device.customer_order_id
+    ? 'consumer'
+    : device.corporate_site_id
+      ? 'corporate'
+      : null;
 
   const handleUnlink = async () => {
     setUnlinking(true);
     setError(null);
 
     try {
-      const response = await fetch(`/api/ruijie/devices/${device.sn}/link`, {
+      const response = await fetch(`/api/ruijie/devices/${encodeURIComponent(device.sn)}/link`, {
         method: 'DELETE',
         credentials: 'include',
       });
@@ -163,19 +75,11 @@ export function DeviceCustomerLink({ device, onUpdate }: DeviceCustomerLinkProps
     }
   };
 
-  const handleOpenDialog = () => {
-    setDialogOpen(true);
-    setSearchQuery('');
-    setSearchResults([]);
-    setError(null);
-  };
-
   return (
     <>
       <SectionCard icon={PiUserBold} title="Customer Assignment" compact>
         {isLinked ? (
           <div className="space-y-4">
-            {/* Linked Customer Info */}
             <div className="p-4 bg-emerald-50 border border-emerald-200 rounded-lg">
               <div className="flex items-start gap-3">
                 <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
@@ -188,7 +92,7 @@ export function DeviceCustomerLink({ device, onUpdate }: DeviceCustomerLinkProps
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
                     <p className="font-semibold text-slate-900 truncate">
-                      {device.customer_name}
+                      {device.customer_name || 'Linked customer'}
                     </p>
                     <Badge
                       className={
@@ -216,7 +120,6 @@ export function DeviceCustomerLink({ device, onUpdate }: DeviceCustomerLinkProps
               </div>
             </div>
 
-            {/* Unlink Button */}
             <Button
               variant="outline"
               className="w-full border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
@@ -231,13 +134,10 @@ export function DeviceCustomerLink({ device, onUpdate }: DeviceCustomerLinkProps
               Unlink Customer
             </Button>
 
-            {error && (
-              <p className="text-sm text-red-600 text-center">{error}</p>
-            )}
+            {error && <p className="text-sm text-red-600 text-center">{error}</p>}
           </div>
         ) : (
           <div className="space-y-4">
-            {/* No Customer Linked */}
             <div className="p-4 bg-slate-50 border border-slate-200 rounded-lg text-center">
               <div className="w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-3">
                 <PiUserBold className="w-6 h-6 text-slate-400" />
@@ -250,10 +150,9 @@ export function DeviceCustomerLink({ device, onUpdate }: DeviceCustomerLinkProps
               </p>
             </div>
 
-            {/* Link Button */}
             <Button
               className="w-full bg-primary hover:bg-primary/90"
-              onClick={handleOpenDialog}
+              onClick={() => setDialogOpen(true)}
             >
               <PiLinkBold className="w-4 h-4 mr-2" />
               Link to Customer
@@ -262,115 +161,13 @@ export function DeviceCustomerLink({ device, onUpdate }: DeviceCustomerLinkProps
         )}
       </SectionCard>
 
-      {/* Search Dialog */}
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle>Link Device to Customer</DialogTitle>
-            <DialogDescription>
-              Search for a consumer order or corporate site to link this device.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4">
-            {/* Search Input */}
-            <div className="flex gap-2">
-              <div className="relative flex-1">
-                <PiMagnifyingGlassBold className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
-                <Input
-                  placeholder="Search by name, email, or phone..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="pl-9"
-                  autoFocus
-                />
-              </div>
-              <Button onClick={handleSearch} disabled={searching}>
-                {searching ? (
-                  <PiSpinnerBold className="w-4 h-4 animate-spin" />
-                ) : (
-                  'Search'
-                )}
-              </Button>
-            </div>
-
-            {/* Error Message */}
-            {error && (
-              <p className="text-sm text-red-600 text-center py-2">{error}</p>
-            )}
-
-            {/* Search Results */}
-            {searchResults.length > 0 && (
-              <div className="border border-slate-200 rounded-lg divide-y divide-slate-100 max-h-80 overflow-y-auto">
-                {searchResults.map((result) => (
-                  <button
-                    key={`${result.type}-${result.id}`}
-                    className="w-full p-3 text-left hover:bg-slate-50 transition-colors disabled:opacity-50"
-                    onClick={() => handleLink(result)}
-                    disabled={linking}
-                  >
-                    <div className="flex items-start gap-3">
-                      <div
-                        className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
-                          result.type === 'corporate'
-                            ? 'bg-blue-100'
-                            : 'bg-purple-100'
-                        }`}
-                      >
-                        {result.type === 'corporate' ? (
-                          <PiBuildingsBold className="w-4 h-4 text-blue-600" />
-                        ) : (
-                          <PiUserCircleBold className="w-4 h-4 text-purple-600" />
-                        )}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <p className="font-medium text-slate-900 truncate">
-                            {result.name}
-                          </p>
-                          <Badge
-                            variant="outline"
-                            className={
-                              result.type === 'corporate'
-                                ? 'text-blue-600 border-blue-200'
-                                : 'text-purple-600 border-purple-200'
-                            }
-                          >
-                            {result.type === 'corporate' ? 'Corporate' : 'Consumer'}
-                          </Badge>
-                        </div>
-                        {result.email && (
-                          <p className="text-xs text-slate-500 truncate mt-0.5">
-                            {result.email}
-                          </p>
-                        )}
-                        {result.address && (
-                          <p className="text-xs text-slate-400 truncate flex items-center gap-1 mt-0.5">
-                            <PiMapPinBold className="w-3 h-3 flex-shrink-0" />
-                            {result.address}
-                          </p>
-                        )}
-                      </div>
-                      {linking && (
-                        <PiSpinnerBold className="w-4 h-4 text-slate-400 animate-spin" />
-                      )}
-                    </div>
-                  </button>
-                ))}
-              </div>
-            )}
-
-            {/* Empty State after search */}
-            {!searching && searchQuery && searchResults.length === 0 && !error && (
-              <div className="text-center py-8 text-slate-500">
-                <PiMagnifyingGlassBold className="w-8 h-8 mx-auto mb-2 text-slate-300" />
-                <p>No results found</p>
-              </div>
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
+      <LinkCustomerDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        sn={device.sn}
+        deviceName={device.device_name}
+        onLinked={onUpdate}
+      />
     </>
   );
 }

--- a/components/admin/network/index.ts
+++ b/components/admin/network/index.ts
@@ -3,3 +3,5 @@ export { DeviceStatCards } from './DeviceStatCards';
 export { DeviceFilters } from './DeviceFilters';
 export { DeviceCard } from './DeviceCard';
 export { DeviceTable } from './DeviceTable';
+export type { RuijieListDevice } from './DeviceTable';
+export { LinkCustomerDialog } from './LinkCustomerDialog';

--- a/docs/analysis/2026-07-31-consumer-service-order-orphans.md
+++ b/docs/analysis/2026-07-31-consumer-service-order-orphans.md
@@ -1,0 +1,59 @@
+# Consumer service ↔ billable order orphan audit
+
+**Date:** 2026-07-31  
+**Script:** `scripts/billing/audit-consumer-service-order-orphans.ts`  
+**Workstream:** Near-term BSS floor (Task C1)
+
+## Definition
+
+- **Consumer service:** `customer_services` with `active=true` and `status=active`, excluding clinic/corporate categories (`corporate`, `business_connectivity`) and Unjani packages.
+- **Billable order:** `consumer_orders.billing_active = true` for the same `customer_id`.
+- **Orphan:** active consumer service with no billable order.
+
+## Dry-run results (live DB, 2026-07-31)
+
+| Metric | Count |
+|--------|------:|
+| Active services (all) | 24 |
+| Active consumer services | 4 |
+| Customers with `billing_active` order | 3 |
+| Matched | 3 |
+| **Orphans** | **1** |
+| Reverse gaps | 0 |
+
+### Matched (OK)
+
+| Customer | Service package | Billable order |
+|----------|-----------------|----------------|
+| Shaun Robertson | SkyFibre Home Plus | ORD-20251108-9841 |
+| Prins Mhlanga | SkyFibre Home Plus | ORD-20251210-6408 |
+| Ashwyn Watkins | CircleConnect 5G 35 Mbps | ORD-20260508-5728 |
+
+### Orphan (needs ops decision — **not auto-fixed**)
+
+| Field | Value |
+|-------|--------|
+| Service ID | `59e7c744-2ad8-4911-97a7-a537242c749e` |
+| Customer | Raymund Watson (`412b8047-47eb-4d01-9328-431ac0e360dc`) |
+| Package | CircleConnect 5G 60 Mbps @ R649 |
+| Activation | 2026-06-04 |
+| Last invoice | 2026-07-02 |
+| Invoices | INV-2026-00012 (paid R605.64); INV-2026-00036 (sent R649) |
+| Candidate order | ORD-20260529-1561 (`413ebaa8-1b0c-4e6a-8098-eb38567801f1`) status=`payment_method_pending` |
+| Other order | ORD-20260519-0313 cancelled |
+
+**Suggested fix:** link (set `billing_active=true` on ORD-20260529-1561) **after** ops confirms payment method / mandate state. Do **not** deactivate: customer has paid invoices.
+
+```bash
+# After ops sign-off only:
+set -a && source .env.local && set +a && \
+  npx tsx scripts/billing/audit-consumer-service-order-orphans.ts \
+    --action=link \
+    --service-id=59e7c744-2ad8-4911-97a7-a537242c749e \
+    --order-id=413ebaa8-1b0c-4e6a-8098-eb38567801f1 \
+    --execute
+```
+
+## Execute status
+
+`--execute` was **not** used. Dry-run only. Re-run audit after ops applies link to confirm zero orphans.

--- a/docs/architecture/adr/2026-07-31-near-term-bss-goal.md
+++ b/docs/architecture/adr/2026-07-31-near-term-bss-goal.md
@@ -1,0 +1,89 @@
+# ADR: Near-term BSS goal — revenue-first with ops floor
+
+**Status:** Accepted  
+**Date:** 2026-07-31  
+**Deciders:** Product / Jeffrey (via wayfinder map *Near-term BSS goal*)  
+**Wayfinder:** `.scratch/near-term-bss-goal/` (tickets 01–07)
+
+---
+
+## Context
+
+- Commercial pressure requires a clear **near-term** focus: convert leads to paid orders without waiting on full BSS/Zoho Inventory/FSM build-out.
+- March 2026 paid social proved **capture works** and **follow-up failed** (large share of leads unworked).
+- Meta WhatsApp Business is **ready** for Flows (verified business, GREEN quality, API scopes); **F1 is not implemented** in the repo.
+- `coverage_leads` capture + alerts exist; there is **no admin workbench** for assignment/SLA.
+- Separate billing maps (engine, recon hub, service↔invoice leakage) are decision-complete; they support ops hygiene but do not replace the revenue bet.
+- WhatsApp **084** support/Desk bridge is a **parallel** support channel effort, not the sales F1 bet.
+
+---
+
+## Decision
+
+**Near-term goal = revenue-first with ops floor.**
+
+### 1. Primary revenue bet
+
+**Lead → paid order conversion**, with choke points:
+
+1. Lead follow-up (assignment, visibility, first response)  
+2. Then quote / KYC (existing B2B journey)
+
+Not: Inventory, FSM, or full provisioning automation first.
+
+### 2. WhatsApp F1 MVP only
+
+| IN | OUT |
+|----|-----|
+| **F1 Lead Qualification** Flow (static/`navigate`) | F2 B2B deep-qualification |
+| 4 screens: Contact → Address → Interest → Contact pref + POPIA | F3 follow-up booking |
+| Entry: site/landing WA link, QR, admin manual send | In-chat quote / KYC / checkout / full order journey |
+| CTWA ads optional later (same flow_id) | Replacing human sales with in-chat close |
+
+**CRM outcome on F1 complete:** insert `coverage_leads` (`lead_source = whatsapp_flow`) + sales alert email + customer confirmation template. Zoho CRM sync **best-effort** (must not drop the lead if Zoho fails).
+
+### 3. Admin lead follow-up MVP
+
+| IN | OUT |
+|----|-----|
+| Admin `coverage_leads` queue + detail | Full CRM / pipeline redesign |
+| Owner via `assigned_admin_id` (or equivalent) | Partner UI rebuild |
+| First-response SLA: **2h business hours** + escalate uncontacted | Zoho lead retry engine |
+| Zoho sync status **visible** (display only) | Admin support tickets as SoR (Desk remains support SoR) |
+
+Queue must accept `whatsapp_flow` leads when F1 ships.
+
+### 4. Service-delivery floor (from Phase 1 roadmap)
+
+| IN (floor) | OUT (deferred under this goal) |
+|------------|--------------------------------|
+| **1.4** Device ↔ customer linkage for critical sites/APs | **1.1** Full fulfillment/dispatch/activation stub pages |
+| **1.3** Minimal `sla_tracking` / activation failure path fix | **1.2** Admin support ticket detail UI rebuild |
+| **1.6** Consumer service/order orphan data fix | **1.5** Env var hygiene polish |
+
+### 5. Explicit out of near-term goal
+
+- Zoho Inventory (Phase 3) and Zoho FSM (Phase 4) implementation  
+- Full MTN wholesale ordering API programme  
+- Full in-chat lead → paid order WhatsApp journey  
+- Phase 5 commercial depth (commissions, exec dashboard, RICA automation, etc.)  
+- Non-floor Phase 1 work unless required to hold the floor  
+
+WhatsApp ↔ Zoho Desk bridge on **084** is **not** this ADR’s primary bet (support channel; track separately).
+
+---
+
+## Consequences
+
+- **Spec / build order:** (1) admin follow-up MVP and/or F1 foundation can proceed per sequencing in `/to-spec`; both feed the same lead→paid-order funnel. (2) Floor fixes keep existing paid base operable.  
+- **Roadmap:** Phase 1 exit criteria in the long roadmap (“ops runs full fulfillment UI”) are **not** the near-term exit criteria; use this ADR’s floor + revenue bet instead.  
+- **Later maps:** F2/F3, full WhatsApp order Flow, Inventory/FSM after revenue milestones (numeric gates not locked here).  
+- **Implementation:** Exact Flow Builder field names locked at build time against the F1 TypeScript contract (`docs/plans/2026-07-08-whatsapp-flows-sales-crm.md`).
+
+---
+
+## Related
+
+- Wayfinder map: `.scratch/near-term-bss-goal/map.md`  
+- Roadmap: `docs/plans/2026-07-29-bss-zoho-feature-roadmap.md`  
+- F1 plan: `docs/plans/2026-07-08-whatsapp-flows-sales-crm.md`  

--- a/docs/integrations/whatsapp/F1_LEAD_QUALIFICATION_OPS.md
+++ b/docs/integrations/whatsapp/F1_LEAD_QUALIFICATION_OPS.md
@@ -159,3 +159,16 @@ ops/scheduler/check-drift.sh
 ## Out of scope here
 
 F2/F3, full in-chat order, Desk bridge on 084, Inventory/FSM.
+
+## Staging E2E (2026-07-31)
+
+| Step | Result |
+|------|--------|
+| Env `WHATSAPP_FLOW_LEAD_QUALIFICATION_ID` | Set on `/home/circletel/.env.staging` → container |
+| Draft send fix | `mode` must be under `parameters`, not `flow_action_payload` (commit `1fa99b1f`) |
+| `POST /api/admin/whatsapp/flows/send` draft | **200** — wamid delivered to `27737288016` |
+| Session | `whatsapp_flow_sessions` status `sent` → after nfm_reply `completed` |
+| Lead | `coverage_leads` `lead_source=whatsapp_flow`, SLA `first_response_due_at` set |
+
+**Phone completion:** Meta app webhooks still point at **production**. Completing the Flow on-device will hit prod until webhook/code is live there. Staging full path verified with a synthetic `nfm_reply` POST to staging webhook using the real `flow_token`.
+

--- a/docs/integrations/whatsapp/F1_LEAD_QUALIFICATION_OPS.md
+++ b/docs/integrations/whatsapp/F1_LEAD_QUALIFICATION_OPS.md
@@ -21,37 +21,61 @@
 
 ## 1. Build DRAFT flow in Meta Flow Builder
 
-1. Meta Business Suite → WhatsApp Manager → **Flows** → Create flow.
-2. Name: `lead_qualification` (or similar; code stores `flow_name` as `lead_qualification` by default in sender).
-3. **First screen name must be `CONTACT`** (matches `F1_DEFAULT_SCREEN` in `flow-sender.ts`). If you use a different first screen, update code before send.
-4. Four screens (product contract):
-   - **CONTACT** — name, customer type, email, phone, company
-   - **ADDRESS** — address, suburb, city, province
-   - **INTEREST** — service_interest, speed, budget_range
-   - **PREF** — contact_preference, best_contact_time, popia_optin
+### Live DRAFT (created 2026-07-31 via Flows API)
+
+| Field | Value |
+|-------|--------|
+| **Flow ID** | `2044303956204342` |
+| **Name** | `lead_qualification` |
+| **Status** | `DRAFT` |
+| **JSON version** | `6.0` |
+| **Category** | `LEAD_GENERATION` |
+| **Validation** | empty (no errors) |
+| **Source JSON** | `docs/integrations/whatsapp/flows/f1_lead_qualification.flow.json` |
+| **Local env** | `WHATSAPP_FLOW_LEAD_QUALIFICATION_ID=2044303956204342` (`.env.local`) |
+
+**Screens:** `CONTACT` → `ADDRESS` → `INTEREST` → `PREF` (terminal). First screen matches `F1_DEFAULT_SCREEN` in `flow-sender.ts`.
+
+**Re-upload / edit (keep DRAFT):**
+
+```bash
+set -a && source .env.local && set +a
+FLOW_JSON=$(python3 -c 'import json; print(json.dumps(json.load(open("docs/integrations/whatsapp/flows/f1_lead_qualification.flow.json"))))')
+curl -sS -X POST "https://graph.facebook.com/v21.0/2044303956204342" \
+  -H "Authorization: Bearer ${WHATSAPP_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"flow_json\": $(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' <<<"$FLOW_JSON")}"
+```
+
+Or recreate from WABA if deleted:
+
+```bash
+# POST /{WABA-ID}/flows with name, categories, flow_json, publish:false
+# See scripts note / source JSON above
+```
+
+**Coolify/production:** set the same flow ID env after deploy; draft sends require `"draft": true` until published.
 
 ### Field names (must match TypeScript exactly)
 
 | Flow field name | Required | Notes |
 |-----------------|----------|--------|
-| `first_name` | yes | |
-| `last_name` | yes | |
-| `customer_type` | yes | Prefer values `consumer` / `business` (`business` → DB `smme`) |
-| `email` | no | |
+| `first_name` | yes | CONTACT |
+| `last_name` | yes | CONTACT |
+| `customer_type` | yes | `consumer` / `business` (`business` → DB `smme`) |
+| `email` | no | CONTACT |
 | `phone` | no | Webhook sender used if empty |
-| `company_name` | no | Show if business |
-| `address` | yes | |
-| `suburb` | yes | |
-| `city` | yes | |
-| `province` | no | |
-| `service_interest` | yes | Maps to `requested_service_type` |
-| `speed` | no | |
-| `budget_range` | no | |
-| `contact_preference` | yes | |
-| `best_contact_time` | no | |
-| `popia_optin` | yes | Must be `true` boolean; false → no lead |
-
-Save **flow ID** from Meta (numeric string).
+| `company_name` | no | CONTACT optional |
+| `address` | yes | ADDRESS |
+| `suburb` | yes | ADDRESS |
+| `city` | yes | ADDRESS |
+| `province` | no | SA provinces dropdown |
+| `service_interest` | yes | INTEREST → `requested_service_type` |
+| `speed` | no | INTEREST |
+| `budget_range` | no | INTEREST |
+| `contact_preference` | yes | PREF |
+| `best_contact_time` | no | PREF |
+| `popia_optin` | yes | OptIn; must be true to create lead |
 
 ---
 

--- a/docs/integrations/whatsapp/F1_LEAD_QUALIFICATION_OPS.md
+++ b/docs/integrations/whatsapp/F1_LEAD_QUALIFICATION_OPS.md
@@ -1,0 +1,137 @@
+# F1 Lead Qualification — Meta Ops & E2E Runbook
+
+**Date:** 2026-07-31  
+**Code status:** Implemented on `feat/near-term-f1-followup-floor` (A1–A5)  
+**This document:** Task A6 — Meta Flow Builder, env, draft/publish E2E (ops + engineer)
+
+---
+
+## Prerequisites (already in code)
+
+| Item | Location |
+|------|----------|
+| Session table + `whatsapp_flow` enum | Applied migration `20260731020000_whatsapp_flow_sessions.sql` |
+| `nfm_reply` webhook branch | `app/api/webhooks/whatsapp/route.ts` |
+| Handler + tests | `lib/integrations/whatsapp/flows/` |
+| Admin send | `POST /api/admin/whatsapp/flows/send` |
+| Admin queue | `/admin/leads` |
+| Env placeholder | `.env.example` → `WHATSAPP_FLOW_LEAD_QUALIFICATION_ID` |
+
+---
+
+## 1. Build DRAFT flow in Meta Flow Builder
+
+1. Meta Business Suite → WhatsApp Manager → **Flows** → Create flow.
+2. Name: `lead_qualification` (or similar; code stores `flow_name` as `lead_qualification` by default in sender).
+3. **First screen name must be `CONTACT`** (matches `F1_DEFAULT_SCREEN` in `flow-sender.ts`). If you use a different first screen, update code before send.
+4. Four screens (product contract):
+   - **CONTACT** — name, customer type, email, phone, company
+   - **ADDRESS** — address, suburb, city, province
+   - **INTEREST** — service_interest, speed, budget_range
+   - **PREF** — contact_preference, best_contact_time, popia_optin
+
+### Field names (must match TypeScript exactly)
+
+| Flow field name | Required | Notes |
+|-----------------|----------|--------|
+| `first_name` | yes | |
+| `last_name` | yes | |
+| `customer_type` | yes | Prefer values `consumer` / `business` (`business` → DB `smme`) |
+| `email` | no | |
+| `phone` | no | Webhook sender used if empty |
+| `company_name` | no | Show if business |
+| `address` | yes | |
+| `suburb` | yes | |
+| `city` | yes | |
+| `province` | no | |
+| `service_interest` | yes | Maps to `requested_service_type` |
+| `speed` | no | |
+| `budget_range` | no | |
+| `contact_preference` | yes | |
+| `best_contact_time` | no | |
+| `popia_optin` | yes | Must be `true` boolean; false → no lead |
+
+Save **flow ID** from Meta (numeric string).
+
+---
+
+## 2. Environment
+
+| Variable | Where |
+|----------|--------|
+| `WHATSAPP_FLOW_LEAD_QUALIFICATION_ID` | `.env.local`, Coolify/production |
+| Existing WA token / phone number ID | already required for Cloud API |
+| `WHATSAPP_APP_SECRET` | recommended for signature verify (separate hardening) |
+
+```bash
+# After setting flow id:
+grep WHATSAPP_FLOW_LEAD_QUALIFICATION_ID .env.local
+```
+
+Redeploy app after Coolify env change.
+
+---
+
+## 3. Draft E2E (test phone)
+
+```bash
+# Admin session cookie required for API; or use Meta draft send from Flow Builder.
+# Prefer admin API once logged into admin:
+
+curl -sS -X POST "https://www.circletel.co.za/api/admin/whatsapp/flows/send" \
+  -H "Content-Type: application/json" \
+  -H "Cookie: <admin-session>" \
+  -d '{"phone":"27XXXXXXXXX","entry_source":"admin","draft":true}'
+```
+
+1. Complete flow on test handset.
+2. Confirm webhook logs show `nfm_reply` / F1 handler lines.
+3. Confirm one row in `coverage_leads` with `lead_source = whatsapp_flow`.
+4. Confirm `whatsapp_flow_sessions.status = completed` and `coverage_lead_id` set.
+5. Capture real payload → replace fixtures under  
+   `lib/integrations/whatsapp/flows/__tests__/fixtures/`.
+6. Re-run tests:
+   ```bash
+   npx jest --testPathIgnorePatterns='/node_modules/' \
+     --modulePathIgnorePatterns='/node_modules/' \
+     --testPathPatterns='flow-response-handler.test'
+   ```
+
+---
+
+## 4. Publish + production smoke
+
+1. Publish flow in Meta when draft E2E is green.
+2. Production send (non-draft) to controlled number.
+3. Open `/admin/leads` — lead visible; assign owner; notes save.
+4. Optional: submit flow-button template for **admin cold-send** outside 24h window (MARKETING; can lag).
+
+---
+
+## 5. Post-deploy ops
+
+```bash
+# After production has lead-followup-sla route:
+ops/scheduler/generate-crontab.sh | crontab -
+ops/scheduler/check-drift.sh
+```
+
+**Do not** install crontab until the route is live on the host/app that `APP_URL` points to.
+
+---
+
+## 6. Acceptance checklist (near-term goal)
+
+- [ ] Draft F1 completes; webhook shows `nfm_reply`
+- [ ] Exactly one `coverage_leads` row per flow_token (retry = idempotent)
+- [ ] POPIA false → no lead
+- [ ] Sales alert email + customer free-form confirm
+- [ ] Zoho fail still leaves Supabase lead
+- [ ] Admin can send F1 (`/api/admin/whatsapp/flows/send`)
+- [ ] Queue + 2h SLA badges + escalation cron (after crontab install)
+
+---
+
+## Out of scope here
+
+F2/F3, full in-chat order, Desk bridge on 084, Inventory/FSM.

--- a/docs/integrations/whatsapp/flows/f1_lead_qualification.flow.json
+++ b/docs/integrations/whatsapp/flows/f1_lead_qualification.flow.json
@@ -1,0 +1,297 @@
+{
+  "version": "6.0",
+  "screens": [
+    {
+      "id": "CONTACT",
+      "title": "Your details",
+      "data": {},
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "TextHeading",
+            "text": "CircleTel enquiry"
+          },
+          {
+            "type": "TextBody",
+            "text": "Tell us who you are so we can help with coverage and packages."
+          },
+          {
+            "type": "Form",
+            "name": "contact_form",
+            "children": [
+              {
+                "type": "TextInput",
+                "name": "first_name",
+                "label": "First name",
+                "required": true,
+                "input-type": "text"
+              },
+              {
+                "type": "TextInput",
+                "name": "last_name",
+                "label": "Last name",
+                "required": true,
+                "input-type": "text"
+              },
+              {
+                "type": "RadioButtonsGroup",
+                "name": "customer_type",
+                "label": "Customer type",
+                "required": true,
+                "data-source": [
+                  { "id": "consumer", "title": "Home / Consumer" },
+                  { "id": "business", "title": "Business" }
+                ]
+              },
+              {
+                "type": "TextInput",
+                "name": "email",
+                "label": "Email",
+                "required": false,
+                "input-type": "email",
+                "helper-text": "Optional"
+              },
+              {
+                "type": "TextInput",
+                "name": "phone",
+                "label": "Phone",
+                "required": false,
+                "input-type": "phone",
+                "helper-text": "Optional if WhatsApp number is correct"
+              },
+              {
+                "type": "TextInput",
+                "name": "company_name",
+                "label": "Company",
+                "required": false,
+                "input-type": "text",
+                "helper-text": "Optional (business)"
+              }
+            ]
+          },
+          {
+            "type": "Footer",
+            "label": "Continue",
+            "on-click-action": {
+              "name": "navigate",
+              "next": { "type": "screen", "name": "ADDRESS" },
+              "payload": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "ADDRESS",
+      "title": "Service address",
+      "data": {},
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "TextHeading",
+            "text": "Where do you need service?"
+          },
+          {
+            "type": "Form",
+            "name": "address_form",
+            "children": [
+              {
+                "type": "TextInput",
+                "name": "address",
+                "label": "Street address",
+                "required": true,
+                "input-type": "text"
+              },
+              {
+                "type": "TextInput",
+                "name": "suburb",
+                "label": "Suburb",
+                "required": true,
+                "input-type": "text"
+              },
+              {
+                "type": "TextInput",
+                "name": "city",
+                "label": "City",
+                "required": true,
+                "input-type": "text"
+              },
+              {
+                "type": "Dropdown",
+                "name": "province",
+                "label": "Province",
+                "required": false,
+                "data-source": [
+                  { "id": "Eastern Cape", "title": "Eastern Cape" },
+                  { "id": "Free State", "title": "Free State" },
+                  { "id": "Gauteng", "title": "Gauteng" },
+                  { "id": "KwaZulu-Natal", "title": "KwaZulu-Natal" },
+                  { "id": "Limpopo", "title": "Limpopo" },
+                  { "id": "Mpumalanga", "title": "Mpumalanga" },
+                  { "id": "North West", "title": "North West" },
+                  { "id": "Northern Cape", "title": "Northern Cape" },
+                  { "id": "Western Cape", "title": "Western Cape" }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "Footer",
+            "label": "Continue",
+            "on-click-action": {
+              "name": "navigate",
+              "next": { "type": "screen", "name": "INTEREST" },
+              "payload": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "INTEREST",
+      "title": "What you need",
+      "data": {},
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "TextHeading",
+            "text": "Service interest"
+          },
+          {
+            "type": "Form",
+            "name": "interest_form",
+            "children": [
+              {
+                "type": "Dropdown",
+                "name": "service_interest",
+                "label": "Service",
+                "required": true,
+                "data-source": [
+                  { "id": "fibre", "title": "Fibre" },
+                  { "id": "wireless", "title": "Fixed Wireless" },
+                  { "id": "5g_lte", "title": "5G / LTE" },
+                  { "id": "business_connectivity", "title": "Business connectivity" },
+                  { "id": "managed_it", "title": "Managed IT" },
+                  { "id": "unsure", "title": "Not sure yet" }
+                ]
+              },
+              {
+                "type": "Dropdown",
+                "name": "speed",
+                "label": "Speed need",
+                "required": false,
+                "data-source": [
+                  { "id": "up_to_50", "title": "Up to 50 Mbps" },
+                  { "id": "50_100", "title": "50–100 Mbps" },
+                  { "id": "100_200", "title": "100–200 Mbps" },
+                  { "id": "200_plus", "title": "200+ Mbps" },
+                  { "id": "unsure", "title": "Not sure" }
+                ]
+              },
+              {
+                "type": "Dropdown",
+                "name": "budget_range",
+                "label": "Budget / mo",
+                "required": false,
+                "data-source": [
+                  { "id": "under_500", "title": "Under R500" },
+                  { "id": "500_1000", "title": "R500–R1,000" },
+                  { "id": "1000_2000", "title": "R1,000–R2,000" },
+                  { "id": "2000_plus", "title": "R2,000+" },
+                  { "id": "unsure", "title": "Not sure" }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "Footer",
+            "label": "Continue",
+            "on-click-action": {
+              "name": "navigate",
+              "next": { "type": "screen", "name": "PREF" },
+              "payload": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "PREF",
+      "title": "Contact & consent",
+      "terminal": true,
+      "success": true,
+      "data": {},
+      "layout": {
+        "type": "SingleColumnLayout",
+        "children": [
+          {
+            "type": "TextHeading",
+            "text": "How should we reach you?"
+          },
+          {
+            "type": "Form",
+            "name": "pref_form",
+            "children": [
+              {
+                "type": "Dropdown",
+                "name": "contact_preference",
+                "label": "Contact via",
+                "required": true,
+                "data-source": [
+                  { "id": "whatsapp", "title": "WhatsApp" },
+                  { "id": "phone", "title": "Phone call" },
+                  { "id": "email", "title": "Email" }
+                ]
+              },
+              {
+                "type": "Dropdown",
+                "name": "best_contact_time",
+                "label": "Best time",
+                "required": false,
+                "data-source": [
+                  { "id": "morning", "title": "Morning (8–12)" },
+                  { "id": "afternoon", "title": "Afternoon (12–17)" },
+                  { "id": "anytime", "title": "Anytime business hours" }
+                ]
+              },
+              {
+                "type": "OptIn",
+                "name": "popia_optin",
+                "label": "I agree to CircleTel contacting me about this enquiry (POPIA).",
+                "required": true
+              }
+            ]
+          },
+          {
+            "type": "Footer",
+            "label": "Submit enquiry",
+            "on-click-action": {
+              "name": "complete",
+              "payload": {
+                "first_name": "${screen.CONTACT.form.first_name}",
+                "last_name": "${screen.CONTACT.form.last_name}",
+                "customer_type": "${screen.CONTACT.form.customer_type}",
+                "email": "${screen.CONTACT.form.email}",
+                "phone": "${screen.CONTACT.form.phone}",
+                "company_name": "${screen.CONTACT.form.company_name}",
+                "address": "${screen.ADDRESS.form.address}",
+                "suburb": "${screen.ADDRESS.form.suburb}",
+                "city": "${screen.ADDRESS.form.city}",
+                "province": "${screen.ADDRESS.form.province}",
+                "service_interest": "${screen.INTEREST.form.service_interest}",
+                "speed": "${screen.INTEREST.form.speed}",
+                "budget_range": "${screen.INTEREST.form.budget_range}",
+                "contact_preference": "${form.contact_preference}",
+                "best_contact_time": "${form.best_contact_time}",
+                "popia_optin": "${form.popia_optin}"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-31-near-term-f1-followup-floor.md
+++ b/docs/superpowers/plans/2026-07-31-near-term-f1-followup-floor.md
@@ -1,0 +1,261 @@
+# Near-term F1 + Admin Follow-up + Ops Floor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship WhatsApp F1 lead capture, admin lead follow-up (2h SLA), and ops floor fixes per ADR `docs/architecture/adr/2026-07-31-near-term-bss-goal.md`.
+
+**Architecture:** Three independent workstreams share `coverage_leads`. F1 writes leads via webhook `nfm_reply`; admin queue assigns and SLAs them; floor stabilizes devices/activation/orphan data. Deterministic CRM writes (no LLM in control plane).
+
+**Tech Stack:** Next.js 15 App Router, Supabase, WhatsApp Cloud API Flows, Resend, existing admin RBAC patterns.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-near-term-f1-followup-floor-design.md`  
+**Do not implement until explicitly executing this plan.**
+
+---
+
+## File map
+
+| Area | Create | Modify |
+|------|--------|--------|
+| F1 | `lib/integrations/whatsapp/flows/*`, migration `whatsapp_flow_sessions`, admin send route, tests | `app/api/webhooks/whatsapp/route.ts`, `lib/integrations/whatsapp/index.ts` |
+| Follow-up | `app/admin/leads/**`, `app/api/admin/leads/**`, SLA cron, migration columns | admin nav |
+| Floor | audit script, optional sla migration or activator guard, device link UI glue | `lib/activation/service-activator.ts`, Ruijie link API/UI |
+
+---
+
+## Workstream C — Ops floor (start first if parallel capacity is limited)
+
+### Task C1: Consumer orphan service audit + fix script
+
+**Files:**
+- Create: `scripts/billing/audit-consumer-service-order-orphans.ts`
+- Docs: append result note to `docs/analysis/` if fix applied
+
+- [ ] **Step 1:** Query active consumer services vs `consumer_orders` with `billing_active` (or project’s billable flag); print orphans.
+- [ ] **Step 2:** With ops confirmation, deactivate orphan **or** link to order; dry-run default, `--execute` writes.
+- [ ] **Step 3:** Re-run audit; expect zero unexplained orphans.
+- [ ] **Step 4:** Commit script + one-line result note.
+
+### Task C2: Guard or create `sla_tracking` path
+
+**Files:**
+- Modify: `lib/activation/service-activator.ts` (~line 115)
+- Optional Create: `supabase/migrations/YYYYMMDDHHMMSS_sla_tracking_minimal.sql`
+
+- [ ] **Step 1:** Confirm whether `sla_tracking` exists in live DB (`information_schema` / select).
+- [ ] **Step 2:** If missing: either add minimal table **or** wrap insert in existence check / try-catch that logs and continues without swallowing all errors.
+- [ ] **Step 3:** Unit or integration test: activator does not throw on missing SLA when guarded.
+- [ ] **Step 4:** Commit.
+
+### Task C3: Device ↔ customer linkage ops path
+
+**Files:**
+- Modify: existing Ruijie link API if needed
+- Create or Modify: admin devices list with link action (smallest UI that uses existing API)
+
+- [ ] **Step 1:** Document current link API request/response from code.
+- [ ] **Step 2:** Admin table: unlinked devices + customer/order picker + link.
+- [ ] **Step 3:** Link ≥ critical sites (ops list); verify `ruijie_device_cache.customer_order_id` or `corporate_site_id` set.
+- [ ] **Step 4:** Commit.
+
+---
+
+## Workstream B — Admin follow-up
+
+### Task B1: Schema for assignment + SLA
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDDHHMMSS_coverage_leads_followup_sla.sql`
+
+```sql
+-- Apply manually to shared DB (no CI migration runner).
+ALTER TABLE public.coverage_leads
+  ADD COLUMN IF NOT EXISTS assigned_admin_id uuid REFERENCES public.admin_users(id),
+  ADD COLUMN IF NOT EXISTS first_response_due_at timestamptz,
+  ADD COLUMN IF NOT EXISTS first_responded_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_coverage_leads_followup_queue
+  ON public.coverage_leads (status, first_response_due_at, created_at DESC);
+```
+
+- [ ] **Step 1:** Confirm `admin_users.id` type matches uuid.
+- [ ] **Step 2:** Write migration file; apply to shared DB manually; verify columns.
+- [ ] **Step 3:** Commit migration file only after apply verified (or commit with ops note if apply is manual later).
+
+### Task B2: Business-hours SLA helper
+
+**Files:**
+- Create: `lib/leads/first-response-sla.ts`
+- Test: `__tests__/lib/leads/first-response-sla.test.ts`
+
+- [ ] **Step 1:** Write failing tests for `addBusinessHours(start, 2)` SAST Mon–Fri 08:00–17:00 (cross weekend, mid-day, after hours).
+- [ ] **Step 2:** Implement helper; tests green.
+- [ ] **Step 3:** Commit.
+
+### Task B3: Admin leads API
+
+**Files:**
+- Create: `app/api/admin/leads/route.ts` (GET list)
+- Create: `app/api/admin/leads/[id]/route.ts` (GET one, PATCH)
+
+- [ ] **Step 1:** GET list: session auth + service role query; filters `status`, `assigned_admin_id`, `overdue` (`first_response_due_at < now` AND `first_responded_at is null` AND status=new), `q` search name/phone/email, `lead_source`.
+- [ ] **Step 2:** PATCH: notes, status, assigned_admin_id, next_follow_up_at; on first response set `first_responded_at` and `last_contacted_at`.
+- [ ] **Step 3:** On create paths that insert leads (later F1), set `first_response_due_at` via helper — for existing leads backfill optional script.
+- [ ] **Step 4:** Smoke with curl as admin; commit.
+
+### Task B4: Admin leads UI
+
+**Files:**
+- Create: `app/admin/leads/page.tsx`
+- Create: `app/admin/leads/[id]/page.tsx`
+- Modify: admin navigation config (find existing nav registry / sidebar)
+
+- [ ] **Step 1:** Queue table with SLA badge (green / amber / red).
+- [ ] **Step 2:** Detail: fields + notes + assign select of admin_users + save.
+- [ ] **Step 3:** Nav entry **Leads** (Sales workspace if multi-workspace).
+- [ ] **Step 4:** Manual UI pass; commit.
+
+### Task B5: SLA escalation cron
+
+**Files:**
+- Create: `app/api/cron/lead-followup-sla/route.ts`
+- Modify: `vercel.json` crons + regenerate host crontab via `ops/scheduler/generate-crontab.sh | crontab -`
+
+- [ ] **Step 1:** Cron GET/POST with `CRON_SECRET`; query overdue first response; Resend to sales inbox; dedupe via metadata or last alert column if needed.
+- [ ] **Step 2:** Schedule e.g. every 30 min business hours or hourly.
+- [ ] **Step 3:** Install crontab with `--max-time 360` generator; `check-drift.sh`.
+- [ ] **Step 4:** Commit.
+
+---
+
+## Workstream A — WhatsApp F1
+
+### Task A1: Migration + enum
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDDHHMMSS_whatsapp_flow_sessions.sql`
+
+```sql
+ALTER TYPE public.lead_source ADD VALUE IF NOT EXISTS 'whatsapp_flow';
+
+CREATE TABLE public.whatsapp_flow_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  flow_token text NOT NULL UNIQUE,
+  flow_id text NOT NULL,
+  flow_name text NOT NULL,
+  phone text NOT NULL,
+  entry_source text NOT NULL,
+  source_campaign text,
+  status text NOT NULL DEFAULT 'sent',
+  response_payload jsonb,
+  raw_webhook jsonb,
+  coverage_lead_id uuid REFERENCES public.coverage_leads(id),
+  whatsapp_message_id text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz
+);
+
+ALTER TABLE public.whatsapp_flow_sessions ENABLE ROW LEVEL SECURITY;
+-- service role only (no anon policies)
+```
+
+- [ ] **Step 1:** Apply manually to shared DB; verify enum + table.
+- [ ] **Step 2:** Commit migration file.
+
+### Task A2: Types + session store + handler tests (TDD)
+
+**Files:**
+- Create: `lib/integrations/whatsapp/flows/types.ts`
+- Create: `lib/integrations/whatsapp/flows/session-store.ts`
+- Create: `lib/integrations/whatsapp/flows/flow-response-handler.ts`
+- Create: `lib/integrations/whatsapp/flows/__tests__/flow-response-handler.test.ts`
+- Create: fixtures under `__tests__/.../fixtures/nfm_reply_f1.json` (replace with real payload after Meta draft test)
+
+- [ ] **Step 1:** Define `F1LeadQualificationResponse` + type guard per design field map.
+- [ ] **Step 2:** Tests: happy path → lead insert mocked supabase; unknown token; duplicate complete; popia false; malformed JSON.
+- [ ] **Step 3:** Implement handler; tests green.
+- [ ] **Step 4:** Commit.
+
+### Task A3: Flow sender + webhook wire
+
+**Files:**
+- Create: `lib/integrations/whatsapp/flows/flow-sender.ts`
+- Modify: `lib/integrations/whatsapp/index.ts` exports
+- Modify: `app/api/webhooks/whatsapp/route.ts` — branch `interactive.nfm_reply`
+
+- [ ] **Step 1:** `sendFlow` creates session then posts Cloud API interactive flow message.
+- [ ] **Step 2:** Webhook calls handler; always return 200.
+- [ ] **Step 3:** Persist non-flow inbound optional log (nice-to-have, not required).
+- [ ] **Step 4:** Commit.
+
+### Task A4: Confirmation + sales alert
+
+**Files:**
+- Modify: handler after lead insert
+- Reuse: Resend patterns from billing notify; confirmation template name TBD (`circletel_lead_received` or existing)
+
+- [ ] **Step 1:** On success, send confirmation template (or temporary free-form only if 24h window — prefer template).
+- [ ] **Step 2:** Sales alert email with deep link `/admin/leads/[id]`.
+- [ ] **Step 3:** Set `first_response_due_at` on lead insert via B2 helper.
+- [ ] **Step 4:** Commit.
+
+### Task A5: Admin send endpoint
+
+**Files:**
+- Create: `app/api/admin/whatsapp/flows/send/route.ts`
+
+- [ ] **Step 1:** POST `{ phone, entry_source, source_campaign? }` RBAC admin; calls `sendFlow`.
+- [ ] **Step 2:** Manual test with draft flow + test number.
+- [ ] **Step 3:** Commit.
+
+### Task A6: Meta Flow Builder + env + E2E (ops + engineer)
+
+**Files:**
+- Modify: `.env.example` with `WHATSAPP_FLOW_LEAD_QUALIFICATION_ID=`
+- Coolify env (ops)
+
+- [ ] **Step 1:** Build DRAFT F1 in Meta Flow Builder; field names match `types.ts`.
+- [ ] **Step 2:** Draft send E2E; capture real `nfm_reply` into fixtures; re-run tests.
+- [ ] **Step 3:** Set env; staging E2E; publish flow; production E2E on controlled number.
+- [ ] **Step 4:** Submit flow-button template if admin cold-send required (can lag).
+
+---
+
+## Env checklist
+
+| Var | Where |
+|-----|--------|
+| Existing WA vars | already |
+| `WHATSAPP_FLOW_LEAD_QUALIFICATION_ID` | local + Coolify |
+| `WHATSAPP_APP_SECRET` | Coolify before signature verify (Desk bridge / hardening) |
+| `CRON_SECRET` | already |
+
+---
+
+## Self-review
+
+| Spec section | Tasks |
+|--------------|--------|
+| F1 fields/CRM | A1–A6 |
+| Admin queue/SLA | B1–B5 |
+| Floor 1.3/1.4/1.6 | C1–C3 |
+| Non-goals | Not tasked |
+
+No placeholder “TBD implement later” steps for core paths; Meta template approval may lag admin cold-send.
+
+---
+
+## Execution handoff
+
+**Plan complete.** Saved to:
+
+- Spec: `docs/superpowers/specs/2026-07-31-near-term-f1-followup-floor-design.md`
+- Plan: `docs/superpowers/plans/2026-07-31-near-term-f1-followup-floor.md`
+
+**Two execution options (when you choose to implement):**
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task + review  
+2. **Inline Execution** — executing-plans in session with checkpoints  
+
+**Do not implement until you pick one.**

--- a/docs/superpowers/specs/2026-07-31-near-term-f1-followup-floor-design.md
+++ b/docs/superpowers/specs/2026-07-31-near-term-f1-followup-floor-design.md
@@ -1,0 +1,264 @@
+# Near-term: WhatsApp F1 + Admin Follow-up + Ops Floor — Design Spec
+
+**Date:** 2026-07-31  
+**Status:** Spec + implementation plan complete — **do not implement** until an explicit execute choice  
+**ADR:** `docs/architecture/adr/2026-07-31-near-term-bss-goal.md`  
+**Wayfinder:** `.scratch/near-term-bss-goal/` (destination met)  
+**Implementation plan:** `docs/superpowers/plans/2026-07-31-near-term-f1-followup-floor.md`  
+**Related plans:** `docs/plans/2026-07-08-whatsapp-flows-sales-crm.md`, `docs/plans/2026-07-29-bss-zoho-feature-roadmap.md`
+
+---
+
+## 1. Overview
+
+### Goals
+
+Deliver the **accepted near-term BSS goal** as three shippable workstreams that can land independently but share the lead funnel:
+
+| Workstream | Outcome |
+|------------|---------|
+| **A — WhatsApp F1** | Customer completes Lead Qualification Flow → row in `coverage_leads` within seconds + confirmation + sales alert |
+| **B — Admin follow-up** | Sales works unworked leads: queue, owner, notes, 2h first-response SLA, Zoho status visible |
+| **C — Ops floor** | Device↔customer linkage for Ruijie APs; minimal activation/SLA path fix; consumer orphan service data fix |
+
+### Non-goals
+
+- F2 / F3 WhatsApp Flows  
+- Full in-chat quote / KYC / checkout / order  
+- Zoho Inventory / FSM  
+- Admin support ticket UI rebuild (Desk remains support SoR)  
+- WhatsApp ↔ Zoho Desk bridge on 084 (separate plan)  
+- Full fulfillment stub pages (1.1)
+
+---
+
+## 2. Current baseline (verified 2026-07-31)
+
+| Fact | Evidence |
+|------|----------|
+| Meta WABA ready for Flows | Wayfinder research 01: verified, GREEN, scopes OK; **0 flows** |
+| F1 code | **None** — no `nfm_reply`, no `whatsapp_flow_sessions`, no flows module |
+| `coverage_leads` | Exists with contact, address, interest, follow-up timestamps, Zoho sync columns; **no `assigned_admin_id`** |
+| Admin “leads” | `app/admin/sales-engine/leads` is **lead scoring**, not a follow-up workbench on `coverage_leads` |
+| Ruijie | **22/22** devices sampled unlinked (`customer_order_id` null) |
+| Activation | `lib/activation/service-activator.ts` references **`sla_tracking`** (orphan risk) |
+| Active services | 24; billing day-1 cron live |
+
+---
+
+## 3. Workstream A — WhatsApp F1 Lead Qualification
+
+### 3.1 Product contract (locked)
+
+- **Boundary:** F1 only  
+- **Entry:** site/landing WA link, QR, admin manual send (CTWA later, same flow)  
+- **Screens:** Contact → Address → Interest → Contact pref + POPIA  
+- **CRM:** `coverage_leads` + sales alert + confirmation; Zoho best-effort  
+
+### 3.2 Field ↔ column map
+
+Flow field names (Flow Builder + TypeScript must match exactly):
+
+| Flow field | `coverage_leads` column | Notes |
+|------------|-------------------------|--------|
+| `first_name` | `first_name` | required |
+| `last_name` | `last_name` | required |
+| `customer_type` | `customer_type` | `consumer` \| `business` (normalize) |
+| `email` | `email` | optional |
+| `phone` | `phone` | prefer webhook sender WA id if form empty |
+| `company_name` | `company_name` | optional; show if business |
+| `address` | `address` | required |
+| `suburb` | `suburb` | required |
+| `city` | `city` | required |
+| `province` | `province` | optional |
+| `service_interest` | `requested_service_type` | map labels → existing enums where possible |
+| `speed` | `requested_speed` | optional string |
+| `budget_range` | `budget_range` | optional |
+| `contact_preference` | `contact_preference` | required |
+| `best_contact_time` | `best_contact_time` | optional |
+| `popia_optin` | `metadata.popia_optin` + reject if false | required true |
+
+Also set on insert:
+
+- `lead_source` = `whatsapp_flow` (**requires** `ALTER TYPE ... ADD VALUE`)  
+- `source_campaign` from session  
+- `status` = `new`  
+- `metadata.entry_source`, `metadata.flow_token`, `metadata.flow_id`  
+
+### 3.3 Data model
+
+**New table `whatsapp_flow_sessions`** (service-role only RLS):
+
+| Column | Type | Notes |
+|--------|------|--------|
+| `id` | uuid PK | |
+| `flow_token` | text UNIQUE | correlation; single-use complete |
+| `flow_id` | text | Meta flow id |
+| `flow_name` | text | e.g. `lead_qualification` |
+| `phone` | text | E.164 digits |
+| `entry_source` | text | `website` \| `qr` \| `admin` \| `ctwa_ad` \| `manual` |
+| `source_campaign` | text nullable | |
+| `status` | text | `sent` → `completed` \| `expired` \| `failed_parse` |
+| `response_payload` | jsonb | parsed form |
+| `raw_webhook` | jsonb | dead-letter |
+| `coverage_lead_id` | uuid FK nullable | |
+| `whatsapp_message_id` | text nullable | |
+| `created_at` / `updated_at` / `completed_at` | timestamptz | |
+
+### 3.4 Components (code)
+
+| Unit | Path | Responsibility |
+|------|------|----------------|
+| Types + guards | `lib/integrations/whatsapp/flows/types.ts` | F1 response type + `isF1Response` |
+| Session repo | `lib/integrations/whatsapp/flows/session-store.ts` | create/lookup/complete session |
+| Sender | `lib/integrations/whatsapp/flows/flow-sender.ts` | `sendFlow`, `sendFlowTemplate` |
+| Completion handler | `lib/integrations/whatsapp/flows/flow-response-handler.ts` | parse → lead insert → alert |
+| Webhook branch | `app/api/webhooks/whatsapp/route.ts` | `nfm_reply` → handler; always 200 |
+| Admin send API | `app/api/admin/whatsapp/flows/send/route.ts` | RBAC; manual F1 send |
+| Public entry helpers | site CTAs already using `CONTACT.WHATSAPP_LINK` + optional prefilled text pointing to “start flow” once published |
+
+### 3.5 Meta / env (ops + code)
+
+| Item | Owner |
+|------|--------|
+| Build F1 in Flow Builder (DRAFT) | Ops + engineer |
+| Draft E2E → capture real `nfm_reply` fixture | Engineer |
+| `WHATSAPP_FLOW_LEAD_QUALIFICATION_ID` | `.env.local`, Coolify, `.env.example` |
+| Flow-button template `circletel_lead_qualification` (MARKETING) | Meta approval |
+| Publish flow when staging green | Ops |
+
+### 3.6 Acceptance criteria (A)
+
+1. Draft F1 completes on a test phone; webhook logs show `nfm_reply`.  
+2. Completing F1 creates exactly one `coverage_leads` row (duplicate webhook = no second lead).  
+3. False POPIA → no lead; session `failed_parse` or explicit reject status.  
+4. Sales alert email sent; customer confirmation template attempted.  
+5. Zoho failure still leaves lead in Supabase with sync error fields set.  
+6. Admin can send F1 to a number (RBAC).  
+7. Unit tests for handler use real payload fixtures (no mock of parser core).
+
+---
+
+## 4. Workstream B — Admin lead follow-up MVP
+
+### 4.1 Product contract (locked)
+
+Queue + detail + assign owner + 2h SLA + Zoho status visible. Not full CRM.
+
+### 4.2 Schema
+
+Migration additive:
+
+```sql
+ALTER TABLE public.coverage_leads
+  ADD COLUMN IF NOT EXISTS assigned_admin_id uuid REFERENCES admin_users(id),
+  ADD COLUMN IF NOT EXISTS first_response_due_at timestamptz,
+  ADD COLUMN IF NOT EXISTS first_responded_at timestamptz;
+
+-- Optional index for queue
+CREATE INDEX IF NOT EXISTS idx_coverage_leads_queue
+  ON public.coverage_leads (status, next_follow_up_at, created_at DESC);
+```
+
+**SLA rule:** On insert (any source) or when status becomes `new`, set  
+`first_response_due_at = created_at + 2 business hours` (SAST Mon–Fri 08:00–17:00 — reuse or add small helper in `lib/dates/business-days.ts`).
+
+On first staff note or status change from `new` → non-new: set `first_responded_at` if null.
+
+### 4.3 Surfaces
+
+| Surface | Path | Behaviour |
+|---------|------|-----------|
+| Queue page | `app/admin/leads/page.tsx` (new; **not** sales-engine scoring page) | Table: name, phone, source, status, age, owner, Zoho status, SLA badge (ok / due soon / overdue) |
+| Detail | `app/admin/leads/[id]/page.tsx` | Full lead fields, notes editor → `follow_up_notes` + bump `last_contacted_at` / `follow_up_count`, set `next_follow_up_at`, assign owner |
+| List API | `app/api/admin/leads/route.ts` | Filters: status, source, assigned, overdue SLA, search |
+| Patch API | `app/api/admin/leads/[id]/route.ts` | Update notes, status, assignment, next follow-up |
+| SLA cron | `app/api/cron/lead-followup-sla/route.ts` | Find `new` + `first_response_due_at < now` + `first_responded_at is null`; send escalate email (existing sales-alert pattern); log execution |
+| Nav | admin nav config | Link **Leads** under Sales / appropriate workspace |
+
+Auth: existing admin session + RBAC pattern from `app/api/admin/billing/whatsapp/send`.
+
+### 4.4 Acceptance criteria (B)
+
+1. Admin sees all `coverage_leads` including `whatsapp_flow` when present.  
+2. Can assign owner; queue filters by unassigned / mine / overdue.  
+3. SLA badge correct for business-hours math.  
+4. Cron emails on overdue first response (dry-run flag optional).  
+5. Zoho columns display-only (no new retry engine).  
+6. Does not replace Desk for support tickets.
+
+---
+
+## 5. Workstream C — Ops floor
+
+### 5.1 Device ↔ customer linkage (1.4)
+
+| Item | Spec |
+|------|------|
+| Problem | All Ruijie APs unlinked |
+| API | Existing `/api/ruijie/devices/[sn]/link` (verify/extend) |
+| Admin | Minimal bulk link UI or table on network devices: SN → customer / order / corporate site |
+| Success | Critical paying sites linkable; reporting can join device → customer |
+
+### 5.2 Minimal activation / SLA path (1.3)
+
+| Item | Spec |
+|------|------|
+| Problem | `service-activator` writes `sla_tracking` which may be missing |
+| Options (pick at implement) | (a) add thin `sla_tracking` table if product still wants SLA rows, or (b) remove/guard insert so activation does not swallow/throw on missing table |
+| Success | Activation path does not fail silently on missing relation; errors logged/alerted |
+
+### 5.3 Consumer orphan service (1.6)
+
+| Item | Spec |
+|------|------|
+| Problem | Active consumer service without matching `billing_active` order (was 4 vs 3) |
+| Work | Scripted audit + data fix (link or deactivate orphan) with finance/ops sign-off |
+| Success | Documented 1:1 active consumer service ↔ billable order (or explicit exception) |
+
+---
+
+## 6. Sequencing
+
+Recommended ship order (each independently testable):
+
+```
+C.1 orphan audit (XS)     ─┐
+C.2 sla_tracking guard    ─┼─ floor stabilizes base
+B.1 schema + APIs         ─┤
+B.2 queue UI + SLA cron   ─┼─ follow-up before/with F1
+A.1 migration + types     ─┤
+A.2 webhook + handler     ─┼─ F1 capture
+A.3 sender + admin send   ─┤
+A.4 Meta draft/publish    ─┘
+C.3 device link UI/ops    ── can parallel after C.1
+```
+
+F1 without admin queue re-creates the March gap — prefer **B before or with A**, not long after.
+
+---
+
+## 7. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| MARKETING template slow approval | Site/QR customer-initiated flow does not need template; template only for admin cold send |
+| Webhook drops inbound | Always 200; dead-letter on session; later persist inbound messages |
+| Double lead on Meta retry | Idempotent complete on `flow_token` |
+| assigned_admin_id FK to wrong table | Confirm `admin_users.id` vs auth.users |
+| Desk bridge / F1 share webhook | Same route: branch by message type; do not block F1 on Desk work |
+
+---
+
+## 8. Success criteria (near-term goal)
+
+1. F1 E2E: phone complete → lead + alert + confirm.  
+2. Unworked leads visible, assignable, SLA escalated after 2h business.  
+3. Floor: no activation hard-fail on sla_tracking; orphan fixed; ≥ critical APs linkable.  
+4. ADR non-goals remain unbuilt.
+
+---
+
+## 9. Out of scope (repeat)
+
+F2/F3, full WhatsApp order, Inventory, FSM, admin Desk UI, env polish, auto-debit of leads.

--- a/lib/activation/__tests__/service-activator-sla.test.ts
+++ b/lib/activation/__tests__/service-activator-sla.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Service Activator — SLA tracking guard
+ *
+ * Ensures SLA update continues (no throw) when public.sla_tracking is missing
+ * (PGRST205 / 42P01). Live DB currently has no sla_tracking table; activation
+ * must not hard-fail. activateService delegates to updateSlaTrackingOnActivation.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  isMissingRelationError,
+  updateSlaTrackingOnActivation,
+} from '@/lib/activation/service-activator';
+import { activationLogger } from '@/lib/logging';
+
+describe('isMissingRelationError', () => {
+  it('detects PostgREST schema-cache miss (PGRST205)', () => {
+    expect(
+      isMissingRelationError({
+        code: 'PGRST205',
+        message: "Could not find the table 'public.sla_tracking' in the schema cache",
+      })
+    ).toBe(true);
+  });
+
+  it('detects Postgres undefined_table (42P01)', () => {
+    expect(
+      isMissingRelationError({
+        code: '42P01',
+        message: 'relation "public.sla_tracking" does not exist',
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(
+      isMissingRelationError({ code: '42501', message: 'permission denied' })
+    ).toBe(false);
+    expect(isMissingRelationError(null)).toBe(false);
+  });
+});
+
+describe('updateSlaTrackingOnActivation (guard)', () => {
+  it('does not throw and warns when sla_tracking is missing (PGRST205)', async () => {
+    const warnSpy = jest.spyOn(activationLogger, 'warn').mockImplementation(() => undefined);
+    const errorSpy = jest.spyOn(activationLogger, 'error').mockImplementation(() => undefined);
+
+    const mockSupabase = {
+      from: jest.fn().mockReturnValue({
+        update: jest.fn().mockReturnValue({
+          eq: jest.fn().mockResolvedValue({
+            data: null,
+            error: {
+              code: 'PGRST205',
+              message:
+                "Could not find the table 'public.sla_tracking' in the schema cache",
+            },
+          }),
+        }),
+      }),
+    };
+
+    await expect(
+      updateSlaTrackingOnActivation(mockSupabase as never, 'order-missing-sla')
+    ).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('sla_tracking table missing'),
+      expect.objectContaining({ orderId: 'order-missing-sla', code: 'PGRST205' })
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('does not throw and logs error for non-missing SLA failures', async () => {
+    const errorSpy = jest.spyOn(activationLogger, 'error').mockImplementation(() => undefined);
+
+    const mockSupabase = {
+      from: jest.fn().mockReturnValue({
+        update: jest.fn().mockReturnValue({
+          eq: jest.fn().mockResolvedValue({
+            data: null,
+            error: {
+              code: '42501',
+              message: 'permission denied for table sla_tracking',
+            },
+          }),
+        }),
+      }),
+    };
+
+    await expect(
+      updateSlaTrackingOnActivation(mockSupabase as never, 'order-perm')
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to update SLA tracking',
+      expect.objectContaining({ orderId: 'order-perm', code: '42501' })
+    );
+
+    errorSpy.mockRestore();
+  });
+
+  it('does not throw when supabase client throws', async () => {
+    const errorSpy = jest.spyOn(activationLogger, 'error').mockImplementation(() => undefined);
+
+    const mockSupabase = {
+      from: jest.fn(() => {
+        throw new Error('network down');
+      }),
+    };
+
+    await expect(
+      updateSlaTrackingOnActivation(mockSupabase as never, 'order-throw')
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'SLA tracking update threw unexpectedly',
+      expect.objectContaining({ orderId: 'order-throw', error: 'network down' })
+    );
+
+    errorSpy.mockRestore();
+  });
+
+  it('logs info on successful SLA update', async () => {
+    const infoSpy = jest.spyOn(activationLogger, 'info').mockImplementation(() => undefined);
+
+    const mockSupabase = {
+      from: jest.fn().mockReturnValue({
+        update: jest.fn().mockReturnValue({
+          eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }),
+    };
+
+    await expect(
+      updateSlaTrackingOnActivation(mockSupabase as never, 'order-ok')
+    ).resolves.toBeUndefined();
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      'SLA tracking updated',
+      expect.objectContaining({ orderId: 'order-ok' })
+    );
+
+    infoSpy.mockRestore();
+  });
+});

--- a/lib/activation/service-activator.ts
+++ b/lib/activation/service-activator.ts
@@ -17,7 +17,7 @@ import { activationLogger } from '@/lib/logging';
  * 2. Updates contracts.status to 'active'
  * 3. Creates billing_cycle for recurring billing
  * 4. Creates customer portal account
- * 5. Updates SLA tracking
+ * 5. Best-effort SLA tracking update (skipped with warn if table missing)
  *
  * @param orderId - UUID of consumer_orders record
  */
@@ -110,20 +110,76 @@ export async function activateService(orderId: string): Promise<void> {
     // Don't throw - account can be created manually
   }
 
-  // 6. Update SLA tracking
-  const { error: slaError } = await supabase
-    .from('sla_tracking')
-    .update({ service_activated_at: new Date().toISOString() })
-    .eq('order_id', orderId);
-
-  if (slaError) {
-    activationLogger.error('Failed to update SLA tracking', { error: slaError.message });
-    // Don't throw - SLA tracking is not critical
-  } else {
-    activationLogger.info('SLA tracking updated');
-  }
+  // 6. Update SLA tracking (optional — table may not exist in all environments)
+  // Live DB currently lacks public.sla_tracking (archived fulfillment migration).
+  // Guard: never fail activation on missing relation; log clearly and continue.
+  await updateSlaTrackingOnActivation(supabase, orderId);
 
   activationLogger.info('Service activation complete', { orderId });
+}
+
+/**
+ * Detect PostgREST / Postgres "relation missing" errors.
+ * PGRST205 = schema-cache miss (Supabase client); 42P01 = undefined_table.
+ */
+export function isMissingRelationError(error: {
+  code?: string;
+  message?: string;
+} | null | undefined): boolean {
+  if (!error) return false;
+  const code = error.code ?? '';
+  if (code === 'PGRST205' || code === '42P01') return true;
+  const message = (error.message ?? '').toLowerCase();
+  return (
+    message.includes('could not find the table') ||
+    message.includes('does not exist') ||
+    message.includes('schema cache')
+  );
+}
+
+/**
+ * Best-effort SLA milestone update. Activation must not depend on sla_tracking.
+ */
+export async function updateSlaTrackingOnActivation(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  orderId: string
+): Promise<void> {
+  try {
+    const { error: slaError } = await supabase
+      .from('sla_tracking')
+      .update({ service_activated_at: new Date().toISOString() })
+      .eq('order_id', orderId);
+
+    if (slaError) {
+      if (isMissingRelationError(slaError)) {
+        activationLogger.warn(
+          'sla_tracking table missing — skipping SLA update; activation continues',
+          {
+            orderId,
+            code: slaError.code,
+            error: slaError.message,
+          }
+        );
+        return;
+      }
+
+      activationLogger.error('Failed to update SLA tracking', {
+        orderId,
+        code: slaError.code,
+        error: slaError.message,
+      });
+      // Don't throw — SLA tracking is not critical to activation
+      return;
+    }
+
+    activationLogger.info('SLA tracking updated', { orderId });
+  } catch (error) {
+    // Defensive: unexpected throws (network, client bugs) must not fail activation
+    activationLogger.error('SLA tracking update threw unexpectedly', {
+      orderId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 /**

--- a/lib/admin/feature-registry.ts
+++ b/lib/admin/feature-registry.ts
@@ -222,6 +222,12 @@ export const featureSections: NavSection[] = [
         ],
       },
       {
+        name: 'Leads',
+        href: '/admin/leads',
+        icon: PiUserPlusBold,
+        description: 'Coverage lead follow-up queue with first-response SLA',
+      },
+      {
         name: 'B2B Feasibility',
         href: '/admin/sales/feasibility',
         icon: PiLightningBold,
@@ -507,6 +513,7 @@ export const ITEM_WORKSPACE: Record<string, WorkspaceId> = {
   Quotes: 'sales',
   Suppliers: 'sales',
   'Sales Engine': 'sales',
+  Leads: 'sales',
   'B2B Feasibility': 'sales',
   'Coverage Checker': 'sales',
   'CPQ Builder': 'sales',
@@ -546,6 +553,7 @@ export const ITEM_MODULE: Record<string, ModuleId> = {
   Suppliers: 'offers',
   'CPQ Builder': 'offers',
   'Sales Engine': 'sales',
+  Leads: 'sales',
   Partners: 'sales',
   'Competitor Analysis': 'sales',
   Marketing: 'sales',

--- a/lib/admin/workspace-access.ts
+++ b/lib/admin/workspace-access.ts
@@ -64,6 +64,7 @@ export const ADMIN_WORKSPACE_ROUTES: ReadonlyArray<{
   // sales (coverage/checker must beat platform's /admin/coverage — longest-first handles it)
   { prefix: '/admin/coverage/checker', workspace: 'sales', module: 'coverage' },
   { prefix: '/admin/sales-engine', workspace: 'sales', module: 'sales' },
+  { prefix: '/admin/leads', workspace: 'sales', module: 'sales' },
   { prefix: '/admin/sales/feasibility', workspace: 'sales', module: 'coverage' },
   { prefix: '/admin/competitor-analysis', workspace: 'sales', module: 'sales' },
   { prefix: '/admin/products', workspace: 'sales', module: 'offers' },

--- a/lib/integrations/whatsapp/flows/__tests__/fixtures/nfm_reply_f1.json
+++ b/lib/integrations/whatsapp/flows/__tests__/fixtures/nfm_reply_f1.json
@@ -1,0 +1,14 @@
+{
+  "from": "27821234567",
+  "id": "wamid.HBgNMjc4MjEyMzQ1NjcVAgASGBQzQUFBQUFBQUFBQUFBQUFBQUE=",
+  "timestamp": "1753900800",
+  "type": "interactive",
+  "interactive": {
+    "type": "nfm_reply",
+    "nfm_reply": {
+      "name": "flow",
+      "body": "Sent",
+      "response_json": "{\"flow_token\":\"f1-token-happy-path-0001\",\"first_name\":\"Thabo\",\"last_name\":\"Molefe\",\"customer_type\":\"consumer\",\"email\":\"thabo.molefe@example.com\",\"phone\":\"\",\"company_name\":\"\",\"address\":\"12 Main Road\",\"suburb\":\"Sandton\",\"city\":\"Johannesburg\",\"province\":\"Gauteng\",\"service_interest\":\"fibre\",\"speed\":\"100Mbps\",\"budget_range\":\"R500-R1000\",\"contact_preference\":\"whatsapp\",\"best_contact_time\":\"morning\",\"popia_optin\":true}"
+    }
+  }
+}

--- a/lib/integrations/whatsapp/flows/__tests__/fixtures/nfm_reply_f1_malformed.json
+++ b/lib/integrations/whatsapp/flows/__tests__/fixtures/nfm_reply_f1_malformed.json
@@ -1,0 +1,14 @@
+{
+  "from": "27821234567",
+  "id": "wamid.HBgNMjc4MjEyMzQ1NjcVAgASGBQzQUFBQUFBQUFBQUFBQUFBQUE=",
+  "timestamp": "1753900800",
+  "type": "interactive",
+  "interactive": {
+    "type": "nfm_reply",
+    "nfm_reply": {
+      "name": "flow",
+      "body": "Sent",
+      "response_json": "{not-valid-json"
+    }
+  }
+}

--- a/lib/integrations/whatsapp/flows/__tests__/fixtures/nfm_reply_f1_popia_false.json
+++ b/lib/integrations/whatsapp/flows/__tests__/fixtures/nfm_reply_f1_popia_false.json
@@ -1,0 +1,14 @@
+{
+  "from": "27821234567",
+  "id": "wamid.HBgNMjc4MjEyMzQ1NjcVAgASGBQzQUFBQUFBQUFBQUFBQUFBQUE=",
+  "timestamp": "1753900800",
+  "type": "interactive",
+  "interactive": {
+    "type": "nfm_reply",
+    "nfm_reply": {
+      "name": "flow",
+      "body": "Sent",
+      "response_json": "{\"flow_token\":\"f1-token-popia-false-0002\",\"first_name\":\"Thabo\",\"last_name\":\"Molefe\",\"customer_type\":\"consumer\",\"email\":\"thabo.molefe@example.com\",\"address\":\"12 Main Road\",\"suburb\":\"Sandton\",\"city\":\"Johannesburg\",\"service_interest\":\"fibre\",\"contact_preference\":\"whatsapp\",\"popia_optin\":false}"
+    }
+  }
+}

--- a/lib/integrations/whatsapp/flows/__tests__/flow-response-handler.test.ts
+++ b/lib/integrations/whatsapp/flows/__tests__/flow-response-handler.test.ts
@@ -1,0 +1,349 @@
+/**
+ * F1 flow-response-handler tests (TDD)
+ *
+ * Real parse logic against nfm_reply fixtures; Supabase mocked at the client boundary.
+ */
+
+import {
+  buildCoverageLeadInsert,
+  handleFlowCompletion,
+  parseNfmReplyResponseJson,
+} from '../flow-response-handler';
+import {
+  coerceF1LeadQualificationResponse,
+  isF1LeadQualificationResponse,
+  normalizeCustomerType,
+} from '../types';
+import type { WhatsAppFlowSession } from '../types';
+
+import happyFixture from './fixtures/nfm_reply_f1.json';
+import popiaFalseFixture from './fixtures/nfm_reply_f1_popia_false.json';
+import malformedFixture from './fixtures/nfm_reply_f1_malformed.json';
+
+// =============================================================================
+// MOCK SUPABASE
+// =============================================================================
+
+type SessionRow = WhatsAppFlowSession;
+type LeadInsert = Record<string, unknown>;
+
+function makeSession(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: 'session-uuid-1',
+    flow_token: 'f1-token-happy-path-0001',
+    flow_id: 'flow-id-f1',
+    flow_name: 'lead_qualification',
+    phone: '27821234567',
+    entry_source: 'website',
+    source_campaign: 'near-term-f1',
+    status: 'sent',
+    response_payload: null,
+    raw_webhook: null,
+    coverage_lead_id: null,
+    whatsapp_message_id: 'wamid.outbound-1',
+    created_at: '2026-07-30T10:00:00.000Z',
+    updated_at: '2026-07-30T10:00:00.000Z',
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+interface MockState {
+  sessions: Map<string, SessionRow>;
+  insertedLeads: LeadInsert[];
+  sessionUpdates: Array<{ token: string; patch: Record<string, unknown> }>;
+}
+
+function createMockSupabase(state: MockState) {
+  const from = jest.fn((table: string) => {
+    if (table === 'whatsapp_flow_sessions') {
+      return {
+        select: jest.fn(() => ({
+          eq: jest.fn((_col: string, token: string) => ({
+            maybeSingle: jest.fn(async () => {
+              const row = state.sessions.get(token) ?? null;
+              return { data: row, error: null };
+            }),
+            single: jest.fn(async () => {
+              const row = state.sessions.get(token) ?? null;
+              return {
+                data: row,
+                error: row ? null : { message: 'not found' },
+              };
+            }),
+          })),
+        })),
+        update: jest.fn((patch: Record<string, unknown>) => ({
+          eq: jest.fn(async (_col: string, token: string) => {
+            state.sessionUpdates.push({ token, patch });
+            const existing = state.sessions.get(token);
+            if (existing) {
+              state.sessions.set(token, {
+                ...existing,
+                ...patch,
+              } as SessionRow);
+            }
+            return { error: null };
+          }),
+        })),
+        insert: jest.fn(() => ({
+          select: jest.fn(() => ({
+            single: jest.fn(async () => ({ data: null, error: null })),
+          })),
+        })),
+      };
+    }
+
+    if (table === 'coverage_leads') {
+      return {
+        insert: jest.fn((row: LeadInsert) => {
+          state.insertedLeads.push(row);
+          return {
+            select: jest.fn(() => ({
+              single: jest.fn(async () => ({
+                data: { id: 'lead-uuid-new-1' },
+                error: null,
+              })),
+            })),
+          };
+        }),
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  });
+
+  return { from };
+}
+
+// =============================================================================
+// TYPE GUARD / PARSE
+// =============================================================================
+
+describe('isF1LeadQualificationResponse', () => {
+  it('accepts a valid happy-path form object', () => {
+    const raw = JSON.parse(happyFixture.interactive.nfm_reply.response_json);
+    expect(isF1LeadQualificationResponse(raw)).toBe(true);
+  });
+
+  it('rejects missing required fields', () => {
+    expect(
+      isF1LeadQualificationResponse({ first_name: 'A', last_name: 'B' })
+    ).toBe(false);
+  });
+
+  it('accepts string popia_optin "true"', () => {
+    const raw = JSON.parse(happyFixture.interactive.nfm_reply.response_json);
+    raw.popia_optin = 'true';
+    expect(isF1LeadQualificationResponse(raw)).toBe(true);
+    expect(coerceF1LeadQualificationResponse(raw).popia_optin).toBe(true);
+  });
+});
+
+describe('normalizeCustomerType', () => {
+  it('maps business → smme and consumer → consumer', () => {
+    expect(normalizeCustomerType('business')).toBe('smme');
+    expect(normalizeCustomerType('Consumer')).toBe('consumer');
+    expect(normalizeCustomerType('enterprise')).toBe('enterprise');
+  });
+});
+
+describe('parseNfmReplyResponseJson', () => {
+  it('parses happy fixture', () => {
+    const result = parseNfmReplyResponseJson(
+      happyFixture.interactive.nfm_reply.response_json
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.flowToken).toBe('f1-token-happy-path-0001');
+      expect(result.form.first_name).toBe('Thabo');
+      expect(result.form.popia_optin).toBe(true);
+    }
+  });
+
+  it('returns malformed_json for invalid JSON', () => {
+    const result = parseNfmReplyResponseJson(
+      malformedFixture.interactive.nfm_reply.response_json
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed_json');
+    }
+  });
+});
+
+// =============================================================================
+// HANDLER
+// =============================================================================
+
+describe('handleFlowCompletion', () => {
+  const fixedNow = () => new Date('2026-07-30T12:00:00.000Z');
+
+  it('happy path: inserts coverage_leads and completes session', async () => {
+    const state: MockState = {
+      sessions: new Map([
+        [
+          'f1-token-happy-path-0001',
+          makeSession({ flow_token: 'f1-token-happy-path-0001' }),
+        ],
+      ]),
+      insertedLeads: [],
+      sessionUpdates: [],
+    };
+    const onLeadCreated = jest.fn(async () => undefined);
+    const supabase = createMockSupabase(state);
+
+    const result = await handleFlowCompletion(happyFixture, {
+      supabase: supabase as never,
+      now: fixedNow,
+      onLeadCreated,
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.reason).toBe('created');
+    expect(result.coverageLeadId).toBe('lead-uuid-new-1');
+    expect(state.insertedLeads).toHaveLength(1);
+
+    const lead = state.insertedLeads[0];
+    expect(lead.lead_source).toBe('whatsapp_flow');
+    expect(lead.status).toBe('new');
+    expect(lead.first_name).toBe('Thabo');
+    expect(lead.last_name).toBe('Molefe');
+    expect(lead.requested_service_type).toBe('fibre');
+    expect(lead.source_campaign).toBe('near-term-f1');
+    expect(lead.phone).toBe('27821234567'); // form empty → webhook sender
+    expect(lead.customer_type).toBe('consumer');
+    expect(lead.first_response_due_at).toBeDefined();
+    expect((lead.metadata as Record<string, unknown>).popia_optin).toBe(true);
+    expect((lead.metadata as Record<string, unknown>).entry_source).toBe(
+      'website'
+    );
+    expect((lead.metadata as Record<string, unknown>).flow_token).toBe(
+      'f1-token-happy-path-0001'
+    );
+    expect((lead.metadata as Record<string, unknown>).flow_id).toBe(
+      'flow-id-f1'
+    );
+
+    const completeUpdate = state.sessionUpdates.find(
+      (u) => u.patch.status === 'completed'
+    );
+    expect(completeUpdate).toBeDefined();
+    expect(completeUpdate?.patch.coverage_lead_id).toBe('lead-uuid-new-1');
+    expect(onLeadCreated).toHaveBeenCalledTimes(1);
+  });
+
+  it('unknown token: no lead insert', async () => {
+    const state: MockState = {
+      sessions: new Map(),
+      insertedLeads: [],
+      sessionUpdates: [],
+    };
+    const supabase = createMockSupabase(state);
+
+    const result = await handleFlowCompletion(happyFixture, {
+      supabase: supabase as never,
+      now: fixedNow,
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('unknown_token');
+    expect(state.insertedLeads).toHaveLength(0);
+  });
+
+  it('duplicate complete: idempotent — returns existing lead, no second insert', async () => {
+    const state: MockState = {
+      sessions: new Map([
+        [
+          'f1-token-happy-path-0001',
+          makeSession({
+            flow_token: 'f1-token-happy-path-0001',
+            status: 'completed',
+            coverage_lead_id: 'lead-existing-99',
+          }),
+        ],
+      ]),
+      insertedLeads: [],
+      sessionUpdates: [],
+    };
+    const supabase = createMockSupabase(state);
+
+    const result = await handleFlowCompletion(happyFixture, {
+      supabase: supabase as never,
+      now: fixedNow,
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.reason).toBe('idempotent');
+    expect(result.coverageLeadId).toBe('lead-existing-99');
+    expect(state.insertedLeads).toHaveLength(0);
+  });
+
+  it('popia false: marks failed_parse, no lead', async () => {
+    const token = 'f1-token-popia-false-0002';
+    const state: MockState = {
+      sessions: new Map([
+        [token, makeSession({ flow_token: token, status: 'sent' })],
+      ]),
+      insertedLeads: [],
+      sessionUpdates: [],
+    };
+    const supabase = createMockSupabase(state);
+
+    const result = await handleFlowCompletion(popiaFalseFixture, {
+      supabase: supabase as never,
+      now: fixedNow,
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('popia_rejected');
+    expect(state.insertedLeads).toHaveLength(0);
+    expect(
+      state.sessionUpdates.some((u) => u.patch.status === 'failed_parse')
+    ).toBe(true);
+  });
+
+  it('malformed JSON: no lead insert', async () => {
+    const state: MockState = {
+      sessions: new Map([
+        [
+          'f1-token-happy-path-0001',
+          makeSession({ flow_token: 'f1-token-happy-path-0001' }),
+        ],
+      ]),
+      insertedLeads: [],
+      sessionUpdates: [],
+    };
+    const supabase = createMockSupabase(state);
+
+    const result = await handleFlowCompletion(malformedFixture, {
+      supabase: supabase as never,
+      now: fixedNow,
+      log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('malformed_json');
+    expect(state.insertedLeads).toHaveLength(0);
+  });
+});
+
+describe('buildCoverageLeadInsert', () => {
+  it('prefers form phone over sender when present', () => {
+    const form = coerceF1LeadQualificationResponse(
+      JSON.parse(happyFixture.interactive.nfm_reply.response_json)
+    );
+    form.phone = '0829998877';
+    const row = buildCoverageLeadInsert({
+      form,
+      session: makeSession(),
+      senderPhone: '27821234567',
+      createdAt: new Date('2026-07-30T12:00:00.000Z'),
+    });
+    expect(row.phone).toBe('0829998877');
+  });
+});

--- a/lib/integrations/whatsapp/flows/f1-lead-notifications.ts
+++ b/lib/integrations/whatsapp/flows/f1-lead-notifications.ts
@@ -1,0 +1,151 @@
+/**
+ * F1 Lead Qualification — post-create notifications.
+ *
+ * Called via `onLeadCreated` after coverage_leads insert succeeds.
+ * Failures are logged; they must never fail the webhook (handler already
+ * wraps the hook in try/catch).
+ *
+ * - Sales: email + Zoho via sendCoverageLeadAlert (admin deep link on email)
+ * - Customer: free-form WhatsApp confirmation (no approved lead template yet)
+ */
+
+import { sendCoverageLeadAlert } from '@/lib/notifications/sales-alerts';
+import { whatsAppService } from '../whatsapp-service';
+import { normalizeCustomerType } from './types';
+import type { LeadCreatedHookContext } from './flow-response-handler';
+
+// Planned Meta template — not registered; do not call sendTemplate with this name.
+const PLANNED_CONFIRMATION_TEMPLATE = 'circletel_lead_received';
+
+export interface F1LeadNotificationResult {
+  salesAlertOk: boolean;
+  confirmationOk: boolean;
+  errors: string[];
+}
+
+function buildConfirmationBody(firstName: string): string {
+  const name = firstName.trim() || 'there';
+  return `Thanks ${name}, we received your enquiry. We'll contact you during business hours.`;
+}
+
+/**
+ * Sales alert (email/SMS/Slack/Zoho) + customer WhatsApp confirmation.
+ * Safe for production: does not invent unapproved WhatsApp template names.
+ */
+export async function notifyF1LeadCreated(
+  ctx: LeadCreatedHookContext
+): Promise<F1LeadNotificationResult> {
+  const result: F1LeadNotificationResult = {
+    salesAlertOk: false,
+    confirmationOk: false,
+    errors: [],
+  };
+
+  const customerType = normalizeCustomerType(ctx.form.customer_type);
+  const phone =
+    (ctx.phone && ctx.phone.trim()) ||
+    ctx.form.phone?.trim() ||
+    ctx.session.phone ||
+    '';
+
+  // --- Sales alert (reuse coverage lead path; includes admin deep link) ---
+  try {
+    const alert = await sendCoverageLeadAlert({
+      id: ctx.leadId,
+      customer_type: customerType,
+      first_name: ctx.form.first_name,
+      last_name: ctx.form.last_name,
+      email: ctx.form.email?.trim() || '',
+      phone,
+      company_name: ctx.form.company_name,
+      address: ctx.form.address,
+      suburb: ctx.form.suburb,
+      city: ctx.form.city,
+      province: ctx.form.province,
+      requested_service_type: ctx.form.service_interest,
+      requested_speed: ctx.form.speed,
+      budget_range: ctx.form.budget_range,
+      lead_source: 'whatsapp_flow',
+      source_campaign: ctx.session.source_campaign ?? undefined,
+    });
+
+    result.salesAlertOk = alert.success;
+    if (!alert.success && alert.errors?.length) {
+      result.errors.push(...alert.errors.map((e) => `sales: ${e}`));
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    result.errors.push(`sales: ${msg}`);
+    console.error('[F1Notifications] Sales alert failed', {
+      leadId: ctx.leadId,
+      error: msg,
+    });
+  }
+
+  // --- Customer confirmation (session window: free-form text) ---
+  // Template `circletel_lead_received` is not approved in Meta yet — skip sendTemplate.
+  console.info(
+    '[F1Notifications] Skipping WhatsApp confirmation template (not approved)',
+    {
+      leadId: ctx.leadId,
+      plannedTemplate: PLANNED_CONFIRMATION_TEMPLATE,
+      fallback: 'free-form text',
+    }
+  );
+
+  try {
+    if (!phone) {
+      result.errors.push('confirmation: no phone number');
+    } else if (!whatsAppService.isConfigured()) {
+      result.errors.push('confirmation: WhatsApp not configured');
+      console.warn('[F1Notifications] WhatsApp not configured — skip confirmation', {
+        leadId: ctx.leadId,
+      });
+    } else {
+      const textResult = await whatsAppService.sendText(
+        phone,
+        buildConfirmationBody(ctx.form.first_name)
+      );
+      result.confirmationOk = textResult.success;
+      if (!textResult.success) {
+        result.errors.push(
+          `confirmation: ${textResult.error || 'send failed'}`
+        );
+        console.warn('[F1Notifications] Free-form confirmation failed', {
+          leadId: ctx.leadId,
+          error: textResult.error,
+          errorCode: textResult.errorCode,
+        });
+      } else {
+        console.info('[F1Notifications] Free-form confirmation sent', {
+          leadId: ctx.leadId,
+          messageId: textResult.messageId,
+        });
+      }
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    result.errors.push(`confirmation: ${msg}`);
+    console.error('[F1Notifications] Confirmation exception', {
+      leadId: ctx.leadId,
+      error: msg,
+    });
+  }
+
+  return result;
+}
+
+/** Default `onLeadCreated` hook for the WhatsApp webhook / handleFlowCompletion */
+export async function onF1LeadCreated(
+  ctx: LeadCreatedHookContext
+): Promise<void> {
+  const outcome = await notifyF1LeadCreated(ctx);
+  if (outcome.errors.length > 0) {
+    console.warn('[F1Notifications] Completed with errors', {
+      leadId: ctx.leadId,
+      salesAlertOk: outcome.salesAlertOk,
+      confirmationOk: outcome.confirmationOk,
+      errors: outcome.errors,
+    });
+  }
+}

--- a/lib/integrations/whatsapp/flows/flow-response-handler.ts
+++ b/lib/integrations/whatsapp/flows/flow-response-handler.ts
@@ -2,7 +2,8 @@
  * WhatsApp Flow completion handler (nfm_reply → coverage_leads).
  *
  * Deterministic CRM write — no LLM in the control plane.
- * Sales alert / confirmation are optional injectables (wired in Task A4).
+ * Sales alert / confirmation via optional `onLeadCreated` (default: webhook wires
+ * `onF1LeadCreated` from f1-lead-notifications).
  */
 
 import { computeFirstResponseDueAt } from '@/lib/leads/first-response-sla';
@@ -53,7 +54,7 @@ export interface LeadCreatedHookContext {
 
 export interface FlowResponseHandlerDeps {
   supabase: FlowSessionSupabase;
-  /** Optional — Task A4 wires confirmation + sales alert here */
+  /** Optional — confirmation + sales alert (webhook uses onF1LeadCreated) */
   onLeadCreated?: (ctx: LeadCreatedHookContext) => Promise<void>;
   /** Injectable clock for SLA / tests */
   now?: () => Date;

--- a/lib/integrations/whatsapp/flows/flow-response-handler.ts
+++ b/lib/integrations/whatsapp/flows/flow-response-handler.ts
@@ -1,0 +1,361 @@
+/**
+ * WhatsApp Flow completion handler (nfm_reply → coverage_leads).
+ *
+ * Deterministic CRM write — no LLM in the control plane.
+ * Sales alert / confirmation are optional injectables (wired in Task A4).
+ */
+
+import { computeFirstResponseDueAt } from '@/lib/leads/first-response-sla';
+import {
+  getSessionByFlowToken,
+  markSessionCompleted,
+  markSessionFailedParse,
+  type FlowSessionSupabase,
+} from './session-store';
+import {
+  coerceF1LeadQualificationResponse,
+  isF1LeadQualificationResponse,
+  isNfmReplyWebhookMessage,
+  normalizeCustomerType,
+  type F1LeadQualificationResponse,
+  type NfmReplyWebhookMessage,
+  type WhatsAppFlowSession,
+} from './types';
+
+// =============================================================================
+// RESULT / DEPS
+// =============================================================================
+
+export type FlowCompletionReason =
+  | 'created'
+  | 'idempotent'
+  | 'unknown_token'
+  | 'popia_rejected'
+  | 'malformed_json'
+  | 'invalid_payload'
+  | 'insert_failed'
+  | 'invalid_message';
+
+export interface FlowCompletionResult {
+  success: boolean;
+  reason: FlowCompletionReason;
+  coverageLeadId?: string;
+  sessionId?: string;
+  error?: string;
+}
+
+export interface LeadCreatedHookContext {
+  leadId: string;
+  session: WhatsAppFlowSession;
+  form: F1LeadQualificationResponse;
+  phone: string;
+}
+
+export interface FlowResponseHandlerDeps {
+  supabase: FlowSessionSupabase;
+  /** Optional — Task A4 wires confirmation + sales alert here */
+  onLeadCreated?: (ctx: LeadCreatedHookContext) => Promise<void>;
+  /** Injectable clock for SLA / tests */
+  now?: () => Date;
+  /** Optional logger (defaults to console) */
+  log?: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+}
+
+// =============================================================================
+// PARSE
+// =============================================================================
+
+export interface ParsedNfmReply {
+  ok: true;
+  form: F1LeadQualificationResponse;
+  flowToken: string;
+  raw: Record<string, unknown>;
+}
+
+export interface ParsedNfmReplyError {
+  ok: false;
+  reason: 'malformed_json' | 'invalid_payload';
+  flowToken?: string;
+  rawText: string;
+  raw?: unknown;
+}
+
+/**
+ * Parse nfm_reply.response_json into a validated F1 form.
+ * Pure — no I/O (unit-test without mocks).
+ */
+export function parseNfmReplyResponseJson(
+  responseJson: string
+): ParsedNfmReply | ParsedNfmReplyError {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(responseJson);
+  } catch {
+    // Best-effort token extract for dead-letter correlation
+    const tokenMatch = responseJson.match(
+      /"flow_token"\s*:\s*"([^"]+)"/
+    );
+    return {
+      ok: false,
+      reason: 'malformed_json',
+      flowToken: tokenMatch?.[1],
+      rawText: responseJson,
+    };
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return {
+      ok: false,
+      reason: 'invalid_payload',
+      rawText: responseJson,
+      raw: parsed,
+    };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const flowToken =
+    typeof record.flow_token === 'string' ? record.flow_token.trim() : '';
+
+  if (!isF1LeadQualificationResponse(record)) {
+    return {
+      ok: false,
+      reason: 'invalid_payload',
+      flowToken: flowToken || undefined,
+      rawText: responseJson,
+      raw: record,
+    };
+  }
+
+  const form = coerceF1LeadQualificationResponse(record);
+  const token = (form.flow_token ?? flowToken).trim();
+  if (!token) {
+    return {
+      ok: false,
+      reason: 'invalid_payload',
+      rawText: responseJson,
+      raw: record,
+    };
+  }
+
+  return { ok: true, form: { ...form, flow_token: token }, flowToken: token, raw: record };
+}
+
+// =============================================================================
+// LEAD ROW
+// =============================================================================
+
+export function buildCoverageLeadInsert(params: {
+  form: F1LeadQualificationResponse;
+  session: WhatsAppFlowSession;
+  senderPhone: string;
+  createdAt: Date;
+}): Record<string, unknown> {
+  const { form, session, senderPhone, createdAt } = params;
+  const phone =
+    (form.phone && form.phone.trim()) ||
+    senderPhone ||
+    session.phone ||
+    '';
+
+  // email is NOT NULL on coverage_leads — use empty string when form omits it
+  const email = form.email?.trim() || '';
+
+  return {
+    first_name: form.first_name,
+    last_name: form.last_name,
+    customer_type: normalizeCustomerType(form.customer_type),
+    email,
+    phone,
+    company_name: form.company_name ?? null,
+    address: form.address,
+    suburb: form.suburb,
+    city: form.city,
+    province: form.province ?? null,
+    requested_service_type: form.service_interest,
+    requested_speed: form.speed ?? null,
+    budget_range: form.budget_range ?? null,
+    contact_preference: form.contact_preference,
+    best_contact_time: form.best_contact_time ?? null,
+    lead_source: 'whatsapp_flow',
+    source_campaign: session.source_campaign,
+    status: 'new',
+    first_response_due_at: computeFirstResponseDueAt(createdAt).toISOString(),
+    metadata: {
+      popia_optin: form.popia_optin,
+      entry_source: session.entry_source,
+      flow_token: session.flow_token,
+      flow_id: session.flow_id,
+      flow_name: session.flow_name,
+    },
+  };
+}
+
+// =============================================================================
+// HANDLER
+// =============================================================================
+
+/**
+ * Handle a single inbound nfm_reply message: parse → session guards → lead insert.
+ */
+export async function handleFlowCompletion(
+  message: unknown,
+  deps: FlowResponseHandlerDeps
+): Promise<FlowCompletionResult> {
+  const log = deps.log ?? console;
+  const now = deps.now ?? (() => new Date());
+  const { supabase } = deps;
+
+  if (!isNfmReplyWebhookMessage(message)) {
+    log.warn('[FlowHandler] Not an nfm_reply message');
+    return { success: false, reason: 'invalid_message' };
+  }
+
+  const msg = message as NfmReplyWebhookMessage;
+  const responseJson = msg.interactive.nfm_reply.response_json;
+  const parsed = parseNfmReplyResponseJson(responseJson);
+
+  if (!parsed.ok) {
+    log.warn('[FlowHandler] Failed to parse nfm_reply', {
+      reason: parsed.reason,
+      flowToken: parsed.flowToken,
+    });
+
+    if (parsed.flowToken) {
+      await markSessionFailedParse(supabase, parsed.flowToken, {
+        responsePayload: parsed.raw ?? null,
+        rawWebhook: msg,
+      });
+    }
+
+    return {
+      success: false,
+      reason: parsed.reason,
+      error: parsed.reason,
+    };
+  }
+
+  const { form, flowToken } = parsed;
+
+  const { data: session, error: sessionError } = await getSessionByFlowToken(
+    supabase,
+    flowToken
+  );
+
+  if (sessionError) {
+    log.error('[FlowHandler] Session lookup failed', {
+      flowToken,
+      error: sessionError.message,
+    });
+    return {
+      success: false,
+      reason: 'unknown_token',
+      error: sessionError.message,
+    };
+  }
+
+  if (!session) {
+    log.warn('[FlowHandler] Unknown flow_token — no session', { flowToken });
+    return { success: false, reason: 'unknown_token' };
+  }
+
+  // Idempotent: Meta retries webhooks
+  if (session.status === 'completed') {
+    log.info('[FlowHandler] Session already completed — idempotent', {
+      flowToken,
+      coverageLeadId: session.coverage_lead_id,
+    });
+    return {
+      success: true,
+      reason: 'idempotent',
+      coverageLeadId: session.coverage_lead_id ?? undefined,
+      sessionId: session.id,
+    };
+  }
+
+  // POPIA: reject if false
+  if (form.popia_optin !== true) {
+    log.warn('[FlowHandler] POPIA opt-in false — rejecting lead', {
+      flowToken,
+      sessionId: session.id,
+    });
+    await markSessionFailedParse(supabase, flowToken, {
+      responsePayload: form,
+      rawWebhook: msg,
+    });
+    return {
+      success: false,
+      reason: 'popia_rejected',
+      sessionId: session.id,
+    };
+  }
+
+  const createdAt = now();
+  const leadRow = buildCoverageLeadInsert({
+    form,
+    session,
+    senderPhone: msg.from,
+    createdAt,
+  });
+
+  const { data: lead, error: insertError } = await supabase
+    .from('coverage_leads')
+    .insert(leadRow)
+    .select('id')
+    .single();
+
+  if (insertError || !lead?.id) {
+    log.error('[FlowHandler] coverage_leads insert failed', {
+      flowToken,
+      error: insertError?.message,
+    });
+    await markSessionFailedParse(supabase, flowToken, {
+      responsePayload: form,
+      rawWebhook: msg,
+    });
+    return {
+      success: false,
+      reason: 'insert_failed',
+      sessionId: session.id,
+      error: insertError?.message ?? 'No lead id returned',
+    };
+  }
+
+  const leadId = lead.id as string;
+
+  await markSessionCompleted(supabase, flowToken, leadId, form, msg);
+
+  if (deps.onLeadCreated) {
+    try {
+      await deps.onLeadCreated({
+        leadId,
+        session: { ...session, coverage_lead_id: leadId, status: 'completed' },
+        form,
+        phone: (leadRow.phone as string) || msg.from,
+      });
+    } catch (hookError) {
+      // Lead is already persisted — hook failures must not fail the webhook
+      log.error('[FlowHandler] onLeadCreated hook failed', {
+        leadId,
+        error:
+          hookError instanceof Error ? hookError.message : String(hookError),
+      });
+    }
+  }
+
+  log.info('[FlowHandler] Lead created from F1 flow', {
+    leadId,
+    flowToken,
+    sessionId: session.id,
+  });
+
+  return {
+    success: true,
+    reason: 'created',
+    coverageLeadId: leadId,
+    sessionId: session.id,
+  };
+}

--- a/lib/integrations/whatsapp/flows/flow-sender.ts
+++ b/lib/integrations/whatsapp/flows/flow-sender.ts
@@ -55,8 +55,8 @@ export interface SendFlowParams {
   headerText?: string;
   footerText?: string;
   /**
-   * When true, includes `mode: "draft"` in flow_action_payload
-   * (required to send unpublished draft flows to test numbers).
+   * When true, sets `parameters.mode = "draft"` (sibling of flow_action_payload).
+   * Required to send unpublished DRAFT flows to test numbers.
    */
   draft?: boolean;
   /** Injectable Supabase (tests); defaults to service-role client */
@@ -123,11 +123,21 @@ export function buildFlowMessagePayload(params: {
   footerText?: string;
   draft?: boolean;
 }): Record<string, unknown> {
-  const flowActionPayload: Record<string, unknown> = {
-    screen: params.screen,
+  // Meta: `mode` is a sibling of flow_action_payload under parameters
+  // (interactive.action.parameters.mode), NOT inside flow_action_payload.
+  // Wrong nesting returns error_code 100: Unexpected key "mode" on flow_action_payload.
+  const parameters: Record<string, unknown> = {
+    flow_message_version: '3',
+    flow_token: params.flowToken,
+    flow_id: params.flowId,
+    flow_cta: params.flowCta,
+    flow_action: 'navigate',
+    flow_action_payload: {
+      screen: params.screen,
+    },
   };
   if (params.draft) {
-    flowActionPayload.mode = 'draft';
+    parameters.mode = 'draft';
   }
 
   const interactive: Record<string, unknown> = {
@@ -135,14 +145,7 @@ export function buildFlowMessagePayload(params: {
     body: { text: params.bodyText },
     action: {
       name: 'flow',
-      parameters: {
-        flow_message_version: '3',
-        flow_token: params.flowToken,
-        flow_id: params.flowId,
-        flow_cta: params.flowCta,
-        flow_action: 'navigate',
-        flow_action_payload: flowActionPayload,
-      },
+      parameters,
     },
   };
 

--- a/lib/integrations/whatsapp/flows/flow-sender.ts
+++ b/lib/integrations/whatsapp/flows/flow-sender.ts
@@ -1,0 +1,328 @@
+/**
+ * WhatsApp Flow sender (Cloud API interactive flow messages).
+ *
+ * Creates a `whatsapp_flow_sessions` row (flow_token) then POSTs the
+ * interactive flow message. Follows whatsapp-service lazy config + SA phone format.
+ *
+ * @see https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-flow-messages
+ */
+
+import { randomUUID } from 'crypto';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type {
+  WhatsAppErrorResponse,
+  WhatsAppMessageResponse,
+  WhatsAppSendResult,
+} from '../types';
+import {
+  createFlowSession,
+  type FlowSessionSupabase,
+} from './session-store';
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/** Default Meta Flow name stored on sessions (not the display CTA). */
+export const F1_FLOW_NAME = 'lead_qualification';
+
+/** Default first screen id — must match Flow Builder screen name. */
+export const F1_DEFAULT_SCREEN = 'CONTACT';
+
+const GRAPH_BASE = 'https://graph.facebook.com/v21.0';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface SendFlowParams {
+  /** Recipient phone (SA local or international) */
+  to: string;
+  /**
+   * Meta flow id. Defaults to `WHATSAPP_FLOW_LEAD_QUALIFICATION_ID`.
+   */
+  flowId?: string;
+  /** Stored on session row; default `lead_qualification` */
+  flowName?: string;
+  /** Button label (max 30 chars per Meta) */
+  flowCta?: string;
+  /** First screen id for `flow_action: navigate` */
+  screen?: string;
+  /** Session entry source: website | qr | admin | ctwa_ad | manual | followup */
+  entrySource: string;
+  sourceCampaign?: string | null;
+  bodyText?: string;
+  headerText?: string;
+  footerText?: string;
+  /**
+   * When true, includes `mode: "draft"` in flow_action_payload
+   * (required to send unpublished draft flows to test numbers).
+   */
+  draft?: boolean;
+  /** Injectable Supabase (tests); defaults to service-role client */
+  supabase?: FlowSessionSupabase;
+}
+
+export interface SendFlowResult extends WhatsAppSendResult {
+  flowToken?: string;
+  sessionId?: string;
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function getPhoneNumberId(): string {
+  return process.env.WHATSAPP_PHONE_NUMBER_ID || '';
+}
+
+function getAccessToken(): string {
+  return process.env.WHATSAPP_ACCESS_TOKEN || '';
+}
+
+/**
+ * Format phone to WhatsApp international digits (no +).
+ * Mirrors WhatsAppService.formatPhoneNumber (SA 0… → 27…).
+ */
+export function formatWhatsAppPhone(phone: string): string {
+  let cleaned = phone.replace(/\D/g, '');
+
+  if (cleaned.startsWith('0')) {
+    cleaned = '27' + cleaned.substring(1);
+  }
+
+  if (!cleaned.startsWith('27') && cleaned.length === 9) {
+    cleaned = '27' + cleaned;
+  }
+
+  return cleaned;
+}
+
+function createServiceRoleClient(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('Supabase service role credentials not configured');
+  }
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+/**
+ * Build Cloud API interactive flow message payload (pure — testable).
+ */
+export function buildFlowMessagePayload(params: {
+  to: string;
+  flowToken: string;
+  flowId: string;
+  flowCta: string;
+  screen: string;
+  bodyText: string;
+  headerText?: string;
+  footerText?: string;
+  draft?: boolean;
+}): Record<string, unknown> {
+  const flowActionPayload: Record<string, unknown> = {
+    screen: params.screen,
+  };
+  if (params.draft) {
+    flowActionPayload.mode = 'draft';
+  }
+
+  const interactive: Record<string, unknown> = {
+    type: 'flow',
+    body: { text: params.bodyText },
+    action: {
+      name: 'flow',
+      parameters: {
+        flow_message_version: '3',
+        flow_token: params.flowToken,
+        flow_id: params.flowId,
+        flow_cta: params.flowCta,
+        flow_action: 'navigate',
+        flow_action_payload: flowActionPayload,
+      },
+    },
+  };
+
+  if (params.headerText) {
+    interactive.header = { type: 'text', text: params.headerText };
+  }
+  if (params.footerText) {
+    interactive.footer = { text: params.footerText };
+  }
+
+  return {
+    messaging_product: 'whatsapp',
+    recipient_type: 'individual',
+    to: params.to,
+    type: 'interactive',
+    interactive,
+  };
+}
+
+// =============================================================================
+// SEND
+// =============================================================================
+
+/**
+ * Create a flow session then send an interactive WhatsApp Flow message.
+ *
+ * Order: generate flow_token → insert session → POST Cloud API.
+ * Session is created first so webhook completions can always correlate.
+ */
+export async function sendFlow(params: SendFlowParams): Promise<SendFlowResult> {
+  const phoneNumberId = getPhoneNumberId();
+  const accessToken = getAccessToken();
+
+  if (!phoneNumberId || !accessToken) {
+    return { success: false, error: 'WhatsApp API not configured' };
+  }
+
+  const flowId =
+    params.flowId || process.env.WHATSAPP_FLOW_LEAD_QUALIFICATION_ID || '';
+  if (!flowId) {
+    return {
+      success: false,
+      error: 'WHATSAPP_FLOW_LEAD_QUALIFICATION_ID not configured',
+    };
+  }
+
+  const formattedPhone = formatWhatsAppPhone(params.to);
+  if (!formattedPhone || formattedPhone.length < 10) {
+    return { success: false, error: 'Invalid phone number' };
+  }
+
+  const flowToken = randomUUID();
+  const flowName = params.flowName ?? F1_FLOW_NAME;
+  const flowCta = params.flowCta ?? 'Get started';
+  const screen = params.screen ?? F1_DEFAULT_SCREEN;
+  const bodyText =
+    params.bodyText ??
+    'Complete this short form so we can check coverage and get you the right CircleTel package.';
+
+  let supabase: FlowSessionSupabase;
+  try {
+    supabase = params.supabase ?? createServiceRoleClient();
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : 'Supabase not configured',
+    };
+  }
+
+  const { data: session, error: sessionError } = await createFlowSession(
+    supabase,
+    {
+      flow_token: flowToken,
+      flow_id: flowId,
+      flow_name: flowName,
+      phone: formattedPhone,
+      entry_source: params.entrySource,
+      source_campaign: params.sourceCampaign ?? null,
+      status: 'sent',
+    }
+  );
+
+  if (sessionError || !session) {
+    console.error('[FlowSender] Failed to create session', sessionError);
+    return {
+      success: false,
+      error: sessionError?.message ?? 'Failed to create flow session',
+      flowToken,
+    };
+  }
+
+  const payload = buildFlowMessagePayload({
+    to: formattedPhone,
+    flowToken,
+    flowId,
+    flowCta,
+    screen,
+    bodyText,
+    headerText: params.headerText,
+    footerText: params.footerText,
+    draft: params.draft,
+  });
+
+  console.log('[FlowSender] Sending flow message', {
+    to: formattedPhone,
+    flowId,
+    flowToken,
+    sessionId: session.id,
+    draft: Boolean(params.draft),
+  });
+
+  try {
+    const response = await fetch(
+      `${GRAPH_BASE}/${phoneNumberId}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      }
+    );
+
+    const data = (await response.json()) as
+      | WhatsAppMessageResponse
+      | WhatsAppErrorResponse;
+
+    if (!response.ok || 'error' in data) {
+      const errorData = data as WhatsAppErrorResponse;
+      console.error('[FlowSender] Cloud API error', errorData);
+      return {
+        success: false,
+        error: errorData.error?.message || `HTTP ${response.status}`,
+        errorCode: errorData.error?.code,
+        flowToken,
+        sessionId: session.id,
+      };
+    }
+
+    const successData = data as WhatsAppMessageResponse;
+    const messageId = successData.messages?.[0]?.id;
+    const waId = successData.contacts?.[0]?.wa_id;
+
+    console.log('[FlowSender] Flow message sent', {
+      messageId,
+      flowToken,
+      sessionId: session.id,
+    });
+
+    // Best-effort: attach wamid to session when send succeeds
+    if (messageId) {
+      try {
+        await supabase
+          .from('whatsapp_flow_sessions')
+          .update({
+            whatsapp_message_id: messageId,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('flow_token', flowToken);
+      } catch (updateErr) {
+        console.warn('[FlowSender] Failed to store whatsapp_message_id', updateErr);
+      }
+    }
+
+    return {
+      success: true,
+      messageId,
+      waId,
+      flowToken,
+      sessionId: session.id,
+    };
+  } catch (error) {
+    console.error('[FlowSender] Send error', error);
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : 'Failed to send flow message',
+      flowToken,
+      sessionId: session.id,
+    };
+  }
+}

--- a/lib/integrations/whatsapp/flows/session-store.ts
+++ b/lib/integrations/whatsapp/flows/session-store.ts
@@ -1,0 +1,108 @@
+/**
+ * WhatsApp Flow session repository (whatsapp_flow_sessions).
+ * Service-role client only — table has RLS with no anon policies.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  FlowSessionStatus,
+  WhatsAppFlowSession,
+} from './types';
+
+export interface CreateFlowSessionInput {
+  flow_token: string;
+  flow_id: string;
+  flow_name: string;
+  phone: string;
+  entry_source: string;
+  source_campaign?: string | null;
+  whatsapp_message_id?: string | null;
+  status?: FlowSessionStatus;
+}
+
+type QueryError = { message: string; code?: string } | null;
+
+/**
+ * Minimal Supabase surface used by the session store (testable).
+ */
+export type FlowSessionSupabase = Pick<SupabaseClient, 'from'>;
+
+export async function createFlowSession(
+  supabase: FlowSessionSupabase,
+  input: CreateFlowSessionInput
+): Promise<{ data: WhatsAppFlowSession | null; error: QueryError }> {
+  const { data, error } = await supabase
+    .from('whatsapp_flow_sessions')
+    .insert({
+      flow_token: input.flow_token,
+      flow_id: input.flow_id,
+      flow_name: input.flow_name,
+      phone: input.phone,
+      entry_source: input.entry_source,
+      source_campaign: input.source_campaign ?? null,
+      whatsapp_message_id: input.whatsapp_message_id ?? null,
+      status: input.status ?? 'sent',
+    })
+    .select()
+    .single();
+
+  return { data: data as WhatsAppFlowSession | null, error: error as QueryError };
+}
+
+export async function getSessionByFlowToken(
+  supabase: FlowSessionSupabase,
+  flowToken: string
+): Promise<{ data: WhatsAppFlowSession | null; error: QueryError }> {
+  const { data, error } = await supabase
+    .from('whatsapp_flow_sessions')
+    .select('*')
+    .eq('flow_token', flowToken)
+    .maybeSingle();
+
+  return { data: data as WhatsAppFlowSession | null, error: error as QueryError };
+}
+
+export async function markSessionCompleted(
+  supabase: FlowSessionSupabase,
+  flowToken: string,
+  coverageLeadId: string,
+  responsePayload: unknown,
+  rawWebhook?: unknown
+): Promise<{ error: QueryError }> {
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from('whatsapp_flow_sessions')
+    .update({
+      status: 'completed',
+      coverage_lead_id: coverageLeadId,
+      response_payload: responsePayload,
+      raw_webhook: rawWebhook ?? null,
+      completed_at: now,
+      updated_at: now,
+    })
+    .eq('flow_token', flowToken);
+
+  return { error: error as QueryError };
+}
+
+export async function markSessionFailedParse(
+  supabase: FlowSessionSupabase,
+  flowToken: string,
+  opts: {
+    responsePayload?: unknown;
+    rawWebhook?: unknown;
+  } = {}
+): Promise<{ error: QueryError }> {
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from('whatsapp_flow_sessions')
+    .update({
+      status: 'failed_parse',
+      response_payload: opts.responsePayload ?? null,
+      raw_webhook: opts.rawWebhook ?? null,
+      updated_at: now,
+    })
+    .eq('flow_token', flowToken);
+
+  return { error: error as QueryError };
+}

--- a/lib/integrations/whatsapp/flows/types.ts
+++ b/lib/integrations/whatsapp/flows/types.ts
@@ -1,0 +1,233 @@
+/**
+ * WhatsApp Flows — F1 Lead Qualification types
+ *
+ * Field names must match Meta Flow Builder JSON exactly (single source of truth).
+ * @see docs/superpowers/specs/2026-07-31-near-term-f1-followup-floor-design.md
+ */
+
+// =============================================================================
+// F1 RESPONSE (form fields from nfm_reply.response_json)
+// =============================================================================
+
+/**
+ * Parsed F1 Lead Qualification form payload.
+ * `flow_token` is included by Meta inside response_json for correlation.
+ */
+export interface F1LeadQualificationResponse {
+  flow_token?: string;
+  first_name: string;
+  last_name: string;
+  /** Raw form value — normalize with `normalizeCustomerType` before DB insert */
+  customer_type: string;
+  email?: string;
+  phone?: string;
+  company_name?: string;
+  address: string;
+  suburb: string;
+  city: string;
+  province?: string;
+  service_interest: string;
+  speed?: string;
+  budget_range?: string;
+  contact_preference: string;
+  best_contact_time?: string;
+  /** Must be true to create a lead (POPIA) */
+  popia_optin: boolean;
+}
+
+/** DB-facing customer_type after normalize (coverage_leads enum) */
+export type CoverageLeadCustomerType = 'consumer' | 'smme' | 'enterprise';
+
+export type FlowSessionStatus =
+  | 'sent'
+  | 'delivered'
+  | 'completed'
+  | 'expired'
+  | 'failed_parse';
+
+export type FlowEntrySource =
+  | 'website'
+  | 'qr'
+  | 'admin'
+  | 'ctwa_ad'
+  | 'manual'
+  | 'followup';
+
+export interface WhatsAppFlowSession {
+  id: string;
+  flow_token: string;
+  flow_id: string;
+  flow_name: string;
+  phone: string;
+  entry_source: string;
+  source_campaign: string | null;
+  status: FlowSessionStatus | string;
+  response_payload: unknown | null;
+  raw_webhook: unknown | null;
+  coverage_lead_id: string | null;
+  whatsapp_message_id: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+/**
+ * Inbound interactive message carrying an nfm_reply (flow completion).
+ * Mirrors Meta Cloud API webhook message shape.
+ */
+export interface NfmReplyWebhookMessage {
+  from: string;
+  id: string;
+  timestamp: string;
+  type: 'interactive';
+  interactive: {
+    type: 'nfm_reply';
+    nfm_reply: {
+      response_json: string;
+      body?: string;
+      name?: string;
+    };
+  };
+}
+
+// =============================================================================
+// TYPE GUARDS / HELPERS
+// =============================================================================
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === 'string';
+}
+
+/**
+ * WhatsApp Flow toggles may arrive as boolean or string ("true"/"false"/"0"/"1").
+ */
+export function parsePopiaOptIn(value: unknown): boolean | null {
+  if (value === true || value === 1) return true;
+  if (value === false || value === 0) return false;
+  if (typeof value === 'string') {
+    const v = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'y', 'on'].includes(v)) return true;
+    if (['false', '0', 'no', 'n', 'off'].includes(v)) return false;
+  }
+  return null;
+}
+
+/**
+ * Normalize form customer_type to coverage_leads enum values.
+ * Design labels: consumer | business → DB: consumer | smme | enterprise.
+ */
+export function normalizeCustomerType(raw: string): CoverageLeadCustomerType {
+  const v = raw.trim().toLowerCase();
+  if (['business', 'smme', 'sme', 'commercial', 'company', 'b2b'].includes(v)) {
+    return 'smme';
+  }
+  if (['enterprise', 'corporate'].includes(v)) {
+    return 'enterprise';
+  }
+  return 'consumer';
+}
+
+/**
+ * Type guard for F1 Lead Qualification response (plain — no new deps).
+ * Required: first_name, last_name, customer_type, address, suburb, city,
+ * service_interest, contact_preference, popia_optin (parseable).
+ */
+export function isF1LeadQualificationResponse(
+  value: unknown
+): value is F1LeadQualificationResponse {
+  if (!value || typeof value !== 'object') return false;
+  const o = value as Record<string, unknown>;
+
+  if (!isNonEmptyString(o.first_name)) return false;
+  if (!isNonEmptyString(o.last_name)) return false;
+  if (!isNonEmptyString(o.customer_type)) return false;
+  if (!isNonEmptyString(o.address)) return false;
+  if (!isNonEmptyString(o.suburb)) return false;
+  if (!isNonEmptyString(o.city)) return false;
+  if (!isNonEmptyString(o.service_interest)) return false;
+  if (!isNonEmptyString(o.contact_preference)) return false;
+
+  if (!isOptionalString(o.email)) return false;
+  if (!isOptionalString(o.phone)) return false;
+  if (!isOptionalString(o.company_name)) return false;
+  if (!isOptionalString(o.province)) return false;
+  if (!isOptionalString(o.speed)) return false;
+  if (!isOptionalString(o.budget_range)) return false;
+  if (!isOptionalString(o.best_contact_time)) return false;
+  if (!isOptionalString(o.flow_token)) return false;
+
+  const popia = parsePopiaOptIn(o.popia_optin);
+  if (popia === null) return false;
+
+  return true;
+}
+
+/**
+ * Coerce a raw parsed object into F1LeadQualificationResponse (popia as boolean).
+ * Call only after isF1LeadQualificationResponse.
+ */
+export function coerceF1LeadQualificationResponse(
+  value: Record<string, unknown>
+): F1LeadQualificationResponse {
+  const popia = parsePopiaOptIn(value.popia_optin);
+  return {
+    flow_token:
+      typeof value.flow_token === 'string' ? value.flow_token : undefined,
+    first_name: String(value.first_name).trim(),
+    last_name: String(value.last_name).trim(),
+    customer_type: String(value.customer_type).trim(),
+    email:
+      typeof value.email === 'string' && value.email.trim()
+        ? value.email.trim()
+        : undefined,
+    phone:
+      typeof value.phone === 'string' && value.phone.trim()
+        ? value.phone.trim()
+        : undefined,
+    company_name:
+      typeof value.company_name === 'string' && value.company_name.trim()
+        ? value.company_name.trim()
+        : undefined,
+    address: String(value.address).trim(),
+    suburb: String(value.suburb).trim(),
+    city: String(value.city).trim(),
+    province:
+      typeof value.province === 'string' && value.province.trim()
+        ? value.province.trim()
+        : undefined,
+    service_interest: String(value.service_interest).trim(),
+    speed:
+      typeof value.speed === 'string' && value.speed.trim()
+        ? value.speed.trim()
+        : undefined,
+    budget_range:
+      typeof value.budget_range === 'string' && value.budget_range.trim()
+        ? value.budget_range.trim()
+        : undefined,
+    contact_preference: String(value.contact_preference).trim(),
+    best_contact_time:
+      typeof value.best_contact_time === 'string' &&
+      value.best_contact_time.trim()
+        ? value.best_contact_time.trim()
+        : undefined,
+    popia_optin: popia === true,
+  };
+}
+
+export function isNfmReplyWebhookMessage(
+  value: unknown
+): value is NfmReplyWebhookMessage {
+  if (!value || typeof value !== 'object') return false;
+  const m = value as Record<string, unknown>;
+  if (m.type !== 'interactive') return false;
+  if (typeof m.from !== 'string' || typeof m.id !== 'string') return false;
+  const interactive = m.interactive as Record<string, unknown> | undefined;
+  if (!interactive || interactive.type !== 'nfm_reply') return false;
+  const nfm = interactive.nfm_reply as Record<string, unknown> | undefined;
+  if (!nfm || typeof nfm.response_json !== 'string') return false;
+  return true;
+}

--- a/lib/integrations/whatsapp/index.ts
+++ b/lib/integrations/whatsapp/index.ts
@@ -49,3 +49,38 @@ export type {
   WhatsAppConsent,
   RATE_LIMIT_TIERS,
 } from './types';
+
+// WhatsApp Flows (F1 Lead Qualification)
+export {
+  sendFlow,
+  buildFlowMessagePayload,
+  formatWhatsAppPhone,
+  F1_FLOW_NAME,
+  F1_DEFAULT_SCREEN,
+  type SendFlowParams,
+  type SendFlowResult,
+} from './flows/flow-sender';
+
+export {
+  handleFlowCompletion,
+  parseNfmReplyResponseJson,
+  buildCoverageLeadInsert,
+  type FlowCompletionResult,
+  type FlowResponseHandlerDeps,
+  type FlowCompletionReason,
+} from './flows/flow-response-handler';
+
+export type {
+  F1LeadQualificationResponse,
+  WhatsAppFlowSession,
+  NfmReplyWebhookMessage,
+  FlowSessionStatus,
+  FlowEntrySource,
+} from './flows/types';
+
+export {
+  isF1LeadQualificationResponse,
+  isNfmReplyWebhookMessage,
+  normalizeCustomerType,
+  parsePopiaOptIn,
+} from './flows/types';

--- a/lib/integrations/whatsapp/index.ts
+++ b/lib/integrations/whatsapp/index.ts
@@ -68,7 +68,14 @@ export {
   type FlowCompletionResult,
   type FlowResponseHandlerDeps,
   type FlowCompletionReason,
+  type LeadCreatedHookContext,
 } from './flows/flow-response-handler';
+
+export {
+  notifyF1LeadCreated,
+  onF1LeadCreated,
+  type F1LeadNotificationResult,
+} from './flows/f1-lead-notifications';
 
 export type {
   F1LeadQualificationResponse,

--- a/lib/integrations/whatsapp/whatsapp-service.ts
+++ b/lib/integrations/whatsapp/whatsapp-service.ts
@@ -15,6 +15,7 @@ import type {
   WhatsAppMessageResponse,
   WhatsAppErrorResponse,
   SendTemplateRequest,
+  SendTextRequest,
   TemplateParameter,
   CircleTelTemplate,
   InvoicePaymentParams,
@@ -164,6 +165,87 @@ export class WhatsAppService {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to send WhatsApp message',
+      };
+    }
+  }
+
+  /**
+   * Send a free-form text message (requires open 24h customer service window).
+   * Use after inbound messages / flow completions — not for cold outreach.
+   */
+  async sendText(
+    to: string,
+    body: string,
+    options: { previewUrl?: boolean } = {}
+  ): Promise<WhatsAppSendResult> {
+    const config = this.getConfig();
+
+    if (!config.phoneNumberId || !config.accessToken) {
+      return {
+        success: false,
+        error: 'WhatsApp API not configured',
+      };
+    }
+
+    const text = body.trim();
+    if (!text) {
+      return { success: false, error: 'Message body is empty' };
+    }
+
+    const formattedPhone = this.formatPhoneNumber(to);
+    console.log(`[WhatsApp] Sending text message to ${formattedPhone}`);
+
+    const payload: SendTextRequest = {
+      messaging_product: 'whatsapp',
+      to: formattedPhone,
+      type: 'text',
+      text: {
+        body: text,
+        preview_url: options.previewUrl ?? false,
+      },
+    };
+
+    try {
+      const response = await fetch(
+        `${config.baseUrl}/${config.phoneNumberId}/messages`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${config.accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        }
+      );
+
+      const data = (await response.json()) as
+        | WhatsAppMessageResponse
+        | WhatsAppErrorResponse;
+
+      if (!response.ok || 'error' in data) {
+        const errorData = data as WhatsAppErrorResponse;
+        console.error('[WhatsApp] Text API error:', errorData);
+        return {
+          success: false,
+          error: errorData.error?.message || `HTTP ${response.status}`,
+          errorCode: errorData.error?.code,
+        };
+      }
+
+      const successData = data as WhatsAppMessageResponse;
+      const messageId = successData.messages?.[0]?.id;
+      const waId = successData.contacts?.[0]?.wa_id;
+
+      console.log(`[WhatsApp] Text message sent: ${messageId}`);
+      return { success: true, messageId, waId };
+    } catch (error) {
+      console.error('[WhatsApp] Text send error:', error);
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to send WhatsApp text message',
       };
     }
   }

--- a/lib/leads/first-response-sla.ts
+++ b/lib/leads/first-response-sla.ts
@@ -1,0 +1,338 @@
+/**
+ * First-response SLA helpers
+ *
+ * Computes business-hours deadlines for lead first response.
+ * Default window: Mon–Fri 08:00–17:00 Africa/Johannesburg (SAST, UTC+2, no DST).
+ *
+ * Design: on insert or when status becomes `new`,
+ * `first_response_due_at = created_at + 2 business hours`.
+ *
+ * Note: day-level business-day helpers live in `lib/dates/business-days.ts`
+ * (weekends + SA public holidays). This module is hour-granularity and
+ * intentionally uses Mon–Fri only (no holiday calendar).
+ *
+ * @module lib/leads/first-response-sla
+ */
+
+import { SAST_TIMEZONE } from '@/lib/dates';
+
+/** Business day open hour (inclusive), local wall clock */
+const BUSINESS_OPEN_HOUR = 8;
+/** Business day close hour (exclusive), local wall clock */
+const BUSINESS_CLOSE_HOUR = 17;
+
+export interface AddBusinessHoursOptions {
+  /** IANA timezone. Defaults to Africa/Johannesburg. */
+  timeZone?: string;
+}
+
+interface ZonedParts {
+  year: number;
+  month: number; // 1–12
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  dayOfWeek: number; // 0=Sun … 6=Sat
+}
+
+const WEEKDAY_TO_NUM: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+function getZonedParts(date: Date, timeZone: string): ZonedParts {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    weekday: 'short',
+    hourCycle: 'h23',
+  });
+
+  const bag: Record<string, string> = {};
+  for (const part of dtf.formatToParts(date)) {
+    if (part.type !== 'literal') {
+      bag[part.type] = part.value;
+    }
+  }
+
+  return {
+    year: Number(bag.year),
+    month: Number(bag.month),
+    day: Number(bag.day),
+    hour: Number(bag.hour),
+    minute: Number(bag.minute),
+    second: Number(bag.second),
+    dayOfWeek: WEEKDAY_TO_NUM[bag.weekday] ?? 0,
+  };
+}
+
+/**
+ * Convert a wall-clock time in `timeZone` to a UTC Date.
+ * Iteratively corrects offset so fixed-offset (SAST) and DST zones work.
+ */
+function zonedTimeToUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  timeZone: string
+): Date {
+  let utcMs = Date.UTC(year, month - 1, day, hour, minute, second);
+
+  for (let i = 0; i < 4; i++) {
+    const zoned = getZonedParts(new Date(utcMs), timeZone);
+    const asIfUtc = Date.UTC(
+      zoned.year,
+      zoned.month - 1,
+      zoned.day,
+      zoned.hour,
+      zoned.minute,
+      zoned.second
+    );
+    const desired = Date.UTC(year, month - 1, day, hour, minute, second);
+    const diff = desired - asIfUtc;
+    if (diff === 0) break;
+    utcMs += diff;
+  }
+
+  return new Date(utcMs);
+}
+
+function isWeekday(dayOfWeek: number): boolean {
+  return dayOfWeek >= 1 && dayOfWeek <= 5;
+}
+
+function minutesSinceMidnight(hour: number, minute: number, second: number): number {
+  return hour * 60 + minute + second / 60;
+}
+
+function addCalendarDays(
+  year: number,
+  month: number,
+  day: number,
+  days: number
+): { year: number; month: number; day: number; dayOfWeek: number } {
+  // Use UTC noon to avoid DST edge issues when advancing calendar days
+  const base = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  base.setUTCDate(base.getUTCDate() + days);
+  return {
+    year: base.getUTCFullYear(),
+    month: base.getUTCMonth() + 1,
+    day: base.getUTCDate(),
+    dayOfWeek: base.getUTCDay(),
+  };
+}
+
+/**
+ * Snap a zoned instant to the start of the next business window if needed.
+ * If already inside Mon–Fri [08:00, 17:00), returns the same parts.
+ */
+function snapToBusinessStart(parts: ZonedParts): ZonedParts {
+  const openMin = BUSINESS_OPEN_HOUR * 60;
+  const closeMin = BUSINESS_CLOSE_HOUR * 60;
+  const currentMin = minutesSinceMidnight(parts.hour, parts.minute, parts.second);
+
+  let year = parts.year;
+  let month = parts.month;
+  let day = parts.day;
+  let dayOfWeek = parts.dayOfWeek;
+  let hour = parts.hour;
+  let minute = parts.minute;
+  let second = parts.second;
+
+  if (isWeekday(dayOfWeek) && currentMin >= openMin && currentMin < closeMin) {
+    return parts;
+  }
+
+  // Before open on a weekday → same day open
+  if (isWeekday(dayOfWeek) && currentMin < openMin) {
+    return {
+      year,
+      month,
+      day,
+      hour: BUSINESS_OPEN_HOUR,
+      minute: 0,
+      second: 0,
+      dayOfWeek,
+    };
+  }
+
+  // After close or weekend → next weekday open
+  let advance = 1;
+  if (isWeekday(dayOfWeek) && currentMin >= closeMin) {
+    advance = 1;
+  } else if (dayOfWeek === 6) {
+    // Saturday → Monday
+    advance = 2;
+  } else if (dayOfWeek === 0) {
+    // Sunday → Monday
+    advance = 1;
+  }
+
+  let next = addCalendarDays(year, month, day, advance);
+  while (!isWeekday(next.dayOfWeek)) {
+    next = addCalendarDays(next.year, next.month, next.day, 1);
+  }
+
+  return {
+    year: next.year,
+    month: next.month,
+    day: next.day,
+    hour: BUSINESS_OPEN_HOUR,
+    minute: 0,
+    second: 0,
+    dayOfWeek: next.dayOfWeek,
+  };
+}
+
+function nextBusinessOpen(parts: ZonedParts): ZonedParts {
+  // Start from "just after" current day close by advancing one calendar day
+  let next = addCalendarDays(parts.year, parts.month, parts.day, 1);
+  while (!isWeekday(next.dayOfWeek)) {
+    next = addCalendarDays(next.year, next.month, next.day, 1);
+  }
+  return {
+    year: next.year,
+    month: next.month,
+    day: next.day,
+    hour: BUSINESS_OPEN_HOUR,
+    minute: 0,
+    second: 0,
+    dayOfWeek: next.dayOfWeek,
+  };
+}
+
+/**
+ * Add N business hours to a start instant.
+ *
+ * Business hours are Mon–Fri 08:00–17:00 in the given timezone
+ * (default Africa/Johannesburg). Time outside the window does not count;
+ * the clock starts at the next open.
+ *
+ * @param start - Start instant (typically UTC Date from the DB)
+ * @param hours - Business hours to add (may be fractional)
+ * @param options.timeZone - IANA timezone (default SAST)
+ */
+export function addBusinessHours(
+  start: Date,
+  hours: number,
+  options?: AddBusinessHoursOptions
+): Date {
+  if (Number.isNaN(start.getTime())) {
+    return new Date(NaN);
+  }
+
+  if (hours === 0) {
+    return new Date(start.getTime());
+  }
+
+  if (hours < 0) {
+    throw new Error('addBusinessHours: hours must be non-negative');
+  }
+
+  const timeZone = options?.timeZone ?? SAST_TIMEZONE;
+  let remainingMs = hours * 60 * 60 * 1000;
+
+  let parts = snapToBusinessStart(getZonedParts(start, timeZone));
+  let cursor = zonedTimeToUtc(
+    parts.year,
+    parts.month,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+    timeZone
+  );
+
+  // Safety: max ~1 year of iterations (365 business days)
+  let guard = 0;
+  while (remainingMs > 0 && guard < 400) {
+    guard += 1;
+    parts = getZonedParts(cursor, timeZone);
+
+    // Ensure we are inside a business window
+    const snapped = snapToBusinessStart(parts);
+    if (
+      snapped.year !== parts.year ||
+      snapped.month !== parts.month ||
+      snapped.day !== parts.day ||
+      snapped.hour !== parts.hour ||
+      snapped.minute !== parts.minute ||
+      snapped.second !== parts.second
+    ) {
+      cursor = zonedTimeToUtc(
+        snapped.year,
+        snapped.month,
+        snapped.day,
+        snapped.hour,
+        snapped.minute,
+        snapped.second,
+        timeZone
+      );
+      parts = snapped;
+    }
+
+    const close = zonedTimeToUtc(
+      parts.year,
+      parts.month,
+      parts.day,
+      BUSINESS_CLOSE_HOUR,
+      0,
+      0,
+      timeZone
+    );
+    const availableMs = close.getTime() - cursor.getTime();
+
+    if (availableMs <= 0) {
+      const next = nextBusinessOpen(parts);
+      cursor = zonedTimeToUtc(
+        next.year,
+        next.month,
+        next.day,
+        next.hour,
+        next.minute,
+        next.second,
+        timeZone
+      );
+      continue;
+    }
+
+    if (remainingMs <= availableMs) {
+      return new Date(cursor.getTime() + remainingMs);
+    }
+
+    remainingMs -= availableMs;
+    const next = nextBusinessOpen(parts);
+    cursor = zonedTimeToUtc(
+      next.year,
+      next.month,
+      next.day,
+      next.hour,
+      next.minute,
+      next.second,
+      timeZone
+    );
+  }
+
+  return cursor;
+}
+
+/**
+ * Convenience: first-response due at = created_at + 2 business hours (SAST).
+ */
+export function computeFirstResponseDueAt(createdAt: Date): Date {
+  return addBusinessHours(createdAt, 2);
+}

--- a/lib/leads/sla-badge.ts
+++ b/lib/leads/sla-badge.ts
@@ -1,0 +1,29 @@
+/**
+ * Client-side first-response SLA badge for coverage_leads admin UI.
+ */
+
+export type LeadSlaVariant = 'success' | 'warning' | 'error' | 'info' | 'neutral';
+
+export function getLeadSlaBadge(lead: {
+  first_responded_at: string | null;
+  first_response_due_at: string | null;
+}): { status: string; variant: LeadSlaVariant } {
+  if (lead.first_responded_at) {
+    return { status: 'Responded', variant: 'success' };
+  }
+  if (!lead.first_response_due_at) {
+    return { status: 'No SLA', variant: 'neutral' };
+  }
+  const due = new Date(lead.first_response_due_at).getTime();
+  const now = Date.now();
+  if (Number.isNaN(due)) {
+    return { status: 'No SLA', variant: 'neutral' };
+  }
+  if (due < now) {
+    return { status: 'Overdue', variant: 'error' };
+  }
+  if (due < now + 30 * 60 * 1000) {
+    return { status: 'Due soon', variant: 'warning' };
+  }
+  return { status: 'On track', variant: 'success' };
+}

--- a/lib/notifications/sales-alerts.ts
+++ b/lib/notifications/sales-alerts.ts
@@ -20,6 +20,14 @@ const SALES_TEAM_PHONE = process.env.SALES_TEAM_PHONE || '+27824873900';
 const SLACK_WEBHOOK_URL = process.env.SLACK_SALES_WEBHOOK_URL;
 const ENABLE_SALES_ALERTS = process.env.ENABLE_SALES_ALERTS !== 'false'; // Enabled by default
 const IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
+const APP_BASE =
+  process.env.NEXT_PUBLIC_APP_URL ||
+  process.env.NEXT_PUBLIC_BASE_URL ||
+  'https://www.circletel.co.za';
+
+function adminLeadUrl(leadId: string): string {
+  return `${APP_BASE.replace(/\/$/, '')}/admin/leads/${leadId}`;
+}
 
 export interface CoverageLeadData {
   id: string;
@@ -119,7 +127,7 @@ export async function sendCoverageLeadAlert(
       result.errors?.push(`Zoho CRM sync failed: ${zohoResult.error}`);
     }
 
-    // Step 2: PiPaperPlaneRightBold Email Alert to Sales Team
+    // Step 2: Email Alert to Sales Team
     try {
       const emailResult = await EmailNotificationService.send({
         to: SALES_TEAM_EMAIL,
@@ -127,6 +135,7 @@ export async function sendCoverageLeadAlert(
         template: 'sales_coverage_lead_alert',
         data: {
           lead_id: leadData.id,
+          admin_lead_url: adminLeadUrl(leadData.id),
           customer_type: getCustomerTypeLabel(leadData.customer_type),
           customer_name: `${leadData.first_name} ${leadData.last_name}`,
           company_name: leadData.company_name,
@@ -187,7 +196,7 @@ export async function sendCoverageLeadAlert(
       }
     }
 
-    // Step 4: PiPaperPlaneRightBold Slack Notification (if configured)
+    // Step 4: Slack Notification (if configured)
     if (SLACK_WEBHOOK_URL) {
       try {
         await sendSlackNotification({
@@ -203,6 +212,7 @@ export async function sendCoverageLeadAlert(
           zohoLeadUrl: result.zohoLeadId
             ? `https://crm.zoho.com/crm/org123/tab/Leads/${result.zohoLeadId}`
             : undefined,
+          adminLeadUrl: adminLeadUrl(leadData.id),
         });
         result.slackSent = true;
       } catch (error) {
@@ -416,11 +426,13 @@ async function sendSlackNotification(data: {
   budgetRange?: string;
   coverageAvailable?: boolean;
   zohoLeadUrl?: string;
+  adminLeadUrl?: string;
 }): Promise<void> {
   if (!SLACK_WEBHOOK_URL) return;
 
   const coverageEmoji = data.coverageAvailable ? '✅' : '❌';
   const typeEmoji = data.customerType === 'enterprise' ? '🏢' : data.customerType === 'smme' ? '🏪' : '👤';
+  const leadAdminUrl = data.adminLeadUrl || adminLeadUrl(data.leadId);
 
   const slackPayload = {
     text: `${typeEmoji} New Lead: ${data.customerName}`,
@@ -498,7 +510,7 @@ async function sendSlackNotification(data: {
               text: 'View Lead Details',
               emoji: true,
             },
-            url: `${process.env.NEXT_PUBLIC_APP_URL}/admin/leads/${data.leadId}`,
+            url: leadAdminUrl,
           },
         ],
       },

--- a/lib/notifications/templates/email/sales_coverage_lead_alert.ts
+++ b/lib/notifications/templates/email/sales_coverage_lead_alert.ts
@@ -76,16 +76,21 @@ export function renderSalesCoverageLeadAlert(data: Record<string, any>): string 
             </div>
             ` : ''}
 
-            ${data.zoho_lead_url ? `
             <div style="text-align: center; margin: 30px 0;">
-              <a href="${data.zoho_lead_url}" class="button" style="background-color: #3B82F6;">
+              ${data.admin_lead_url ? `
+              <a href="${data.admin_lead_url}" class="button" style="background-color: #E87A1E; margin: 0 8px 12px;">
+                Open lead in admin
+              </a>
+              ` : ''}
+              ${data.zoho_lead_url ? `
+              <a href="${data.zoho_lead_url}" class="button" style="background-color: #3B82F6; margin: 0 8px 12px;">
                 🔗 Open in Zoho CRM
               </a>
+              ` : ''}
             </div>
-            ` : ''}
 
             <div style="background-color: #FEF3C7; padding: 15px; border-radius: 8px; border-left: 4px solid #F59E0B; margin: 20px 0;">
-              <p style="margin: 0;"><strong>⏰ ACTION REQUIRED:</strong> Contact this lead within 30 minutes for best conversion rate!</p>
+              <p style="margin: 0;"><strong>⏰ ACTION REQUIRED:</strong> Contact this lead within 2 business hours (first-response SLA)!</p>
             </div>
 
             <p style="font-size: 12px; color: #6B7280; margin-top: 30px;">

--- a/ops/scheduler/generate-crontab.sh
+++ b/ops/scheduler/generate-crontab.sh
@@ -13,5 +13,9 @@ echo "# CircleTel platform cron jobs — GENERATED from vercel.json"
 echo "# Regenerate: ops/scheduler/generate-crontab.sh | crontab -"
 echo "# Requires /root/.cron-env exporting CRON_SECRET and APP_URL"
 echo "# All times UTC. Logs: /var/log/circletel-cron.log"
+echo "# curl: --connect-timeout 15 --max-time 360 (prevent multi-hour hung clients; longest route maxDuration=300s)"
 
-jq -r '.crons[] | "\(.schedule)\t. /root/.cron-env && curl -sfH \"Authorization: Bearer $CRON_SECRET\" $APP_URL\(.path) >> /var/log/circletel-cron.log 2>&1"' vercel.json
+# --max-time 360s: hard client cap so a stuck API cannot leave curl running for hours
+# (incident 2026-07-31: zoho-sync hung ~23min). Slightly above vercel maxDuration 300s
+# for generate-monthly-invoices. --connect-timeout fails fast on DNS/TCP hang.
+jq -r '.crons[] | "\(.schedule) . /root/.cron-env && curl -sf --connect-timeout 15 --max-time 360 -H \"Authorization: Bearer $CRON_SECRET\" \"$APP_URL\(.path)\" >> /var/log/circletel-cron.log 2>&1"' vercel.json

--- a/scripts/billing/audit-consumer-service-order-orphans.ts
+++ b/scripts/billing/audit-consumer-service-order-orphans.ts
@@ -1,0 +1,619 @@
+/**
+ * Audit active consumer services vs billable consumer_orders.
+ *
+ * An orphan is an active consumer service whose customer has no
+ * consumer_orders row with billing_active = true.
+ * (Clinic/corporate services are excluded — they are not consumer.)
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a && \\
+ *     npx tsx scripts/billing/audit-consumer-service-order-orphans.ts
+ *
+ *   # Deactivate one orphan (writes only with --execute):
+ *   ... --action=deactivate --service-id=<uuid> --execute
+ *
+ *   # Mark matching order billing_active (writes only with --execute):
+ *   ... --action=link --service-id=<uuid> --order-id=<uuid> --execute
+ *
+ * Default is dry-run (read-only). Env: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { isClinicBillingCategory } from '../../lib/billing/new-clinic-billing-helper';
+
+type Action = 'audit' | 'deactivate' | 'link';
+
+interface CliArgs {
+  action: Action;
+  execute: boolean;
+  serviceId: string | null;
+  orderId: string | null;
+  json: boolean;
+  force: boolean;
+}
+
+interface ServiceRow {
+  id: string;
+  customer_id: string;
+  package_name: string | null;
+  monthly_price: number | null;
+  status: string | null;
+  active: boolean | null;
+  product_category: string | null;
+  service_type: string | null;
+  activation_date: string | null;
+  connection_id: string | null;
+  last_invoice_date: string | null;
+  billing_start_date: string | null;
+}
+
+interface OrderRow {
+  id: string;
+  customer_id: string | null;
+  order_number: string | null;
+  billing_active: boolean | null;
+  status: string | null;
+  package_name: string | null;
+  package_price: number | null;
+  email: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  payment_status: string | null;
+  activation_date: string | null;
+}
+
+interface CustomerRow {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  account_type: string | null;
+  account_status: string | null;
+}
+
+interface OrphanReport {
+  service: ServiceRow;
+  customer: CustomerRow | null;
+  candidateOrders: OrderRow[];
+  suggestedAction: 'link' | 'deactivate' | 'review';
+  reason: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  let action: Action = 'audit';
+  let execute = false;
+  let serviceId: string | null = null;
+  let orderId: string | null = null;
+  let json = false;
+  let force = false;
+
+  for (const a of argv) {
+    if (a === '--execute') execute = true;
+    else if (a === '--json') json = true;
+    else if (a === '--force') force = true;
+    else if (a.startsWith('--action=')) {
+      const v = a.slice('--action='.length);
+      if (v === 'audit' || v === 'deactivate' || v === 'link') action = v;
+      else throw new Error(`Invalid --action=${v} (use audit|deactivate|link)`);
+    } else if (a.startsWith('--service-id=')) {
+      serviceId = a.slice('--service-id='.length);
+    } else if (a.startsWith('--order-id=')) {
+      orderId = a.slice('--order-id='.length);
+    } else if (a === '--help' || a === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+
+  return { action, execute, serviceId, orderId, json, force };
+}
+
+function printHelp() {
+  console.log(`Audit active consumer services without billing_active consumer_orders.
+
+Usage:
+  set -a && source .env.local && set +a && npx tsx scripts/billing/audit-consumer-service-order-orphans.ts [options]
+
+Options:
+  (default)                 Dry-run audit — print orphans and candidates
+  --json                    Emit machine-readable JSON summary
+  --action=deactivate       Soft-cancel one orphan service
+  --action=link             Set billing_active on a candidate order for the service customer
+  --service-id=<uuid>       Target service (required for deactivate/link)
+  --order-id=<uuid>         Target order (required for link)
+  --execute                 Persist writes (without this, mutations are dry-run only)
+  --force                   Allow linking a cancelled order (still requires --execute)
+  --help                    Show this help
+
+Consumer filter:
+  active=true AND status=active, excluding clinic/corporate product categories
+  (and Unjani package names). Matched to consumer_orders.billing_active = true
+  on the same customer_id.
+
+Env: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY`);
+}
+
+function isConsumerService(s: ServiceRow): boolean {
+  if (isClinicBillingCategory(s.product_category)) return false;
+  const pkg = (s.package_name ?? '').toLowerCase();
+  if (pkg.includes('unjani')) return false;
+  return true;
+}
+
+function customerLabel(c: CustomerRow | null, fallbackId: string): string {
+  if (!c) return fallbackId;
+  const name = [c.first_name, c.last_name].filter(Boolean).join(' ').trim();
+  return name || c.email || c.id;
+}
+
+function createServiceRoleClient(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY. Run: set -a && source .env.local && set +a'
+    );
+    process.exit(1);
+  }
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+async function loadActiveServices(supabase: SupabaseClient): Promise<ServiceRow[]> {
+  const { data, error } = await supabase
+    .from('customer_services')
+    .select(
+      'id, customer_id, package_name, monthly_price, status, active, product_category, service_type, activation_date, connection_id, last_invoice_date, billing_start_date'
+    )
+    .eq('active', true)
+    .eq('status', 'active');
+
+  if (error) throw new Error(`customer_services: ${error.message}`);
+  return (data ?? []) as ServiceRow[];
+}
+
+async function loadOrdersForCustomers(
+  supabase: SupabaseClient,
+  customerIds: string[]
+): Promise<OrderRow[]> {
+  if (customerIds.length === 0) return [];
+  const all: OrderRow[] = [];
+  for (let i = 0; i < customerIds.length; i += 50) {
+    const batch = customerIds.slice(i, i + 50);
+    const { data, error } = await supabase
+      .from('consumer_orders')
+      .select(
+        'id, customer_id, order_number, billing_active, status, package_name, package_price, email, first_name, last_name, payment_status, activation_date'
+      )
+      .in('customer_id', batch);
+    if (error) throw new Error(`consumer_orders: ${error.message}`);
+    all.push(...((data ?? []) as OrderRow[]));
+  }
+  return all;
+}
+
+async function loadCustomers(
+  supabase: SupabaseClient,
+  customerIds: string[]
+): Promise<Map<string, CustomerRow>> {
+  const map = new Map<string, CustomerRow>();
+  if (customerIds.length === 0) return map;
+  for (let i = 0; i < customerIds.length; i += 50) {
+    const batch = customerIds.slice(i, i + 50);
+    const { data, error } = await supabase
+      .from('customers')
+      .select('id, first_name, last_name, email, account_type, account_status')
+      .in('id', batch);
+    if (error) throw new Error(`customers: ${error.message}`);
+    for (const c of (data ?? []) as CustomerRow[]) {
+      map.set(c.id, c);
+    }
+  }
+  return map;
+}
+
+function suggestForOrphan(service: ServiceRow, candidates: OrderRow[]): {
+  suggestedAction: OrphanReport['suggestedAction'];
+  reason: string;
+} {
+  const linkable = candidates.filter(
+    (o) => o.status !== 'cancelled' && o.billing_active !== true
+  );
+  if (linkable.length === 1) {
+    return {
+      suggestedAction: 'link',
+      reason: `Single non-cancelled order ${linkable[0].order_number ?? linkable[0].id} (status=${linkable[0].status}) — candidate to set billing_active`,
+    };
+  }
+  if (linkable.length > 1) {
+    return {
+      suggestedAction: 'review',
+      reason: `${linkable.length} non-cancelled orders — pick one with --action=link --order-id=…`,
+    };
+  }
+  if (candidates.length > 0) {
+    return {
+      suggestedAction: 'deactivate',
+      reason: 'Only cancelled/billable-mismatch orders exist — deactivate service if not a live customer',
+    };
+  }
+  return {
+    suggestedAction: 'deactivate',
+    reason: 'No consumer_orders for this customer — deactivate if service was test/orphan',
+  };
+}
+
+async function runAudit(supabase: SupabaseClient): Promise<{
+  allActive: number;
+  consumerActive: number;
+  billableOrderCustomers: number;
+  matched: number;
+  orphans: OrphanReport[];
+  reverseGaps: { order: OrderRow; reason: string }[];
+}> {
+  const allActive = await loadActiveServices(supabase);
+  const consumer = allActive.filter(isConsumerService);
+  const customerIds = [...new Set(consumer.map((s) => s.customer_id))];
+  const [orders, customers] = await Promise.all([
+    loadOrdersForCustomers(supabase, customerIds),
+    loadCustomers(supabase, customerIds),
+  ]);
+
+  const billableByCustomer = new Map<string, OrderRow[]>();
+  const allOrdersByCustomer = new Map<string, OrderRow[]>();
+  for (const o of orders) {
+    if (!o.customer_id) continue;
+    const list = allOrdersByCustomer.get(o.customer_id) ?? [];
+    list.push(o);
+    allOrdersByCustomer.set(o.customer_id, list);
+    if (o.billing_active === true) {
+      const b = billableByCustomer.get(o.customer_id) ?? [];
+      b.push(o);
+      billableByCustomer.set(o.customer_id, b);
+    }
+  }
+
+  const orphans: OrphanReport[] = [];
+  let matched = 0;
+  for (const service of consumer) {
+    const billable = billableByCustomer.get(service.customer_id) ?? [];
+    if (billable.length > 0) {
+      matched += 1;
+      continue;
+    }
+    const candidates = allOrdersByCustomer.get(service.customer_id) ?? [];
+    const { suggestedAction, reason } = suggestForOrphan(service, candidates);
+    orphans.push({
+      service,
+      customer: customers.get(service.customer_id) ?? null,
+      candidateOrders: candidates,
+      suggestedAction,
+      reason,
+    });
+  }
+
+  // Reverse: billing_active orders whose customer has no active consumer service
+  const { data: allBillable, error: baErr } = await supabase
+    .from('consumer_orders')
+    .select(
+      'id, customer_id, order_number, billing_active, status, package_name, package_price, email, first_name, last_name, payment_status, activation_date'
+    )
+    .eq('billing_active', true);
+  if (baErr) throw new Error(`billing_active orders: ${baErr.message}`);
+
+  const consumerCustomerIds = new Set(consumer.map((s) => s.customer_id));
+  const reverseGaps: { order: OrderRow; reason: string }[] = [];
+  for (const o of (allBillable ?? []) as OrderRow[]) {
+    if (!o.customer_id || !consumerCustomerIds.has(o.customer_id)) {
+      // Customer may still have an active consumer service we already loaded under another path
+      const has = consumer.some((s) => s.customer_id === o.customer_id);
+      if (!has) {
+        reverseGaps.push({
+          order: o,
+          reason: 'billing_active order with no active consumer service for customer_id',
+        });
+      }
+    }
+  }
+
+  return {
+    allActive: allActive.length,
+    consumerActive: consumer.length,
+    billableOrderCustomers: billableByCustomer.size,
+    matched,
+    orphans,
+    reverseGaps,
+  };
+}
+
+function printAuditHuman(
+  report: Awaited<ReturnType<typeof runAudit>>,
+  mode: string
+) {
+  console.log('=== Consumer service ↔ billable order audit ===');
+  console.log(`Mode: ${mode}`);
+  console.log(`Active services (all categories): ${report.allActive}`);
+  console.log(`Active consumer services:         ${report.consumerActive}`);
+  console.log(`Customers with billing_active:    ${report.billableOrderCustomers}`);
+  console.log(`Matched (service has billable):   ${report.matched}`);
+  console.log(`Orphans:                          ${report.orphans.length}`);
+  console.log(`Reverse gaps (billable w/o svc):  ${report.reverseGaps.length}`);
+  console.log('');
+
+  if (report.orphans.length === 0) {
+    console.log('✅ No unexplained consumer service orphans.');
+  } else {
+    console.log('--- ORPHANS (active consumer service, no billing_active order) ---');
+    for (const o of report.orphans) {
+      const s = o.service;
+      const label = customerLabel(o.customer, s.customer_id);
+      console.log(`\n• service=${s.id}`);
+      console.log(`  customer=${s.customer_id} (${label})`);
+      console.log(
+        `  package=${s.package_name} R${s.monthly_price ?? '?'} type=${s.service_type} cat=${s.product_category ?? 'null'}`
+      );
+      console.log(
+        `  activation=${s.activation_date ?? '—'} last_invoice=${s.last_invoice_date ?? '—'} connection=${s.connection_id ?? '—'}`
+      );
+      console.log(`  suggested=${o.suggestedAction} — ${o.reason}`);
+      if (o.candidateOrders.length === 0) {
+        console.log('  candidates: (none)');
+      } else {
+        console.log('  candidates:');
+        for (const c of o.candidateOrders) {
+          console.log(
+            `    - ${c.order_number ?? c.id} status=${c.status} billing_active=${c.billing_active} payment=${c.payment_status} pkg=${c.package_name} R${c.package_price ?? '?'}`
+          );
+          console.log(`      order_id=${c.id}`);
+        }
+      }
+      if (o.suggestedAction === 'link' && o.candidateOrders.length > 0) {
+        const cand =
+          o.candidateOrders.find((c) => c.status !== 'cancelled') ??
+          o.candidateOrders[0];
+        console.log(
+          `  dry-run link: --action=link --service-id=${s.id} --order-id=${cand.id}`
+        );
+      }
+      if (o.suggestedAction === 'deactivate') {
+        console.log(`  dry-run deactivate: --action=deactivate --service-id=${s.id}`);
+      }
+    }
+  }
+
+  if (report.reverseGaps.length > 0) {
+    console.log('\n--- REVERSE GAPS (informational) ---');
+    for (const g of report.reverseGaps) {
+      const o = g.order;
+      console.log(
+        `• ${o.order_number ?? o.id} customer=${o.customer_id} status=${o.status} — ${g.reason}`
+      );
+    }
+  }
+
+  console.log('\nWrites require --execute. Prefer ops sign-off before mutating production.');
+}
+
+async function deactivateService(
+  supabase: SupabaseClient,
+  serviceId: string,
+  execute: boolean
+): Promise<void> {
+  const { data: service, error } = await supabase
+    .from('customer_services')
+    .select(
+      'id, customer_id, package_name, monthly_price, status, active, product_category, service_type, activation_date, connection_id, last_invoice_date, billing_start_date'
+    )
+    .eq('id', serviceId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!service) throw new Error(`Service not found: ${serviceId}`);
+
+  const row = service as ServiceRow;
+  if (!isConsumerService(row)) {
+    throw new Error(
+      `Service ${serviceId} is not classified as consumer (category=${row.product_category}). Refusing.`
+    );
+  }
+  if (row.status !== 'active' || row.active !== true) {
+    console.log(`Service already inactive: status=${row.status} active=${row.active}`);
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const patch = {
+    status: 'cancelled',
+    active: false,
+    cancelled_at: now,
+    updated_at: now,
+  };
+
+  console.log(`Would deactivate service ${serviceId}:`, patch);
+  if (!execute) {
+    console.log('DRY-RUN — no write. Re-run with --execute to apply.');
+    return;
+  }
+
+  const { error: upErr } = await supabase
+    .from('customer_services')
+    .update(patch)
+    .eq('id', serviceId)
+    .eq('status', 'active')
+    .eq('active', true);
+
+  if (upErr) throw new Error(`deactivate failed: ${upErr.message}`);
+  console.log(`✅ Deactivated service ${serviceId}`);
+}
+
+async function linkOrder(
+  supabase: SupabaseClient,
+  serviceId: string,
+  orderId: string,
+  execute: boolean,
+  force: boolean
+): Promise<void> {
+  const { data: service, error: sErr } = await supabase
+    .from('customer_services')
+    .select(
+      'id, customer_id, package_name, monthly_price, status, active, product_category, service_type, activation_date, connection_id, last_invoice_date, billing_start_date'
+    )
+    .eq('id', serviceId)
+    .maybeSingle();
+  if (sErr) throw new Error(sErr.message);
+  if (!service) throw new Error(`Service not found: ${serviceId}`);
+  const row = service as ServiceRow;
+
+  if (!isConsumerService(row)) {
+    throw new Error(
+      `Service ${serviceId} is not classified as consumer (category=${row.product_category}). Refusing.`
+    );
+  }
+  if (row.status !== 'active' || row.active !== true) {
+    throw new Error(`Service ${serviceId} is not active (status=${row.status}, active=${row.active})`);
+  }
+
+  const { data: order, error: oErr } = await supabase
+    .from('consumer_orders')
+    .select(
+      'id, customer_id, order_number, billing_active, status, package_name, package_price, email, first_name, last_name, payment_status, activation_date'
+    )
+    .eq('id', orderId)
+    .maybeSingle();
+  if (oErr) throw new Error(oErr.message);
+  if (!order) throw new Error(`Order not found: ${orderId}`);
+  const ord = order as OrderRow;
+
+  if (ord.customer_id !== row.customer_id) {
+    throw new Error(
+      `Order customer_id ${ord.customer_id} does not match service customer_id ${row.customer_id}`
+    );
+  }
+  if (ord.billing_active === true) {
+    console.log(`Order ${ord.order_number ?? ord.id} already billing_active=true — nothing to do.`);
+    return;
+  }
+  if (ord.status === 'cancelled' && !force) {
+    throw new Error(
+      `Order ${ord.order_number ?? ord.id} is cancelled. Pass --force if you really intend to reactivate billing on it.`
+    );
+  }
+
+  const now = new Date().toISOString();
+  const patch: Record<string, unknown> = {
+    billing_active: true,
+    billing_activated_at: now,
+    updated_at: now,
+  };
+  // Only lift non-cancelled orders to active when linking for billing
+  if (ord.status !== 'active' && ord.status !== 'cancelled') {
+    patch.status = 'active';
+  }
+
+  console.log(
+    `Would link service ${serviceId} → order ${ord.order_number ?? ord.id} (${orderId}):`,
+    patch
+  );
+  if (!execute) {
+    console.log('DRY-RUN — no write. Re-run with --execute to apply.');
+    return;
+  }
+
+  const { error: upErr } = await supabase
+    .from('consumer_orders')
+    .update(patch)
+    .eq('id', orderId)
+    .eq('billing_active', false);
+  if (upErr) throw new Error(`link failed: ${upErr.message}`);
+  console.log(
+    `✅ Linked: set billing_active on ${ord.order_number ?? orderId} for service ${serviceId}`
+  );
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const supabase = createServiceRoleClient();
+  const mode = args.execute ? 'EXECUTE (writes enabled)' : 'DRY-RUN (read-only)';
+
+  if (args.action === 'audit') {
+    const report = await runAudit(supabase);
+    if (args.json) {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            mode: args.execute ? 'execute' : 'dry-run',
+            summary: {
+              allActive: report.allActive,
+              consumerActive: report.consumerActive,
+              billableOrderCustomers: report.billableOrderCustomers,
+              matched: report.matched,
+              orphanCount: report.orphans.length,
+              reverseGapCount: report.reverseGaps.length,
+            },
+            orphans: report.orphans.map((o) => ({
+              serviceId: o.service.id,
+              customerId: o.service.customer_id,
+              customer: customerLabel(o.customer, o.service.customer_id),
+              packageName: o.service.package_name,
+              monthlyPrice: o.service.monthly_price,
+              productCategory: o.service.product_category,
+              serviceType: o.service.service_type,
+              activationDate: o.service.activation_date,
+              lastInvoiceDate: o.service.last_invoice_date,
+              suggestedAction: o.suggestedAction,
+              reason: o.reason,
+              candidateOrders: o.candidateOrders.map((c) => ({
+                id: c.id,
+                orderNumber: c.order_number,
+                status: c.status,
+                billingActive: c.billing_active,
+                paymentStatus: c.payment_status,
+                packageName: c.package_name,
+              })),
+            })),
+            reverseGaps: report.reverseGaps.map((g) => ({
+              orderId: g.order.id,
+              orderNumber: g.order.order_number,
+              customerId: g.order.customer_id,
+              reason: g.reason,
+            })),
+          },
+          null,
+          2
+        ) + '\n'
+      );
+    } else {
+      printAuditHuman(report, mode);
+    }
+    if (report.orphans.length > 0) process.exitCode = 1;
+    return;
+  }
+
+  if (args.action === 'deactivate') {
+    if (!args.serviceId) {
+      throw new Error('--action=deactivate requires --service-id=<uuid>');
+    }
+    console.log(`Mode: ${mode}`);
+    await deactivateService(supabase, args.serviceId, args.execute);
+    console.log('\nRe-run audit (no flags) to verify orphan count.');
+    return;
+  }
+
+  if (args.action === 'link') {
+    if (!args.serviceId || !args.orderId) {
+      throw new Error('--action=link requires --service-id=<uuid> and --order-id=<uuid>');
+    }
+    console.log(`Mode: ${mode}`);
+    await linkOrder(supabase, args.serviceId, args.orderId, args.execute, args.force);
+    console.log('\nRe-run audit (no flags) to verify orphan count.');
+    return;
+  }
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(2);
+});

--- a/supabase/migrations/20260731010500_coverage_leads_followup_sla.sql
+++ b/supabase/migrations/20260731010500_coverage_leads_followup_sla.sql
@@ -1,0 +1,10 @@
+-- Coverage leads: assignment + first-response SLA columns for follow-up queue (F1).
+-- Apply manually to shared DB (no CI migration runner).
+
+ALTER TABLE public.coverage_leads
+  ADD COLUMN IF NOT EXISTS assigned_admin_id uuid REFERENCES public.admin_users(id),
+  ADD COLUMN IF NOT EXISTS first_response_due_at timestamptz,
+  ADD COLUMN IF NOT EXISTS first_responded_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_coverage_leads_followup_queue
+  ON public.coverage_leads (status, first_response_due_at, created_at DESC);

--- a/supabase/migrations/20260731020000_whatsapp_flow_sessions.sql
+++ b/supabase/migrations/20260731020000_whatsapp_flow_sessions.sql
@@ -1,0 +1,26 @@
+-- WhatsApp Flow sessions: store Meta Flow token state + link to coverage_leads (F1).
+-- Apply manually to shared DB (no CI migration runner).
+-- NOTE: ALTER TYPE ... ADD VALUE cannot run inside a transaction block on some PG versions.
+
+ALTER TYPE public.lead_source ADD VALUE IF NOT EXISTS 'whatsapp_flow';
+
+CREATE TABLE public.whatsapp_flow_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  flow_token text NOT NULL UNIQUE,
+  flow_id text NOT NULL,
+  flow_name text NOT NULL,
+  phone text NOT NULL,
+  entry_source text NOT NULL,
+  source_campaign text,
+  status text NOT NULL DEFAULT 'sent',
+  response_payload jsonb,
+  raw_webhook jsonb,
+  coverage_lead_id uuid REFERENCES public.coverage_leads(id),
+  whatsapp_message_id text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz
+);
+
+ALTER TABLE public.whatsapp_flow_sessions ENABLE ROW LEVEL SECURITY;
+-- service role only (no anon policies)

--- a/vercel.json
+++ b/vercel.json
@@ -238,6 +238,10 @@
     {
       "path": "/api/cron/tarana-metrics",
       "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/cron/lead-followup-sla",
+      "schedule": "*/30 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Ships the accepted near-term BSS goal (ADR 2026-07-31): WhatsApp F1 lead capture, admin lead follow-up queue with 2h business-hours SLA, and ops floor fixes.

### Workstream C — Ops floor
- Consumer service ↔ billable order orphan audit script (dry-run; 1 documented orphan pending ops)
- Guard activation when `sla_tracking` table missing (live DB confirmed)
- Ruijie device list: unlinked filter + shared Link Customer dialog

### Workstream B — Admin follow-up
- DB: `assigned_admin_id`, `first_response_due_at`, `first_responded_at` (applied)
- Business-hours SLA helper + unit tests
- `GET/PATCH /api/admin/leads` + `/admin/leads` UI
- SLA escalation cron every 30m (crontab install deferred until deploy)

### Workstream A — WhatsApp F1
- DB: `whatsapp_flow` enum + `whatsapp_flow_sessions` (applied)
- Types, session store, completion handler (TDD 12 tests)
- `sendFlow` + webhook `nfm_reply` branch (always 200)
- Sales alert + free-form customer confirm
- Admin `POST /api/admin/whatsapp/flows/send`
- Ops runbook for Meta Flow Builder / E2E

## Test plan
- [ ] `npx jest --testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='/node_modules/' --testPathPatterns='first-response-sla|flow-response-handler|service-activator-sla'`
- [ ] Deploy staging/prod; set `WHATSAPP_FLOW_LEAD_QUALIFICATION_ID`
- [ ] Meta draft F1 E2E → verify `coverage_leads` + `/admin/leads`
- [ ] After deploy: `ops/scheduler/generate-crontab.sh | crontab -` + `check-drift.sh`
- [ ] Ops: decide Raymund orphan link (see `docs/analysis/2026-07-31-consumer-service-order-orphans.md`)

## Notes
- Migrations applied manually to shared Supabase; files committed for history
- Do not install lead-followup-sla crontab until route is live
- Meta Flow Builder still required before F1 can send live (A6 runbook)

Spec: `docs/superpowers/specs/2026-07-31-near-term-f1-followup-floor-design.md`
Plan: `docs/superpowers/plans/2026-07-31-near-term-f1-followup-floor.md`