### PR TITLE
feat(network): 5-min Ruijie STA SSID sampler

### DIFF
--- a/__tests__/lib/ruijie/ssid-sta-rollup.test.ts
+++ b/__tests__/lib/ruijie/ssid-sta-rollup.test.ts
@@ -1,0 +1,150 @@
+import {
+  computeSsidHourDeltas,
+  positiveCounterDelta,
+  sampleStateKey,
+} from '@/lib/ruijie/ssid-sta-rollup';
+
+describe('positiveCounterDelta', () => {
+  it('returns 0 when previous is missing (baseline)', () => {
+    expect(positiveCounterDelta(1000, undefined)).toBe(0);
+  });
+
+  it('credits increase', () => {
+    expect(positiveCounterDelta(1500, 1000)).toBe(500);
+  });
+
+  it('credits current on session reset (decrease)', () => {
+    expect(positiveCounterDelta(200, 1000)).toBe(200);
+  });
+
+  it('returns 0 for invalid current', () => {
+    expect(positiveCounterDelta(Number.NaN, 10)).toBe(0);
+    expect(positiveCounterDelta(-1, 10)).toBe(0);
+  });
+});
+
+describe('computeSsidHourDeltas', () => {
+  const sampledAtMs = Date.parse('2026-08-01T14:37:00.000Z');
+  const hour = '2026-08-01T14:00:00.000Z';
+
+  it('ignores Free SSID and incomplete rows; baselines Staff with no credit', () => {
+    const result = computeSsidHourDeltas({
+      samples: [
+        {
+          sn: 'AP1',
+          mac: 'AA:BB:CC:DD:EE:01',
+          ssid: 'Unjani Clinic Free WiFi',
+          wifiUp: 999,
+          wifiDown: 999,
+        },
+        {
+          sn: 'AP1',
+          mac: 'AA:BB:CC:DD:EE:02',
+          ssid: 'Unjani Clinic Staff',
+          wifiUp: 1000,
+          wifiDown: 2000,
+        },
+        { sn: '', mac: 'aa', ssid: 'Unjani Clinic Staff', wifiUp: 1, wifiDown: 1 },
+      ],
+      previous: new Map(),
+      sampledAtMs,
+    });
+
+    expect(result.hourDeltas).toEqual([]);
+    expect(result.skippedNonAllowlisted).toBe(1);
+    expect(result.skippedIncomplete).toBe(1);
+    expect(result.nextState).toEqual([
+      {
+        device_sn: 'AP1',
+        mac: 'aa:bb:cc:dd:ee:02',
+        ssid: 'Unjani Clinic Staff',
+        last_wifi_up: 1000,
+        last_wifi_down: 2000,
+      },
+    ]);
+  });
+
+  it('sums Staff deltas into the UTC hour bucket', () => {
+    const prevKey = sampleStateKey('AP1', 'aa:bb:cc:dd:ee:02', 'Unjani Clinic Staff');
+    const previous = new Map([
+      [
+        prevKey,
+        {
+          device_sn: 'AP1',
+          mac: 'aa:bb:cc:dd:ee:02',
+          ssid: 'Unjani Clinic Staff',
+          last_wifi_up: 1000,
+          last_wifi_down: 2000,
+        },
+      ],
+    ]);
+
+    const result = computeSsidHourDeltas({
+      samples: [
+        {
+          sn: 'AP1',
+          mac: 'AA:BB:CC:DD:EE:02',
+          ssid: 'Unjani Clinic Staff',
+          wifiUp: 1500,
+          wifiDown: 2600,
+        },
+        {
+          sn: 'AP1',
+          mac: 'AA:BB:CC:DD:EE:03',
+          ssid: 'Unjani Clinic Staff',
+          wifiUp: 100,
+          wifiDown: 50,
+        },
+      ],
+      previous,
+      sampledAtMs,
+    });
+
+    expect(result.hourDeltas).toEqual([
+      {
+        device_sn: 'AP1',
+        ssid: 'Unjani Clinic Staff',
+        hour_bucket: hour,
+        rx_bytes: 600,
+        tx_bytes: 500,
+      },
+    ]);
+    expect(result.nextState).toHaveLength(2);
+  });
+
+  it('credits fresh cumulative after counter reset', () => {
+    const prevKey = sampleStateKey('AP1', 'aa:bb:cc:dd:ee:02', 'Unjani Clinic Staff');
+    const previous = new Map([
+      [
+        prevKey,
+        {
+          device_sn: 'AP1',
+          mac: 'aa:bb:cc:dd:ee:02',
+          ssid: 'Unjani Clinic Staff',
+          last_wifi_up: 5000,
+          last_wifi_down: 8000,
+        },
+      ],
+    ]);
+
+    const result = computeSsidHourDeltas({
+      samples: [
+        {
+          sn: 'AP1',
+          mac: 'aa:bb:cc:dd:ee:02',
+          ssid: 'Unjani Clinic Staff',
+          wifiUp: 120,
+          wifiDown: 80,
+        },
+      ],
+      previous,
+      sampledAtMs,
+    });
+
+    expect(result.hourDeltas[0]).toMatchObject({
+      rx_bytes: 80,
+      tx_bytes: 120,
+      hour_bucket: hour,
+    });
+  });
+});

