### PR TITLE
feat(network): Ruijie SSID traffic rollup schema

### DIFF
--- a/lib/ruijie/types.ts
+++ b/lib/ruijie/types.ts
@@ -179,3 +179,34 @@ export interface RuijieTrafficRollupRow {
   raw_summary: Record<string, unknown> | null;
   created_at: string;
 }
+
+/** Hourly STA session-byte deltas per AP + allow-listed SSID (Usage Reports Staff GB). */
+export interface RuijieSsidTrafficRollupRow {
+  id: string;
+  device_sn: string;
+  ssid: string;
+  hour_bucket: string;
+  hours_window: number;
+  corporate_site_id: string | null;
+  rx_bytes: number;
+  tx_bytes: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Last-seen STA counters for positive-delta sampling between 5-min polls. */
+export interface RuijieSsidStaSampleStateRow {
+  device_sn: string;
+  mac: string;
+  ssid: string;
+  last_wifi_up: number;
+  last_wifi_down: number;
+  sampled_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Go-live allow-list (#676): Staff only. Free radio deferred. */
+export const RUIJIE_SSID_ROLLUP_ALLOWLIST = ['Unjani Clinic Staff'] as const;
+export type RuijieSsidRollupAllowlistedSsid =
+  (typeof RUIJIE_SSID_ROLLUP_ALLOWLIST)[number];

--- a/supabase/migrations/20260801140000_ruijie_ssid_traffic_rollups.sql
+++ b/supabase/migrations/20260801140000_ruijie_ssid_traffic_rollups.sql
@@ -1,0 +1,106 @@
+-- SSID STA session-byte hour rollups for Unjani Site Network Usage Reports (Staff).
+-- Wayfinder #672 / #675 / #678. Written by a dedicated 5-min sampler (#679); not group flow.
+-- Do NOT extend ruijie_traffic_rollups — different grain, source, and retention (90d).
+
+CREATE TABLE IF NOT EXISTS public.ruijie_ssid_traffic_rollups (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  device_sn text NOT NULL,
+  ssid text NOT NULL,
+  hour_bucket timestamptz NOT NULL,
+  hours_window integer NOT NULL DEFAULT 1,
+  corporate_site_id uuid REFERENCES public.corporate_sites(id) ON DELETE SET NULL,
+  rx_bytes bigint NOT NULL DEFAULT 0,
+  tx_bytes bigint NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ruijie_ssid_traffic_rollups_hours_window_chk CHECK (hours_window = 1),
+  CONSTRAINT ruijie_ssid_traffic_rollups_sn_ssid_hour_key
+    UNIQUE (device_sn, ssid, hour_bucket)
+);
+
+COMMENT ON TABLE public.ruijie_ssid_traffic_rollups IS
+  'Hourly STA session-byte deltas per AP SN + allow-listed SSID. Forward-only sampled telemetry for Usage Reports Staff period GB (90d retention).';
+
+COMMENT ON COLUMN public.ruijie_ssid_traffic_rollups.hour_bucket IS
+  'UTC hour start (timestamptz). Sampler sums 5-min positive deltas into this bucket.';
+
+COMMENT ON COLUMN public.ruijie_ssid_traffic_rollups.corporate_site_id IS
+  'Denormalized site link at write time from network_devices / ruijie_device_cache; null if unlinked.';
+
+COMMENT ON COLUMN public.ruijie_ssid_traffic_rollups.rx_bytes IS
+  'Summed positive wifiDown deltas for the hour (client download).';
+
+COMMENT ON COLUMN public.ruijie_ssid_traffic_rollups.tx_bytes IS
+  'Summed positive wifiUp deltas for the hour (client upload).';
+
+CREATE INDEX IF NOT EXISTS idx_ruijie_ssid_rollups_site_ssid_hour
+  ON public.ruijie_ssid_traffic_rollups (corporate_site_id, ssid, hour_bucket DESC)
+  WHERE corporate_site_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ruijie_ssid_rollups_sn_hour
+  ON public.ruijie_ssid_traffic_rollups (device_sn, hour_bucket DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ruijie_ssid_rollups_hour
+  ON public.ruijie_ssid_traffic_rollups (hour_bucket DESC);
+
+ALTER TABLE public.ruijie_ssid_traffic_rollups ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admin users can read ssid traffic rollups"
+  ON public.ruijie_ssid_traffic_rollups
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.admin_users
+      WHERE admin_users.email = (auth.jwt() ->> 'email')
+    )
+  );
+
+CREATE POLICY "Service role full access ssid traffic rollups"
+  ON public.ruijie_ssid_traffic_rollups
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Last-seen STA counters for positive-delta computation between 5-min samples.
+CREATE TABLE IF NOT EXISTS public.ruijie_ssid_sta_sample_state (
+  device_sn text NOT NULL,
+  mac text NOT NULL,
+  ssid text NOT NULL,
+  last_wifi_up bigint NOT NULL DEFAULT 0,
+  last_wifi_down bigint NOT NULL DEFAULT 0,
+  sampled_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ruijie_ssid_sta_sample_state_pkey
+    PRIMARY KEY (device_sn, mac, ssid)
+);
+
+COMMENT ON TABLE public.ruijie_ssid_sta_sample_state IS
+  'Checkpoint of last STA session byte counters (wifiUp/wifiDown) per AP+MAC+SSID for sampler deltas. Prune rows not seen ~24–48h.';
+
+CREATE INDEX IF NOT EXISTS idx_ruijie_ssid_sta_sample_state_sampled
+  ON public.ruijie_ssid_sta_sample_state (sampled_at);
+
+ALTER TABLE public.ruijie_ssid_sta_sample_state ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admin users can read ssid sta sample state"
+  ON public.ruijie_ssid_sta_sample_state
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.admin_users
+      WHERE admin_users.email = (auth.jwt() ->> 'email')
+    )
+  );
+
+CREATE POLICY "Service role full access ssid sta sample state"
+  ON public.ruijie_ssid_sta_sample_state
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- Add `ruijie_ssid_traffic_rollups` and `ruijie_ssid_sta_sample_state` for STA session-byte hour rollups (Wayfinder #678 / #672 / #675).
- Add TypeScript row types and Staff-only SSID allow-list constant (`Unjani Clinic Staff`) for the upcoming 5-min sampler (#679).

## Test plan
- [ ] Apply migration to Supabase (`agyjovdugmtopasyvlng`) and confirm both tables exist with RLS
- [ ] Verify unique key `(device_sn, ssid, hour_bucket)` and FK on `corporate_site_id`
- [ ] Confirm no sampler/write path yet (schema + types only)

Closes #678

Made with [Cursor](https://cursor.com)