### PR TITLE
feat(admin): Billing Health dashboard across finance pages

### DIFF
--- a/__tests__/lib/billing/health/aging.test.ts
+++ b/__tests__/lib/billing/health/aging.test.ts
@@ -1,0 +1,138 @@
+import {
+  agingBucketForDays,
+  buildAgingBuckets,
+  buildOverdueRegister,
+  buildWatchlist,
+  countUnpaidCustomers,
+  daysPastDue,
+  type UnpaidInvoiceInput,
+} from '@/lib/billing/health/aging';
+
+const TODAY = '2026-07-30';
+
+function inv(partial: Partial<UnpaidInvoiceInput>): UnpaidInvoiceInput {
+  return {
+    id: 'i1',
+    customerId: 'c1',
+    customerName: 'TechHub Solutions',
+    invoiceNumber: 'INV-1',
+    packageName: 'Home 100/50 Mbps',
+    dueDate: '2026-07-30',
+    amountDue: 100,
+    ...partial,
+  };
+}
+
+describe('daysPastDue', () => {
+  it('is 0 when due today', () => {
+    expect(daysPastDue('2026-07-30', TODAY)).toBe(0);
+  });
+
+  it('is positive after the due date', () => {
+    expect(daysPastDue('2026-07-22', TODAY)).toBe(8);
+  });
+
+  it('is negative before the due date', () => {
+    expect(daysPastDue('2026-08-05', TODAY)).toBe(-6);
+  });
+
+  it('handles full ISO timestamps by truncating to the day', () => {
+    expect(daysPastDue('2026-07-25T23:59:59.000Z', TODAY)).toBe(5);
+  });
+});
+
+describe('agingBucketForDays', () => {
+  it.each([
+    [-3, 'current'],
+    [0, 'current'],
+    [1, '1-7d'],
+    [7, '1-7d'],
+    [8, '8-30d'],
+    [30, '8-30d'],
+    [31, '31-60d'],
+    [60, '31-60d'],
+    [61, '61d+'],
+    [400, '61d+'],
+  ] as const)('%i days -> %s', (days, bucket) => {
+    expect(agingBucketForDays(days)).toBe(bucket);
+  });
+});
+
+describe('buildAgingBuckets', () => {
+  it('sums amounts into the right buckets', () => {
+    const buckets = buildAgingBuckets(
+      [
+        inv({ id: 'a', amountDue: 2120, dueDate: '2026-08-01' }), // current
+        inv({ id: 'b', amountDue: 890, dueDate: '2026-07-25' }), // 5d
+        inv({ id: 'c', amountDue: 1450, dueDate: '2026-07-09' }), // 21d
+        inv({ id: 'd', amountDue: 1240, dueDate: '2026-06-26' }), // 34d
+        inv({ id: 'e', amountDue: 800, dueDate: '2026-04-30' }), // 91d
+      ],
+      TODAY
+    );
+    expect(buckets).toEqual({
+      current: 2120,
+      '1-7d': 890,
+      '8-30d': 1450,
+      '31-60d': 1240,
+      '61d+': 800,
+    });
+  });
+});
+
+describe('buildWatchlist', () => {
+  it('groups by customer, keeps max days, sorts desc, excludes current bucket', () => {
+    const services = new Map<string, string[]>([
+      ['c1', ['s1']],
+      ['c2', ['s2', 's3']],
+    ]);
+    const rows = buildWatchlist(
+      [
+        inv({ id: 'a', customerId: 'c1', customerName: 'Cafe Roasters', dueDate: '2026-06-26', amountDue: 1240 }), // 34d
+        inv({ id: 'b', customerId: 'c1', customerName: 'Cafe Roasters', dueDate: '2026-07-20', amountDue: 300 }), // 10d
+        inv({ id: 'c', customerId: 'c2', customerName: 'FitZone Gym', dueDate: '2026-07-12', amountDue: 1450 }), // 18d
+        inv({ id: 'd', customerId: 'c3', customerName: 'Not Yet Due Co', dueDate: '2026-08-02', amountDue: 500 }), // current
+      ],
+      TODAY,
+      services
+    );
+
+    expect(rows.map((r) => r.customerName)).toEqual(['Cafe Roasters', 'FitZone Gym']);
+    expect(rows[0].daysPastDue).toBe(34);
+    expect(rows[0].agingBucket).toBe('31-60d');
+    expect(rows[0].overdueInvoiceCount).toBe(2);
+    expect(rows[0].overdueAmount).toBe(1540);
+    expect(rows[0].activeServiceIds).toEqual(['s1']);
+    expect(rows[1].activeServiceIds).toEqual(['s2', 's3']);
+  });
+});
+
+describe('buildOverdueRegister', () => {
+  it('excludes not-yet-due invoices and sorts by days overdue desc', () => {
+    const rows = buildOverdueRegister(
+      [
+        inv({ id: 'a', invoiceNumber: 'INV-2042', dueDate: '2026-07-25', amountDue: 890 }), // 5d
+        inv({ id: 'b', invoiceNumber: 'INV-2038', dueDate: '2026-06-26', amountDue: 1240 }), // 34d
+        inv({ id: 'c', invoiceNumber: 'INV-2099', dueDate: '2026-08-10', amountDue: 100 }), // current
+      ],
+      TODAY
+    );
+
+    expect(rows.map((r) => r.invoiceNumber)).toEqual(['INV-2038', 'INV-2042']);
+    expect(rows[0].daysOverdue).toBe(34);
+    expect(rows[0].agingBucket).toBe('31-60d');
+    expect(rows[0].href).toBe('/admin/billing/invoices/b');
+  });
+});
+
+describe('countUnpaidCustomers', () => {
+  it('counts distinct customers', () => {
+    expect(
+      countUnpaidCustomers([
+        inv({ id: 'a', customerId: 'c1' }),
+        inv({ id: 'b', customerId: 'c1' }),
+        inv({ id: 'c', customerId: 'c2' }),
+      ])
+    ).toBe(2);
+  });
+});

--- a/app/admin/billing/customers/page.tsx
+++ b/app/admin/billing/customers/page.tsx
@@ -3,7 +3,7 @@
 import {
   PiArrowsClockwiseBold,
   PiCurrencyDollarBold,
-  PiDotsThreeBold,
+  PiEyeBold,
   PiMagnifyingGlassBold,
   PiUserCheckBold,
   PiUsersBold,
@@ -12,16 +12,22 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
   AdminPage,
-  PageHeader,
-  StatCard,
-  SectionCard,
   StatusBadge,
   LoadingState,
   ErrorState,
   EmptyState,
   type StatusVariant,
 } from '@/components/backend';
