### PR TITLE
feat(network): link Unjani hardware to corporate_sites

### DIFF
--- a/docs/analysis/2026-07-31-unjani-hardware-site-link-backfill.md
+++ b/docs/analysis/2026-07-31-unjani-hardware-site-link-backfill.md
@@ -1,0 +1,42 @@
+# Unjani hardware ↔ corporate_sites backfill
+
+**Date:** 2026-07-31  
+**Ticket:** [#674](https://github.com/jdeweedata/circletel/issues/674)  
+**Map:** [#672](https://github.com/jdeweedata/circletel/issues/672)
+
+## What was done
+
+1. **Schema:** added `network_devices.corporate_site_id` → `corporate_sites(id)` (migration `20260731220000_network_devices_corporate_site_id.sql`), applied to prod.
+2. **Backfill script:** `scripts/backfill-unjani-hardware-site-links.ts`  
+   - Source of truth for matches: `service_network_identifiers` (`ruijie_sn`) → `corporate_sites.service_id`  
+   - Sets `corporate_sites.ruijie_device_sn` (primary AP when multi-AP)  
+   - Sets `network_devices.corporate_site_id` + `ruijie_device_sn`  
+   - Upserts `ruijie_device_cache` stubs when Cloud sync cache is empty (FK required for `network_devices.ruijie_device_sn`)
+
+## Before → after
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Unjani sites with `ruijie_device_sn` | 1 / 26 | **20 / 26** |
+| `network_devices` (ruijie_ap) with `corporate_site_id` | 0 | **23** |
+| `ruijie_device_cache` rows | **0** (sync empty) | **23** stubs linked to sites |
+
+Multi-AP sites (all APs linked to same site; primary on `corporate_sites.ruijie_device_sn`):
+
+- Cosmo City (`CT-UNJ-007`): primary `G1U52HL044450` + `G1V30SM00301A`
+- Barcelona (`CT-UNJ-013`): primary `G1UQ9C800686A` + `G1VQ3C8007507` + `G1U52HL044471`
+
+## Residual (no Ruijie SN in SNI)
+
+- CT-UNJ-001 Soweto (Diepkloof) — pending
+- CT-UNJ-003 Khayelitsha — pending
+- CT-UNJ-004 Mamelodi — pending
+- CT-UNJ-005 Umlazi — pending
+- CT-UNJ-022 Durban — has Tozed/SIM hardware, no Ruijie AP in SNI
+- CT-UNJ-026 Delmas — pipeline / no AP
+
+## Ops notes
+
+- **`ruijie_device_cache` was empty** at backfill time — Ruijie Cloud sync needs investigation separately. Stubs are marked in `support_notes`; next healthy sync should refresh telemetry fields. Confirm sync upserts preserve `corporate_site_id`.
+- Re-run: `set -a && source .env.local && set +a && npx tsx scripts/backfill-unjani-hardware-site-links.ts` (idempotent for already-linked rows).
+- `DRY_RUN=1` prints the plan without writes.

--- a/scripts/backfill-unjani-hardware-site-links.ts
+++ b/scripts/backfill-unjani-hardware-site-links.ts
@@ -1,0 +1,267 @@
+/**
+ * Backfill Unjani AP ↔ corporate_sites (+ network_devices.corporate_site_id).
+ *
+ * Wayfinder: Task #674 / map #672
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a && npx tsx scripts/backfill-unjani-hardware-site-links.ts
+ *   DRY_RUN=1 ...  # print plan only
+ *
+ * Safe matches: service_network_identifiers.ruijie_sn → customer_services → corporate_sites.service_id
+ * Primary SN on corporate_sites.ruijie_device_sn: existing site SN if set; else network_devices name match; else first SNI SN.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const DRY = process.env.DRY_RUN === '1' || process.env.DRY_RUN === 'true';
+
+type Site = {
+  id: string;
+  account_number: string;
+  site_name: string;
+  service_id: string | null;
+  ruijie_device_sn: string | null;
+  status: string;
+};
+
+type Hw = {
+  id: string;
+  serial_number: string;
+  device_name: string;
+  device_type: string;
+  site_name: string | null;
+  ruijie_device_sn: string | null;
+  corporate_site_id?: string | null;
+};
+
+/** Prefer these SNs as corporate_sites.ruijie_device_sn when a site has multiple APs. */
+const PRIMARY_SN_PREFERENCE: Record<string, string> = {
+  'CT-UNJ-007': 'G1U52HL044450', // Cosmo City — RAP in hardware inventory
+  'CT-UNJ-013': 'G1UQ9C800686A', // Barcelona — named UNJANICLINICBARCELONA
+};
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing ${name}`);
+  return v;
+}
+
+async function main() {
+  const url = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const key = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
+  const sb = createClient(url, key, { auth: { persistSession: false } });
+
+  const { data: sites, error: sitesErr } = await sb
+    .from('corporate_sites')
+    .select('id, account_number, site_name, service_id, ruijie_device_sn, status')
+    .like('account_number', 'CT-UNJ-%')
+    .order('account_number');
+  if (sitesErr) throw sitesErr;
+
+  const { data: sni, error: sniErr } = await sb
+    .from('service_network_identifiers')
+    .select('identifier_value, service_id')
+    .eq('identifier_type', 'ruijie_sn');
+  if (sniErr) throw sniErr;
+
+  const { data: hardware, error: hwErr } = await sb
+    .from('network_devices')
+    .select('id, serial_number, device_name, device_type, site_name, ruijie_device_sn, corporate_site_id')
+    .eq('device_type', 'ruijie_ap');
+  if (hwErr) {
+    // Column may not exist yet — retry without it
+    const retry = await sb
+      .from('network_devices')
+      .select('id, serial_number, device_name, device_type, site_name, ruijie_device_sn')
+      .eq('device_type', 'ruijie_ap');
+    if (retry.error) throw hwErr;
+    for (const h of retry.data ?? []) (h as Hw).corporate_site_id = null;
+    console.warn('WARN: network_devices.corporate_site_id missing — apply migration first');
+  }
+
+  const hwRows: Hw[] = (hardware as Hw[]) ?? [];
+  const hwBySn = new Map(hwRows.map((h) => [h.serial_number, h]));
+
+  const { count: cacheCount } = await sb
+    .from('ruijie_device_cache')
+    .select('sn', { count: 'exact', head: true });
+
+  const siteByService = new Map(
+    (sites as Site[]).filter((s) => s.service_id).map((s) => [s.service_id as string, s])
+  );
+
+  /** account_number → list of SNs from SNI */
+  const snsByAccount = new Map<string, string[]>();
+  for (const row of sni ?? []) {
+    const site = siteByService.get(row.service_id as string);
+    if (!site) continue;
+    const list = snsByAccount.get(site.account_number) ?? [];
+    list.push(row.identifier_value as string);
+    snsByAccount.set(site.account_number, list);
+  }
+
+  const beforeSitesWithSn = (sites as Site[]).filter((s) => s.ruijie_device_sn).length;
+  const beforeHwLinked = hwRows.filter((h) => h.corporate_site_id).length;
+
+  type PlanRow = {
+    account: string;
+    siteId: string;
+    primarySn: string;
+    allSns: string[];
+    siteSnUpdate: boolean;
+    hwUpserts: string[];
+  };
+  const plan: PlanRow[] = [];
+  const residual: string[] = [];
+
+  for (const site of sites as Site[]) {
+    const sns = snsByAccount.get(site.account_number) ?? [];
+    if (sns.length === 0) {
+      residual.push(`${site.account_number} ${site.site_name} — no ruijie_sn in service_network_identifiers`);
+      continue;
+    }
+    const preferred = PRIMARY_SN_PREFERENCE[site.account_number];
+    const primarySn =
+      site.ruijie_device_sn && sns.includes(site.ruijie_device_sn)
+        ? site.ruijie_device_sn
+        : preferred && sns.includes(preferred)
+          ? preferred
+          : sns.find((sn) => hwBySn.has(sn)) ?? sns[0];
+
+    plan.push({
+      account: site.account_number,
+      siteId: site.id,
+      primarySn,
+      allSns: sns,
+      siteSnUpdate: site.ruijie_device_sn !== primarySn,
+      hwUpserts: sns,
+    });
+  }
+
+  console.log(JSON.stringify({ dryRun: DRY, cacheCount, beforeSitesWithSn, beforeHwLinked, planCount: plan.length, residual }, null, 2));
+  for (const p of plan) {
+    console.log(
+      `${p.account} primary=${p.primarySn} (+${p.allSns.length - 1} more) siteSnUpdate=${p.siteSnUpdate}`
+    );
+  }
+  for (const r of residual) console.log(`RESIDUAL: ${r}`);
+
+  if (DRY) {
+    console.log('DRY_RUN — no writes');
+    return;
+  }
+
+  let sitesUpdated = 0;
+  let hwUpdated = 0;
+  let hwInserted = 0;
+  let cacheUpdated = 0;
+
+  for (const p of plan) {
+    if (p.siteSnUpdate) {
+      const { error } = await sb
+        .from('corporate_sites')
+        .update({ ruijie_device_sn: p.primarySn, updated_at: new Date().toISOString() })
+        .eq('id', p.siteId);
+      if (error) throw new Error(`site ${p.account}: ${error.message}`);
+      sitesUpdated++;
+    }
+
+    const site = (sites as Site[]).find((s) => s.id === p.siteId)!;
+
+    for (const sn of p.allSns) {
+      // network_devices.ruijie_device_sn FK → ruijie_device_cache.sn — ensure stub exists
+      // when Cloud sync cache is empty so hardware + site links can land.
+      const { data: cacheRow } = await sb
+        .from('ruijie_device_cache')
+        .select('sn, corporate_site_id')
+        .eq('sn', sn)
+        .maybeSingle();
+
+      if (!cacheRow) {
+        const { error } = await sb.from('ruijie_device_cache').insert({
+          sn,
+          device_name: site.site_name,
+          group_name: 'Unjani',
+          status: 'unknown',
+          corporate_site_id: p.siteId,
+          customer_name: site.site_name,
+          mock_data: false,
+          support_notes: 'Stub upserted by backfill-unjani-hardware-site-links (#674) — replace on next Ruijie sync',
+        });
+        if (error) throw new Error(`cache stub ${sn}: ${error.message}`);
+        cacheUpdated++;
+      } else {
+        const { error } = await sb
+          .from('ruijie_device_cache')
+          .update({
+            corporate_site_id: p.siteId,
+            customer_name: site.site_name,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('sn', sn);
+        if (error) throw new Error(`cache ${sn}: ${error.message}`);
+        cacheUpdated++;
+      }
+
+      const existing = hwBySn.get(sn);
+      if (existing) {
+        const { error } = await sb
+          .from('network_devices')
+          .update({
+            corporate_site_id: p.siteId,
+            ruijie_device_sn: sn,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', existing.id);
+        if (error) throw new Error(`hw update ${sn}: ${error.message}`);
+        hwUpdated++;
+      } else {
+        const { error } = await sb.from('network_devices').insert({
+          serial_number: sn,
+          device_name: `UNJANI-${site.account_number}-${sn.slice(-4)}`,
+          device_type: 'ruijie_ap',
+          site_name: site.site_name.replace(/^Unjani Clinic - /, 'Unjani '),
+          channel: 'mtn_wholesale',
+          status: 'active',
+          ruijie_device_sn: sn,
+          corporate_site_id: p.siteId,
+        });
+        if (error) throw new Error(`hw insert ${sn}: ${error.message}`);
+        hwInserted++;
+      }
+    }
+  }
+
+  const { count: afterSites } = await sb
+    .from('corporate_sites')
+    .select('id', { count: 'exact', head: true })
+    .like('account_number', 'CT-UNJ-%')
+    .not('ruijie_device_sn', 'is', null);
+
+  const { count: afterHw } = await sb
+    .from('network_devices')
+    .select('id', { count: 'exact', head: true })
+    .eq('device_type', 'ruijie_ap')
+    .not('corporate_site_id', 'is', null);
+
+  console.log(
+    JSON.stringify(
+      {
+        sitesUpdated,
+        hwUpdated,
+        hwInserted,
+        cacheUpdated,
+        cacheWasEmpty: (cacheCount ?? 0) === 0,
+        afterSitesWithSn: afterSites,
+        afterHwLinked: afterHw,
+        residual,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/supabase/migrations/20260731220000_network_devices_corporate_site_id.sql
+++ b/supabase/migrations/20260731220000_network_devices_corporate_site_id.sql
@@ -1,0 +1,28 @@
+-- Link hardware inventory (network_devices) to corporate MSA sites.
+-- Enables Unjani AP ↔ site joins for Usage Reports / SSID rollups when
+-- ruijie_device_cache is sparse or empty. Wayfinder #674 / #672.
+
+ALTER TABLE public.network_devices
+  ADD COLUMN IF NOT EXISTS corporate_site_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'network_devices_corporate_site_id_fkey'
+  ) THEN
+    ALTER TABLE public.network_devices
+      ADD CONSTRAINT network_devices_corporate_site_id_fkey
+      FOREIGN KEY (corporate_site_id)
+      REFERENCES public.corporate_sites(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_network_devices_corporate_site
+  ON public.network_devices (corporate_site_id)
+  WHERE corporate_site_id IS NOT NULL;
+
+COMMENT ON COLUMN public.network_devices.corporate_site_id IS
+  'B2B corporate site this hardware is installed at (e.g. Unjani clinic). Complements consumer_order_id for residential installs.';


### PR DESCRIPTION
## Summary
- Add `network_devices.corporate_site_id` FK to `corporate_sites` so hardware inventory can join MSA sites.
- Add idempotent backfill script (`scripts/backfill-unjani-hardware-site-links.ts`) that links Unjani APs via `service_network_identifiers` → sites, and stubs `ruijie_device_cache` when Cloud sync is empty.
- Document before/after counts and residual unlinked clinics in `docs/analysis/2026-07-31-unjani-hardware-site-link-backfill.md`.

Closes #674 (Wayfinder map #672).

## Test plan
- [ ] Review migration `20260731220000_network_devices_corporate_site_id.sql`
- [ ] Confirm prod already has column + backfill (applied 2026-07-31); migration is no-op/`IF NOT EXISTS` safe on re-apply
- [ ] Optional: `DRY_RUN=1 npx tsx scripts/backfill-unjani-hardware-site-links.ts` shows 20 linked sites / residuals unchanged
- [ ] Spot-check Alexandra (`CT-UNJ-002` → `G1U52HL00261B`) and a multi-AP site (Cosmo / Barcelona)


Made with [Cursor](https://cursor.com)