--- a/lib/inngest/functions/ruijie-ssid-sta-sampler.ts
+++ b/lib/inngest/functions/ruijie-ssid-sta-sampler.ts
@@ -1,0 +1,278 @@
+/**
+ * Ruijie SSID STA Sampler
+ *
+ * Every 5 minutes: pull `/sta/sta_users` per group, credit allow-listed SSID
+ * (`Unjani Clinic Staff`) session-byte deltas into UTC hour buckets on
+ * `ruijie_ssid_traffic_rollups`, maintain `ruijie_ssid_sta_sample_state`.
+ *
+ * Wayfinder #679 / #672. Retention: 90d rollups, ~36h sample-state.
+ *
+ * Ops: re-register Inngest after deploy (`PUT /api/inngest`).
+ */
+
+import { inngest } from '../client';
+import { createClient } from '@/lib/supabase/server';
+import { getGroupStaUsers } from '@/lib/ruijie/client';
+import type { StaUserRaw } from '@/lib/ruijie/performance-metrics';
+import {
+  SSID_GROUP_DELAY_MS,
+  SSID_ROLLUP_RETENTION_DAYS,
+  SSID_SAMPLE_STATE_RETENTION_HOURS,
+  computeSsidHourDeltas,
+  sampleStateKey,
+  type StaSampleStateSnapshot,
+} from '@/lib/ruijie/ssid-sta-rollup';
+
+type GroupRow = { group_id: string };
+
+function toSampleInput(sta: StaUserRaw) {
+  return {
+    sn: String(sta.sn ?? ''),
+    mac: String(sta.mac ?? ''),
+    ssid: String(sta.ssid ?? ''),
+    wifiUp: Number(sta.wifiUp),
+    wifiDown: Number(sta.wifiDown),
+  };
+}
+
+async function loadSiteIdBySn(
+  supabase: Awaited<ReturnType<typeof createClient>>
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+
+  const { data: devices } = await supabase
+    .from('network_devices')
+    .select('serial_number, ruijie_device_sn, corporate_site_id')
+    .not('corporate_site_id', 'is', null);
+
+  for (const row of devices || []) {
+    const siteId = row.corporate_site_id as string | null;
+    if (!siteId) continue;
+    if (row.serial_number) map.set(String(row.serial_number), siteId);
+    if (row.ruijie_device_sn) map.set(String(row.ruijie_device_sn), siteId);
+  }
+
+  const { data: cache } = await supabase
+    .from('ruijie_device_cache')
+    .select('sn, corporate_site_id')
+    .not('corporate_site_id', 'is', null);
+
+  for (const row of cache || []) {
+    if (!row.sn || !row.corporate_site_id) continue;
+    if (!map.has(row.sn)) {
+      map.set(row.sn, row.corporate_site_id as string);
+    }
+  }
+
+  return map;
+}
+
+export const ruijieSsidStaSamplerFunction = inngest.createFunction(
+  {
+    id: 'ruijie-ssid-sta-sampler',
+    name: 'Ruijie SSID STA Sampler',
+    retries: 2,
+    concurrency: {
+      // One sampler at a time — share Ruijie rate budget with sync/rollup.
+      limit: 1,
+    },
+    triggers: [
+      { cron: '*/5 * * * *' },
+      { event: 'ruijie/ssid-sta-sample.requested' },
+    ],
+  },
+  async ({ step }) => {
+    const groups = await step.run('fetch-groups', async () => {
+      const supabase = await createClient();
+      const { data, error } = await supabase
+        .from('ruijie_device_cache')
+        .select('group_id')
+        .not('group_id', 'is', null);
+
+      if (error) {
+        console.error('[SsidStaSampler] Failed to fetch groups:', error);
+        return [] as GroupRow[];
+      }
+
+      const ids = new Set<string>();
+      for (const row of data || []) {
+        if (row.group_id) ids.add(String(row.group_id));
+      }
+      return Array.from(ids).map((group_id) => ({ group_id }));
+    });
+
+    if (groups.length === 0) {
+      console.warn('[SsidStaSampler] No groups in device cache');
+      return { groupsProcessed: 0, hourRowsTouched: 0, stasSeen: 0 };
+    }
+
+    const previous = await step.run('load-sample-state', async () => {
+      const supabase = await createClient();
+      const { data, error } = await supabase
+        .from('ruijie_ssid_sta_sample_state')
+        .select('device_sn, mac, ssid, last_wifi_up, last_wifi_down');
+
+      if (error) {
+        console.error('[SsidStaSampler] Failed to load sample state:', error);
+        return [] as StaSampleStateSnapshot[];
+      }
+
+      return (data || []) as StaSampleStateSnapshot[];
+    });
+
+    const previousMap = new Map(
+      previous.map((row) => [sampleStateKey(row.device_sn, row.mac, row.ssid), row] as const)
+    );
+
+    const sampleResult = await step.run('sample-groups-and-delta', async () => {
+      const sampledAtMs = Date.now();
+      const sampledAtIso = new Date(sampledAtMs).toISOString();
+      const allStas: ReturnType<typeof toSampleInput>[] = [];
+
+      for (let i = 0; i < groups.length; i += 1) {
+        const group = groups[i];
+        try {
+          const stas = await getGroupStaUsers(group.group_id);
+          for (const sta of stas) {
+            allStas.push(toSampleInput(sta));
+          }
+        } catch (err) {
+          console.error(`[SsidStaSampler] STA fetch failed group=${group.group_id}:`, err);
+        }
+        if (i < groups.length - 1) {
+          await new Promise((r) => setTimeout(r, SSID_GROUP_DELAY_MS));
+        }
+      }
+
+      const deltas = computeSsidHourDeltas({
+        samples: allStas,
+        previous: previousMap,
+        sampledAtMs,
+      });
+
+      return {
+        stasSeen: allStas.length,
+        sampledAtIso,
+        ...deltas,
+      };
+    });
+
+    const hourRowsTouched = await step.run('upsert-hour-rollups', async () => {
+      if (sampleResult.hourDeltas.length === 0) return 0;
+
+      const supabase = await createClient();
+      const siteBySn = await loadSiteIdBySn(supabase);
+      const nowIso = new Date().toISOString();
+      let touched = 0;
+
+      for (const delta of sampleResult.hourDeltas) {
+        const { data: existing, error: readError } = await supabase
+          .from('ruijie_ssid_traffic_rollups')
+          .select('rx_bytes, tx_bytes, corporate_site_id')
+          .eq('device_sn', delta.device_sn)
+          .eq('ssid', delta.ssid)
+          .eq('hour_bucket', delta.hour_bucket)
+          .maybeSingle();
+
+        if (readError) {
+          console.error('[SsidStaSampler] Read hour row failed:', readError);
+          continue;
+        }
+
+        const siteId =
+          siteBySn.get(delta.device_sn) ??
+          (existing?.corporate_site_id as string | null) ??
+          null;
+
+        const row = {
+          device_sn: delta.device_sn,
+          ssid: delta.ssid,
+          hour_bucket: delta.hour_bucket,
+          hours_window: 1,
+          corporate_site_id: siteId,
+          rx_bytes: Number(existing?.rx_bytes ?? 0) + delta.rx_bytes,
+          tx_bytes: Number(existing?.tx_bytes ?? 0) + delta.tx_bytes,
+          updated_at: nowIso,
+        };
+
+        const { error } = await supabase.from('ruijie_ssid_traffic_rollups').upsert(row, {
+          onConflict: 'device_sn,ssid,hour_bucket',
+        });
+
+        if (error) {
+          console.error('[SsidStaSampler] Hour upsert failed:', error, row);
+        } else {
+          touched += 1;
+        }
+      }
+
+      return touched;
+    });
+
+    await step.run('upsert-sample-state', async () => {
+      if (sampleResult.nextState.length === 0) return;
+
+      const supabase = await createClient();
+      const nowIso = new Date().toISOString();
+      const upserts = sampleResult.nextState.map((s) => ({
+        device_sn: s.device_sn,
+        mac: s.mac,
+        ssid: s.ssid,
+        last_wifi_up: s.last_wifi_up,
+        last_wifi_down: s.last_wifi_down,
+        sampled_at: sampleResult.sampledAtIso,
+        updated_at: nowIso,
+      }));
+
+      // Chunk to keep payloads modest
+      const chunkSize = 200;
+      for (let i = 0; i < upserts.length; i += chunkSize) {
+        const chunk = upserts.slice(i, i + chunkSize);
+        const { error } = await supabase.from('ruijie_ssid_sta_sample_state').upsert(chunk, {
+          onConflict: 'device_sn,mac,ssid',
+        });
+        if (error) {
+          console.error('[SsidStaSampler] Sample-state upsert failed:', error);
+        }
+      }
+    });
+
+    await step.run('prune-old-rows', async () => {
+      const supabase = await createClient();
+      const rollupCutoff = new Date(
+        Date.now() - SSID_ROLLUP_RETENTION_DAYS * 24 * 60 * 60 * 1000
+      ).toISOString();
+      const stateCutoff = new Date(
+        Date.now() - SSID_SAMPLE_STATE_RETENTION_HOURS * 60 * 60 * 1000
+      ).toISOString();
+
+      const { error: rollupErr } = await supabase
+        .from('ruijie_ssid_traffic_rollups')
+        .delete()
+        .lt('hour_bucket', rollupCutoff);
+      if (rollupErr) {
+        console.error('[SsidStaSampler] Rollup prune failed:', rollupErr);
+      }
+
+      const { error: stateErr } = await supabase
+        .from('ruijie_ssid_sta_sample_state')
+        .delete()
+        .lt('sampled_at', stateCutoff);
+      if (stateErr) {
+        console.error('[SsidStaSampler] Sample-state prune failed:', stateErr);
+      }
+    });
+
+    console.log(
+      `[SsidStaSampler] done groups=${groups.length} stas=${sampleResult.stasSeen} hourRows=${hourRowsTouched} skippedFree=${sampleResult.skippedNonAllowlisted}`
+    );
+
+    return {
+      groupsProcessed: groups.length,
+      stasSeen: sampleResult.stasSeen,
+      hourRowsTouched,
+      skippedNonAllowlisted: sampleResult.skippedNonAllowlisted,
+      skippedIncomplete: sampleResult.skippedIncomplete,
+    };
+  }
+);