+import { HealthCard, formatRand, formatDueDate } from '@/components/admin/billing/health';
 
 interface Customer {
   id: string;
@@ -91,21 +97,6 @@ export default function CustomersPage() {
       customer.account_number?.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString('en-ZA', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-    });
-  };
-
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-ZA', {
-      style: 'currency',
-      currency: 'ZAR',
-    }).format(amount);
-  };
-
   if (loading) {
     return (
       <AdminPage>
@@ -122,146 +113,159 @@ export default function CustomersPage() {
     );
   }
 
+  const inactiveCount = (stats?.totalCustomers ?? 0) - (stats?.activeCustomers ?? 0);
+
   return (
     <AdminPage>
-      <PageHeader
-        title="Customer Billing"
-        subtitle="Manage customer billing and accounts"
-        actions={
-          <Button variant="outline" onClick={fetchCustomers}>
-            <PiArrowsClockwiseBold className="h-4 w-4 mr-2" />
-            Refresh
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="mb-1 text-xs text-slate-400">Finance / Billing / Customers</p>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Customer Billing</h1>
+          <p className="mt-1 text-sm text-slate-500">Manage customer billing and accounts</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-xs text-slate-400">
+            {filteredCustomers.length} of {customers.length} customers
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={fetchCustomers}
+            disabled={loading}
+            aria-label="Refresh customers"
+          >
+            <PiArrowsClockwiseBold className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
           </Button>
-        }
-      />
+        </div>
+      </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <StatCard
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <HealthCard
           label="Total Customers"
-          value={stats?.totalCustomers || 0}
+          value={String(stats?.totalCustomers ?? 0)}
+          primaryLine={`${stats?.activeCustomers ?? 0} active`}
+          primaryClassName="text-teal-600"
+          secondaryLine="All billing accounts"
           icon={<PiUsersBold className="h-5 w-5" />}
+          iconClassName="bg-teal-50 text-teal-600"
         />
-        <StatCard
+        <HealthCard
           label="Active Customers"
-          value={stats?.activeCustomers || 0}
+          value={String(stats?.activeCustomers ?? 0)}
+          primaryLine={`${inactiveCount} inactive or suspended`}
+          secondaryLine="Account status = active"
           icon={<PiUserCheckBold className="h-5 w-5" />}
+          iconClassName="bg-teal-50 text-teal-600"
         />
-        <StatCard
+        <HealthCard
           label="Total Outstanding"
-          value={formatCurrency(stats?.totalOutstanding || 0)}
+          value={formatRand(stats?.totalOutstanding ?? 0)}
+          primaryLine="Unpaid balances"
+          primaryClassName="text-orange-500"
+          secondaryLine="Across all customers"
           icon={<PiCurrencyDollarBold className="h-5 w-5" />}
+          iconClassName="bg-orange-50 text-orange-500"
         />
       </div>
 
-      <SectionCard
-        title="Customer List"
-        action={
-          <span className="text-sm text-gray-500">
-            {filteredCustomers.length} of {customers.length}
-          </span>
-        }
-      >
-        <div className="mb-4">
-          <div className="relative max-w-md">
-            <PiMagnifyingGlassBold className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+      <div className="flex flex-col rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-6 py-4">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">Customer List</h2>
+            <p className="mt-0.5 text-sm text-slate-500">
+              {filteredCustomers.length} of {customers.length} customers
+            </p>
+          </div>
+          <div className="relative w-full max-w-md">
+            <PiMagnifyingGlassBold className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
             <input
               type="text"
               placeholder="Search customers..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-circleTel-orange focus:border-transparent w-full"
+              className="w-full rounded-lg border border-slate-200 py-2 pl-10 pr-4 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-circleTel-orange"
             />
           </div>
         </div>
 
         {filteredCustomers.length === 0 ? (
-          <EmptyState
-            icon={<PiUsersBold />}
-            title={searchTerm ? 'No customers match your search' : 'No customers found'}
-          />
+          <div className="px-6 py-12">
+            <EmptyState
+              icon={<PiUsersBold />}
+              title={searchTerm ? 'No customers match your search' : 'No customers found'}
+            />
+          </div>
         ) : (
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Customer
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Contact
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Outstanding
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Services
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Created
-                  </th>
-                  <th className="relative px-6 py-3">
-                    <span className="sr-only">Actions</span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+            <Table>
+              <TableHeader>
+                <TableRow className="border-slate-100 hover:bg-transparent">
+                  <TableHead className="pl-6 text-xs font-medium uppercase tracking-wide text-slate-400">Customer</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Contact</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Status</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Outstanding</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Services</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Created</TableHead>
+                  <TableHead className="pr-6 text-right text-xs font-medium uppercase tracking-wide text-slate-400">
+                    <span className="sr-only">View</span>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {filteredCustomers.map((customer) => (
-                  <tr key={customer.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div>
-                        <div className="text-sm font-medium text-gray-900">{customer.name}</div>
-                        {customer.company && (
-                          <div className="text-sm text-gray-500">{customer.company}</div>
-                        )}
-                        {customer.account_number && (
-                          <div className="text-xs text-gray-400">{customer.account_number}</div>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm text-gray-900">{customer.email}</div>
-                      {customer.phone && (
-                        <div className="text-sm text-gray-500">{customer.phone}</div>
+                  <TableRow key={customer.id} className="border-slate-100">
+                    <TableCell className="pl-6">
+                      <div className="text-sm font-medium text-slate-900">{customer.name}</div>
+                      {customer.company && (
+                        <div className="text-sm text-slate-500">{customer.company}</div>
                       )}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
+                      {customer.account_number && (
+                        <div className="text-xs text-slate-400">{customer.account_number}</div>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm text-slate-900">{customer.email}</div>
+                      {customer.phone && (
+                        <div className="text-sm text-slate-500">{customer.phone}</div>
+                      )}
+                    </TableCell>
+                    <TableCell>
                       <StatusBadge
                         status={customer.status.charAt(0).toUpperCase() + customer.status.slice(1)}
                         variant={CUSTOMER_STATUS_VARIANT[customer.status] ?? 'neutral'}
                       />
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div
-                        className={`text-sm font-medium tabular-nums ${
-                          customer.outstanding_amount > 0 ? 'text-orange-600' : 'text-gray-500'
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={`text-sm font-semibold tabular-nums ${
+                          customer.outstanding_amount > 0 ? 'text-red-600' : 'text-slate-400'
                         }`}
                       >
-                        {formatCurrency(customer.outstanding_amount)}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {formatRand(customer.outstanding_amount)}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-sm text-slate-500">
                       {customer.active_services}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {formatDate(customer.created_at)}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <Link href={`/admin/customers/${customer.id}`}>
-                        <Button variant="ghost" size="icon">
-                          <PiDotsThreeBold className="h-4 w-4" />
-                        </Button>
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-sm text-slate-500">
+                      {formatDueDate(customer.created_at)}
+                    </TableCell>
+                    <TableCell className="pr-6 text-right">
+                      <Link
+                        href={`/admin/customers/${customer.id}`}
+                        aria-label={`View customer ${customer.name}`}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                      >
+                        <PiEyeBold className="h-4 w-4" />
                       </Link>
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ))}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </div>
         )}
-      </SectionCard>
+      </div>
     </AdminPage>
   );
 }

--- a/app/admin/billing/invoices/page.tsx
+++ b/app/admin/billing/invoices/page.tsx
@@ -2,6 +2,7 @@
 
 import {
   PiArrowsClockwiseBold,
+  PiCheckCircleBold,
   PiDotsThreeBold,
   PiDownloadSimpleBold,
   PiEnvelopeBold,
@@ -9,21 +10,34 @@ import {
   PiFileTextBold,
   PiMagnifyingGlassBold,
   PiPlusBold,
+  PiWarningCircleBold,
 } from 'react-icons/pi';
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
   AdminPage,
-  PageHeader,
-  StatCard,
-  SectionCard,
   StatusBadge,
   LoadingState,
   ErrorState,
   EmptyState,
   type StatusVariant,
 } from '@/components/backend';
+import {
+  HealthCard,
+  csvCell,
+  downloadCsv,
+  formatRand,
+  formatDueDate,
+} from '@/components/admin/billing/health';
 
 interface Invoice {
   id: string;
@@ -48,6 +62,21 @@ interface InvoiceStats {
   overdueAmount: number;
   overdueCount: number;
 }
+
+const INVOICE_STATUS_VARIANT: Record<string, StatusVariant> = {
+  paid: 'success',
+  sent: 'info',
+  overdue: 'error',
+  draft: 'neutral',
+  partial: 'warning',
+  voided: 'neutral',
+  cancelled: 'neutral',
+};
+
+const INVOICE_STATUS_LABEL: Record<string, string> = {
+  voided: 'Voided',
+  cancelled: 'Voided',
+};
 
 export default function InvoicesPage() {
   const [invoices, setInvoices] = useState<Invoice[]>([]);
@@ -81,42 +110,6 @@ export default function InvoicesPage() {
     fetchInvoices();
   }, []);
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-ZA', {
-      style: 'currency',
-      currency: 'ZAR',
-    }).format(amount);
-  };
-
-  const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString('en-ZA', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-    });
-  };
-
-  const INVOICE_STATUS_VARIANT: Record<string, StatusVariant> = {
-    paid: 'success',
-    sent: 'info',
-    overdue: 'error',
-    draft: 'neutral',
-    partial: 'warning',
-    voided: 'neutral',
-    cancelled: 'neutral',
-  };
-  const INVOICE_STATUS_LABEL: Record<string, string> = {
-    voided: 'Voided',
-    cancelled: 'Voided',
-  };
-
-  const getStatusBadge = (status: string) => (
-    <StatusBadge
-      status={INVOICE_STATUS_LABEL[status] ?? status.charAt(0).toUpperCase() + status.slice(1)}
-      variant={INVOICE_STATUS_VARIANT[status] ?? 'neutral'}
-    />
-  );
-
   const filteredInvoices = invoices.filter((invoice) => {
     if (!searchQuery) return true;
     const query = searchQuery.toLowerCase();
@@ -126,6 +119,24 @@ export default function InvoicesPage() {
       invoice.customer_email.toLowerCase().includes(query)
     );
   });
+
+  const handleExport = () => {
+    const today = new Date().toISOString().slice(0, 10);
+    downloadCsv(`invoices-${today}.csv`, [
+      ['Invoice #', 'Customer', 'Email', 'Invoice date', 'Due date', 'Total', 'Paid', 'Due', 'Status'],
+      ...filteredInvoices.map((inv) => [
+        csvCell(inv.invoice_number),
+        csvCell(inv.customer_name),
+        csvCell(inv.customer_email),
+        inv.invoice_date,
+        inv.due_date,
+        inv.total_amount.toFixed(2),
+        inv.amount_paid.toFixed(2),
+        inv.amount_due.toFixed(2),
+        inv.status,
+      ]),
+    ]);
+  };
 
   if (loading) {
     return (
@@ -145,148 +156,189 @@ export default function InvoicesPage() {
 
   return (
     <AdminPage>
-      <PageHeader
-        title="Invoices"
-        subtitle="Manage billing and invoices"
-        actions={
-          <>
-            <Button variant="outline" onClick={fetchInvoices}>
-              <PiArrowsClockwiseBold className="h-4 w-4 mr-2" />
-              Refresh
-            </Button>
-            <Button className="bg-circleTel-orange hover:bg-circleTel-orange-dark" disabled>
-              <PiPlusBold className="h-4 w-4 mr-2" />
-              Create Invoice
-            </Button>
-          </>
-        }
-      />
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="mb-1 text-xs text-slate-400">Finance / Billing / Invoices</p>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Invoices</h1>
+          <p className="mt-1 text-sm text-slate-500">Manage billing and invoices</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={fetchInvoices}
+            disabled={loading}
+            aria-label="Refresh invoices"
+          >
+            <PiArrowsClockwiseBold className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </Button>
+          <Button
+            size="sm"
+            className="bg-slate-900 text-white hover:bg-slate-800"
+            onClick={handleExport}
+            disabled={filteredInvoices.length === 0}
+          >
+            <PiDownloadSimpleBold className="mr-2 h-4 w-4" />
+            Export
+          </Button>
+          <Button size="sm" className="bg-circleTel-orange hover:bg-circleTel-orange-dark" disabled>
+            <PiPlusBold className="mr-2 h-4 w-4" />
+            Create Invoice
+          </Button>
+        </div>
+      </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <StatCard
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <HealthCard
           label="Total Outstanding"
-          value={formatCurrency(stats?.totalOutstanding || 0)}
+          value={formatRand(stats?.totalOutstanding ?? 0)}
+          primaryLine="Unpaid balances"
+          primaryClassName="text-orange-500"
+          secondaryLine="Sent, partial & overdue"
           icon={<PiFileTextBold className="h-5 w-5" />}
+          iconClassName="bg-orange-50 text-orange-500"
         />
-        <StatCard
+        <HealthCard
           label="Paid This Month"
-          value={formatCurrency(stats?.paidThisMonth || 0)}
-          icon={<PiFileTextBold className="h-5 w-5" />}
+          value={formatRand(stats?.paidThisMonth ?? 0)}
+          primaryLine="Collected"
+          primaryClassName="text-teal-600"
+          secondaryLine="Payments received this month"
+          icon={<PiCheckCircleBold className="h-5 w-5" />}
+          iconClassName="bg-teal-50 text-teal-600"
         />
-        <StatCard
+        <HealthCard
           label="Overdue"
-          value={formatCurrency(stats?.overdueAmount || 0)}
-          icon={<PiFileTextBold className="h-5 w-5" />}
-          subtitle={
-            (stats?.overdueCount || 0) > 0
+          value={formatRand(stats?.overdueAmount ?? 0)}
+          primaryLine={
+            (stats?.overdueCount ?? 0) > 0
               ? `${stats?.overdueCount} invoice${stats?.overdueCount !== 1 ? 's' : ''} overdue`
-              : undefined
+              : 'No overdue invoices'
           }
+          primaryClassName={(stats?.overdueCount ?? 0) > 0 ? 'text-red-600' : undefined}
+          secondaryLine="Past due date"
+          icon={<PiWarningCircleBold className="h-5 w-5" />}
+          iconClassName="bg-red-50 text-red-600"
         />
       </div>
 
-      <SectionCard
-        title="All Invoices"
-        action={
-          <span className="text-sm text-gray-500">
-            {invoices.length} invoice{invoices.length !== 1 ? 's' : ''} total
-          </span>
-        }
-      >
-        <div className="mb-4 flex justify-between items-center gap-4 flex-wrap">
-          <div className="relative max-w-md w-full">
-            <PiMagnifyingGlassBold className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+      <div className="flex flex-col rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-6 py-4">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">All Invoices</h2>
+            <p className="mt-0.5 text-sm text-slate-500">
+              {filteredInvoices.length} of {invoices.length} invoice{invoices.length !== 1 ? 's' : ''}
+            </p>
+          </div>
+          <div className="relative w-full max-w-md">
+            <PiMagnifyingGlassBold className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
             <input
               type="text"
               placeholder="Search invoices..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-circleTel-orange focus:border-transparent w-full"
+              className="w-full rounded-lg border border-slate-200 py-2 pl-10 pr-4 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-circleTel-orange"
             />
           </div>
-          <Button variant="outline" disabled>
-            <PiDownloadSimpleBold className="h-4 w-4 mr-2" />
-            Export
-          </Button>
         </div>
 
         {filteredInvoices.length === 0 ? (
-          <EmptyState
-            icon={<PiFileTextBold />}
-            title={searchQuery ? 'No invoices match your search' : 'No invoices found'}
-          />
+          <div className="px-6 py-12">
+            <EmptyState
+              icon={<PiFileTextBold />}
+              title={searchQuery ? 'No invoices match your search' : 'No invoices found'}
+            />
+          </div>
         ) : (
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Invoice
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Customer
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Amount
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Due Date
-                  </th>
-                  <th className="relative px-6 py-3">
+            <Table>
+              <TableHeader>
+                <TableRow className="border-slate-100 hover:bg-transparent">
+                  <TableHead className="pl-6 text-xs font-medium uppercase tracking-wide text-slate-400">Invoice</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Customer</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Amount</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Status</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Due date</TableHead>
+                  <TableHead className="pr-6 text-right text-xs font-medium uppercase tracking-wide text-slate-400">
                     <span className="sr-only">Actions</span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {filteredInvoices.map((invoice) => (
-                  <tr key={invoice.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900">{invoice.invoice_number}</div>
-                      <div className="text-sm text-gray-500">{formatDate(invoice.invoice_date)}</div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900">{invoice.customer_name}</div>
-                      <div className="text-sm text-gray-500">{invoice.customer_email}</div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900 tabular-nums">
-                        {formatCurrency(invoice.total_amount)}
+                  <TableRow key={invoice.id} className="border-slate-100">
+                    <TableCell className="pl-6">
+                      <div className="text-sm font-medium text-slate-900">{invoice.invoice_number}</div>
+                      <div className="text-sm text-slate-500">{formatDueDate(invoice.invoice_date)}</div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm font-medium text-slate-900">{invoice.customer_name}</div>
+                      <div className="text-sm text-slate-500">{invoice.customer_email}</div>
+                    </TableCell>
+                    <TableCell>
+                      <div
+                        className={`text-sm font-semibold tabular-nums ${
+                          invoice.status === 'overdue' ? 'text-red-600' : 'text-slate-900'
+                        }`}
+                      >
+                        {formatRand(invoice.total_amount)}
                       </div>
                       {invoice.amount_paid > 0 && invoice.amount_paid < invoice.total_amount && (
-                        <div className="text-sm text-gray-500 tabular-nums">
-                          Paid: {formatCurrency(invoice.amount_paid)}
+                        <div className="text-xs text-slate-500 tabular-nums">
+                          Paid: {formatRand(invoice.amount_paid)}
                         </div>
                       )}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">{getStatusBadge(invoice.status)}</td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {formatDate(invoice.due_date)}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge
+                        status={
+                          INVOICE_STATUS_LABEL[invoice.status] ??
+                          invoice.status.charAt(0).toUpperCase() + invoice.status.slice(1)
+                        }
+                        variant={INVOICE_STATUS_VARIANT[invoice.status] ?? 'neutral'}
+                      />
+                    </TableCell>
+                    <TableCell
+                      className={`whitespace-nowrap text-sm ${
+                        invoice.status === 'overdue' ? 'font-medium text-red-600' : 'text-slate-500'
+                      }`}
+                    >
+                      {formatDueDate(invoice.due_date)}
+                    </TableCell>
+                    <TableCell className="pr-6">
                       <div className="flex items-center justify-end gap-1">
-                        <Link href={`/admin/billing/invoices/${invoice.id}`}>
-                          <Button variant="ghost" size="icon" title="View Invoice">
-                            <PiEyeBold className="h-4 w-4" />
-                          </Button>
+                        <Link
+                          href={`/admin/billing/invoices/${invoice.id}`}
+                          aria-label={`View invoice ${invoice.invoice_number}`}
+                          className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                        >
+                          <PiEyeBold className="h-4 w-4" />
                         </Link>
-                        <Button variant="ghost" size="icon" title="Send Reminder" disabled>
+                        <button
+                          type="button"
+                          title="Send Reminder"
+                          disabled
+                          className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-40"
+                        >
                           <PiEnvelopeBold className="h-4 w-4" />
-                        </Button>
-                        <Button variant="ghost" size="icon">
+                        </button>
+                        <button
+                          type="button"
+                          title="More actions"
+                          disabled
+                          className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-40"
+                        >
                           <PiDotsThreeBold className="h-4 w-4" />
-                        </Button>
+                        </button>
                       </div>
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ))}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </div>
         )}
-      </SectionCard>
+      </div>
     </AdminPage>
   );
 }

--- a/app/admin/billing/page.tsx
+++ b/app/admin/billing/page.tsx
@@ -1,114 +1,94 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import Link from 'next/link';
 import {
   PiArrowsClockwiseBold,
-  PiClockBold,
-  PiFileTextBold,
-  PiPlayBold,
+  PiDownloadSimpleBold,
 } from 'react-icons/pi';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import {
   AdminPage,
   LoadingState,
   ErrorState,
 } from '@/components/backend';
 import {
-  CashMatchStrip,
-  DayDoneBanner,
-  DeepLinks,
-  ExceptionTable,
-  SecondaryKpis,
-} from '@/components/admin/billing/recon';
+  AgingBucketsChart,
+  HealthStatCards,
+  MrrCollectionsChart,
+  OverdueInvoiceRegister,
+  SuspensionWatchlist,
+  csvCell,
+  downloadCsv,
+  formatRand,
+} from '@/components/admin/billing/health';
+import { AGING_BUCKET_LABELS } from '@/lib/billing/health/aging';
 import type {
-  ReconHubResponse,
-  ReconWindow,
-} from '@/lib/billing/recon-hub/types';
+  AgingBucketKey,
+  BillingHealthResponse,
+} from '@/lib/billing/health/types';
 
-const WINDOW_OPTIONS: Array<{ value: ReconWindow; label: string }> = [
-  { value: 'today', label: 'Today' },
-  { value: 'yesterday', label: 'Yesterday' },
-  { value: '48h', label: 'Last 48 hours' },
-];
+function exportArAgingCsv(data: BillingHealthResponse) {
+  const lines: Array<string | number>[] = [
+    ['AR Aging Summary'],
+    ['Bucket', 'Amount'],
+    ...(Object.keys(AGING_BUCKET_LABELS) as AgingBucketKey[]).map((key) => [
+      AGING_BUCKET_LABELS[key],
+      csvCell(formatRand(data.aging[key])),
+    ]),
+    ['Total unpaid', csvCell(formatRand(data.pastDue.totalAmount))],
+    [''],
+    ['Overdue Invoice Register'],
+    ['Invoice #', 'Customer', 'Package', 'Due date', 'Days overdue', 'Aging', 'Amount due'],
+    ...data.overdueInvoices.map((row) => [
+      csvCell(row.invoiceNumber),
+      csvCell(row.customerName),
+      csvCell(row.packageName ?? ''),
+      csvCell(row.dueDate),
+      row.daysOverdue,
+      AGING_BUCKET_LABELS[row.agingBucket],
+      csvCell(formatRand(row.amountDue)),
+    ]),
+  ];
 
-function windowLabel(window: ReconWindow): string {
-  return WINDOW_OPTIONS.find((o) => o.value === window)?.label ?? window;
+  downloadCsv(`ar-aging-${data.generatedAt.slice(0, 10)}.csv`, lines);
 }
 
 export default function BillingDashboard() {
-  const [window, setWindow] = useState<ReconWindow>('yesterday');
-  const [data, setData] = useState<ReconHubResponse | null>(null);
+  const [data, setData] = useState<BillingHealthResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [triggerLoading, setTriggerLoading] = useState(false);
 
-  const fetchHub = useCallback(async () => {
+  const fetchHealth = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
 
-      const res = await fetch(
-        `/api/admin/billing/recon-hub?window=${encodeURIComponent(window)}`
-      );
+      const res = await fetch('/api/admin/billing/health');
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(
-          (body as { error?: string }).error || 'Failed to load recon hub'
+          (body as { error?: string }).error || 'Failed to load billing health'
         );
       }
 
-      const body = (await res.json()) as ReconHubResponse;
-      setData(body);
+      setData((await res.json()) as BillingHealthResponse);
     } catch (err) {
-      console.error('Error fetching recon hub:', err);
-      setError(err instanceof Error ? err.message : 'Failed to load recon hub');
+      console.error('Error fetching billing health:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load billing health');
       setData(null);
     } finally {
       setLoading(false);
     }
-  }, [window]);
+  }, []);
 
   useEffect(() => {
-    fetchHub();
-  }, [fetchHub]);
-
-  const handleTriggerPayNow = async () => {
-    setTriggerLoading(true);
-    try {
-      const res = await fetch('/api/admin/billing/reconciliation/trigger', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type: 'paynow' }),
-      });
-      const body = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        throw new Error(
-          (body as { error?: string }).error || 'Failed to trigger PayNow recon'
-        );
-      }
-      await fetchHub();
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to trigger PayNow recon'
-      );
-    } finally {
-      setTriggerLoading(false);
-    }
-  };
+    fetchHealth();
+  }, [fetchHealth]);
 
   if (loading && !data) {
     return (
       <AdminPage>
-        <LoadingState message="Loading cash-match recon hub..." />
+        <LoadingState message="Loading billing health..." />
       </AdminPage>
     );
   }
@@ -117,117 +97,94 @@ export default function BillingDashboard() {
     return (
       <AdminPage>
         <ErrorState
-          title="Unable to load recon hub"
+          title="Unable to load billing health"
           message={error}
-          onRetry={fetchHub}
+          onRetry={fetchHealth}
         />
       </AdminPage>
     );
   }
 
-  const summary = data?.summary;
-
   return (
     <AdminPage>
-      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <p className="text-xs text-slate-400 mb-1">Finance / Billing / Cash Match</p>
-          <h1 className="text-2xl font-semibold text-slate-900 tracking-tight">Billing</h1>
-          <p className="text-slate-500 mt-1 text-sm">
-            Daily cash match — NetCash completed payments to CircleTel invoices
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
+            Billing Health
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            Receivables, collections, and suspension queue
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Select value={window} onValueChange={(value) => setWindow(value as ReconWindow)}>
-            <SelectTrigger className="w-[160px] rounded-lg border-slate-200" aria-label="Recon window">
-              <SelectValue placeholder="Window" />
-            </SelectTrigger>
-            <SelectContent>
-              {WINDOW_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Button variant="outline" size="sm" onClick={fetchHub} disabled={loading || triggerLoading}>
-            <PiArrowsClockwiseBold className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
-            Refresh
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-xs text-slate-400">Auto-updated daily 08:00 SAST</span>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={fetchHealth}
+            disabled={loading}
+            aria-label="Refresh billing health"
+          >
+            <PiArrowsClockwiseBold className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
           </Button>
           <Button
-            variant="outline"
             size="sm"
-            onClick={handleTriggerPayNow}
-            disabled={triggerLoading || loading}
+            className="bg-slate-900 text-white hover:bg-slate-800"
+            onClick={() => data && exportArAgingCsv(data)}
+            disabled={!data}
           >
-            <PiPlayBold className="w-4 h-4 mr-2" />
-            {triggerLoading ? 'Triggering…' : 'Trigger PayNow recon'}
-          </Button>
-          <Button size="sm" className="bg-circleTel-orange hover:bg-circleTel-orange-dark" asChild>
-            <Link href="/admin/billing/invoices">
-              <PiFileTextBold className="w-4 h-4 mr-2" />
-              View All Invoices
-            </Link>
+            <PiDownloadSimpleBold className="mr-2 h-4 w-4" />
+            Export AR aging
           </Button>
         </div>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant="outline" className="border-slate-200 bg-slate-50 text-slate-600">
-          Supabase recon hub
-        </Badge>
-        <span className="text-xs text-slate-400">Window · {windowLabel(window)}</span>
-        {summary ? (
-          <span className="text-xs text-slate-500">
-            {summary.netcashCompletedInWindow} NetCash completed ·{' '}
-            {summary.netcashMatchedInWindow} matched
-          </span>
-        ) : null}
       </div>
 
       {error && data && (
         <div
           role="alert"
-          className="rounded-xl border border-red-200/80 bg-red-50/80 shadow-sm px-4 py-3 text-sm text-red-800"
+          className="rounded-xl border border-red-200/80 bg-red-50/80 px-4 py-3 text-sm text-red-800 shadow-sm"
         >
           {error}
         </div>
       )}
 
-      {summary && (
+      {data && (
         <>
-          <DayDoneBanner
-            dayDone={summary.dayDone}
-            unmatchedCount={summary.unmatchedNetcashToCt}
-            windowLabel={windowLabel(window)}
+          <HealthStatCards
+            data={{
+              mrr: data.mrr,
+              pastDue: data.pastDue,
+              suspension: data.suspension,
+              unpaid: data.unpaid,
+            }}
           />
 
-          <CashMatchStrip
-            unmatchedNetcashToCt={summary.unmatchedNetcashToCt}
-            netcashCompletedInWindow={summary.netcashCompletedInWindow}
-            netcashMatchedInWindow={summary.netcashMatchedInWindow}
-            zohoPaymentLagCount={summary.zohoPaymentLagCount}
-            paynowRecon={summary.paynowRecon}
-          />
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+            <div className="min-w-0">
+              <MrrCollectionsChart data={data.trend} />
+            </div>
+            <div className="min-w-0">
+              <AgingBucketsChart aging={data.aging} />
+            </div>
+          </div>
 
-          <SecondaryKpis
-            openAr={summary.secondary.openAr}
-            collectedLast30Days={summary.secondary.collectedLast30Days}
-            activeServices={summary.secondary.activeServices}
-          />
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+            <div className="min-w-0">
+              <SuspensionWatchlist
+                entries={data.watchlist}
+                policyDays={data.suspension.policyDays}
+                onSuspended={fetchHealth}
+              />
+            </div>
+            <div className="min-w-0">
+              <OverdueInvoiceRegister
+                rows={data.overdueInvoices}
+                totalOverdue={data.unpaid.overdue}
+              />
+            </div>
+          </div>
         </>
       )}
-
-      <ExceptionTable exceptions={data?.exceptions ?? []} />
-
-      <DeepLinks />
-
-      <div className="flex flex-wrap items-center justify-end gap-3 text-sm text-slate-500">
-        <span className="inline-flex items-center gap-2">
-          <PiClockBold className="w-4 h-4" aria-hidden="true" />
-          {loading ? 'Refreshing…' : `Recon window · ${windowLabel(window)}`}
-        </span>
-      </div>
     </AdminPage>
   );
 }

--- a/app/admin/finance/ar-analytics/page.tsx
+++ b/app/admin/finance/ar-analytics/page.tsx
@@ -9,18 +9,16 @@ import {
   AdminPage,
   LoadingState,
   ErrorState,
-  MetricCard,
   Tabs,
   ConsoleTabsList,
   ConsoleTabsContent,
 } from '@/components/backend';
+import { HealthCard, formatRand } from '@/components/admin/billing/health';
 import {
   ArAgingPanel,
   DsoMetricsPanel,
   HistoryPanel,
   NotificationsPanel,
-  TrendIcon,
-  formatCurrency,
   type ARAnalyticsData,
 } from '@/components/admin/finance/ar';
 
@@ -119,46 +117,54 @@ export default function ARAnalyticsPage() {
         <span className="text-xs text-slate-400">Last {period} days</span>
         <span className="text-xs text-slate-500">
           {data.ar_aging.total_outstanding_invoices} open invoices ·{' '}
-          {formatCurrency(data.ar_aging.total_outstanding_amount)} outstanding
+          {formatRand(data.ar_aging.total_outstanding_amount)} outstanding
         </span>
       </div>
 
       {/* KPI Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <MetricCard
-          title="Total Outstanding"
-          value={formatCurrency(data.ar_aging.total_outstanding_amount)}
-          subtitle={`${data.ar_aging.total_outstanding_invoices} invoices`}
-        >
-          <PiCurrencyDollarBold className="w-5 h-5 text-amber-600" aria-hidden="true" />
-        </MetricCard>
-
-        <MetricCard
-          title="Days Sales Outstanding"
+        <HealthCard
+          label="Total Outstanding"
+          value={formatRand(data.ar_aging.total_outstanding_amount)}
+          primaryLine={`${data.ar_aging.total_outstanding_invoices} open invoices`}
+          primaryClassName="text-orange-500"
+          secondaryLine="Accounts receivable balance"
+          icon={<PiCurrencyDollarBold className="h-5 w-5" />}
+          iconClassName="bg-orange-50 text-orange-500"
+        />
+        <HealthCard
+          label="Days Sales Outstanding"
           value={data.dso.dso_current.toFixed(1)}
-          subtitle={`30-day avg: ${data.dso.dso_30_day_avg.toFixed(1)} days`}
-        >
-          <span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
-            <TrendIcon trend={data.dso.dso_trend} />
-            <span className="capitalize">{data.dso.dso_trend}</span>
-          </span>
-        </MetricCard>
-
-        <MetricCard
-          title="Collection Rate"
+          primaryLine={data.dso.dso_trend.charAt(0).toUpperCase() + data.dso.dso_trend.slice(1)}
+          primaryClassName={
+            data.dso.dso_trend === 'improving'
+              ? 'text-teal-600'
+              : data.dso.dso_trend === 'worsening'
+                ? 'text-red-600'
+                : undefined
+          }
+          secondaryLine={`30-day avg: ${data.dso.dso_30_day_avg.toFixed(1)} days`}
+          icon={<PiClockBold className="h-5 w-5" />}
+          iconClassName="bg-slate-100 text-slate-600"
+        />
+        <HealthCard
+          label="Collection Rate"
           value={`${data.collection.collection_rate.toFixed(1)}%`}
-          subtitle={`${formatCurrency(data.collection.total_amount_collected)} collected`}
-        >
-          <PiTargetBold className="w-5 h-5 text-emerald-600" aria-hidden="true" />
-        </MetricCard>
-
-        <MetricCard
-          title="Notifications Sent"
+          primaryLine={`${formatRand(data.collection.total_amount_collected)} collected`}
+          primaryClassName="text-teal-600"
+          secondaryLine={`Last ${period} days`}
+          icon={<PiTargetBold className="h-5 w-5" />}
+          iconClassName="bg-teal-50 text-teal-600"
+        />
+        <HealthCard
+          label="Notifications Sent"
           value={`${data.notifications.total_sms + data.notifications.total_email}`}
-          subtitle={`${data.notifications.delivery_rate.toFixed(1)}% delivery rate`}
-        >
-          <PiPulseBold className="w-5 h-5 text-blue-600" aria-hidden="true" />
-        </MetricCard>
+          primaryLine={`${data.notifications.delivery_rate.toFixed(1)}% delivery rate`}
+          primaryClassName="text-blue-600"
+          secondaryLine="SMS & email reminders"
+          icon={<PiPulseBold className="h-5 w-5" />}
+          iconClassName="bg-blue-50 text-blue-600"
+        />
       </div>
 
       <Tabs defaultValue="aging" className="space-y-4">

--- a/app/admin/finance/outstanding/page.tsx
+++ b/app/admin/finance/outstanding/page.tsx
@@ -13,7 +13,7 @@ import {
   PiWarningCircleBold,
   PiXCircleBold,
 } from 'react-icons/pi';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -33,14 +33,18 @@ import {
 } from '@/components/ui/select';
 import {
   AdminPage,
-  PageHeader,
-  StatCard,
-  SectionCard,
   StatusBadge,
   LoadingState,
+  ErrorState,
   EmptyState,
-  type StatusVariant,
 } from '@/components/backend';
+import {
+  HealthCard,
+  csvCell,
+  downloadCsv,
+  formatRand,
+  formatDueDate,
+} from '@/components/admin/billing/health';
 
 interface OutstandingInvoice {
   id: string;
@@ -55,9 +59,8 @@ interface OutstandingInvoice {
   days_overdue: number;
   status: 'unpaid' | 'partial' | 'overdue';
   invoice_type: string;
-  payment_method: string | null;
+  payment_collection_method: string | null;
   has_active_mandate: boolean;
-  order_number: string | null;
   created_at: string;
 }
 
@@ -82,18 +85,16 @@ export default function OutstandingInvoicesPage() {
   const [invoices, setInvoices] = useState<OutstandingInvoice[]>([]);
   const [summary, setSummary] = useState<Summary | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [verifying, setVerifying] = useState(false);
   const [selectedInvoices, setSelectedInvoices] = useState<Set<string>>(new Set());
   const [verificationResults, setVerificationResults] = useState<VerificationResult[]>([]);
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [searchTerm, setSearchTerm] = useState('');
 
-  useEffect(() => {
-    fetchOutstandingInvoices();
-  }, [statusFilter]);
-
-  const fetchOutstandingInvoices = async () => {
+  const fetchOutstandingInvoices = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const response = await fetch(`/api/admin/finance/outstanding-invoices?status=${statusFilter}`);
       const data = await response.json();
@@ -101,13 +102,20 @@ export default function OutstandingInvoicesPage() {
       if (data.success) {
         setInvoices(data.data.invoices);
         setSummary(data.data.summary);
+      } else {
+        throw new Error(data.error || 'Failed to fetch outstanding invoices');
       }
-    } catch (error) {
-      console.error('Failed to fetch invoices:', error);
+    } catch (err) {
+      console.error('Failed to fetch invoices:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load outstanding invoices');
     } finally {
       setLoading(false);
     }
-  };
+  }, [statusFilter]);
+
+  useEffect(() => {
+    fetchOutstandingInvoices();
+  }, [fetchOutstandingInvoices]);
 
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
@@ -124,8 +132,9 @@ export default function OutstandingInvoicesPage() {
     setSelectedInvoices(next);
   };
 
-  const handleVerifyPayments = async () => {
-    if (selectedInvoices.size === 0) return;
+  const handleVerifyPayments = async (ids?: string[]) => {
+    const invoiceIds = ids ?? Array.from(selectedInvoices);
+    if (invoiceIds.length === 0) return;
 
     setVerifying(true);
     setVerificationResults([]);
@@ -134,7 +143,7 @@ export default function OutstandingInvoicesPage() {
       const response = await fetch('/api/admin/finance/outstanding-invoices', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ invoiceIds: Array.from(selectedInvoices) }),
+        body: JSON.stringify({ invoiceIds }),
       });
 
       const data = await response.json();
@@ -143,23 +152,16 @@ export default function OutstandingInvoicesPage() {
         setVerificationResults(data.results);
         await fetchOutstandingInvoices();
         setSelectedInvoices(new Set());
+      } else {
+        throw new Error(data.error || 'Verification failed');
       }
-    } catch (error) {
-      console.error('Verification failed:', error);
+    } catch (err) {
+      console.error('Verification failed:', err);
+      setError(err instanceof Error ? err.message : 'Verification failed');
     } finally {
       setVerifying(false);
     }
   };
-
-  const formatCurrency = (amount: number) =>
-    new Intl.NumberFormat('en-ZA', { style: 'currency', currency: 'ZAR' }).format(amount);
-
-  const formatDate = (dateStr: string) =>
-    new Date(dateStr).toLocaleDateString('en-ZA', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-    });
 
   const getStatusBadge = (invoice: OutstandingInvoice) => {
     if (invoice.days_overdue > 30) {
@@ -187,223 +189,308 @@ export default function OutstandingInvoicesPage() {
     return (
       inv.invoice_number.toLowerCase().includes(search) ||
       inv.customer_name.toLowerCase().includes(search) ||
-      inv.customer_email.toLowerCase().includes(search) ||
-      inv.order_number?.toLowerCase().includes(search)
+      inv.customer_email.toLowerCase().includes(search)
     );
   });
 
+  const handleExport = () => {
+    const today = new Date().toISOString().slice(0, 10);
+    downloadCsv(`outstanding-invoices-${today}.csv`, [
+      ['Invoice #', 'Customer', 'Email', 'Total', 'Paid', 'Amount due', 'Due date', 'Days overdue', 'Status', 'Mandate'],
+      ...filteredInvoices.map((inv) => [
+        csvCell(inv.invoice_number),
+        csvCell(inv.customer_name),
+        csvCell(inv.customer_email),
+        inv.total_amount.toFixed(2),
+        inv.amount_paid.toFixed(2),
+        inv.amount_due.toFixed(2),
+        inv.due_date,
+        inv.days_overdue,
+        inv.status,
+        inv.has_active_mandate ? 'active' : 'none',
+      ]),
+    ]);
+  };
+
+  if (error && invoices.length === 0) {
+    return (
+      <AdminPage>
+        <ErrorState
+          title="Unable to load outstanding invoices"
+          message={error}
+          onRetry={fetchOutstandingInvoices}
+        />
+      </AdminPage>
+    );
+  }
+
   return (
     <AdminPage>
-      <PageHeader
-        title="Outstanding Invoices"
-        subtitle="Monitor and verify payment status for unpaid invoices"
-        actions={
-          <>
-            <Button variant="outline" onClick={fetchOutstandingInvoices} disabled={loading}>
-              <PiArrowsClockwiseBold className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
-              Refresh
-            </Button>
-            <Button
-              onClick={handleVerifyPayments}
-              disabled={selectedInvoices.size === 0 || verifying}
-              className="bg-circleTel-orange hover:bg-circleTel-orange-dark"
-            >
-              {verifying ? (
-                <PiSpinnerBold className="h-4 w-4 mr-2 animate-spin" />
-              ) : (
-                <PiCheckCircleBold className="h-4 w-4 mr-2" />
-              )}
-              Verify Selected ({selectedInvoices.size})
-            </Button>
-          </>
-        }
-      />
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="mb-1 text-xs text-slate-400">Finance / Receivables / Outstanding</p>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Outstanding Invoices</h1>
+          <p className="mt-1 text-sm text-slate-500">Monitor and verify payment status for unpaid invoices</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={fetchOutstandingInvoices}
+            disabled={loading || verifying}
+            aria-label="Refresh outstanding invoices"
+          >
+            <PiArrowsClockwiseBold className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </Button>
+          <Button
+            size="sm"
+            className="bg-slate-900 text-white hover:bg-slate-800"
+            onClick={() => handleVerifyPayments()}
+            disabled={selectedInvoices.size === 0 || verifying}
+          >
+            {verifying ? (
+              <PiSpinnerBold className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <PiCheckCircleBold className="mr-2 h-4 w-4" />
+            )}
+            Verify Selected ({selectedInvoices.size})
+          </Button>
+        </div>
+      </div>
+
+      {error && invoices.length > 0 && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-200/80 bg-red-50/80 px-4 py-3 text-sm text-red-800 shadow-sm"
+        >
+          {error}
+        </div>
+      )}
 
       {summary && (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          <StatCard
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <HealthCard
             label="Total Outstanding"
-            value={formatCurrency(summary.total_outstanding)}
+            value={formatRand(summary.total_outstanding)}
+            primaryLine={`${summary.total_invoices} invoices`}
+            secondaryLine="Unpaid and partially paid"
             icon={<PiFileTextBold className="h-5 w-5" />}
-            subtitle={`${summary.total_invoices} invoices`}
+            iconClassName="bg-orange-50 text-orange-500"
           />
-          <StatCard
+          <HealthCard
             label="Overdue Amount"
-            value={formatCurrency(summary.total_overdue)}
+            value={formatRand(summary.total_overdue)}
+            primaryLine={`${summary.overdue_invoices} overdue invoices`}
+            primaryClassName={summary.overdue_invoices > 0 ? 'text-red-600' : undefined}
+            secondaryLine="Past due date"
             icon={<PiWarningCircleBold className="h-5 w-5" />}
-            subtitle={`${summary.overdue_invoices} overdue invoices`}
+            iconClassName="bg-red-50 text-red-600"
           />
-          <StatCard
+          <HealthCard
             label="With Active Mandate"
-            value={summary.invoices_with_mandate}
+            value={String(summary.invoices_with_mandate)}
+            primaryLine="Auto-collection enabled"
+            primaryClassName="text-teal-600"
+            secondaryLine="Debit order on file"
             icon={<PiCreditCardBold className="h-5 w-5" />}
-            subtitle="Auto-collection enabled"
+            iconClassName="bg-teal-50 text-teal-600"
           />
-          <StatCard
+          <HealthCard
             label="Without Mandate"
-            value={summary.invoices_without_mandate}
+            value={String(summary.invoices_without_mandate)}
+            primaryLine="Manual follow-up required"
+            primaryClassName="text-orange-500"
+            secondaryLine="No payment method on file"
             icon={<PiTrendDownBold className="h-5 w-5" />}
-            subtitle="Manual follow-up required"
+            iconClassName="bg-orange-50 text-orange-500"
           />
         </div>
       )}
 
       {verificationResults.length > 0 && (
-        <SectionCard title="Verification Results">
-          <div className="space-y-2">
+        <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="border-b border-slate-100 px-6 py-4">
+            <h2 className="text-base font-semibold text-slate-900">Verification Results</h2>
+            <p className="mt-0.5 text-sm text-slate-500">Latest NetCash payment status check</p>
+          </div>
+          <div className="space-y-2 px-6 py-4">
             {verificationResults.map((result) => (
               <div
                 key={result.invoiceId}
-                className={`flex items-center justify-between p-2 rounded ${
+                className={`flex items-center justify-between rounded-lg border px-3 py-2 text-sm ${
                   result.paymentStatus === 'paid'
-                    ? 'bg-green-100'
+                    ? 'border-teal-200 bg-teal-50'
                     : result.success
-                      ? 'bg-yellow-100'
-                      : 'bg-red-100'
+                      ? 'border-amber-200 bg-amber-50'
+                      : 'border-red-200 bg-red-50'
                 }`}
               >
-                <span className="font-medium">{result.invoiceNumber}</span>
+                <span className="font-medium text-slate-900">{result.invoiceNumber}</span>
                 <span className="flex items-center gap-2">
                   {result.paymentStatus === 'paid' ? (
                     <>
-                      <PiCheckCircleBold className="h-4 w-4 text-green-600" />
-                      <span className="text-green-600">Paid</span>
+                      <PiCheckCircleBold className="h-4 w-4 text-teal-600" />
+                      <span className="font-medium text-teal-700">Paid</span>
                     </>
                   ) : result.paymentStatus === 'not_found' ? (
                     <>
-                      <PiClockBold className="h-4 w-4 text-yellow-600" />
-                      <span className="text-yellow-600">Pending</span>
+                      <PiClockBold className="h-4 w-4 text-amber-600" />
+                      <span className="font-medium text-amber-700">Pending</span>
                     </>
                   ) : (
                     <>
                       <PiXCircleBold className="h-4 w-4 text-red-600" />
-                      <span className="text-red-600">{result.error || 'Failed'}</span>
+                      <span className="font-medium text-red-700">{result.error || 'Failed'}</span>
                     </>
                   )}
                 </span>
               </div>
             ))}
           </div>
-        </SectionCard>
+        </div>
       )}
 
-      <SectionCard title="Filters">
-        <div className="flex flex-col md:flex-row gap-4">
-          <div className="relative flex-1">
-            <PiMagnifyingGlassBold className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
-            <input
-              type="text"
-              placeholder="Search by invoice, customer, or order..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-circleTel-orange focus:border-transparent w-full"
-            />
+      <div className="flex flex-col rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-6 py-4">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">Outstanding Invoices</h2>
+            <p className="mt-0.5 text-sm text-slate-500">{filteredInvoices.length} invoices found</p>
           </div>
-          <Select value={statusFilter} onValueChange={setStatusFilter}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="Filter by status" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Outstanding</SelectItem>
-              <SelectItem value="unpaid">Unpaid</SelectItem>
-              <SelectItem value="partial">Partial</SelectItem>
-              <SelectItem value="overdue">Overdue</SelectItem>
-            </SelectContent>
-          </Select>
-          <Button variant="outline">
-            <PiDownloadSimpleBold className="h-4 w-4 mr-2" />
-            Export
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="relative w-full sm:w-72">
+              <PiMagnifyingGlassBold className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <input
+                type="text"
+                placeholder="Search invoice or customer..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full rounded-lg border border-slate-200 py-2 pl-10 pr-4 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-circleTel-orange"
+              />
+            </div>
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-[160px] rounded-lg border-slate-200" aria-label="Filter by status">
+                <SelectValue placeholder="Filter by status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Outstanding</SelectItem>
+                <SelectItem value="unpaid">Unpaid</SelectItem>
+                <SelectItem value="partial">Partial</SelectItem>
+                <SelectItem value="overdue">Overdue</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              variant="outline"
+              size="sm"
+              className="rounded-lg border-slate-200"
+              onClick={handleExport}
+              disabled={filteredInvoices.length === 0}
+            >
+              <PiDownloadSimpleBold className="mr-2 h-4 w-4" />
+              Export
+            </Button>
+          </div>
         </div>
-      </SectionCard>
 
-      <SectionCard
-        title="Outstanding Invoices"
-        action={<span className="text-sm text-gray-500">{filteredInvoices.length} invoices found</span>}
-      >
-        {loading ? (
-          <LoadingState message="Loading outstanding invoices..." />
+        {loading && invoices.length === 0 ? (
+          <div className="px-6 py-12">
+            <LoadingState message="Loading outstanding invoices..." />
+          </div>
         ) : filteredInvoices.length === 0 ? (
-          <EmptyState icon={<PiFileTextBold />} title="No outstanding invoices found" />
+          <div className="px-6 py-12">
+            <EmptyState icon={<PiFileTextBold />} title="No outstanding invoices found" />
+          </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-12">
-                  <Checkbox
-                    checked={
-                      selectedInvoices.size === filteredInvoices.length && filteredInvoices.length > 0
-                    }
-                    onCheckedChange={handleSelectAll}
-                  />
-                </TableHead>
-                <TableHead>Invoice</TableHead>
-                <TableHead>Customer</TableHead>
-                <TableHead>Amount Due</TableHead>
-                <TableHead>Due Date</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Payment Method</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredInvoices.map((invoice) => (
-                <TableRow key={invoice.id} className="hover:bg-gray-50">
-                  <TableCell>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow className="border-slate-100 hover:bg-transparent">
+                  <TableHead className="w-12 pl-6">
                     <Checkbox
-                      checked={selectedInvoices.has(invoice.id)}
-                      onCheckedChange={(checked) =>
-                        handleSelectInvoice(invoice.id, checked as boolean)
+                      checked={
+                        selectedInvoices.size === filteredInvoices.length && filteredInvoices.length > 0
                       }
+                      onCheckedChange={handleSelectAll}
+                      aria-label="Select all invoices"
                     />
-                  </TableCell>
-                  <TableCell>
-                    <div className="font-medium">{invoice.invoice_number}</div>
-                    {invoice.order_number && (
-                      <div className="text-xs text-gray-500">{invoice.order_number}</div>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <div className="font-medium">{invoice.customer_name}</div>
-                    <div className="text-xs text-gray-500">{invoice.customer_email}</div>
-                  </TableCell>
-                  <TableCell>
-                    <div className="font-semibold tabular-nums">
-                      {formatCurrency(invoice.amount_due)}
-                    </div>
-                    {invoice.amount_paid > 0 && (
-                      <div className="text-xs text-green-600 tabular-nums">
-                        Paid: {formatCurrency(invoice.amount_paid)}
-                      </div>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <div>{formatDate(invoice.due_date)}</div>
-                    {invoice.days_overdue > 0 && (
-                      <div className="text-xs text-red-500">{invoice.days_overdue} days ago</div>
-                    )}
-                  </TableCell>
-                  <TableCell>{getStatusBadge(invoice)}</TableCell>
-                  <TableCell>{getMandateBadge(invoice.has_active_mandate)}</TableCell>
-                  <TableCell className="text-right">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        setSelectedInvoices(new Set([invoice.id]));
-                        handleVerifyPayments();
-                      }}
-                      disabled={verifying}
-                    >
-                      <PiArrowsClockwiseBold className="h-4 w-4" />
-                    </Button>
-                  </TableCell>
+                  </TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Invoice</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Customer</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Amount due</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Due date</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Status</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Payment method</TableHead>
+                  <TableHead className="pr-6 text-right text-xs font-medium uppercase tracking-wide text-slate-400">
+                    <span className="sr-only">Verify</span>
+                  </TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {filteredInvoices.map((invoice) => (
+                  <TableRow key={invoice.id} className="border-slate-100">
+                    <TableCell className="pl-6">
+                      <Checkbox
+                        checked={selectedInvoices.has(invoice.id)}
+                        onCheckedChange={(checked) =>
+                          handleSelectInvoice(invoice.id, checked as boolean)
+                        }
+                        aria-label={`Select invoice ${invoice.invoice_number}`}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm font-medium text-slate-900">{invoice.invoice_number}</div>
+                      <div className="text-xs capitalize text-slate-400">
+                        {invoice.invoice_type.replace(/_/g, ' ')}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm font-medium text-slate-900">{invoice.customer_name}</div>
+                      <div className="text-xs text-slate-500">{invoice.customer_email}</div>
+                    </TableCell>
+                    <TableCell>
+                      <div
+                        className={`text-sm font-semibold tabular-nums ${
+                          invoice.days_overdue > 0 ? 'text-red-600' : 'text-slate-900'
+                        }`}
+                      >
+                        {formatRand(invoice.amount_due)}
+                      </div>
+                      {invoice.amount_paid > 0 && (
+                        <div className="text-xs text-teal-600 tabular-nums">
+                          Paid: {formatRand(invoice.amount_paid)}
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="whitespace-nowrap text-sm text-slate-500">
+                        {formatDueDate(invoice.due_date)}
+                      </div>
+                      {invoice.days_overdue > 0 && (
+                        <div className="text-xs font-medium text-red-600">
+                          {invoice.days_overdue} days ago
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell>{getStatusBadge(invoice)}</TableCell>
+                    <TableCell>{getMandateBadge(invoice.has_active_mandate)}</TableCell>
+                    <TableCell className="pr-6 text-right">
+                      <button
+                        type="button"
+                        onClick={() => handleVerifyPayments([invoice.id])}
+                        disabled={verifying}
+                        title={`Verify payment for ${invoice.invoice_number}`}
+                        aria-label={`Verify payment for ${invoice.invoice_number}`}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <PiArrowsClockwiseBold className="h-4 w-4" />
+                      </button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         )}
-      </SectionCard>
+      </div>
     </AdminPage>
   );
 }

--- a/app/api/admin/billing/health/route.ts
+++ b/app/api/admin/billing/health/route.ts
@@ -1,0 +1,243 @@
+/**
+ * Billing Health dashboard API
+ * GET /api/admin/billing/health
+ *
+ * One composed payload for /admin/billing: MRR, past-due totals, aging
+ * buckets, 6-month invoiced/collected trend, suspension watchlist and the
+ * overdue invoice register. Month boundaries are UTC (matches stats route).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { apiLogger } from '@/lib/logging';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import {
+  buildAgingBuckets,
+  buildOverdueRegister,
+  buildWatchlist,
+  countUnpaidCustomers,
+  daysPastDue,
+  type UnpaidInvoiceInput,
+} from '@/lib/billing/health/aging';
+import type {
+  BillingHealthResponse,
+  BillingHealthTrendPoint,
+} from '@/lib/billing/health/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UNPAID_STATUSES = ['sent', 'partial', 'overdue'] as const;
+const EXCLUDED_FROM_INVOICED = ['draft', 'cancelled', 'voided'] as const;
+const SUSPENSION_POLICY_DAYS = 30;
+const URGENT_DAYS = 31;
+
+function monthStartUTC(offset: number, now: Date): Date {
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offset, 1)
+  );
+}
+
+function monthLabel(date: Date): string {
+  return `${date.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })} ${date.getUTCFullYear()}`;
+}
+
+function toMonthKey(iso: string): string {
+  return iso.slice(0, 7); // YYYY-MM
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) return authResult.response;
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+        },
+      }
+    );
+
+    const now = new Date();
+    const todayISO = now.toISOString().slice(0, 10);
+    const currentMonthStart = monthStartUTC(0, now);
+    const trendStart = monthStartUTC(-5, now);
+    const prevMonthLabel = monthLabel(monthStartUTC(-1, now)).split(' ')[0];
+
+    const [activeServicesResult, unpaidInvoicesResult, invoicedRowsResult, collectedRowsResult] =
+      await Promise.all([
+        // MRR + suspend targets
+        supabase
+          .from('customer_services')
+          .select('id, customer_id, monthly_price, created_at')
+          .eq('status', 'active'),
+
+        // Unpaid invoices (aging, watchlist, register)
+        supabase
+          .from('customer_invoices')
+          .select('id, customer_id, invoice_number, due_date, amount_due, service_id')
+          .in('status', [...UNPAID_STATUSES])
+          .gt('amount_due', 0),
+
+        // Trend: invoiced per month (last 6 months)
+        supabase
+          .from('customer_invoices')
+          .select('invoice_date, total_amount')
+          .gte('invoice_date', trendStart.toISOString().slice(0, 10))
+          .not('status', 'in', `(${EXCLUDED_FROM_INVOICED.join(',')})`),
+
+        // Trend: collected per month (last 6 months)
+        supabase
+          .from('customer_invoices')
+          .select('paid_at, amount_paid')
+          .in('status', ['paid', 'partial'])
+          .not('paid_at', 'is', null)
+          .gte('paid_at', trendStart.toISOString()),
+      ]);
+
+    if (activeServicesResult.error) throw activeServicesResult.error;
+    if (unpaidInvoicesResult.error) throw unpaidInvoicesResult.error;
+    if (invoicedRowsResult.error) throw invoicedRowsResult.error;
+    if (collectedRowsResult.error) throw collectedRowsResult.error;
+
+    // ---- MRR ----
+    const activeServices = activeServicesResult.data || [];
+    let mrrCurrent = 0;
+    let mrrPrevious = 0;
+    const activeServiceIdsByCustomer = new Map<string, string[]>();
+
+    for (const svc of activeServices) {
+      const price = Number(svc.monthly_price || 0);
+      mrrCurrent += price;
+      if (svc.created_at && svc.created_at < currentMonthStart.toISOString()) {
+        mrrPrevious += price;
+      }
+      const list = activeServiceIdsByCustomer.get(svc.customer_id) ?? [];
+      list.push(svc.id);
+      activeServiceIdsByCustomer.set(svc.customer_id, list);
+    }
+
+    const momChangePct =
+      mrrPrevious > 0 ? ((mrrCurrent - mrrPrevious) / mrrPrevious) * 100 : null;
+
+    // ---- Unpaid invoices → names + package names ----
+    const unpaidRows = unpaidInvoicesResult.data || [];
+    const customerIds = [...new Set(unpaidRows.map((r) => r.customer_id))];
+    const serviceIds = [
+      ...new Set(unpaidRows.map((r) => r.service_id).filter(Boolean)),
+    ] as string[];
+
+    const [customersResult, packagesResult] = await Promise.all([
+      customerIds.length
+        ? supabase
+            .from('customers')
+            .select('id, first_name, last_name, business_name, account_type')
+            .in('id', customerIds)
+        : Promise.resolve({ data: [], error: null }),
+      serviceIds.length
+        ? supabase.from('customer_services').select('id, package_name').in('id', serviceIds)
+        : Promise.resolve({ data: [], error: null }),
+    ]);
+
+    if (customersResult.error) throw customersResult.error;
+    if (packagesResult.error) throw packagesResult.error;
+
+    const customerNameById = new Map<string, string>();
+    for (const c of customersResult.data || []) {
+      const business = c.account_type === 'business' && c.business_name;
+      customerNameById.set(
+        c.id,
+        business ? c.business_name : `${c.first_name} ${c.last_name}`.trim()
+      );
+    }
+    const packageNameById = new Map<string, string>();
+    for (const s of packagesResult.data || []) {
+      packageNameById.set(s.id, s.package_name);
+    }
+
+    const unpaidInvoices: UnpaidInvoiceInput[] = unpaidRows.map((r) => ({
+      id: r.id,
+      customerId: r.customer_id,
+      customerName: customerNameById.get(r.customer_id) ?? 'Unknown customer',
+      invoiceNumber: r.invoice_number,
+      packageName: r.service_id ? packageNameById.get(r.service_id) ?? null : null,
+      dueDate: r.due_date,
+      amountDue: Number(r.amount_due || 0),
+    }));
+
+    // ---- Aggregations ----
+    const aging = buildAgingBuckets(unpaidInvoices, todayISO);
+    const watchlist = buildWatchlist(unpaidInvoices, todayISO, activeServiceIdsByCustomer);
+    const overdueInvoices = buildOverdueRegister(unpaidInvoices, todayISO).slice(0, 100);
+
+    const pastDueTotal = unpaidInvoices.reduce((sum, inv) => sum + inv.amountDue, 0);
+    const overdueCount = unpaidInvoices.filter(
+      (inv) => daysPastDue(inv.dueDate, todayISO) > 0
+    ).length;
+
+    // ---- Trend (oldest → newest) ----
+    const invoicedByMonth = new Map<string, number>();
+    for (const row of invoicedRowsResult.data || []) {
+      const key = toMonthKey(row.invoice_date);
+      invoicedByMonth.set(key, (invoicedByMonth.get(key) ?? 0) + Number(row.total_amount || 0));
+    }
+    const collectedByMonth = new Map<string, number>();
+    for (const row of collectedRowsResult.data || []) {
+      const key = toMonthKey(row.paid_at);
+      collectedByMonth.set(key, (collectedByMonth.get(key) ?? 0) + Number(row.amount_paid || 0));
+    }
+
+    const trend: BillingHealthTrendPoint[] = [];
+    for (let offset = -5; offset <= 0; offset++) {
+      const start = monthStartUTC(offset, now);
+      const key = `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, '0')}`;
+      trend.push({
+        month: monthLabel(start),
+        invoiced: Math.round((invoicedByMonth.get(key) ?? 0) * 100) / 100,
+        collected: Math.round((collectedByMonth.get(key) ?? 0) * 100) / 100,
+        mrr: Math.round(mrrCurrent * 100) / 100,
+      });
+    }
+
+    const response: BillingHealthResponse = {
+      generatedAt: now.toISOString(),
+      mrr: {
+        current: Math.round(mrrCurrent * 100) / 100,
+        previous: Math.round(mrrPrevious * 100) / 100,
+        momChangePct: momChangePct === null ? null : Math.round(momChangePct * 10) / 10,
+        deltaLabel: `Delta vs ${prevMonthLabel}`,
+      },
+      pastDue: {
+        totalAmount: Math.round(pastDueTotal * 100) / 100,
+        customerCount: countUnpaidCustomers(unpaidInvoices),
+      },
+      suspension: {
+        candidates: watchlist.length,
+        urgent: watchlist.filter((w) => w.daysPastDue >= URGENT_DAYS).length,
+        policyDays: SUSPENSION_POLICY_DAYS,
+      },
+      unpaid: {
+        total: unpaidInvoices.length,
+        overdue: overdueCount,
+      },
+      trend,
+      aging,
+      watchlist,
+      overdueInvoices,
+    };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    apiLogger.error('Error fetching billing health', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: 'Failed to fetch billing health' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/finance/outstanding-invoices/route.ts
+++ b/app/api/admin/finance/outstanding-invoices/route.ts
@@ -22,9 +22,8 @@ export interface OutstandingInvoice {
   days_overdue: number;
   status: 'unpaid' | 'partial' | 'overdue';
   invoice_type: string;
-  payment_method: string | null;
+  payment_collection_method: string | null;
   has_active_mandate: boolean;
-  order_number: string | null;
   created_at: string;
 }
 
@@ -67,7 +66,7 @@ export async function GET(request: NextRequest) {
         due_date,
         status,
         invoice_type,
-        payment_method,
+        payment_collection_method,
         created_at,
         service_id,
         customers!inner (
@@ -81,9 +80,6 @@ export async function GET(request: NextRequest) {
             mandate_status,
             is_active
           )
-        ),
-        consumer_orders (
-          order_number
         )
       `)
       .in('status', status === 'all' ? ['unpaid', 'partial', 'overdue'] : [status || 'unpaid', 'partial', 'overdue']);
@@ -136,9 +132,8 @@ export async function GET(request: NextRequest) {
         days_overdue: daysOverdue,
         status: daysOverdue > 0 && invoice.status === 'unpaid' ? 'overdue' : invoice.status,
         invoice_type: invoice.invoice_type,
-        payment_method: invoice.payment_method,
+        payment_collection_method: invoice.payment_collection_method,
         has_active_mandate: hasActiveMandate,
-        order_number: invoice.consumer_orders?.[0]?.order_number || null,
         created_at: invoice.created_at,
       };
     });

--- a/components/admin/billing/health/AgingBadge.tsx
+++ b/components/admin/billing/health/AgingBadge.tsx
@@ -1,0 +1,31 @@
+import { cn } from '@/lib/utils';
+import { AGING_BUCKET_LABELS } from '@/lib/billing/health/aging';
+import type { AgingBucketKey } from '@/lib/billing/health/types';
+
+const BUCKET_STYLES: Record<AgingBucketKey, string> = {
+  current: 'bg-teal-50 text-teal-700 ring-teal-600/20',
+  '1-7d': 'bg-teal-50 text-teal-700 ring-teal-600/20',
+  '8-30d': 'bg-amber-50 text-amber-700 ring-amber-600/20',
+  '31-60d': 'bg-red-50 text-red-700 ring-red-600/20',
+  '61d+': 'bg-red-100 text-red-800 ring-red-700/20',
+};
+
+export function AgingBadge({
+  bucket,
+  className,
+}: {
+  bucket: AgingBucketKey;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset',
+        BUCKET_STYLES[bucket],
+        className
+      )}
+    >
+      {AGING_BUCKET_LABELS[bucket]}
+    </span>
+  );
+}

--- a/components/admin/billing/health/AgingBucketsChart.tsx
+++ b/components/admin/billing/health/AgingBucketsChart.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  LabelList,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { AgingBucketKey, AgingBuckets } from '@/lib/billing/health/types';
+import { AGING_BUCKET_LABELS } from '@/lib/billing/health/aging';
+import {
+  axisProps,
+  gridProps,
+  tooltipStyle,
+  formatRandTick,
+} from '@/components/admin/dashboard/charts/chart-theme';
+import { formatRand } from './format';
+
+const BUCKET_COLORS: Record<AgingBucketKey, string> = {
+  current: '#0E7C86',
+  '1-7d': '#0E7C86',
+  '8-30d': '#E87A1E',
+  '31-60d': '#EF4444',
+  '61d+': '#B91C1C',
+};
+
+interface AgingBucketsChartProps {
+  aging: AgingBuckets;
+}
+
+export function AgingBucketsChart({ aging }: AgingBucketsChartProps) {
+  const data = (Object.keys(AGING_BUCKET_LABELS) as AgingBucketKey[]).map((key) => ({
+    key,
+    name: AGING_BUCKET_LABELS[key],
+    value: Math.round(aging[key] * 100) / 100,
+  }));
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 className="text-base font-semibold text-slate-900">Past-due Aging Buckets</h2>
+      <p className="mt-0.5 text-sm text-slate-500">Balance by days past due</p>
+      <div className="mt-4 h-[300px] w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 24, right: 8, left: 0, bottom: 0 }}>
+            <CartesianGrid {...gridProps} />
+            <XAxis dataKey="name" {...axisProps} />
+            <YAxis {...axisProps} tickFormatter={formatRandTick} />
+            <Tooltip
+              cursor={{ fill: '#F3F4F6' }}
+              contentStyle={tooltipStyle}
+              formatter={(value: number) => [formatRand(value), 'Balance']}
+            />
+            <Bar dataKey="value" radius={[4, 4, 0, 0]} maxBarSize={56}>
+              {data.map((entry) => (
+                <Cell key={entry.key} fill={BUCKET_COLORS[entry.key]} />
+              ))}
+              <LabelList
+                dataKey="value"
+                position="top"
+                formatter={(value: number) => (value > 0 ? formatRand(value) : '')}
+                className="fill-slate-600 text-xs font-medium"
+              />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/billing/health/HealthCard.tsx
+++ b/components/admin/billing/health/HealthCard.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * Billing Health stat tile — icon in a coloured circle, label, large value,
+ * one coloured primary line and one muted secondary line.
+ * Shared across the Finance/Billing admin section.
+ */
+export function HealthCard({
+  label,
+  value,
+  primaryLine,
+  primaryClassName,
+  secondaryLine,
+  icon,
+  iconClassName,
+}: {
+  label: string;
+  value: string;
+  primaryLine: string;
+  primaryClassName?: string;
+  secondaryLine: string;
+  icon: React.ReactNode;
+  iconClassName: string;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-medium text-slate-500">{label}</p>
+        <span
+          className={cn(
+            'flex h-10 w-10 shrink-0 items-center justify-center rounded-full',
+            iconClassName
+          )}
+        >
+          {icon}
+        </span>
+      </div>
+      <p className="mt-1 text-3xl font-semibold tracking-tight text-slate-900">{value}</p>
+      <p className={cn('mt-2 text-sm font-medium', primaryClassName ?? 'text-slate-600')}>
+        {primaryLine}
+      </p>
+      <p className="text-xs text-slate-400">{secondaryLine}</p>
+    </div>
+  );
+}

--- a/components/admin/billing/health/HealthStatCards.tsx
+++ b/components/admin/billing/health/HealthStatCards.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import {
+  PiClockBold,
+  PiFileTextBold,
+  PiMoneyBold,
+  PiUserMinusBold,
+} from 'react-icons/pi';
+import type { BillingHealthResponse } from '@/lib/billing/health/types';
+import { HealthCard } from './HealthCard';
+import { formatRand } from './format';
+
+interface HealthStatCardsProps {
+  data: Pick<BillingHealthResponse, 'mrr' | 'pastDue' | 'suspension' | 'unpaid'>;
+}
+
+export function HealthStatCards({ data }: HealthStatCardsProps) {
+  const { mrr, pastDue, suspension, unpaid } = data;
+  const momText =
+    mrr.momChangePct === null
+      ? 'No prior-month baseline'
+      : `${mrr.momChangePct >= 0 ? '+' : ''}${mrr.momChangePct}% MoM`;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <HealthCard
+        label="MRR"
+        value={formatRand(mrr.current)}
+        primaryLine={momText}
+        primaryClassName={mrr.momChangePct !== null && mrr.momChangePct < 0 ? 'text-red-600' : 'text-teal-600'}
+        secondaryLine={mrr.deltaLabel}
+        icon={<PiMoneyBold className="h-5 w-5" />}
+        iconClassName="bg-teal-50 text-teal-600"
+      />
+      <HealthCard
+        label="Past-due amount"
+        value={formatRand(pastDue.totalAmount)}
+        primaryLine={`${pastDue.customerCount} customer${pastDue.customerCount === 1 ? '' : 's'} past due`}
+        secondaryLine="Includes current bucket"
+        icon={<PiClockBold className="h-5 w-5" />}
+        iconClassName="bg-orange-50 text-orange-500"
+      />
+      <HealthCard
+        label="Suspension Candidates"
+        value={String(suspension.candidates)}
+        primaryLine={`${suspension.urgent} urgent ≥31 days`}
+        primaryClassName="text-red-600"
+        secondaryLine={`Policy: ${suspension.policyDays}+ days past due`}
+        icon={<PiUserMinusBold className="h-5 w-5" />}
+        iconClassName="bg-red-50 text-red-600"
+      />
+      <HealthCard
+        label="Unpaid Invoices"
+        value={String(unpaid.total)}
+        primaryLine={`${unpaid.overdue} overdue`}
+        primaryClassName="text-orange-500"
+        secondaryLine="Sent, partial & overdue"
+        icon={<PiFileTextBold className="h-5 w-5" />}
+        iconClassName="bg-teal-50 text-teal-600"
+      />
+    </div>
+  );
+}

--- a/components/admin/billing/health/MrrCollectionsChart.tsx
+++ b/components/admin/billing/health/MrrCollectionsChart.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { BillingHealthTrendPoint } from '@/lib/billing/health/types';
+import {
+  axisProps,
+  gridProps,
+  tooltipStyle,
+  formatRandTick,
+} from '@/components/admin/dashboard/charts/chart-theme';
+import { formatRand } from './format';
+
+const COLORS = {
+  collected: '#0E7C86', // teal
+  invoiced: '#94A3B8', // slate-400
+  mrr: '#EF4444', // red
+} as const;
+
+interface MrrCollectionsChartProps {
+  data: BillingHealthTrendPoint[];
+}
+
+export function MrrCollectionsChart({ data }: MrrCollectionsChartProps) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 className="text-base font-semibold text-slate-900">MRR &amp; Collections Trend</h2>
+      <div className="mt-4 h-[300px] w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <CartesianGrid {...gridProps} />
+            <XAxis dataKey="month" {...axisProps} />
+            <YAxis {...axisProps} tickFormatter={formatRandTick} />
+            <Tooltip
+              cursor={{ fill: '#F3F4F6' }}
+              contentStyle={tooltipStyle}
+              formatter={(value: number, name: string) => [formatRand(value), name]}
+            />
+            <Legend verticalAlign="top" align="right" iconType="circle" iconSize={8} />
+            <Bar dataKey="collected" name="Collected" fill={COLORS.collected} radius={[4, 4, 0, 0]} maxBarSize={36} />
+            <Bar dataKey="invoiced" name="Invoiced" fill={COLORS.invoiced} radius={[4, 4, 0, 0]} maxBarSize={36} />
+            <Line
+              type="monotone"
+              dataKey="mrr"
+              name="MRR"
+              stroke={COLORS.mrr}
+              strokeWidth={2}
+              dot={{ r: 3, fill: COLORS.mrr, strokeWidth: 0 }}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/billing/health/OverdueInvoiceRegister.tsx
+++ b/components/admin/billing/health/OverdueInvoiceRegister.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import Link from 'next/link';
+import { PiEyeBold, PiFileTextBold } from 'react-icons/pi';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { OverdueInvoiceRow } from '@/lib/billing/health/types';
+import { AgingBadge } from './AgingBadge';
+import { formatDueDate, formatRand } from './format';
+
+interface OverdueInvoiceRegisterProps {
+  rows: OverdueInvoiceRow[];
+  totalOverdue: number;
+}
+
+export function OverdueInvoiceRegister({ rows, totalOverdue }: OverdueInvoiceRegisterProps) {
+  return (
+    <div className="flex flex-col rounded-xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-100 px-6 py-4">
+        <h2 className="text-base font-semibold text-slate-900">Overdue Invoice Register</h2>
+        <p className="mt-0.5 text-sm text-slate-500">All unpaid invoices past due date</p>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 py-12 text-center">
+          <PiFileTextBold className="h-8 w-8 text-slate-300" aria-hidden="true" />
+          <p className="text-sm font-medium text-slate-600">No overdue invoices</p>
+          <p className="text-xs text-slate-400">Every unpaid invoice is still inside its due date.</p>
+        </div>
+      ) : (
+        <>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow className="border-slate-100 hover:bg-transparent">
+                  <TableHead className="pl-6 text-xs font-medium uppercase tracking-wide text-slate-400">Invoice #</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Customer</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Package</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Due date</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Days overdue</TableHead>
+                  <TableHead className="text-xs font-medium uppercase tracking-wide text-slate-400">Aging</TableHead>
+                  <TableHead className="text-right text-xs font-medium uppercase tracking-wide text-slate-400">Amount</TableHead>
+                  <TableHead className="pr-6 text-right text-xs font-medium uppercase tracking-wide text-slate-400">
+                    <span className="sr-only">View</span>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.id} className="border-slate-100">
+                    <TableCell className="pl-6 text-sm font-medium text-slate-900">
+                      {row.invoiceNumber}
+                    </TableCell>
+                    <TableCell className="max-w-[160px] truncate text-sm text-slate-600">
+                      {row.customerName}
+                    </TableCell>
+                    <TableCell className="max-w-[160px] truncate text-sm text-slate-500">
+                      {row.packageName ?? '—'}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-sm text-slate-500">
+                      {formatDueDate(row.dueDate)}
+                    </TableCell>
+                    <TableCell className="text-sm font-semibold text-red-600">
+                      {row.daysOverdue}d
+                    </TableCell>
+                    <TableCell>
+                      <AgingBadge bucket={row.agingBucket} />
+                    </TableCell>
+                    <TableCell className="text-right text-sm font-semibold text-red-600">
+                      {formatRand(row.amountDue)}
+                    </TableCell>
+                    <TableCell className="pr-6 text-right">
+                      <Link
+                        href={row.href}
+                        aria-label={`View invoice ${row.invoiceNumber}`}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+                      >
+                        <PiEyeBold className="h-4 w-4" />
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+          <p className="border-t border-slate-100 px-6 py-3 text-xs text-slate-400">
+            Showing {rows.length} of {totalOverdue} overdue invoice{totalOverdue === 1 ? '' : 's'}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/admin/billing/health/SuspensionWatchlist.tsx
+++ b/components/admin/billing/health/SuspensionWatchlist.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { PiUserMinusBold } from 'react-icons/pi';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import type { SuspensionWatchlistEntry } from '@/lib/billing/health/types';
+import { AgingBadge } from './AgingBadge';
+import { formatRand } from './format';
+
+interface SuspensionWatchlistProps {
+  entries: SuspensionWatchlistEntry[];
+  policyDays: number;
+  onSuspended: () => void;
+}
+
+export function SuspensionWatchlist({ entries, policyDays, onSuspended }: SuspensionWatchlistProps) {
+  const [target, setTarget] = useState<SuspensionWatchlistEntry | null>(null);
+  const [suspending, setSuspending] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const handleSuspend = async () => {
+    if (!target) return;
+    setSuspending(true);
+    setActionError(null);
+    try {
+      for (const serviceId of target.activeServiceIds) {
+        const res = await fetch(`/api/admin/customers/${target.customerId}/services/suspend`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            service_id: serviceId,
+            suspension_type: 'non_payment',
+            reason: `Non-payment — ${target.daysPastDue}d past due (Billing Health watchlist)`,
+          }),
+        });
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error((body as { error?: string }).error || 'Failed to suspend service');
+        }
+      }
+      setTarget(null);
+      onSuspended();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to suspend service');
+    } finally {
+      setSuspending(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col rounded-xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-100 px-6 py-4">
+        <h2 className="text-base font-semibold text-slate-900">Suspension Watchlist</h2>
+        <p className="mt-0.5 text-sm text-slate-500">
+          Sorted by days past due · policy threshold {policyDays} days
+        </p>
+      </div>
+
+      {actionError && (
+        <div role="alert" className="mx-6 mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">
+          {actionError}
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 py-12 text-center">
+          <PiUserMinusBold className="h-8 w-8 text-slate-300" aria-hidden="true" />
+          <p className="text-sm font-medium text-slate-600">No customers past due</p>
+          <p className="text-xs text-slate-400">Customers will appear here once an invoice passes its due date.</p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-slate-100">
+          {entries.map((entry) => (
+            <li key={entry.customerId} className="flex items-center justify-between gap-4 px-6 py-4">
+              <div className="min-w-0">
+                <Link
+                  href={entry.href}
+                  className="block truncate text-sm font-semibold text-slate-900 hover:text-circleTel-orange"
+                >
+                  {entry.customerName}
+                </Link>
+                <p className="mt-0.5 text-xs text-slate-500">{entry.daysPastDue}d past due</p>
+              </div>
+              <div className="flex shrink-0 flex-col items-end gap-1.5">
+                <div className="flex items-center gap-2">
+                  <AgingBadge bucket={entry.agingBucket} />
+                  <button
+                    type="button"
+                    onClick={() => setTarget(entry)}
+                    disabled={entry.activeServiceIds.length === 0}
+                    title={
+                      entry.activeServiceIds.length === 0
+                        ? 'No active services to suspend'
+                        : `Suspend ${entry.customerName}`
+                    }
+                    className="rounded-lg border border-red-200 bg-white px-3 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    Suspend
+                  </button>
+                </div>
+                <p className="text-xs text-slate-400">
+                  {entry.overdueInvoiceCount} overdue invoice{entry.overdueInvoiceCount === 1 ? '' : 's'} ·{' '}
+                  {formatRand(entry.overdueAmount)} overdue
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <AlertDialog open={target !== null} onOpenChange={(open) => !open && setTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Suspend {target?.customerName}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This suspends {target?.activeServiceIds.length ?? 0} active service
+              {(target?.activeServiceIds.length ?? 0) === 1 ? '' : 's'} for non-payment (
+              {target?.daysPastDue}d past due). The customer can be reactivated from their profile
+              once payment is received.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={suspending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleSuspend}
+              disabled={suspending}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              {suspending ? 'Suspending…' : 'Suspend services'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/components/admin/billing/health/format.ts
+++ b/components/admin/billing/health/format.ts
@@ -1,0 +1,32 @@
+/** Format Rand with comma thousands separators, e.g. R62,230 (matches mock). */
+export function formatRand(value: number): string {
+  return `R${Math.round(value).toLocaleString('en-US')}`;
+}
+
+/** "22 Jul 2026" */
+export function formatDueDate(isoDate: string): string {
+  return new Date(`${isoDate.slice(0, 10)}T00:00:00Z`).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** Quote a CSV cell when it contains separators or quotes. */
+export function csvCell(value: string | number): string {
+  const text = String(value);
+  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+/** Build a CSV string and trigger a browser download. */
+export function downloadCsv(filename: string, lines: Array<string | number>[]) {
+  const csv = lines.map((cells) => cells.join(',')).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/components/admin/billing/health/index.ts
+++ b/components/admin/billing/health/index.ts
@@ -1,0 +1,8 @@
+export { AgingBadge } from './AgingBadge';
+export { AgingBucketsChart } from './AgingBucketsChart';
+export { HealthCard } from './HealthCard';
+export { HealthStatCards } from './HealthStatCards';
+export { MrrCollectionsChart } from './MrrCollectionsChart';
+export { OverdueInvoiceRegister } from './OverdueInvoiceRegister';
+export { SuspensionWatchlist } from './SuspensionWatchlist';
+export { formatRand, formatDueDate, csvCell, downloadCsv } from './format';

--- a/components/admin/layout/AdminHeader.tsx
+++ b/components/admin/layout/AdminHeader.tsx
@@ -154,7 +154,7 @@ const getPageInfo = (pathname: string): { title: string; description: string } =
     }
     return {
       title: 'Billing',
-      description: 'Daily cash match · NetCash → invoices → Zoho',
+      description: 'Receivables, collections, and suspension queue',
     };
   }
 

--- a/lib/billing/health/aging.ts
+++ b/lib/billing/health/aging.ts
@@ -1,0 +1,134 @@
+/**
+ * Pure helpers for the Billing Health dashboard — aging buckets,
+ * days-past-due math, watchlist and register builders. Unit-tested.
+ */
+
+import type {
+  AgingBucketKey,
+  AgingBuckets,
+  OverdueInvoiceRow,
+  SuspensionWatchlistEntry,
+} from './types';
+
+/** Days between a due date and "today" (positive = past due). */
+export function daysPastDue(dueDateISO: string, todayISO: string): number {
+  const due = Date.parse(`${dueDateISO.slice(0, 10)}T00:00:00Z`);
+  const today = Date.parse(`${todayISO.slice(0, 10)}T00:00:00Z`);
+  return Math.round((today - due) / 86_400_000);
+}
+
+/** Map days past due (<= 0 = not yet due) to an aging bucket. */
+export function agingBucketForDays(days: number): AgingBucketKey {
+  if (days <= 0) return 'current';
+  if (days <= 7) return '1-7d';
+  if (days <= 30) return '8-30d';
+  if (days <= 60) return '31-60d';
+  return '61d+';
+}
+
+export const AGING_BUCKET_LABELS: Record<AgingBucketKey, string> = {
+  current: 'Current',
+  '1-7d': '1-7d',
+  '8-30d': '8-30d',
+  '31-60d': '31-60d',
+  '61d+': '61d+',
+};
+
+export interface UnpaidInvoiceInput {
+  id: string;
+  customerId: string;
+  customerName: string;
+  invoiceNumber: string;
+  packageName: string | null;
+  dueDate: string; // ISO date
+  amountDue: number;
+}
+
+export function buildAgingBuckets(
+  invoices: UnpaidInvoiceInput[],
+  todayISO: string
+): AgingBuckets {
+  const buckets: AgingBuckets = {
+    current: 0,
+    '1-7d': 0,
+    '8-30d': 0,
+    '31-60d': 0,
+    '61d+': 0,
+  };
+  for (const inv of invoices) {
+    const bucket = agingBucketForDays(daysPastDue(inv.dueDate, todayISO));
+    buckets[bucket] += inv.amountDue;
+  }
+  return buckets;
+}
+
+/**
+ * Suspension watchlist — one row per customer with at least one invoice
+ * past its due date, sorted by max days past due (desc).
+ */
+export function buildWatchlist(
+  invoices: UnpaidInvoiceInput[],
+  todayISO: string,
+  activeServiceIdsByCustomer: Map<string, string[]>
+): SuspensionWatchlistEntry[] {
+  const byCustomer = new Map<string, SuspensionWatchlistEntry>();
+
+  for (const inv of invoices) {
+    const days = daysPastDue(inv.dueDate, todayISO);
+    if (days <= 0) continue; // watchlist = past due only
+
+    const existing = byCustomer.get(inv.customerId);
+    if (existing) {
+      existing.overdueInvoiceCount += 1;
+      existing.overdueAmount += inv.amountDue;
+      if (days > existing.daysPastDue) {
+        existing.daysPastDue = days;
+        existing.agingBucket = agingBucketForDays(days);
+      }
+    } else {
+      byCustomer.set(inv.customerId, {
+        customerId: inv.customerId,
+        customerName: inv.customerName,
+        daysPastDue: days,
+        agingBucket: agingBucketForDays(days),
+        overdueInvoiceCount: 1,
+        overdueAmount: inv.amountDue,
+        activeServiceIds: activeServiceIdsByCustomer.get(inv.customerId) ?? [],
+        href: `/admin/customers/${inv.customerId}`,
+      });
+    }
+  }
+
+  return Array.from(byCustomer.values()).sort(
+    (a, b) => b.daysPastDue - a.daysPastDue
+  );
+}
+
+/**
+ * Overdue invoice register — unpaid invoices past due date,
+ * sorted by days overdue (desc).
+ */
+export function buildOverdueRegister(
+  invoices: UnpaidInvoiceInput[],
+  todayISO: string
+): OverdueInvoiceRow[] {
+  return invoices
+    .map((inv) => ({
+      id: inv.id,
+      invoiceNumber: inv.invoiceNumber,
+      customerName: inv.customerName,
+      packageName: inv.packageName,
+      dueDate: inv.dueDate,
+      daysOverdue: daysPastDue(inv.dueDate, todayISO),
+      agingBucket: agingBucketForDays(daysPastDue(inv.dueDate, todayISO)),
+      amountDue: inv.amountDue,
+      href: `/admin/billing/invoices/${inv.id}`,
+    }))
+    .filter((row) => row.daysOverdue > 0)
+    .sort((a, b) => b.daysOverdue - a.daysOverdue);
+}
+
+/** Distinct customer count across unpaid invoices. */
+export function countUnpaidCustomers(invoices: UnpaidInvoiceInput[]): number {
+  return new Set(invoices.map((inv) => inv.customerId)).size;
+}

--- a/lib/billing/health/types.ts
+++ b/lib/billing/health/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared types for the Billing Health dashboard
+ * (`/admin/billing` + `GET /api/admin/billing/health`).
+ */
+
+export type AgingBucketKey = 'current' | '1-7d' | '8-30d' | '31-60d' | '61d+';
+
+export interface AgingBuckets {
+  current: number;
+  '1-7d': number;
+  '8-30d': number;
+  '31-60d': number;
+  '61d+': number;
+}
+
+export interface BillingHealthTrendPoint {
+  /** Short label, e.g. "Jan 2026" */
+  month: string;
+  invoiced: number;
+  collected: number;
+  /** MRR reference line (current active-services MRR) */
+  mrr: number;
+}
+
+export interface SuspensionWatchlistEntry {
+  customerId: string;
+  customerName: string;
+  /** Max days past due across the customer's unpaid invoices */
+  daysPastDue: number;
+  agingBucket: AgingBucketKey;
+  overdueInvoiceCount: number;
+  overdueAmount: number;
+  /** Active service ids — used by the Suspend action */
+  activeServiceIds: string[];
+  href: string;
+}
+
+export interface OverdueInvoiceRow {
+  id: string;
+  invoiceNumber: string;
+  customerName: string;
+  packageName: string | null;
+  dueDate: string;
+  daysOverdue: number;
+  agingBucket: AgingBucketKey;
+  amountDue: number;
+  href: string;
+}
+
+export interface BillingHealthResponse {
+  generatedAt: string;
+  mrr: {
+    current: number;
+    /** Approximation: active services created before the 1st of this month */
+    previous: number;
+    momChangePct: number | null;
+    /** e.g. "Delta vs Jun" */
+    deltaLabel: string;
+  };
+  pastDue: {
+    /** Sum of amount_due across all unpaid invoices (includes current bucket) */
+    totalAmount: number;
+    customerCount: number;
+  };
+  suspension: {
+    candidates: number;
+    /** Customers with max days past due >= 31 */
+    urgent: number;
+    policyDays: number;
+  };
+  unpaid: {
+    total: number;
+    overdue: number;
+  };
+  trend: BillingHealthTrendPoint[];
+  aging: AgingBuckets;
+  watchlist: SuspensionWatchlistEntry[];
+  overdueInvoices: OverdueInvoiceRow[];
+}

--- a/memory-os/long-term/mistakes.md
+++ b/memory-os/long-term/mistakes.md
@@ -11,6 +11,12 @@ Prevention: How to avoid this forever
 
 ---
 
+### [2026-07-30] outstanding-invoices API joined non-existent schema relations (silent 500)
+**What happened**: `GET /api/admin/finance/outstanding-invoices` returned 500 for months; the old page swallowed the error and showed an empty table, so nobody noticed.
+**Root cause**: Query selected `payment_method` (column is `payment_collection_method`) and embedded `consumer_orders (order_number)` — `customer_invoices` has no FK to `consumer_orders` (PGRST200). Two invalid references in one select.
+**Fix**: Dropped the `consumer_orders` embed + `order_number` field, renamed to `payment_collection_method` (app/api/admin/finance/outstanding-invoices/route.ts).
+**Prevention**: PostgREST embeds silently break when FKs don't exist — test the raw query with service role before shipping; never let pages swallow API errors without an error state.
+
 ### [2025-10-24] Queried `invoices` table instead of `customer_invoices`
 **What happened**: Billing queries failed silently — returned empty results
 **Root cause**: Assumed standard naming. Didn't verify schema first.


### PR DESCRIPTION
## Summary
- Replace `/admin/billing` recon hub and legacy StatCard tables with a shared Billing Health design (`HealthCard`, aging charts, watchlist, overdue register).
- Align `/admin/billing/customers`, `/admin/billing/invoices`, `/admin/finance/outstanding`, and `/admin/finance/ar-analytics` to the same UI language, with working CSV export on invoices/outstanding.
- Add `GET /api/admin/billing/health` aggregator + aging unit tests; fix `/api/admin/finance/outstanding-invoices` PostgREST join that was silently 500ing (`payment_collection_method`, drop invalid `consumer_orders` embed).

## Test plan
- [ ] Open `/admin/billing` — KPI cards, MRR/collections chart, aging buckets, watchlist, overdue register load
- [ ] Open `/admin/billing/customers` and `/admin/billing/invoices` — HealthCards + tables; Export CSV on invoices
- [ ] Open `/admin/finance/outstanding` — data loads (no 500); Verify Selected + per-row verify; Export CSV
- [ ] Open `/admin/finance/ar-analytics` — four HealthCards + existing tabs still work
- [ ] Confirm side nav unchanged; `npm test -- __tests__/lib/billing/health/aging.test.ts` passes


Made with [Cursor](https://cursor.com)