--- a/lib/inngest/index.ts
+++ b/lib/inngest/index.ts
@@ -87,6 +87,10 @@ export {
 } from './functions/ruijie-traffic-rollup';
 
 export {
+  ruijieSsidStaSamplerFunction,
+} from './functions/ruijie-ssid-sta-sampler';
+
+export {
   mikrotikSyncFunction,
   mikrotikSyncCompletedFunction,
 } from './functions/mikrotik-sync';
@@ -236,6 +240,10 @@ import {
 } from './functions/ruijie-traffic-rollup';
 
 import {
+  ruijieSsidStaSamplerFunction,
+} from './functions/ruijie-ssid-sta-sampler';
+
+import {
   mikrotikSyncFunction,
   mikrotikSyncCompletedFunction,
 } from './functions/mikrotik-sync';
@@ -354,6 +362,8 @@ export const functions = [
   ruijieHealthMonitorFunction,
   // Ruijie traffic rollups for System Health / Analytics
   ruijieTrafficRollupFunction,
+  // Ruijie STA → SSID hour rollups (Usage Reports Staff GB)
+  ruijieSsidStaSamplerFunction,
   // MikroTik router sync
   mikrotikSyncFunction,
   mikrotikSyncCompletedFunction,

--- a/lib/ruijie/ssid-sta-rollup.ts
+++ b/lib/ruijie/ssid-sta-rollup.ts
@@ -1,0 +1,145 @@
+/**
+ * Ruijie STA session-byte → hourly SSID rollup helpers.
+ *
+ * Wayfinder #672 / #673 / #675 / #679: sample STA wifiUp/wifiDown, credit
+ * positive deltas into UTC hour buckets for allow-listed SSIDs only.
+ */
+
+import { hourBucketIso } from '@/lib/network/analytics-aggregates';
+import { RUIJIE_SSID_ROLLUP_ALLOWLIST } from '@/lib/ruijie/types';
+
+export const SSID_ROLLUP_RETENTION_DAYS = 90;
+export const SSID_SAMPLE_STATE_RETENTION_HOURS = 36;
+export const SSID_GROUP_DELAY_MS = 250;
+
+export type StaSampleInput = {
+  sn: string;
+  mac: string;
+  ssid: string;
+  wifiUp: number;
+  wifiDown: number;
+};
+
+export type StaSampleStateSnapshot = {
+  device_sn: string;
+  mac: string;
+  ssid: string;
+  last_wifi_up: number;
+  last_wifi_down: number;
+};
+
+export type HourBucketDelta = {
+  device_sn: string;
+  ssid: string;
+  hour_bucket: string;
+  rx_bytes: number;
+  tx_bytes: number;
+};
+
+export function sampleStateKey(deviceSn: string, mac: string, ssid: string): string {
+  return `${deviceSn}\0${mac}\0${ssid}`;
+}
+
+export function hourBucketKey(deviceSn: string, ssid: string, hourBucket: string): string {
+  return `${deviceSn}\0${ssid}\0${hourBucket}`;
+}
+
+export function isAllowlistedSsid(
+  ssid: string,
+  allowlist: readonly string[] = RUIJIE_SSID_ROLLUP_ALLOWLIST
+): boolean {
+  return allowlist.includes(ssid);
+}
+
+/**
+ * Positive delta between consecutive samples for one counter.
+ * - No previous → 0 (baseline only; avoid dumping long-lived session into first hour)
+ * - Current >= previous → current - previous
+ * - Current < previous → session reset; credit current as fresh cumulative
+ */
+export function positiveCounterDelta(current: number, previous: number | undefined): number {
+  if (!Number.isFinite(current) || current < 0) return 0;
+  if (previous === undefined || !Number.isFinite(previous)) return 0;
+  if (current >= previous) return current - previous;
+  return current;
+}
+
+/**
+ * Compute hour-bucket byte credits and next checkpoint state from a STA sample.
+ */
+export function computeSsidHourDeltas(params: {
+  samples: StaSampleInput[];
+  previous: ReadonlyMap<string, StaSampleStateSnapshot>;
+  sampledAtMs: number;
+  allowlist?: readonly string[];
+}): {
+  hourDeltas: HourBucketDelta[];
+  nextState: StaSampleStateSnapshot[];
+  skippedNonAllowlisted: number;
+  skippedIncomplete: number;
+} {
+  const allowlist = params.allowlist ?? RUIJIE_SSID_ROLLUP_ALLOWLIST;
+  const hourIso = hourBucketIso(params.sampledAtMs);
+  const byHour = new Map<string, HourBucketDelta>();
+  const nextState: StaSampleStateSnapshot[] = [];
+  let skippedNonAllowlisted = 0;
+  let skippedIncomplete = 0;
+
+  for (const sample of params.samples) {
+    const sn = (sample.sn || '').trim();
+    const mac = (sample.mac || '').trim().toLowerCase();
+    const ssid = (sample.ssid || '').trim();
+    if (!sn || !mac || !ssid) {
+      skippedIncomplete += 1;
+      continue;
+    }
+    if (!isAllowlistedSsid(ssid, allowlist)) {
+      skippedNonAllowlisted += 1;
+      continue;
+    }
+
+    const wifiUp = Number(sample.wifiUp);
+    const wifiDown = Number(sample.wifiDown);
+    if (!Number.isFinite(wifiUp) || !Number.isFinite(wifiDown)) {
+      skippedIncomplete += 1;
+      continue;
+    }
+
+    const key = sampleStateKey(sn, mac, ssid);
+    const prev = params.previous.get(key);
+    const txDelta = positiveCounterDelta(wifiUp, prev?.last_wifi_up);
+    const rxDelta = positiveCounterDelta(wifiDown, prev?.last_wifi_down);
+
+    if (txDelta > 0 || rxDelta > 0) {
+      const hKey = hourBucketKey(sn, ssid, hourIso);
+      const existing = byHour.get(hKey);
+      if (existing) {
+        existing.rx_bytes += rxDelta;
+        existing.tx_bytes += txDelta;
+      } else {
+        byHour.set(hKey, {
+          device_sn: sn,
+          ssid,
+          hour_bucket: hourIso,
+          rx_bytes: rxDelta,
+          tx_bytes: txDelta,
+        });
+      }
+    }
+
+    nextState.push({
+      device_sn: sn,
+      mac,
+      ssid,
+      last_wifi_up: wifiUp,
+      last_wifi_down: wifiDown,
+    });
+  }
+
+  return {
+    hourDeltas: Array.from(byHour.values()),
+    nextState,
+    skippedNonAllowlisted,
+    skippedIncomplete,
+  };
+}


### PR DESCRIPTION
## Summary
- Add Inngest cron `ruijie-ssid-sta-sampler` (`*/5 * * * *`, concurrency 1) that pulls `/sta/sta_users` per group and credits **Staff-only** (`Unjani Clinic Staff`) session-byte deltas into `ruijie_ssid_traffic_rollups`.
- Maintain `ruijie_ssid_sta_sample_state`; denormalize `corporate_site_id` from `network_devices` / `ruijie_device_cache`; prune rollups at 90d and sample-state at ~36h.
- Pure delta helpers + unit tests (`lib/ruijie/ssid-sta-rollup.ts`).

## Test plan
- [x] Helper assertions (baseline, increase, reset, Free SSID skipped)
- [ ] After merge: confirm Inngest re-register (`PUT /api/inngest`) includes `ruijie-ssid-sta-sampler`
- [ ] After ~10 min: `ruijie_ssid_sta_sample_state` rows for Staff; hour rollups grow for linked sites
- [ ] Confirm no `Unjani Clinic Free WiFi` rows written

Closes #679

Made with [Cursor](https://cursor.com)