### PR TITLE
feat(network): Site Network Usage Reports MVP

### DIFF
--- a/__tests__/lib/usage-reports/artifacts.test.ts
+++ b/__tests__/lib/usage-reports/artifacts.test.ts
@@ -1,0 +1,126 @@
+import JSZip from 'jszip';
+
+import {
+  buildUsageReportArtifact,
+  type UsageReportArtifactDeps,
+} from '@/lib/usage-reports/artifacts';
+import type { SiteUsageReportModel } from '@/lib/usage-reports/types';
+
+const period: SiteUsageReportModel['period'] = {
+  preset: 'weekly',
+  timezone: 'Africa/Johannesburg',
+  startIso: '2026-07-20T00:00:00+02:00',
+  endIso: '2026-07-26T23:59:59.999+02:00',
+  startUtc: new Date('2026-07-19T22:00:00.000Z'),
+  endUtc: new Date('2026-07-26T21:59:59.999Z'),
+  label: 'Weekly',
+  rangeLabel: '20 Jul – 26 Jul 2026',
+  inclusiveDayCount: 7,
+  isShortPeriod: true,
+};
+
+function model(siteId: string, accountNumber: string): SiteUsageReportModel {
+  return {
+    generatedAtIso: '2026-08-01T18:00:00+02:00',
+    site: {
+      id: siteId,
+      name: `Clinic ${siteId}`,
+      accountNumber,
+      corporateCode: 'UNJ',
+      accountName: 'Unjani Clinics',
+    },
+    period,
+    core: {
+      source: 'ruijie_hourly',
+      sourceLabel: 'Ruijie hourly',
+      downloadBytes: 10,
+      uploadBytes: 5,
+      avgDownKbps: 1,
+      peakBucketBytes: 2,
+      dailyDownloadBytes: [1, 1, 1, 1, 1, 1, 1],
+      note: 'Measured',
+    },
+    device: null,
+    unjani: true,
+    staff: { kind: 'no_samples' },
+    patient: { kind: 'awaiting_export' },
+  };
+}
+
+describe('buildUsageReportArtifact', () => {
+  it('returns a PDF directly for one generated site', async () => {
+    const deps: UsageReportArtifactDeps = {
+      assemble: async ({ siteId }) => ({ ok: true, model: model(siteId, 'UNJ-001') }),
+      reportPdf: () => Uint8Array.from([1, 2, 3]).buffer,
+      skipPdf: () => Uint8Array.from([9]).buffer,
+      csv: () => 'csv',
+    };
+
+    const artifact = await buildUsageReportArtifact(
+      {
+        sites: [{ id: 'site-1', accountNumber: 'UNJ-001' }],
+        period,
+        patientRows: [],
+        includeCsv: false,
+      },
+      deps
+    );
+
+    expect(artifact.contentType).toBe('application/pdf');
+    expect(artifact.filename).toBe('CircleTel_Usage_UNJ-001_2026-07-20_to_2026-07-26.pdf');
+    expect([...artifact.bytes]).toEqual([1, 2, 3]);
+    expect(artifact.outcome).toEqual({ generated: ['site-1'], skipped: [] });
+  });
+
+  it('packs PDFs, CSVs, and explicit skip slips into a ZIP', async () => {
+    const seenPatientRows: unknown[] = [];
+    const deps: UsageReportArtifactDeps = {
+      assemble: async ({ siteId, patientRow }) => {
+        seenPatientRows.push(patientRow);
+        return siteId === 'site-2'
+          ? {
+              ok: false,
+              reason: 'core_unavailable',
+              siteId,
+              siteLabel: 'Clinic Two',
+            }
+          : { ok: true, model: model(siteId, 'UNJ-001') };
+      },
+      reportPdf: () => Uint8Array.from([1]).buffer,
+      skipPdf: () => Uint8Array.from([9]).buffer,
+      csv: () => 'site,data\r\n',
+    };
+
+    const artifact = await buildUsageReportArtifact(
+      {
+        sites: [
+          { id: 'site-1', accountNumber: 'UNJ-001' },
+          { id: 'site-2', accountNumber: 'UNJ-002' },
+        ],
+        period,
+        patientRows: [
+          { siteCode: 'unj-001', uniqueUsers: 3, loginSessions: 4, downloadGb: 5 },
+        ],
+        includeCsv: true,
+      },
+      deps
+    );
+    const zip = await JSZip.loadAsync(artifact.bytes);
+
+    expect(artifact.contentType).toBe('application/zip');
+    expect(Object.keys(zip.files).sort()).toEqual([
+      'CircleTel_Usage_Clinic_Two_2026-07-20_to_2026-07-26_SKIPPED.pdf',
+      'CircleTel_Usage_UNJ-001_2026-07-20_to_2026-07-26.csv',
+      'CircleTel_Usage_UNJ-001_2026-07-20_to_2026-07-26.pdf',
+    ]);
+    expect(await zip.file(/SKIPPED/)[0].async('uint8array')).toEqual(Uint8Array.from([9]));
+    expect(seenPatientRows).toEqual([
+      { siteCode: 'unj-001', uniqueUsers: 3, loginSessions: 4, downloadGb: 5 },
+      null,
+    ]);
+    expect(artifact.outcome).toEqual({
+      generated: ['site-1'],
+      skipped: [{ siteId: 'site-2', reason: 'core_unavailable' }],
+    });
+  });
+});

--- a/__tests__/lib/usage-reports/assemble-report.test.ts
+++ b/__tests__/lib/usage-reports/assemble-report.test.ts
@@ -1,0 +1,195 @@
+import {
+  assembleSiteUsageReport,
+  type AssembleReportDeps,
+} from '@/lib/usage-reports/assemble-report';
+import type {
+  ReportPeriod,
+  SiteUsageReportModel,
+} from '@/lib/usage-reports/types';
+
+const period: ReportPeriod = {
+  preset: 'weekly',
+  timezone: 'Africa/Johannesburg',
+  startIso: '2026-07-20T00:00:00.000+02:00',
+  endIso: '2026-07-26T23:59:59.999+02:00',
+  startUtc: new Date('2026-07-19T22:00:00.000Z'),
+  endUtc: new Date('2026-07-26T21:59:59.999Z'),
+  label: 'Last complete week',
+  rangeLabel: '20 - 26 Jul 2026',
+  inclusiveDayCount: 7,
+  isShortPeriod: true,
+};
+
+const site = {
+  id: 's1',
+  name: 'Unjani Clinic',
+  account_number: 'UNJ-001',
+  status: 'active',
+  service_id: 'svc-1',
+  service_status: 'active',
+  corporate_code: 'UNJ',
+  account_name: 'Unjani Clinics',
+};
+
+const availableCore: SiteUsageReportModel['core'] = {
+  source: 'ruijie_hourly',
+  sourceLabel: 'Ruijie traffic rollups (hourly)',
+  downloadBytes: 1_000,
+  uploadBytes: 200,
+  avgDownKbps: 25,
+  peakBucketBytes: 400,
+  dailyDownloadBytes: [100, 200, 300, 100, 100, 100, 100],
+  note: 'Hourly rollups.',
+};
+
+function buildDeps(
+  overrides: Partial<AssembleReportDeps> = {}
+): AssembleReportDeps {
+  return {
+    loadSite: async () => site,
+    loadCore: async () => availableCore,
+    loadStaff: async () => ({ kind: 'no_samples' }),
+    loadDevice: async () => null,
+    generatedAtIso: () => '2026-08-01T17:40:00.000+02:00',
+    ...overrides,
+  };
+}
+
+describe('assembleSiteUsageReport', () => {
+  it('returns a core_unavailable skip with site identity', async () => {
+    const result = await assembleSiteUsageReport({
+      siteId: site.id,
+      period,
+      patientRow: null,
+      deps: buildDeps({
+        loadCore: async () => ({
+          ...availableCore,
+          source: 'unavailable',
+          sourceLabel: 'Not available',
+        }),
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'core_unavailable',
+      siteId: 's1',
+      siteLabel: 'Unjani Clinic',
+    });
+  });
+
+  it('builds an Unjani model and leaves absent patient data awaiting export', async () => {
+    const device = {
+      name: 'Clinic AP',
+      model: 'RG-EG105G',
+      serial: 'SN-1',
+      group: 'Unjani',
+      status: 'online',
+    };
+    const result = await assembleSiteUsageReport({
+      siteId: site.id,
+      period,
+      patientRow: null,
+      deps: buildDeps({
+        loadStaff: async () => ({
+          kind: 'available',
+          totalBytes: 50,
+          rxBytes: 40,
+          txBytes: 10,
+        }),
+        loadDevice: async () => device,
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.model).toMatchObject({
+      generatedAtIso: '2026-08-01T17:40:00.000+02:00',
+      site: {
+        id: 's1',
+        name: 'Unjani Clinic',
+        accountNumber: 'UNJ-001',
+        corporateCode: 'UNJ',
+        accountName: 'Unjani Clinics',
+      },
+      period,
+      core: availableCore,
+      device,
+      unjani: true,
+      staff: { kind: 'available' },
+      patient: { kind: 'awaiting_export' },
+    });
+  });
+
+  it('maps an Unjani patient export row into available patient usage', async () => {
+    const result = await assembleSiteUsageReport({
+      siteId: site.id,
+      period,
+      patientRow: {
+        siteCode: 'UNJ-001',
+        uniqueUsers: 12,
+        loginSessions: 20,
+        downloadGb: 2.5,
+      },
+      deps: buildDeps(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.model.patient).toEqual({
+      kind: 'available',
+      uniqueUsers: 12,
+      loginSessions: 20,
+      downloadGb: 2.5,
+    });
+  });
+
+  it('does not load Unjani-only staff data for another corporate account', async () => {
+    let staffLoads = 0;
+    const result = await assembleSiteUsageReport({
+      siteId: 'other-1',
+      period,
+      patientRow: {
+        siteCode: 'OTHER-1',
+        uniqueUsers: 12,
+        loginSessions: 20,
+        downloadGb: 2,
+      },
+      deps: buildDeps({
+        loadSite: async () => ({
+          ...site,
+          id: 'other-1',
+          name: 'Other Site',
+          corporate_code: 'OTHER',
+        }),
+        loadStaff: async () => {
+          staffLoads += 1;
+          return { kind: 'no_samples' };
+        },
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(staffLoads).toBe(0);
+    expect(result.model.unjani).toBe(false);
+    expect(result.model.staff).toEqual({ kind: 'no_samples' });
+    expect(result.model.patient).toEqual({ kind: 'awaiting_export' });
+  });
+
+  it('returns site_not_eligible when the site loader has no match', async () => {
+    const result = await assembleSiteUsageReport({
+      siteId: 'missing',
+      period,
+      patientRow: null,
+      deps: buildDeps({ loadSite: async () => null }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'site_not_eligible',
+      siteId: 'missing',
+      siteLabel: 'missing',
+    });
+  });
+});

--- a/__tests__/lib/usage-reports/core-traffic.test.ts
+++ b/__tests__/lib/usage-reports/core-traffic.test.ts
@@ -1,0 +1,200 @@
+import {
+  aggregateInterstellioDaily,
+  aggregateRuijieHourly,
+  CORE_SOURCE_LABEL,
+  selectCorePrimarySource,
+  shouldAttachSecondaryInterstellio,
+} from '@/lib/usage-reports/core-traffic';
+
+describe('selectCorePrimarySource', () => {
+  it('prefers covered Ruijie data for a short period', () => {
+    expect(
+      selectCorePrimarySource({
+        isShortPeriod: true,
+        ruijieLinked: true,
+        ruijieCoversWindow: true,
+        interstellioMapped: true,
+      })
+    ).toBe('ruijie_hourly');
+  });
+
+  it('falls back to Interstellio when short-period Ruijie data is absent', () => {
+    expect(
+      selectCorePrimarySource({
+        isShortPeriod: true,
+        ruijieLinked: true,
+        ruijieCoversWindow: false,
+        interstellioMapped: true,
+      })
+    ).toBe('interstellio_daily');
+  });
+
+  it('does not use Ruijie coverage unless the site is linked', () => {
+    expect(
+      selectCorePrimarySource({
+        isShortPeriod: true,
+        ruijieLinked: false,
+        ruijieCoversWindow: true,
+        interstellioMapped: true,
+      })
+    ).toBe('interstellio_daily');
+  });
+
+  it('uses Interstellio only for a long period', () => {
+    expect(
+      selectCorePrimarySource({
+        isShortPeriod: false,
+        ruijieLinked: true,
+        ruijieCoversWindow: true,
+        interstellioMapped: true,
+      })
+    ).toBe('interstellio_daily');
+  });
+
+  it('returns unavailable when no permitted source exists', () => {
+    expect(
+      selectCorePrimarySource({
+        isShortPeriod: false,
+        ruijieLinked: true,
+        ruijieCoversWindow: true,
+        interstellioMapped: false,
+      })
+    ).toBe('unavailable');
+  });
+});
+
+describe('shouldAttachSecondaryInterstellio', () => {
+  it('allows a secondary only beside a short-period Ruijie primary', () => {
+    expect(
+      shouldAttachSecondaryInterstellio({
+        isShortPeriod: true,
+        primary: 'ruijie_hourly',
+        interstellioMapped: true,
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    [false, 'ruijie_hourly', true],
+    [true, 'interstellio_daily', true],
+    [true, 'ruijie_hourly', false],
+  ] as const)(
+    'rejects secondary for short=%s primary=%s mapped=%s',
+    (isShortPeriod, primary, interstellioMapped) => {
+      expect(
+        shouldAttachSecondaryInterstellio({
+          isShortPeriod,
+          primary,
+          interstellioMapped,
+        })
+      ).toBe(false);
+    }
+  );
+});
+
+describe('CORE_SOURCE_LABEL', () => {
+  it('defines a display label for every core source', () => {
+    expect(CORE_SOURCE_LABEL).toEqual({
+      ruijie_hourly: 'Ruijie traffic rollups (hourly)',
+      interstellio_daily: 'Interstellio subscriber usage (daily)',
+      unavailable: 'Not available',
+    });
+  });
+});
+
+describe('aggregateRuijieHourly', () => {
+  it('sums present rows and buckets downloads by SAST day', () => {
+    const result = aggregateRuijieHourly(
+      [
+        {
+          captured_at: '2026-07-01T21:30:00.000Z',
+          total_rx_bytes: 1_000_000_000,
+          total_tx_bytes: 100_000_000,
+          avg_rx_bps: 8_000_000,
+          peak_rx_bps: 20_000_000,
+        },
+        {
+          captured_at: '2026-07-01T22:30:00.000Z',
+          total_rx_bytes: 500_000_000,
+          total_tx_bytes: 50_000_000,
+          avg_rx_bps: 4_000_000,
+          peak_rx_bps: 10_000_000,
+        },
+      ],
+      2,
+      new Date('2026-07-01T00:00:00+02:00')
+    );
+
+    expect(result).toEqual({
+      downloadBytes: 1_500_000_000,
+      uploadBytes: 150_000_000,
+      avgDownKbps: 6_000,
+      peakBucketBytes: 1_000_000_000,
+      dailyDownloadBytes: [1_000_000_000, 500_000_000],
+    });
+  });
+
+  it('fills missing days with zero without inventing totals', () => {
+    const result = aggregateRuijieHourly(
+      [
+        {
+          captured_at: '2026-07-03T08:00:00+02:00',
+          total_rx_bytes: 25,
+          total_tx_bytes: 5,
+          avg_rx_bps: 1_000,
+          peak_rx_bps: 2_000,
+        },
+      ],
+      3,
+      new Date('2026-07-01T00:00:00+02:00')
+    );
+
+    expect(result.downloadBytes).toBe(25);
+    expect(result.dailyDownloadBytes).toEqual([0, 0, 25]);
+  });
+
+  it('returns null rate and peak metrics for no rows', () => {
+    expect(
+      aggregateRuijieHourly([], 1, new Date('2026-07-01T00:00:00+02:00'))
+    ).toEqual({
+      downloadBytes: 0,
+      uploadBytes: 0,
+      avgDownKbps: null,
+      peakBucketBytes: null,
+      dailyDownloadBytes: [0],
+    });
+  });
+});
+
+describe('aggregateInterstellioDaily', () => {
+  it('maps Interstellio KiB to bytes and keeps daily gaps at zero', () => {
+    const result = aggregateInterstellioDaily(
+      [
+        {
+          time: '2026-07-01T22:30:00.000Z',
+          download_kb: 2_000,
+          upload_kb: 500,
+          combined_kb: 2_500,
+          download_kbps: 800,
+        },
+        {
+          time: '2026-07-03T12:00:00+02:00',
+          download_kb: 1_000,
+          upload_kb: 250,
+          combined_kb: 1_250,
+          download_kbps: 400,
+        },
+      ],
+      3,
+      new Date('2026-07-01T00:00:00+02:00')
+    );
+
+    expect(result).toEqual({
+      downloadBytes: 3_072_000,
+      uploadBytes: 768_000,
+      avgDownKbps: 600,
+      peakBucketBytes: 2_048_000,
+      dailyDownloadBytes: [0, 2_048_000, 1_024_000],
+    });
+  });
+});

--- a/__tests__/lib/usage-reports/core-traffic.test.ts
+++ b/__tests__/lib/usage-reports/core-traffic.test.ts
@@ -40,7 +40,7 @@ describe('selectCorePrimarySource', () => {
     ).toBe('interstellio_daily');
   });
 
-  it('uses Interstellio only for a long period', () => {
+  it('uses Interstellio for a long period when mapped', () => {
     expect(
       selectCorePrimarySource({
         isShortPeriod: false,
@@ -51,12 +51,23 @@ describe('selectCorePrimarySource', () => {
     ).toBe('interstellio_daily');
   });
 
-  it('returns unavailable when no permitted source exists', () => {
+  it('falls back to Ruijie for a long period when Interstellio is absent (MTN/TDX)', () => {
     expect(
       selectCorePrimarySource({
         isShortPeriod: false,
         ruijieLinked: true,
         ruijieCoversWindow: true,
+        interstellioMapped: false,
+      })
+    ).toBe('ruijie_hourly');
+  });
+
+  it('returns unavailable when long period has neither Interstellio nor Ruijie samples', () => {
+    expect(
+      selectCorePrimarySource({
+        isShortPeriod: false,
+        ruijieLinked: true,
+        ruijieCoversWindow: false,
         interstellioMapped: false,
       })
     ).toBe('unavailable');

--- a/__tests__/lib/usage-reports/inclusion.test.ts
+++ b/__tests__/lib/usage-reports/inclusion.test.ts
@@ -1,0 +1,38 @@
+import { filterEligibleSites, type InclusionSiteRow } from '@/lib/usage-reports/inclusion';
+
+const base: InclusionSiteRow = {
+  id: 's1',
+  name: 'Alexandra',
+  account_number: 'CT-UNJ-002',
+  status: 'active',
+  service_id: null,
+  service_status: null,
+  corporate_code: 'UNJ',
+  account_name: 'Unjani Clinics NPC',
+};
+
+describe('filterEligibleSites', () => {
+  it('includes active with null service_id', () => {
+    expect(filterEligibleSites([base], { includeProvisioned: false }).map((s) => s.id)).toEqual([
+      's1',
+    ]);
+  });
+
+  it('excludes active when linked service is not active', () => {
+    const row = { ...base, service_id: 'svc', service_status: 'suspended' };
+    expect(filterEligibleSites([row], { includeProvisioned: false })).toHaveLength(0);
+  });
+
+  it('includeProvisioned adds provisioned sites', () => {
+    const row = { ...base, id: 's2', status: 'provisioned' as const };
+    expect(filterEligibleSites([base, row], { includeProvisioned: false })).toHaveLength(1);
+    expect(filterEligibleSites([base, row], { includeProvisioned: true })).toHaveLength(2);
+  });
+
+  it('unjaniOnly filters corporate_code UNJ', () => {
+    const other = { ...base, id: 's3', corporate_code: 'ACME' };
+    expect(
+      filterEligibleSites([base, other], { includeProvisioned: false, unjaniOnly: true })
+    ).toHaveLength(1);
+  });
+});

--- a/__tests__/lib/usage-reports/patient-wifi.test.ts
+++ b/__tests__/lib/usage-reports/patient-wifi.test.ts
@@ -1,0 +1,20 @@
+import { parseTdxPatientCsv, resolvePatientWifi } from '@/lib/usage-reports/patient-wifi';
+
+describe('parseTdxPatientCsv', () => {
+  it('maps Looker columns case-insensitively', () => {
+    const csv = `Site Code,Unique Users,Sessions,Download GB\nCT-UNJ-002,120,400,12.5\n`;
+    const rows = parseTdxPatientCsv(csv);
+    expect(rows[0]).toMatchObject({
+      siteCode: 'CT-UNJ-002',
+      uniqueUsers: 120,
+      loginSessions: 400,
+      downloadGb: 12.5,
+    });
+  });
+});
+
+describe('resolvePatientWifi', () => {
+  it('awaiting_export when no row for site', () => {
+    expect(resolvePatientWifi(null).kind).toBe('awaiting_export');
+  });
+});

--- a/__tests__/lib/usage-reports/pdf-generator.test.ts
+++ b/__tests__/lib/usage-reports/pdf-generator.test.ts
@@ -1,0 +1,111 @@
+import { reportModelToCsv } from '@/lib/usage-reports/csv';
+import {
+  buildWeekBands,
+  generateSiteUsageReportPdf,
+  generateSkipSlipPdf,
+} from '@/lib/usage-reports/pdf-generator';
+import type { SiteUsageReportModel } from '@/lib/usage-reports/types';
+
+const minimalModel: SiteUsageReportModel = {
+  generatedAtIso: '2026-08-01T12:00:00+02:00',
+  site: {
+    id: 'site-alexandra',
+    name: 'Alexandra',
+    accountNumber: 'CT-2026-00001',
+    corporateCode: 'UNJ-ALEX',
+    accountName: 'Unjani Clinics',
+  },
+  period: {
+    preset: 'monthly',
+    timezone: 'Africa/Johannesburg',
+    startIso: '2026-07-01T00:00:00+02:00',
+    endIso: '2026-08-01T00:00:00+02:00',
+    startUtc: new Date('2026-06-30T22:00:00Z'),
+    endUtc: new Date('2026-07-31T22:00:00Z'),
+    label: 'Monthly · Jul 2026',
+    rangeLabel: '1–31 Jul 2026',
+    inclusiveDayCount: 31,
+    isShortPeriod: false,
+  },
+  core: {
+    source: 'interstellio_daily',
+    sourceLabel: 'Interstellio daily',
+    downloadBytes: 120_000_000_000,
+    uploadBytes: 12_000_000_000,
+    avgDownKbps: 850,
+    peakBucketBytes: 1_500_000_000,
+    dailyDownloadBytes: Array.from({ length: 31 }, (_, index) => (index + 1) * 100_000_000),
+    note: 'Daily BNG usage for the selected period.',
+  },
+  device: {
+    name: 'Alexandra AP',
+    model: 'RG-EG105G',
+    serial: 'SN-ALEX-001',
+    group: 'Unjani',
+    status: 'online',
+  },
+  unjani: true,
+  staff: {
+    kind: 'available',
+    totalBytes: 8_000_000_000,
+    rxBytes: 6_000_000_000,
+    txBytes: 2_000_000_000,
+  },
+  patient: {
+    kind: 'available',
+    uniqueUsers: 250,
+    loginSessions: 410,
+    downloadGb: 18.5,
+  },
+};
+
+describe('site usage report exports', () => {
+  it('generates a PDF buffer', () => {
+    const buffer = generateSiteUsageReportPdf(minimalModel);
+
+    expect(Buffer.from(buffer).subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('generates a skip slip PDF buffer', () => {
+    const buffer = generateSkipSlipPdf({
+      siteLabel: 'Alexandra',
+      periodLabel: 'Monthly · Jul 2026',
+      reason: 'No usable Ruijie or Interstellio source for this period',
+      generatedAtIso: '2026-08-01T12:00:00+02:00',
+    });
+
+    expect(Buffer.from(buffer).subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('generates the companion CSV', () => {
+    const csv = reportModelToCsv(minimalModel);
+
+    expect(csv).toContain('site,period,core source,download GB,upload GB');
+    expect(csv).toContain('Alexandra,Monthly · Jul 2026,Interstellio daily');
+    expect(csv).toContain('250,410,18.50');
+  });
+
+  it('uses Monday-aligned week bands', () => {
+    expect(buildWeekBands('2026-07-01T00:00:00+02:00', 31)).toEqual([
+      { label: 'Week 1', start: 0, span: 5 },
+      { label: 'Week 2', start: 5, span: 7 },
+      { label: 'Week 3', start: 12, span: 7 },
+      { label: 'Week 4', start: 19, span: 7 },
+      { label: 'Week 5', start: 26, span: 5 },
+    ]);
+  });
+
+  it.each([
+    ['no_samples', 'Not available — no Staff Wi-Fi samples in this period'],
+    ['ap_unlinked', 'Not available — AP not linked to site'],
+  ] as const)('exports the %s Staff N/A reason', (kind, reason) => {
+    const csv = reportModelToCsv({
+      ...minimalModel,
+      staff: { kind },
+      patient: { kind: 'awaiting_export' },
+    });
+
+    expect(csv).toContain(reason);
+    expect(csv).toContain('Awaiting TDX export');
+  });
+});

--- a/__tests__/lib/usage-reports/periods.test.ts
+++ b/__tests__/lib/usage-reports/periods.test.ts
@@ -1,0 +1,46 @@
+import {
+  resolveReportPeriod,
+  type ReportPeriodPreset,
+} from '@/lib/usage-reports/periods';
+
+describe('resolveReportPeriod', () => {
+  // Freeze "now" as Wednesday 2026-08-05 15:00 SAST
+  const now = new Date('2026-08-05T13:00:00.000Z'); // 15:00 SAST
+
+  it('weekly = last complete Mon–Sun week', () => {
+    const p = resolveReportPeriod('weekly', now);
+    expect(p.startIso).toBe('2026-07-27T00:00:00.000+02:00'); // Mon
+    expect(p.endIso).toBe('2026-08-02T23:59:59.999+02:00'); // Sun
+    expect(p.label).toMatch(/week/i);
+  });
+
+  it('monthly = last complete calendar month', () => {
+    const p = resolveReportPeriod('monthly', now);
+    expect(p.startIso).toBe('2026-07-01T00:00:00.000+02:00');
+    expect(p.endIso).toBe('2026-07-31T23:59:59.999+02:00');
+  });
+
+  it('sixty_day ends yesterday', () => {
+    const p = resolveReportPeriod('sixty_day', now);
+    expect(p.endIso).toBe('2026-08-04T23:59:59.999+02:00');
+    // 60 inclusive days ending yesterday
+    expect(p.startIso).toBe('2026-06-06T00:00:00.000+02:00');
+  });
+
+  it('custom rejects >90 days', () => {
+    expect(() =>
+      resolveReportPeriod('custom', now, {
+        startDate: '2026-01-01',
+        endDate: '2026-05-01',
+      })
+    ).toThrow(/90/);
+  });
+
+  it('periodDayCount drives #669 short vs long', () => {
+    const week = resolveReportPeriod('weekly', now);
+    expect(week.inclusiveDayCount).toBe(7);
+    expect(week.isShortPeriod).toBe(true);
+    const month = resolveReportPeriod('monthly', now);
+    expect(month.isShortPeriod).toBe(false);
+  });
+});

--- a/__tests__/lib/usage-reports/staff-wifi.test.ts
+++ b/__tests__/lib/usage-reports/staff-wifi.test.ts
@@ -1,0 +1,27 @@
+import { resolveStaffWifi } from '@/lib/usage-reports/staff-wifi';
+
+describe('resolveStaffWifi', () => {
+  it('ap_unlinked when no device linked to site', () => {
+    expect(resolveStaffWifi({ apLinkedToSite: false, hourRows: [] }).kind).toBe('ap_unlinked');
+  });
+
+  it('no_samples when linked but empty rows', () => {
+    expect(resolveStaffWifi({ apLinkedToSite: true, hourRows: [] }).kind).toBe('no_samples');
+  });
+
+  it('sums rx+tx for available', () => {
+    const s = resolveStaffWifi({
+      apLinkedToSite: true,
+      hourRows: [
+        { rx_bytes: 100, tx_bytes: 40 },
+        { rx_bytes: 50, tx_bytes: 10 },
+      ],
+    });
+    expect(s).toEqual({
+      kind: 'available',
+      rxBytes: 150,
+      txBytes: 50,
+      totalBytes: 200,
+    });
+  });
+});

--- a/app/admin/corporate/[id]/sites/[siteId]/page.tsx
+++ b/app/admin/corporate/[id]/sites/[siteId]/page.tsx
@@ -16,6 +16,7 @@ import {
   PiWifiHighBold,
   PiWarningCircleBold,
   PiCaretRightBold,
+  PiFileTextBold,
 } from 'react-icons/pi';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -298,9 +299,19 @@ export default function SiteEditPage() {
               </Badge>
             )}
           </div>
-          {site.pppoeUsername && (
-            <span className="font-mono text-sm text-slate-500">{site.pppoeUsername}</span>
-          )}
+          <div className="flex items-center gap-3">
+            {site.pppoeUsername && (
+              <span className="font-mono text-sm text-slate-500">{site.pppoeUsername}</span>
+            )}
+            <Button asChild variant="outline">
+              <Link
+                href={`/admin/network/usage-reports?siteId=${encodeURIComponent(siteId)}&unjani=1`}
+              >
+                <PiFileTextBold className="mr-2 h-4 w-4" />
+                Generate usage report
+              </Link>
+            </Button>
+          </div>
         </div>
       </div>
 

--- a/app/admin/network/usage-reports/page.tsx
+++ b/app/admin/network/usage-reports/page.tsx
@@ -1,0 +1,41 @@
+import { PiFileTextBold } from 'react-icons/pi';
+
+import { UsageReportBuilder } from '@/components/admin/network/usage-reports/UsageReportBuilder';
+
+interface UsageReportsPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function UsageReportsPage({
+  searchParams,
+}: UsageReportsPageProps) {
+  const params = await searchParams;
+  const initialSiteId = firstParam(params.siteId);
+  const initialUnjaniOnly = firstParam(params.unjani) === '1';
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <div className="flex items-start gap-4">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-orange-100 text-orange-700">
+          <PiFileTextBold className="h-6 w-6" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Site Usage Reports</h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Generate CircleTel-branded network usage reports for eligible corporate
+            sites.
+          </p>
+        </div>
+      </div>
+
+      <UsageReportBuilder
+        initialSiteId={initialSiteId}
+        initialUnjaniOnly={initialUnjaniOnly}
+      />
+    </div>
+  );
+}

--- a/app/api/admin/network/usage-reports/generate/route.ts
+++ b/app/api/admin/network/usage-reports/generate/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { createClient } from '@/lib/supabase/server';
+import { buildUsageReportArtifact } from '@/lib/usage-reports/artifacts';
+import { fetchInclusionSiteRows } from '@/lib/usage-reports/inclusion';
+import type { TdxPatientRow } from '@/lib/usage-reports/patient-wifi';
+import { resolveReportPeriod } from '@/lib/usage-reports/periods';
+import type { ReportPeriodPreset } from '@/lib/usage-reports/types';
+import { uploadReportArtifact } from '@/lib/usage-reports/storage';
+
+interface GenerateRequest {
+  siteIds?: unknown;
+  period?: unknown;
+  custom?: { startDate?: unknown; endDate?: unknown };
+  includeCsv?: unknown;
+  patientRows?: unknown;
+}
+
+const PERIOD_PRESETS = new Set<ReportPeriodPreset>([
+  'weekly',
+  'monthly',
+  'sixty_day',
+  'custom',
+]);
+
+class RequestValidationError extends Error {}
+
+export const runtime = 'nodejs';
+
+function isPatientRow(value: unknown): value is TdxPatientRow {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.siteCode === 'string' &&
+    typeof row.uniqueUsers === 'number' &&
+    Number.isFinite(row.uniqueUsers) &&
+    row.uniqueUsers >= 0 &&
+    typeof row.loginSessions === 'number' &&
+    Number.isFinite(row.loginSessions) &&
+    row.loginSessions >= 0 &&
+    typeof row.downloadGb === 'number' &&
+    Number.isFinite(row.downloadGb) &&
+    row.downloadGb >= 0
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) return authResult.response;
+
+  let failedJobId: string | null = null;
+  try {
+    const body = (await request.json()) as GenerateRequest;
+    const siteIds = Array.isArray(body.siteIds)
+      ? [...new Set(body.siteIds.filter((id): id is string => typeof id === 'string'))]
+      : [];
+    if (siteIds.length < 1 || siteIds.length > 5) {
+      return NextResponse.json(
+        { error: 'Sync generation requires 1–5 unique site IDs; use jobs for more than 5' },
+        { status: 400 }
+      );
+    }
+    if (typeof body.period !== 'string' || !PERIOD_PRESETS.has(body.period as ReportPeriodPreset)) {
+      return NextResponse.json({ error: 'Invalid report period preset' }, { status: 400 });
+    }
+    const patientRows = Array.isArray(body.patientRows)
+      ? body.patientRows.filter(isPatientRow)
+      : [];
+    if (Array.isArray(body.patientRows) && patientRows.length !== body.patientRows.length) {
+      return NextResponse.json({ error: 'Invalid patientRows payload' }, { status: 400 });
+    }
+
+    const custom =
+      typeof body.custom?.startDate === 'string' && typeof body.custom?.endDate === 'string'
+        ? { startDate: body.custom.startDate, endDate: body.custom.endDate }
+        : undefined;
+    let period: ReturnType<typeof resolveReportPeriod>;
+    try {
+      period = resolveReportPeriod(body.period as ReportPeriodPreset, new Date(), custom);
+    } catch (error) {
+      throw new RequestValidationError(
+        error instanceof Error ? error.message : 'Invalid report period'
+      );
+    }
+    const supabase = await createClient();
+    const rows = await fetchInclusionSiteRows(supabase);
+    const rowsById = new Map(rows.map((row) => [row.id, row]));
+    const artifact = await buildUsageReportArtifact({
+      sites: siteIds.map((id) => ({
+        id,
+        accountNumber: rowsById.get(id)?.account_number ?? id,
+      })),
+      period,
+      patientRows,
+      includeCsv: body.includeCsv === true,
+    });
+
+    const createdAt = new Date();
+    const createdAtIso = createdAt.toISOString();
+    const expiresAtIso = new Date(
+      createdAt.getTime() + 14 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const { data: job, error: insertError } = await supabase
+      .from('site_usage_report_jobs')
+      .insert({
+        created_by: authResult.user.id,
+        created_at: createdAtIso,
+        updated_at: createdAtIso,
+        status: 'succeeded',
+        period_preset: period.preset,
+        period_start: period.startUtc.toISOString(),
+        period_end: period.endUtc.toISOString(),
+        site_ids: siteIds,
+        include_csv: body.includeCsv === true,
+        primary_sources: artifact.primarySources,
+        outcome: artifact.outcome,
+        content_type: artifact.contentType,
+        byte_size: artifact.bytes.length,
+        expires_at: expiresAtIso,
+      })
+      .select('id')
+      .single();
+    if (insertError || !job) {
+      throw new Error(`Failed to create report audit job: ${insertError?.message ?? 'No job returned'}`);
+    }
+    failedJobId = job.id;
+
+    const storagePath = await uploadReportArtifact(
+      supabase,
+      `jobs/${job.id}/${artifact.filename}`,
+      artifact.bytes,
+      artifact.contentType
+    );
+    const { error: updateError } = await supabase
+      .from('site_usage_report_jobs')
+      .update({ storage_path: storagePath, updated_at: new Date().toISOString() })
+      .eq('id', job.id);
+    if (updateError) {
+      throw new Error(`Failed to attach report artifact to job: ${updateError.message}`);
+    }
+    failedJobId = null;
+
+    return new NextResponse(new Uint8Array(artifact.bytes), {
+      headers: {
+        'Content-Type': artifact.contentType,
+        'Content-Disposition': `attachment; filename="${artifact.filename}"`,
+        'Content-Length': String(artifact.bytes.length),
+        'Cache-Control': 'private, no-store',
+        'X-Report-Job-Id': job.id,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[UsageReportsGenerate] Generation failed:', error);
+    if (failedJobId) {
+      const supabase = await createClient();
+      await supabase
+        .from('site_usage_report_jobs')
+        .update({
+          status: 'failed',
+          error_message: message,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', failedJobId);
+    }
+    const status =
+      error instanceof RequestValidationError || error instanceof SyntaxError ? 400 : 500;
+    return NextResponse.json(
+      { error: status === 400 ? message : 'Failed to generate usage report' },
+      { status }
+    );
+  }
+}

--- a/app/api/admin/network/usage-reports/jobs/[id]/route.ts
+++ b/app/api/admin/network/usage-reports/jobs/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { createClient } from '@/lib/supabase/server';
+import { signedReportUrl } from '@/lib/usage-reports/storage';
+
+interface ReportJobRow {
+  id: string;
+  status: 'queued' | 'running' | 'succeeded' | 'failed';
+  outcome: { progress?: number } | null;
+  error_message: string | null;
+  storage_path: string | null;
+  content_type: string | null;
+  byte_size: number | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) return authResult.response;
+
+  try {
+    const { id } = await context.params;
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from('site_usage_report_jobs')
+      .select(
+        'id,status,outcome,error_message,storage_path,content_type,byte_size,expires_at,created_at,updated_at'
+      )
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) {
+      return NextResponse.json({ error: 'Report job not found' }, { status: 404 });
+    }
+
+    const job = data as ReportJobRow;
+    const downloadUrl =
+      job.status === 'succeeded' && job.storage_path
+        ? await signedReportUrl(supabase, job.storage_path)
+        : undefined;
+    const fallbackProgress = {
+      queued: 0,
+      running: 25,
+      succeeded: 100,
+      failed: 100,
+    }[job.status];
+
+    return NextResponse.json({
+      id: job.id,
+      status: job.status,
+      progress: job.outcome?.progress ?? fallbackProgress,
+      downloadUrl,
+      error: job.error_message ?? undefined,
+      contentType: job.content_type,
+      byteSize: job.byte_size,
+      expiresAt: job.expires_at,
+      createdAt: job.created_at,
+      updatedAt: job.updated_at,
+    });
+  } catch (error) {
+    console.error('[UsageReportsJob] Failed to load job:', error);
+    return NextResponse.json({ error: 'Failed to load report job' }, { status: 500 });
+  }
+}

--- a/app/api/admin/network/usage-reports/jobs/route.ts
+++ b/app/api/admin/network/usage-reports/jobs/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { inngest } from '@/lib/inngest/client';
+import { createClient } from '@/lib/supabase/server';
+import type { TdxPatientRow } from '@/lib/usage-reports/patient-wifi';
+import { resolveReportPeriod } from '@/lib/usage-reports/periods';
+import type { ReportPeriodPreset } from '@/lib/usage-reports/types';
+
+interface JobRequest {
+  siteIds?: unknown;
+  period?: unknown;
+  custom?: { startDate?: unknown; endDate?: unknown };
+  includeCsv?: unknown;
+  patientRows?: unknown;
+}
+
+const PERIOD_PRESETS = new Set<ReportPeriodPreset>([
+  'weekly',
+  'monthly',
+  'sixty_day',
+  'custom',
+]);
+
+class RequestValidationError extends Error {}
+
+function isPatientRow(value: unknown): value is TdxPatientRow {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.siteCode === 'string' &&
+    typeof row.uniqueUsers === 'number' &&
+    Number.isFinite(row.uniqueUsers) &&
+    row.uniqueUsers >= 0 &&
+    typeof row.loginSessions === 'number' &&
+    Number.isFinite(row.loginSessions) &&
+    row.loginSessions >= 0 &&
+    typeof row.downloadGb === 'number' &&
+    Number.isFinite(row.downloadGb) &&
+    row.downloadGb >= 0
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) return authResult.response;
+
+  let jobId: string | null = null;
+  try {
+    const body = (await request.json()) as JobRequest;
+    const siteIds = Array.isArray(body.siteIds)
+      ? [...new Set(body.siteIds.filter((id): id is string => typeof id === 'string'))]
+      : [];
+    if (siteIds.length <= 5) {
+      return NextResponse.json(
+        { error: 'Async generation requires more than 5 unique site IDs' },
+        { status: 400 }
+      );
+    }
+    if (typeof body.period !== 'string' || !PERIOD_PRESETS.has(body.period as ReportPeriodPreset)) {
+      return NextResponse.json({ error: 'Invalid report period preset' }, { status: 400 });
+    }
+    const patientRows = Array.isArray(body.patientRows)
+      ? body.patientRows.filter(isPatientRow)
+      : [];
+    if (Array.isArray(body.patientRows) && patientRows.length !== body.patientRows.length) {
+      return NextResponse.json({ error: 'Invalid patientRows payload' }, { status: 400 });
+    }
+
+    const custom =
+      typeof body.custom?.startDate === 'string' && typeof body.custom?.endDate === 'string'
+        ? { startDate: body.custom.startDate, endDate: body.custom.endDate }
+        : undefined;
+    let period: ReturnType<typeof resolveReportPeriod>;
+    try {
+      period = resolveReportPeriod(body.period as ReportPeriodPreset, new Date(), custom);
+    } catch (error) {
+      throw new RequestValidationError(
+        error instanceof Error ? error.message : 'Invalid report period'
+      );
+    }
+    const createdAt = new Date();
+    const createdAtIso = createdAt.toISOString();
+    const expiresAtIso = new Date(
+      createdAt.getTime() + 14 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const supabase = await createClient();
+    const { data: job, error: insertError } = await supabase
+      .from('site_usage_report_jobs')
+      .insert({
+        created_by: authResult.user.id,
+        created_at: createdAtIso,
+        updated_at: createdAtIso,
+        status: 'queued',
+        period_preset: period.preset,
+        period_start: period.startUtc.toISOString(),
+        period_end: period.endUtc.toISOString(),
+        site_ids: siteIds,
+        include_csv: body.includeCsv === true,
+        primary_sources: {},
+        outcome: { progress: 0 },
+        expires_at: expiresAtIso,
+      })
+      .select('id')
+      .single();
+    if (insertError || !job) {
+      throw new Error(`Failed to queue report job: ${insertError?.message ?? 'No job returned'}`);
+    }
+    jobId = job.id;
+
+    await inngest.send({
+      name: 'usage-reports/zip.requested',
+      data: { jobId, patientRows },
+    });
+
+    return NextResponse.json({ jobId }, { status: 202 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[UsageReportsJobs] Failed to queue job:', error);
+    if (jobId) {
+      const supabase = await createClient();
+      await supabase
+        .from('site_usage_report_jobs')
+        .update({
+          status: 'failed',
+          error_message: message,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', jobId);
+    }
+    const status =
+      error instanceof RequestValidationError || error instanceof SyntaxError ? 400 : 500;
+    return NextResponse.json(
+      { error: status === 400 ? message : 'Failed to queue usage report job' },
+      { status }
+    );
+  }
+}

--- a/app/api/admin/network/usage-reports/patient-csv/route.ts
+++ b/app/api/admin/network/usage-reports/patient-csv/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { parseTdxPatientCsv } from '@/lib/usage-reports/patient-wifi';
+
+const MAX_UPLOAD_BYTES = 2 * 1024 * 1024;
+const MAX_MULTIPART_BYTES = MAX_UPLOAD_BYTES + 64 * 1024;
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) return authResult.response;
+
+  try {
+    const contentLength = Number(request.headers.get('content-length'));
+    if (Number.isFinite(contentLength) && contentLength > MAX_MULTIPART_BYTES) {
+      return NextResponse.json(
+        { error: 'Patient CSV must not exceed 2MB' },
+        { status: 413 }
+      );
+    }
+    const formData = await request.formData();
+    const value = formData.get('file');
+    if (!value || typeof value === 'string') {
+      return NextResponse.json({ error: 'A CSV file is required' }, { status: 400 });
+    }
+    if (value.size > MAX_UPLOAD_BYTES) {
+      return NextResponse.json(
+        { error: 'Patient CSV must not exceed 2MB' },
+        { status: 413 }
+      );
+    }
+    const isCsv =
+      value.type === 'text/csv' || value.name.toLowerCase().endsWith('.csv');
+    if (!isCsv) {
+      return NextResponse.json({ error: 'The uploaded file must be a CSV' }, { status: 415 });
+    }
+
+    const rows = parseTdxPatientCsv(await value.text());
+    const hasInvalidMetrics = rows.some(
+      (row) =>
+        !Number.isFinite(row.uniqueUsers) ||
+        !Number.isFinite(row.loginSessions) ||
+        !Number.isFinite(row.downloadGb) ||
+        row.uniqueUsers < 0 ||
+        row.loginSessions < 0 ||
+        row.downloadGb < 0
+    );
+    if (hasInvalidMetrics) {
+      return NextResponse.json(
+        { error: 'Patient CSV contains invalid or negative metrics' },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json({ rows });
+  } catch (error) {
+    console.error('[UsageReportsPatientCsv] Failed to parse upload:', error);
+    return NextResponse.json({ error: 'Failed to parse patient CSV' }, { status: 400 });
+  }
+}

--- a/app/api/admin/network/usage-reports/sites/route.ts
+++ b/app/api/admin/network/usage-reports/sites/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import {
+  fetchInclusionSiteRows,
+  filterEligibleSites,
+} from '@/lib/usage-reports/inclusion';
+import { createClient } from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) return authResult.response;
+
+  try {
+    const includeProvisioned =
+      request.nextUrl.searchParams.get('includeProvisioned') === '1';
+    const unjaniOnly = request.nextUrl.searchParams.get('unjaniOnly') === '1';
+    const supabase = await createClient();
+    const rows = await fetchInclusionSiteRows(supabase);
+    const sites = filterEligibleSites(rows, { includeProvisioned, unjaniOnly });
+
+    return NextResponse.json({ sites });
+  } catch (error) {
+    console.error('[UsageReportsSites] Failed to list sites:', error);
+    return NextResponse.json({ error: 'Failed to load eligible sites' }, { status: 500 });
+  }
+}

--- a/components/admin/network/usage-reports/JobProgress.tsx
+++ b/components/admin/network/usage-reports/JobProgress.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  PiCheckCircleBold,
+  PiDownloadSimpleBold,
+  PiSpinnerGapBold,
+  PiWarningCircleBold,
+} from 'react-icons/pi';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+
+interface UsageReportJob {
+  id: string;
+  status: 'queued' | 'running' | 'succeeded' | 'failed';
+  progress: number;
+  downloadUrl?: string;
+  error?: string;
+}
+
+interface JobProgressProps {
+  jobId: string;
+  onReset: () => void;
+}
+
+export function JobProgress({ jobId, onReset }: JobProgressProps) {
+  const [job, setJob] = useState<UsageReportJob | null>(null);
+  const [pollError, setPollError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async () => {
+      try {
+        const response = await fetch(
+          `/api/admin/network/usage-reports/jobs/${encodeURIComponent(jobId)}`,
+          { credentials: 'include', cache: 'no-store' }
+        );
+        const data = (await response.json()) as UsageReportJob & { error?: string };
+        if (!response.ok) throw new Error(data.error || 'Failed to load report job');
+        if (cancelled) return;
+
+        setJob(data);
+        setPollError(null);
+        if (data.status === 'queued' || data.status === 'running') {
+          timer = setTimeout(poll, 2_000);
+        }
+      } catch (error) {
+        if (cancelled) return;
+        setPollError(error instanceof Error ? error.message : 'Failed to load report job');
+        timer = setTimeout(poll, 2_000);
+      }
+    };
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [jobId]);
+
+  const status = job?.status ?? 'queued';
+  const progress = Math.max(0, Math.min(100, job?.progress ?? 0));
+  const isWorking = status === 'queued' || status === 'running';
+
+  return (
+    <Card className="border-slate-200">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          {isWorking && <PiSpinnerGapBold className="h-5 w-5 animate-spin text-orange-600" />}
+          {status === 'succeeded' && (
+            <PiCheckCircleBold className="h-5 w-5 text-emerald-600" />
+          )}
+          {status === 'failed' && (
+            <PiWarningCircleBold className="h-5 w-5 text-red-600" />
+          )}
+          {isWorking
+            ? 'Preparing report archive'
+            : status === 'succeeded'
+              ? 'Report archive ready'
+              : 'Report generation failed'}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex justify-between text-xs text-slate-500">
+            <span className="capitalize">{status}</span>
+            <span>{progress}%</span>
+          </div>
+          <Progress value={progress} className="h-2 bg-slate-100" />
+        </div>
+
+        {(pollError || job?.error) && (
+          <p className="text-sm text-red-600">{pollError || job?.error}</p>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          {status === 'succeeded' && job?.downloadUrl && (
+            <Button asChild>
+              <a href={job.downloadUrl}>
+                <PiDownloadSimpleBold className="mr-2 h-4 w-4" />
+                Download ZIP
+              </a>
+            </Button>
+          )}
+          <Button type="button" variant="outline" onClick={onReset}>
+            Create another report
+          </Button>
+        </div>
+
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/network/usage-reports/PeriodPicker.tsx
+++ b/components/admin/network/usage-reports/PeriodPicker.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ReportPeriodPreset } from '@/lib/usage-reports/types';
+
+export interface CustomPeriodValue {
+  startDate: string;
+  endDate: string;
+}
+
+interface PeriodPickerProps {
+  value: ReportPeriodPreset;
+  custom: CustomPeriodValue;
+  onChange: (value: ReportPeriodPreset) => void;
+  onCustomChange: (value: CustomPeriodValue) => void;
+}
+
+const PERIOD_OPTIONS: Array<{
+  value: ReportPeriodPreset;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'weekly',
+    label: 'Last complete week',
+    description: 'Monday through Sunday',
+  },
+  {
+    value: 'monthly',
+    label: 'Previous month',
+    description: 'Last complete calendar month',
+  },
+  {
+    value: 'sixty_day',
+    label: 'Last 60 days',
+    description: 'Through yesterday',
+  },
+  {
+    value: 'custom',
+    label: 'Custom range',
+    description: 'Up to 90 inclusive days',
+  },
+];
+
+export function isCustomPeriod(value: ReportPeriodPreset): boolean {
+  return value === 'custom';
+}
+
+export function PeriodPicker({
+  value,
+  custom,
+  onChange,
+  onCustomChange,
+}: PeriodPickerProps) {
+  return (
+    <fieldset className="space-y-4">
+      <legend className="text-sm font-semibold text-slate-900">Report period</legend>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {PERIOD_OPTIONS.map((option) => (
+          <label
+            key={option.value}
+            className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors ${
+              value === option.value
+                ? 'border-orange-400 bg-orange-50'
+                : 'border-slate-200 bg-white hover:border-slate-300'
+            }`}
+          >
+            <input
+              type="radio"
+              name="usage-report-period"
+              value={option.value}
+              checked={value === option.value}
+              onChange={() => onChange(option.value)}
+              className="mt-1 accent-orange-600"
+            />
+            <span>
+              <span className="block text-sm font-medium text-slate-900">
+                {option.label}
+              </span>
+              <span className="block text-xs text-slate-500">{option.description}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+
+      {isCustomPeriod(value) && (
+        <div className="grid gap-4 rounded-lg bg-slate-50 p-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="usage-report-start">Start date</Label>
+            <Input
+              id="usage-report-start"
+              type="date"
+              value={custom.startDate}
+              onChange={(event) =>
+                onCustomChange({ ...custom, startDate: event.target.value })
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="usage-report-end">End date</Label>
+            <Input
+              id="usage-report-end"
+              type="date"
+              value={custom.endDate}
+              onChange={(event) =>
+                onCustomChange({ ...custom, endDate: event.target.value })
+              }
+            />
+          </div>
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/components/admin/network/usage-reports/SiteMultiSelect.tsx
+++ b/components/admin/network/usage-reports/SiteMultiSelect.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { PiMagnifyingGlassBold } from 'react-icons/pi';
+
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface UsageReportSite {
+  id: string;
+  name: string;
+  account_number: string;
+  status: string;
+  service_id: string | null;
+  service_status: string | null;
+  corporate_code: string;
+  account_name: string;
+}
+
+interface SiteMultiSelectProps {
+  sites: UsageReportSite[];
+  selectedIds: string[];
+  loading: boolean;
+  onChange: (siteIds: string[]) => void;
+}
+
+export function filterUsageReportSites(
+  sites: UsageReportSite[],
+  query: string
+): UsageReportSite[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return sites;
+  return sites.filter((site) =>
+    [site.name, site.account_number, site.account_name, site.corporate_code]
+      .join(' ')
+      .toLowerCase()
+      .includes(normalized)
+  );
+}
+
+export function SiteMultiSelect({
+  sites,
+  selectedIds,
+  loading,
+  onChange,
+}: SiteMultiSelectProps) {
+  const [query, setQuery] = useState('');
+  const visibleSites = useMemo(
+    () => filterUsageReportSites(sites, query),
+    [query, sites]
+  );
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const allVisibleSelected =
+    visibleSites.length > 0 && visibleSites.every((site) => selectedSet.has(site.id));
+
+  const toggleSite = (siteId: string, checked: boolean) => {
+    if (checked) onChange([...new Set([...selectedIds, siteId])]);
+    else onChange(selectedIds.filter((id) => id !== siteId));
+  };
+
+  const toggleVisible = () => {
+    if (allVisibleSelected) {
+      const visibleIds = new Set(visibleSites.map((site) => site.id));
+      onChange(selectedIds.filter((id) => !visibleIds.has(id)));
+      return;
+    }
+    onChange([...new Set([...selectedIds, ...visibleSites.map((site) => site.id)])]);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm font-semibold text-slate-900">Sites</p>
+        <span className="text-xs font-medium text-slate-500">
+          {selectedIds.length} selected
+        </span>
+      </div>
+
+      <div className="relative">
+        <PiMagnifyingGlassBold className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-slate-400" />
+        <Input
+          aria-label="Search sites"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search by site, account or corporate"
+          className="pl-9"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={toggleVisible}
+          disabled={loading || visibleSites.length === 0}
+        >
+          {allVisibleSelected ? 'Clear visible' : 'Select visible'}
+        </Button>
+        {selectedIds.length > 0 && (
+          <Button type="button" variant="ghost" size="sm" onClick={() => onChange([])}>
+            Clear all
+          </Button>
+        )}
+      </div>
+
+      <div className="max-h-80 overflow-y-auto rounded-lg border border-slate-200">
+        {loading ? (
+          <p className="p-6 text-center text-sm text-slate-500">Loading eligible sites…</p>
+        ) : visibleSites.length === 0 ? (
+          <p className="p-6 text-center text-sm text-slate-500">
+            No eligible sites match these filters.
+          </p>
+        ) : (
+          visibleSites.map((site) => (
+            <div
+              key={site.id}
+              className="flex items-start gap-3 border-b border-slate-100 p-3 last:border-b-0 hover:bg-slate-50"
+            >
+              <Checkbox
+                id={`usage-site-${site.id}`}
+                aria-label={`Select ${site.name}`}
+                checked={selectedSet.has(site.id)}
+                onCheckedChange={(checked) => toggleSite(site.id, checked === true)}
+                className="mt-0.5"
+              />
+              <Label
+                htmlFor={`usage-site-${site.id}`}
+                className="min-w-0 flex-1 cursor-pointer font-normal"
+              >
+                <span className="block truncate text-sm font-medium text-slate-900">
+                  {site.name}
+                </span>
+                <span className="block truncate text-xs text-slate-500">
+                  {site.account_number || 'No account number'} · {site.account_name}
+                </span>
+              </Label>
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+                {site.status}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/network/usage-reports/UsageReportBuilder.tsx
+++ b/components/admin/network/usage-reports/UsageReportBuilder.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  PiClockBold,
+  PiDownloadSimpleBold,
+  PiFileTextBold,
+  PiSpinnerGapBold,
+} from 'react-icons/pi';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { TdxPatientRow } from '@/lib/usage-reports/patient-wifi';
+import type { ReportPeriodPreset } from '@/lib/usage-reports/types';
+
+import { JobProgress } from './JobProgress';
+import {
+  PeriodPicker,
+  type CustomPeriodValue,
+} from './PeriodPicker';
+import {
+  SiteMultiSelect,
+  type UsageReportSite,
+} from './SiteMultiSelect';
+
+interface UsageReportBuilderProps {
+  initialSiteId?: string;
+  initialUnjaniOnly?: boolean;
+}
+
+interface SitesResponse {
+  sites?: UsageReportSite[];
+  error?: string;
+}
+
+function filenameFromDisposition(value: string | null): string {
+  const encodedMatch = value?.match(/filename\*=UTF-8''([^;]+)/i);
+  if (encodedMatch?.[1]) return decodeURIComponent(encodedMatch[1]);
+  const match = value?.match(/filename="([^"]+)"/i);
+  return match?.[1] || `CircleTel_Usage_Reports_${new Date().toISOString().slice(0, 10)}.zip`;
+}
+
+async function responseError(response: Response, fallback: string): Promise<string> {
+  try {
+    const data = (await response.json()) as { error?: string };
+    return data.error || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function downloadResponseBlob(response: Response, blob: Blob) {
+  const url = window.URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filenameFromDisposition(response.headers.get('content-disposition'));
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => window.URL.revokeObjectURL(url), 0);
+}
+
+export function UsageReportBuilder({
+  initialSiteId,
+  initialUnjaniOnly = false,
+}: UsageReportBuilderProps) {
+  const [period, setPeriod] = useState<ReportPeriodPreset>('monthly');
+  const [custom, setCustom] = useState<CustomPeriodValue>({
+    startDate: '',
+    endDate: '',
+  });
+  const [includeProvisioned, setIncludeProvisioned] = useState(true);
+  const [unjaniOnly, setUnjaniOnly] = useState(initialUnjaniOnly);
+  const [includeCsv, setIncludeCsv] = useState(false);
+  const [sites, setSites] = useState<UsageReportSite[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>(
+    initialSiteId ? [initialSiteId] : []
+  );
+  const [sitesLoading, setSitesLoading] = useState(true);
+  const [patientRows, setPatientRows] = useState<TdxPatientRow[]>([]);
+  const [patientFilename, setPatientFilename] = useState<string | null>(null);
+  const [uploadingPatientCsv, setUploadingPatientCsv] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadSites = async () => {
+      setSitesLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        if (includeProvisioned) params.set('includeProvisioned', '1');
+        if (unjaniOnly) params.set('unjaniOnly', '1');
+        const response = await fetch(
+          `/api/admin/network/usage-reports/sites?${params.toString()}`,
+          {
+            credentials: 'include',
+            cache: 'no-store',
+            signal: controller.signal,
+          }
+        );
+        const data = (await response.json()) as SitesResponse;
+        if (!response.ok) throw new Error(data.error || 'Failed to load eligible sites');
+
+        const nextSites = data.sites ?? [];
+        const eligibleIds = new Set(nextSites.map((site) => site.id));
+        setSites(nextSites);
+        setSelectedIds((current) => current.filter((id) => eligibleIds.has(id)));
+      } catch (loadError) {
+        if (controller.signal.aborted) return;
+        setSites([]);
+        setError(
+          loadError instanceof Error ? loadError.message : 'Failed to load eligible sites'
+        );
+      } finally {
+        if (!controller.signal.aborted) setSitesLoading(false);
+      }
+    };
+
+    void loadSites();
+    return () => controller.abort();
+  }, [includeProvisioned, unjaniOnly]);
+
+  const handlePatientCsv = async (file: File | undefined) => {
+    if (!file) return;
+    setUploadingPatientCsv(true);
+    setError(null);
+    try {
+      const formData = new FormData();
+      formData.set('file', file);
+      const response = await fetch('/api/admin/network/usage-reports/patient-csv', {
+        method: 'POST',
+        credentials: 'include',
+        body: formData,
+      });
+      const data = (await response.json()) as {
+        rows?: TdxPatientRow[];
+        error?: string;
+      };
+      if (!response.ok) throw new Error(data.error || 'Failed to parse patient CSV');
+      setPatientRows(data.rows ?? []);
+      setPatientFilename(file.name);
+    } catch (uploadError) {
+      setPatientRows([]);
+      setPatientFilename(null);
+      setError(
+        uploadError instanceof Error ? uploadError.message : 'Failed to parse patient CSV'
+      );
+    } finally {
+      setUploadingPatientCsv(false);
+    }
+  };
+
+  const handleGenerate = async () => {
+    if (selectedIds.length === 0) {
+      setError('Select at least one site.');
+      return;
+    }
+    if (period === 'custom' && (!custom.startDate || !custom.endDate)) {
+      setError('Choose both a start and end date for the custom period.');
+      return;
+    }
+    if (period === 'custom' && custom.endDate < custom.startDate) {
+      setError('The custom end date must be on or after the start date.');
+      return;
+    }
+
+    setSubmitting(true);
+    setJobId(null);
+    setError(null);
+    const payload = {
+      siteIds: selectedIds,
+      period,
+      custom: period === 'custom' ? custom : undefined,
+      includeCsv,
+      patientRows: unjaniOnly ? patientRows : [],
+    };
+
+    try {
+      if (selectedIds.length <= 5) {
+        const response = await fetch('/api/admin/network/usage-reports/generate', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          throw new Error(await responseError(response, 'Failed to generate usage report'));
+        }
+        downloadResponseBlob(response, await response.blob());
+      } else {
+        const response = await fetch('/api/admin/network/usage-reports/jobs', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = (await response.json()) as { jobId?: string; error?: string };
+        if (!response.ok || !data.jobId) {
+          throw new Error(data.error || 'Failed to queue usage report job');
+        }
+        setJobId(data.jobId);
+      }
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error ? submitError.message : 'Failed to generate usage report'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (jobId) {
+    return <JobProgress jobId={jobId} onReset={() => setJobId(null)} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card className="border-slate-200">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <PiFileTextBold className="h-5 w-5 text-orange-600" />
+            Report options
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <PeriodPicker
+            value={period}
+            custom={custom}
+            onChange={setPeriod}
+            onCustomChange={setCustom}
+          />
+
+          <div className="grid gap-4 border-t border-slate-100 pt-5 sm:grid-cols-2">
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="include-provisioned"
+                checked={includeProvisioned}
+                onCheckedChange={(checked) => setIncludeProvisioned(checked === true)}
+                className="mt-0.5"
+              />
+              <Label htmlFor="include-provisioned" className="cursor-pointer font-normal">
+                <span className="block text-sm font-medium text-slate-900">
+                  Include provisioned sites
+                </span>
+                <span className="block text-xs text-slate-500">
+                  Include sites not yet marked active.
+                </span>
+              </Label>
+            </div>
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="unjani-only"
+                checked={unjaniOnly}
+                onCheckedChange={(checked) => setUnjaniOnly(checked === true)}
+                className="mt-0.5"
+              />
+              <Label htmlFor="unjani-only" className="cursor-pointer font-normal">
+                <span className="block text-sm font-medium text-slate-900">
+                  Unjani sites only
+                </span>
+                <span className="block text-xs text-slate-500">
+                  Enables Staff and optional Patient Wi-Fi sections.
+                </span>
+              </Label>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-slate-200">
+        <CardHeader>
+          <CardTitle className="text-lg">Choose sites</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SiteMultiSelect
+            sites={sites}
+            selectedIds={selectedIds}
+            loading={sitesLoading}
+            onChange={setSelectedIds}
+          />
+        </CardContent>
+      </Card>
+
+      <Card className="border-slate-200">
+        <CardHeader>
+          <CardTitle className="text-lg">Files and output</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {unjaniOnly && (
+            <div className="space-y-2">
+              <Label htmlFor="patient-csv">TDX Patient Wi-Fi CSV (optional)</Label>
+              <div className="flex flex-wrap items-center gap-3">
+                <Input
+                  id="patient-csv"
+                  type="file"
+                  accept=".csv,text/csv"
+                  disabled={uploadingPatientCsv}
+                  onChange={(event) => void handlePatientCsv(event.target.files?.[0])}
+                  className="max-w-md"
+                />
+                {uploadingPatientCsv && (
+                  <PiSpinnerGapBold className="h-5 w-5 animate-spin text-orange-600" />
+                )}
+              </div>
+              {patientFilename && (
+                <p className="text-xs text-emerald-700">
+                  {patientFilename}: {patientRows.length} patient usage rows ready.
+                </p>
+              )}
+            </div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <Checkbox
+              id="include-csv"
+              checked={includeCsv}
+              onCheckedChange={(checked) => setIncludeCsv(checked === true)}
+            />
+            <Label htmlFor="include-csv" className="cursor-pointer text-sm font-medium text-slate-900">
+              Include CSV companion
+            </Label>
+          </div>
+
+          {error && (
+            <div
+              role="alert"
+              className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+            >
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              onClick={() => void handleGenerate()}
+              disabled={
+                submitting ||
+                sitesLoading ||
+                uploadingPatientCsv ||
+                selectedIds.length === 0
+              }
+            >
+              {submitting ? (
+                <PiSpinnerGapBold className="mr-2 h-4 w-4 animate-spin" />
+              ) : selectedIds.length <= 5 ? (
+                <PiDownloadSimpleBold className="mr-2 h-4 w-4" />
+              ) : (
+                <PiClockBold className="mr-2 h-4 w-4" />
+              )}
+              {submitting
+                ? 'Generating…'
+                : selectedIds.length > 5
+                  ? 'Queue ZIP report'
+                  : 'Generate report'}
+            </Button>
+            <p className="text-xs text-slate-500">
+              {selectedIds.length > 5
+                ? 'Bulk reports run in the background and download as a ZIP.'
+                : 'Up to five selected sites generate immediately.'}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/admin/network/usage-reports/__tests__/usage-report-controls.test.tsx
+++ b/components/admin/network/usage-reports/__tests__/usage-report-controls.test.tsx
@@ -1,0 +1,40 @@
+import { isCustomPeriod } from '../PeriodPicker';
+import {
+  filterUsageReportSites,
+  type UsageReportSite,
+} from '../SiteMultiSelect';
+
+describe('usage report controls', () => {
+  it('identifies when custom date inputs are required', () => {
+    expect(isCustomPeriod('custom')).toBe(true);
+    expect(isCustomPeriod('monthly')).toBe(false);
+  });
+
+  it('filters sites by name, account number, and corporate account', () => {
+    const sites: UsageReportSite[] = [
+      {
+        id: 'site-1',
+        name: 'Alexandra Clinic',
+        account_number: 'CT-UNJ-001',
+        status: 'active',
+        service_id: 'service-1',
+        service_status: 'active',
+        corporate_code: 'UNJ',
+        account_name: 'Unjani Clinics',
+      },
+      {
+        id: 'site-2',
+        name: 'Rosebank Office',
+        account_number: 'CT-BIZ-002',
+        status: 'active',
+        service_id: null,
+        service_status: null,
+        corporate_code: 'BIZ',
+        account_name: 'Business Co',
+      },
+    ];
+    expect(filterUsageReportSites(sites, 'Alexandra')).toEqual([sites[0]]);
+    expect(filterUsageReportSites(sites, 'CT-BIZ')).toEqual([sites[1]]);
+    expect(filterUsageReportSites(sites, 'unjani clinics')).toEqual([sites[0]]);
+  });
+});

--- a/docs/features/2026-08-01_site-network-usage-reports/SPEC_OUTLINE.md
+++ b/docs/features/2026-08-01_site-network-usage-reports/SPEC_OUTLINE.md
@@ -1,6 +1,6 @@
 # Site Network Usage Reports — Product / Design Spec Outline
 
-**Status:** Spec locked · Implementation plan ready
+**Status:** Implementing
 **Implementation plan:** [`docs/superpowers/plans/2026-08-01-site-network-usage-reports.md`](../../superpowers/plans/2026-08-01-site-network-usage-reports.md)  
 **Date:** 2026-08-01  
 **Wayfinder:** [#661](https://github.com/jdeweedata/circletel/issues/661) · Assemble task [#683](https://github.com/jdeweedata/circletel/issues/683)  

--- a/docs/features/2026-08-01_site-network-usage-reports/SPEC_OUTLINE.md
+++ b/docs/features/2026-08-01_site-network-usage-reports/SPEC_OUTLINE.md
@@ -56,8 +56,10 @@ One **primary** byte series per report. Never sum Ruijie + Interstellio.
 | Period | Primary |
 |--------|---------|
 | Weekly + custom ≤7 days | **Ruijie** hourly rollups when site→device→`group_id` linked and window covered; else **Interstellio** if mapped |
-| Monthly / 60-day / custom >7 days | **Interstellio only** (daily, ≤90d). Ruijie must not be sole source |
+| Monthly / 60-day / custom >7 days | **Interstellio** when mapped (BNG). If **no Interstellio** (MTN breakout / TDX-locked MikroTik / unmapped): **Ruijie** for hours that exist, with AP/group + ~14d retention footnote (month may be partial) |
 | Neither / incomplete | Site **not available** → ZIP skip slip |
+
+Never invent Interstellio for MTN/TDX sites.
 
 **Labelling**
 

--- a/lib/admin/feature-registry.ts
+++ b/lib/admin/feature-registry.ts
@@ -338,6 +338,7 @@ export const featureSections: NavSection[] = [
           { name: 'Devices', href: '/admin/network/devices', icon: PiWifiHighBold },
           { name: 'System Health', href: '/admin/network/health', icon: PiPulseBold },
           { name: 'Analytics', href: '/admin/network/analytics', icon: PiChartBarBold },
+          { name: 'Usage Reports', href: '/admin/network/usage-reports', icon: PiFileTextBold },
           { name: 'Network Map', href: '/admin/network/map', icon: PiMapTrifoldBold },
         ],
       },

--- a/lib/inngest/client.ts
+++ b/lib/inngest/client.ts
@@ -807,6 +807,19 @@ export type OfferPricingRecomputeCompletedEvent = {
   };
 };
 
+export type UsageReportZipRequestedEvent = {
+  name: 'usage-reports/zip.requested';
+  data: {
+    jobId: string;
+    patientRows?: Array<{
+      siteCode: string;
+      uniqueUsers: number;
+      loginSessions: number;
+      downloadGb: number;
+    }>;
+  };
+};
+
 // Union type for all events
 export type InngestEvents = {
   'competitor/scrape.requested': CompetitorScrapeEvent;
@@ -888,4 +901,6 @@ export type InngestEvents = {
   // Offer pricing events
   'offer/pricing.recompute.requested': OfferPricingRecomputeRequestedEvent;
   'offer/pricing.recompute.completed': OfferPricingRecomputeCompletedEvent;
+  // Site usage report events
+  'usage-reports/zip.requested': UsageReportZipRequestedEvent;
 };

--- a/lib/inngest/functions/__tests__/site-usage-report-purge.test.ts
+++ b/lib/inngest/functions/__tests__/site-usage-report-purge.test.ts
@@ -1,0 +1,58 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+jest.mock('../../client', () => ({
+  inngest: {
+    createFunction: jest.fn((config, handler) => ({ ...config, handler })),
+  },
+}));
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+jest.mock('@/lib/usage-reports/storage', () => ({
+  deleteReportArtifact: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { deleteReportArtifact } from '@/lib/usage-reports/storage';
+import {
+  purgeExpiredReportArtifacts,
+  siteUsageReportPurgeFunction,
+} from '../site-usage-report-purge';
+
+describe('site usage report purge', () => {
+  it('deletes expired artifacts and retains their audit rows', async () => {
+    const rows = [
+      { id: 'job-1', storage_path: 'jobs/job-1/report.zip' },
+      { id: 'job-2', storage_path: 'jobs/job-2/report.pdf' },
+    ];
+    const not = jest.fn().mockResolvedValue({ data: rows, error: null });
+    const lt = jest.fn().mockReturnValue({ not });
+    const select = jest.fn().mockReturnValue({ lt });
+    const eq = jest.fn().mockResolvedValue({ error: null });
+    const update = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ select, update });
+    const supabase = { from } as unknown as SupabaseClient;
+    const now = '2026-08-01T03:15:00.000Z';
+
+    const purged = await purgeExpiredReportArtifacts(supabase, now);
+
+    expect(select).toHaveBeenCalledWith('id, storage_path');
+    expect(lt).toHaveBeenCalledWith('expires_at', now);
+    expect(not).toHaveBeenCalledWith('storage_path', 'is', null);
+    expect(deleteReportArtifact).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenNthCalledWith(1, {
+      storage_path: null,
+      updated_at: now,
+    });
+    expect(eq).toHaveBeenNthCalledWith(1, 'id', 'job-1');
+    expect(eq).toHaveBeenNthCalledWith(2, 'id', 'job-2');
+    expect(purged).toBe(2);
+  });
+
+  it('uses the required daily cron schedule', () => {
+    expect(siteUsageReportPurgeFunction.triggers).toEqual({
+      cron: '15 3 * * *',
+    });
+  });
+});

--- a/lib/inngest/functions/site-usage-report-purge.ts
+++ b/lib/inngest/functions/site-usage-report-purge.ts
@@ -1,0 +1,64 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { createClient } from '@/lib/supabase/server';
+import { deleteReportArtifact } from '@/lib/usage-reports/storage';
+import { inngest } from '../client';
+
+interface ExpiredReportArtifact {
+  id: string;
+  storage_path: string;
+}
+
+export async function purgeExpiredReportArtifacts(
+  supabase: SupabaseClient,
+  nowIso = new Date().toISOString()
+): Promise<number> {
+  const { data, error } = await supabase
+    .from('site_usage_report_jobs')
+    .select('id, storage_path')
+    .lt('expires_at', nowIso)
+    .not('storage_path', 'is', null);
+
+  if (error) {
+    throw new Error(`Failed to load expired report artifacts: ${error.message}`);
+  }
+
+  const artifacts = (data ?? []) as ExpiredReportArtifact[];
+
+  for (const artifact of artifacts) {
+    await deleteReportArtifact(supabase, artifact.storage_path);
+
+    const { error: updateError } = await supabase
+      .from('site_usage_report_jobs')
+      .update({
+        storage_path: null,
+        updated_at: nowIso,
+      })
+      .eq('id', artifact.id);
+
+    if (updateError) {
+      throw new Error(
+        `Failed to retain purged report audit row ${artifact.id}: ${updateError.message}`
+      );
+    }
+  }
+
+  return artifacts.length;
+}
+
+export const siteUsageReportPurgeFunction = inngest.createFunction(
+  {
+    id: 'site-usage-report-purge',
+    name: 'Site Usage Report Artifact Purge',
+    retries: 2,
+    triggers: { cron: '15 3 * * *' },
+  },
+  async ({ step }) => {
+    const purgedCount = await step.run('purge-expired-report-artifacts', async () => {
+      const supabase = await createClient();
+      return purgeExpiredReportArtifacts(supabase);
+    });
+
+    return { purgedCount };
+  }
+);

--- a/lib/inngest/functions/site-usage-report-zip.ts
+++ b/lib/inngest/functions/site-usage-report-zip.ts
@@ -1,0 +1,166 @@
+import { inngest } from '@/lib/inngest/client';
+import { displayDateRange } from '@/lib/dates';
+import { createClient } from '@/lib/supabase/server';
+import { buildUsageReportArtifact } from '@/lib/usage-reports/artifacts';
+import { fetchInclusionSiteRows } from '@/lib/usage-reports/inclusion';
+import type { TdxPatientRow } from '@/lib/usage-reports/patient-wifi';
+import type { ReportPeriod, ReportPeriodPreset } from '@/lib/usage-reports/types';
+import { uploadReportArtifact } from '@/lib/usage-reports/storage';
+
+interface UsageReportJobRow {
+  id: string;
+  created_at: string;
+  period_preset: ReportPeriodPreset;
+  period_start: string;
+  period_end: string;
+  site_ids: string[];
+  include_csv: boolean;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const SAST_OFFSET_MS = 2 * 60 * 60 * 1000;
+
+function sastIso(date: Date): string {
+  return new Date(date.getTime() + SAST_OFFSET_MS)
+    .toISOString()
+    .replace('Z', '+02:00');
+}
+
+function hydratePeriod(job: UsageReportJobRow): ReportPeriod {
+  const startUtc = new Date(job.period_start);
+  const endUtc = new Date(job.period_end);
+  const startIso = sastIso(startUtc);
+  const endIso = sastIso(endUtc);
+  const startDate = new Date(`${startIso.slice(0, 10)}T00:00:00Z`);
+  const endDate = new Date(`${endIso.slice(0, 10)}T00:00:00Z`);
+  const inclusiveDayCount = Math.round((endDate.getTime() - startDate.getTime()) / DAY_MS) + 1;
+  const labels: Record<ReportPeriodPreset, string> = {
+    weekly: 'Weekly',
+    monthly: 'Monthly',
+    sixty_day: 'Last 60 days',
+    custom: 'Custom period',
+  };
+
+  return {
+    preset: job.period_preset,
+    timezone: 'Africa/Johannesburg',
+    startIso,
+    endIso,
+    startUtc,
+    endUtc,
+    label: labels[job.period_preset],
+    rangeLabel: displayDateRange(new Date(startIso), new Date(endIso)),
+    inclusiveDayCount,
+    isShortPeriod: inclusiveDayCount <= 7,
+  };
+}
+
+export const siteUsageReportZipFunction = inngest.createFunction(
+  {
+    id: 'site-usage-report-zip',
+    name: 'Site Usage Report ZIP',
+    retries: 2,
+    concurrency: { limit: 2 },
+    triggers: { event: 'usage-reports/zip.requested' },
+  },
+  async ({ event, step }) => {
+    const jobId = event.data.jobId as string;
+    const patientRows = (event.data.patientRows ?? []) as TdxPatientRow[];
+
+    try {
+      const job = await step.run('mark-running', async () => {
+        const supabase = await createClient();
+        const { data, error } = await supabase
+          .from('site_usage_report_jobs')
+          .select(
+            'id,created_at,period_preset,period_start,period_end,site_ids,include_csv'
+          )
+          .eq('id', jobId)
+          .single();
+        if (error || !data) {
+          throw new Error(`Failed to load report job: ${error?.message ?? 'Not found'}`);
+        }
+        const { error: updateError } = await supabase
+          .from('site_usage_report_jobs')
+          .update({
+            status: 'running',
+            outcome: { progress: 10 },
+            error_message: null,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', jobId);
+        if (updateError) {
+          throw new Error(`Failed to mark report job running: ${updateError.message}`);
+        }
+        return data as UsageReportJobRow;
+      });
+
+      const artifact = await step.run('build-and-upload-zip', async () => {
+        const supabase = await createClient();
+        const rows = await fetchInclusionSiteRows(supabase);
+        const rowsById = new Map(rows.map((row) => [row.id, row]));
+        const built = await buildUsageReportArtifact({
+          sites: job.site_ids.map((id) => ({
+            id,
+            accountNumber: rowsById.get(id)?.account_number ?? id,
+          })),
+          period: hydratePeriod(job),
+          patientRows,
+          includeCsv: job.include_csv,
+        });
+        const storagePath = await uploadReportArtifact(
+          supabase,
+          `jobs/${job.id}/${built.filename}`,
+          built.bytes,
+          built.contentType
+        );
+        return {
+          storagePath,
+          contentType: built.contentType,
+          byteSize: built.bytes.length,
+          primarySources: built.primarySources,
+          outcome: built.outcome,
+          filename: built.filename,
+        };
+      });
+
+      await step.run('mark-succeeded', async () => {
+        const supabase = await createClient();
+        const { error } = await supabase
+          .from('site_usage_report_jobs')
+          .update({
+            status: 'succeeded',
+            storage_path: artifact.storagePath,
+            content_type: artifact.contentType,
+            byte_size: artifact.byteSize,
+            primary_sources: artifact.primarySources,
+            outcome: { ...artifact.outcome, progress: 100 },
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', jobId);
+        if (error) throw new Error(`Failed to complete report job: ${error.message}`);
+      });
+
+      return {
+        jobId,
+        storagePath: artifact.storagePath,
+        filename: artifact.filename,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await step.run('mark-failed', async () => {
+        const supabase = await createClient();
+        await supabase
+          .from('site_usage_report_jobs')
+          .update({
+            status: 'failed',
+            error_message: message,
+            outcome: { progress: 100 },
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', jobId);
+      });
+      throw error;
+    }
+  }
+);

--- a/lib/inngest/index.ts
+++ b/lib/inngest/index.ts
@@ -164,6 +164,10 @@ export {
   siteUsageReportPurgeFunction,
 } from './functions/site-usage-report-purge';
 
+export {
+  siteUsageReportZipFunction,
+} from './functions/site-usage-report-zip';
+
 // Collect all functions for the serve handler
 import {
   competitorScrapeFunction,
@@ -321,6 +325,10 @@ import {
   siteUsageReportPurgeFunction,
 } from './functions/site-usage-report-purge';
 
+import {
+  siteUsageReportZipFunction,
+} from './functions/site-usage-report-zip';
+
 export const functions = [
   // Competitor analysis
   competitorScrapeFunction,
@@ -416,6 +424,8 @@ export const functions = [
   recomputeOfferPricing,
   // Expired site usage report artifact purge (daily at 03:15 UTC)
   siteUsageReportPurgeFunction,
+  // On-demand ZIP generation for usage report jobs with more than five sites
+  siteUsageReportZipFunction,
 ];
 
 export { ruijieSyncCompleted, ruijieSyncSessions } from './events/ruijie';

--- a/lib/inngest/index.ts
+++ b/lib/inngest/index.ts
@@ -160,6 +160,10 @@ export {
   recomputeOfferPricing,
 } from './functions/recompute-offer-pricing';
 
+export {
+  siteUsageReportPurgeFunction,
+} from './functions/site-usage-report-purge';
+
 // Collect all functions for the serve handler
 import {
   competitorScrapeFunction,
@@ -313,6 +317,10 @@ import {
   recomputeOfferPricing,
 } from './functions/recompute-offer-pricing';
 
+import {
+  siteUsageReportPurgeFunction,
+} from './functions/site-usage-report-purge';
+
 export const functions = [
   // Competitor analysis
   competitorScrapeFunction,
@@ -406,6 +414,8 @@ export const functions = [
   clinicMandatePollFunction,
   // Offer pricing recomputation
   recomputeOfferPricing,
+  // Expired site usage report artifact purge (daily at 03:15 UTC)
+  siteUsageReportPurgeFunction,
 ];
 
 export { ruijieSyncCompleted, ruijieSyncSessions } from './events/ruijie';

--- a/lib/usage-reports/__tests__/storage.test.ts
+++ b/lib/usage-reports/__tests__/storage.test.ts
@@ -1,0 +1,81 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  deleteReportArtifact,
+  signedReportUrl,
+  uploadReportArtifact,
+} from '../storage';
+
+function storageClient(overrides: Record<string, jest.Mock> = {}) {
+  const bucket = {
+    upload: jest.fn().mockResolvedValue({
+      data: { path: 'jobs/job-1/report.zip' },
+      error: null,
+    }),
+    createSignedUrl: jest.fn().mockResolvedValue({
+      data: { signedUrl: 'https://storage.test/signed' },
+      error: null,
+    }),
+    remove: jest.fn().mockResolvedValue({ error: null }),
+    ...overrides,
+  };
+  const from = jest.fn().mockReturnValue(bucket);
+
+  return {
+    client: { storage: { from } } as unknown as SupabaseClient,
+    bucket,
+    from,
+  };
+}
+
+describe('site usage report storage', () => {
+  it('uploads bytes to the private report bucket', async () => {
+    const { client, bucket, from } = storageClient();
+    const bytes = Buffer.from('report');
+
+    const path = await uploadReportArtifact(
+      client,
+      'jobs/job-1/report.zip',
+      bytes,
+      'application/zip'
+    );
+
+    expect(from).toHaveBeenCalledWith('site-usage-reports');
+    expect(bucket.upload).toHaveBeenCalledWith('jobs/job-1/report.zip', bytes, {
+      contentType: 'application/zip',
+      upsert: false,
+    });
+    expect(path).toBe('jobs/job-1/report.zip');
+  });
+
+  it('creates a signed URL with the requested lifetime', async () => {
+    const { client, bucket } = storageClient();
+
+    const url = await signedReportUrl(client, 'jobs/job-1/report.zip', 900);
+
+    expect(bucket.createSignedUrl).toHaveBeenCalledWith(
+      'jobs/job-1/report.zip',
+      900
+    );
+    expect(url).toBe('https://storage.test/signed');
+  });
+
+  it('deletes the requested report artifact', async () => {
+    const { client, bucket } = storageClient();
+
+    await deleteReportArtifact(client, 'jobs/job-1/report.zip');
+
+    expect(bucket.remove).toHaveBeenCalledWith(['jobs/job-1/report.zip']);
+  });
+
+  it('surfaces storage errors without losing their context', async () => {
+    const { client } = storageClient({
+      remove: jest.fn().mockResolvedValue({
+        error: { message: 'storage unavailable' },
+      }),
+    });
+
+    await expect(
+      deleteReportArtifact(client, 'jobs/job-1/report.zip')
+    ).rejects.toThrow('Failed to delete report artifact: storage unavailable');
+  });
+});

--- a/lib/usage-reports/artifacts.ts
+++ b/lib/usage-reports/artifacts.ts
@@ -1,0 +1,165 @@
+import JSZip from 'jszip';
+
+import {
+  assembleSiteUsageReport,
+  type AssembleResult,
+  type AssembleSiteUsageReportInput,
+} from './assemble-report';
+import { reportModelToCsv } from './csv';
+import type { TdxPatientRow } from './patient-wifi';
+import {
+  generateSiteUsageReportPdf,
+  generateSkipSlipPdf,
+  type SkipSlipInput,
+} from './pdf-generator';
+import type {
+  AssembleSkipReason,
+  ReportPeriod,
+  SiteUsageReportModel,
+} from './types';
+
+export interface UsageReportArtifactSite {
+  id: string;
+  accountNumber: string;
+}
+
+export interface UsageReportArtifactInput {
+  sites: UsageReportArtifactSite[];
+  period: ReportPeriod;
+  patientRows: TdxPatientRow[];
+  includeCsv: boolean;
+}
+
+export interface UsageReportArtifactDeps {
+  assemble(input: AssembleSiteUsageReportInput): Promise<AssembleResult>;
+  reportPdf(model: SiteUsageReportModel): ArrayBuffer;
+  skipPdf(input: SkipSlipInput): ArrayBuffer;
+  csv(model: SiteUsageReportModel): string;
+}
+
+export interface UsageReportArtifact {
+  bytes: Buffer;
+  contentType: 'application/pdf' | 'application/zip';
+  filename: string;
+  primarySources: Record<string, string>;
+  outcome: {
+    generated: string[];
+    skipped: Array<{ siteId: string; reason: string }>;
+  };
+}
+
+const defaultDeps: UsageReportArtifactDeps = {
+  assemble: assembleSiteUsageReport,
+  reportPdf: generateSiteUsageReportPdf,
+  skipPdf: generateSkipSlipPdf,
+  csv: reportModelToCsv,
+};
+
+function safeFilenamePart(value: string): string {
+  const sanitized = value.trim().replace(/[^a-zA-Z0-9_-]+/g, '_').replace(/^_+|_+$/g, '');
+  return sanitized || 'site';
+}
+
+function periodFilenamePart(period: ReportPeriod): string {
+  return `${period.startIso.slice(0, 10)}_to_${period.endIso.slice(0, 10)}`;
+}
+
+function patientRowForSite(
+  rows: TdxPatientRow[],
+  accountNumber: string
+): TdxPatientRow | null {
+  const normalizedAccount = accountNumber.trim().toLowerCase();
+  return (
+    rows.find((row) => row.siteCode.trim().toLowerCase() === normalizedAccount) ?? null
+  );
+}
+
+function skipReason(reason: AssembleSkipReason): string {
+  return reason === 'core_unavailable'
+    ? 'Core traffic data was unavailable for the selected period.'
+    : 'The site is not eligible for usage reporting.';
+}
+
+export async function buildUsageReportArtifact(
+  input: UsageReportArtifactInput,
+  deps: UsageReportArtifactDeps = defaultDeps
+): Promise<UsageReportArtifact> {
+  const periodPart = periodFilenamePart(input.period);
+  const generated: Array<{ siteId: string; filenameBase: string; model: SiteUsageReportModel }> = [];
+  const skipped: Array<{
+    siteId: string;
+    filenameBase: string;
+    result: Extract<AssembleResult, { ok: false }>;
+  }> = [];
+
+  for (const site of input.sites) {
+    const result = await deps.assemble({
+      siteId: site.id,
+      period: input.period,
+      patientRow: patientRowForSite(input.patientRows, site.accountNumber),
+    });
+
+    if (result.ok) {
+      generated.push({
+        siteId: site.id,
+        filenameBase: safeFilenamePart(result.model.site.accountNumber || result.model.site.name),
+        model: result.model,
+      });
+    } else {
+      skipped.push({
+        siteId: site.id,
+        filenameBase: safeFilenamePart(result.siteLabel),
+        result,
+      });
+    }
+  }
+
+  const outcome = {
+    generated: generated.map(({ siteId }) => siteId),
+    skipped: skipped.map(({ siteId, result }) => ({ siteId, reason: result.reason })),
+  };
+  const primarySources = Object.fromEntries(
+    generated.map(({ siteId, model }) => [siteId, model.core.source])
+  );
+
+  if (generated.length === 1 && skipped.length === 0 && !input.includeCsv) {
+    const report = generated[0];
+    return {
+      bytes: Buffer.from(deps.reportPdf(report.model)),
+      contentType: 'application/pdf',
+      filename: `CircleTel_Usage_${report.filenameBase}_${periodPart}.pdf`,
+      primarySources,
+      outcome,
+    };
+  }
+
+  const zip = new JSZip();
+  for (const report of generated) {
+    const base = `CircleTel_Usage_${report.filenameBase}_${periodPart}`;
+    zip.file(`${base}.pdf`, Buffer.from(deps.reportPdf(report.model)));
+    if (input.includeCsv) {
+      zip.file(`${base}.csv`, deps.csv(report.model));
+    }
+  }
+  for (const skip of skipped) {
+    zip.file(
+      `CircleTel_Usage_${skip.filenameBase}_${periodPart}_SKIPPED.pdf`,
+      Buffer.from(
+        deps.skipPdf({
+          siteLabel: skip.result.siteLabel,
+          periodLabel: input.period.rangeLabel,
+          reason: skipReason(skip.result.reason),
+          generatedAtIso: new Date().toISOString(),
+        })
+      )
+    );
+  }
+
+  return {
+    bytes: await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' }),
+    contentType: 'application/zip',
+    filename: `CircleTel_Usage_${periodPart}.zip`,
+    primarySources,
+    outcome,
+  };
+}

--- a/lib/usage-reports/assemble-report.ts
+++ b/lib/usage-reports/assemble-report.ts
@@ -1,0 +1,175 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { now, SAST_OFFSET_MS } from '@/lib/dates';
+import { createClient } from '@/lib/supabase/server';
+import { assembleCoreTraffic } from './core-traffic';
+import {
+  fetchInclusionSiteRows,
+  filterEligibleSites,
+  type InclusionSiteRow,
+} from './inclusion';
+import { resolvePatientWifi, type TdxPatientRow } from './patient-wifi';
+import { loadStaffHourRows, resolveStaffWifi, siteHasLinkedAp } from './staff-wifi';
+import type {
+  AssembleSkipReason,
+  ReportPeriod,
+  SiteUsageReportModel,
+  StaffWifiState,
+} from './types';
+
+type ReportCore = SiteUsageReportModel['core'];
+type ReportDevice = NonNullable<SiteUsageReportModel['device']>;
+
+export type AssembleResult =
+  | { ok: true; model: SiteUsageReportModel }
+  | {
+      ok: false;
+      reason: AssembleSkipReason;
+      siteId: string;
+      siteLabel: string;
+    };
+
+export interface AssembleReportDeps {
+  loadSite(siteId: string): Promise<InclusionSiteRow | null>;
+  loadCore(siteId: string, period: ReportPeriod): Promise<ReportCore>;
+  loadStaff(siteId: string, period: ReportPeriod): Promise<StaffWifiState>;
+  loadDevice(siteId: string): Promise<ReportDevice | null>;
+  generatedAtIso?(): string;
+}
+
+export interface AssembleSiteUsageReportInput {
+  siteId: string;
+  period: ReportPeriod;
+  patientRow: TdxPatientRow | null;
+  deps?: AssembleReportDeps;
+}
+
+function generatedAtSastIso(): string {
+  return new Date(now().getTime() + SAST_OFFSET_MS)
+    .toISOString()
+    .replace('Z', '+02:00');
+}
+
+async function loadReportDevice(
+  supabase: SupabaseClient,
+  siteId: string
+): Promise<ReportDevice | null> {
+  const { data: device, error } = await supabase
+    .from('network_devices')
+    .select('device_name,model,serial_number,ruijie_device_sn,status')
+    .eq('corporate_site_id', siteId)
+    .not('ruijie_device_sn', 'is', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!device) return null;
+
+  const ruijieSerial = device.ruijie_device_sn as string | null;
+  const { data: cache, error: cacheError } = ruijieSerial
+    ? await supabase
+        .from('ruijie_device_cache')
+        .select('group_name,status')
+        .eq('sn', ruijieSerial)
+        .maybeSingle()
+    : { data: null, error: null };
+
+  if (cacheError) throw cacheError;
+  return {
+    name: String(device.device_name ?? ''),
+    model: String(device.model ?? ''),
+    serial: String(ruijieSerial ?? device.serial_number ?? ''),
+    group: String(cache?.group_name ?? ''),
+    status: String(cache?.status ?? device.status ?? ''),
+  };
+}
+
+export function createDefaultAssembleReportDeps(): AssembleReportDeps {
+  let clientPromise: ReturnType<typeof createClient> | null = null;
+  const getClient = () => {
+    clientPromise ??= createClient();
+    return clientPromise;
+  };
+
+  return {
+    async loadSite(siteId) {
+      const rows = await fetchInclusionSiteRows(await getClient());
+      return (
+        filterEligibleSites(rows, { includeProvisioned: false }).find(
+          (site) => site.id === siteId
+        ) ?? null
+      );
+    },
+    async loadCore(siteId, period) {
+      return assembleCoreTraffic(await getClient(), siteId, period);
+    },
+    async loadStaff(siteId, period) {
+      const supabase = await getClient();
+      const [apLinkedToSite, hourRows] = await Promise.all([
+        siteHasLinkedAp(supabase, siteId),
+        loadStaffHourRows(supabase, siteId, period.startUtc, period.endUtc),
+      ]);
+      return resolveStaffWifi({ apLinkedToSite, hourRows });
+    },
+    async loadDevice(siteId) {
+      return loadReportDevice(await getClient(), siteId);
+    },
+    generatedAtIso: generatedAtSastIso,
+  };
+}
+
+export const defaultAssembleReportDeps = createDefaultAssembleReportDeps();
+
+export async function assembleSiteUsageReport({
+  siteId,
+  period,
+  patientRow,
+  deps = defaultAssembleReportDeps,
+}: AssembleSiteUsageReportInput): Promise<AssembleResult> {
+  const site = await deps.loadSite(siteId);
+  if (!site) {
+    return {
+      ok: false,
+      reason: 'site_not_eligible',
+      siteId,
+      siteLabel: siteId,
+    };
+  }
+
+  const core = await deps.loadCore(siteId, period);
+  if (core.source === 'unavailable') {
+    return {
+      ok: false,
+      reason: 'core_unavailable',
+      siteId,
+      siteLabel: site.name,
+    };
+  }
+
+  const unjani = site.corporate_code === 'UNJ';
+  const [staff, device] = await Promise.all([
+    unjani
+      ? deps.loadStaff(siteId, period)
+      : Promise.resolve<StaffWifiState>({ kind: 'no_samples' }),
+    deps.loadDevice(siteId),
+  ]);
+
+  return {
+    ok: true,
+    model: {
+      generatedAtIso: deps.generatedAtIso?.() ?? generatedAtSastIso(),
+      site: {
+        id: site.id,
+        name: site.name,
+        accountNumber: site.account_number,
+        corporateCode: site.corporate_code,
+        accountName: site.account_name,
+      },
+      period,
+      core,
+      device,
+      unjani,
+      staff,
+      patient: resolvePatientWifi(unjani ? patientRow : null),
+    },
+  };
+}

--- a/lib/usage-reports/bytes.ts
+++ b/lib/usage-reports/bytes.ts
@@ -1,0 +1,20 @@
+const BYTES_PER_GB = 1_000_000_000;
+const BYTES_PER_MB = 1_000_000;
+
+export function bytesToGb(bytes: number): number {
+  return bytes / BYTES_PER_GB;
+}
+
+export function formatBytesAsGb(bytes: number, fractionDigits = 2): string {
+  return `${bytesToGb(bytes).toLocaleString('en-ZA', {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })} GB`;
+}
+
+export function formatBytesAsMb(bytes: number, fractionDigits = 1): string {
+  return `${(bytes / BYTES_PER_MB).toLocaleString('en-ZA', {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })} MB`;
+}

--- a/lib/usage-reports/core-traffic.ts
+++ b/lib/usage-reports/core-traffic.ts
@@ -43,14 +43,18 @@ export function selectCorePrimarySource(input: {
   ruijieCoversWindow: boolean;
   interstellioMapped: boolean;
 }): CoreTrafficSource {
+  const ruijieOk = input.ruijieLinked && input.ruijieCoversWindow;
+
   if (input.isShortPeriod) {
-    if (input.ruijieLinked && input.ruijieCoversWindow) {
-      return 'ruijie_hourly';
-    }
+    if (ruijieOk) return 'ruijie_hourly';
     return input.interstellioMapped ? 'interstellio_daily' : 'unavailable';
   }
 
-  return input.interstellioMapped ? 'interstellio_daily' : 'unavailable';
+  // Long periods: prefer Interstellio (BNG accounting). MTN / TDX sites with no
+  // Interstellio fall back to Ruijie AP/group rollups for hours that exist.
+  if (input.interstellioMapped) return 'interstellio_daily';
+  if (ruijieOk) return 'ruijie_hourly';
+  return 'unavailable';
 }
 
 export function shouldAttachSecondaryInterstellio(input: {
@@ -257,17 +261,34 @@ export async function loadInterstellioDailyEntries(
   });
 }
 
+function ruijieCoreNote(
+  period: ReportPeriod,
+  dailyDownloadBytes: number[]
+): string {
+  const daysWithSamples = dailyDownloadBytes.filter((bytes) => bytes > 0).length;
+  const partial =
+    !period.isShortPeriod && daysWithSamples < period.inclusiveDayCount
+      ? ` Coverage is partial (${daysWithSamples} of ${period.inclusiveDayCount} days have samples; Ruijie retention is typically ~14 days).`
+      : '';
+  return (
+    'AP / Wi-Fi group hourly rollups only — not BNG or MTN subscriber accounting. ' +
+    'Totals include available hours only; missing hours may undercount.' +
+    partial
+  );
+}
+
 export async function assembleCoreTraffic(
   supabase: SupabaseClient,
   siteId: string,
   period: ReportPeriod
 ): Promise<SiteUsageReportModel['core']> {
-  const [subscriberId, ruijie] = await Promise.all([
-    loadInterstellioSubscriberId(supabase, siteId),
-    period.isShortPeriod
-      ? loadRuijieHourlyRows(supabase, siteId, period.startUtc, period.endUtc)
-      : Promise.resolve<RuijieHourlyLoad>({ groupId: null, rows: [] }),
-  ]);
+  const subscriberId = await loadInterstellioSubscriberId(supabase, siteId);
+  // Load Ruijie for short periods always; for long periods only when Interstellio
+  // is absent (MTN / TDX / unmapped BNG) so we can fall back.
+  const needsRuijie = period.isShortPeriod || subscriberId === null;
+  const ruijie = needsRuijie
+    ? await loadRuijieHourlyRows(supabase, siteId, period.startUtc, period.endUtc)
+    : ({ groupId: null, rows: [] } satisfies RuijieHourlyLoad);
 
   const source = selectCorePrimarySource({
     isShortPeriod: period.isShortPeriod,
@@ -330,8 +351,7 @@ export async function assembleCoreTraffic(
     source,
     sourceLabel: CORE_SOURCE_LABEL[source],
     ...primary,
-    note:
-      'Totals include available hourly Ruijie rollups only; missing hours may undercount usage.',
+    note: ruijieCoreNote(period, primary.dailyDownloadBytes),
     ...(secondary
       ? {
           secondaryInterstellio: {

--- a/lib/usage-reports/core-traffic.ts
+++ b/lib/usage-reports/core-traffic.ts
@@ -1,0 +1,344 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getInterstellioClient } from '@/lib/interstellio';
+import type { DataUsageEntry } from '@/lib/interstellio/types';
+import type {
+  CoreTrafficSource,
+  ReportPeriod,
+  SiteUsageReportModel,
+} from './types';
+
+const SAST_OFFSET_MS = 2 * 60 * 60 * 1_000;
+const BYTES_PER_INTERSTELLIO_KB = 1_024;
+
+export interface RuijieHourlyRow {
+  captured_at: string;
+  total_rx_bytes: number | string | null;
+  total_tx_bytes: number | string | null;
+  avg_rx_bps: number | string | null;
+  peak_rx_bps: number | string | null;
+}
+
+export interface CoreTrafficAggregate {
+  downloadBytes: number;
+  uploadBytes: number;
+  avgDownKbps: number | null;
+  peakBucketBytes: number | null;
+  dailyDownloadBytes: number[];
+}
+
+export interface RuijieHourlyLoad {
+  groupId: string | null;
+  rows: RuijieHourlyRow[];
+}
+
+export const CORE_SOURCE_LABEL: Record<CoreTrafficSource, string> = {
+  ruijie_hourly: 'Ruijie traffic rollups (hourly)',
+  interstellio_daily: 'Interstellio subscriber usage (daily)',
+  unavailable: 'Not available',
+};
+
+export function selectCorePrimarySource(input: {
+  isShortPeriod: boolean;
+  ruijieLinked: boolean;
+  ruijieCoversWindow: boolean;
+  interstellioMapped: boolean;
+}): CoreTrafficSource {
+  if (input.isShortPeriod) {
+    if (input.ruijieLinked && input.ruijieCoversWindow) {
+      return 'ruijie_hourly';
+    }
+    return input.interstellioMapped ? 'interstellio_daily' : 'unavailable';
+  }
+
+  return input.interstellioMapped ? 'interstellio_daily' : 'unavailable';
+}
+
+export function shouldAttachSecondaryInterstellio(input: {
+  isShortPeriod: boolean;
+  primary: CoreTrafficSource;
+  interstellioMapped: boolean;
+}): boolean {
+  return (
+    input.isShortPeriod &&
+    input.primary === 'ruijie_hourly' &&
+    input.interstellioMapped
+  );
+}
+
+function numberOrZero(value: number | string | null | undefined): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function sastDayKey(value: Date | string): string | null {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Date(date.getTime() + SAST_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+function buildSastDayIndex(
+  dayCount: number,
+  start: Date
+): { dailyDownloadBytes: number[]; indexByDay: Map<string, number> } {
+  const startKey = sastDayKey(start);
+  const normalizedDayCount = Math.max(0, Math.trunc(dayCount));
+  const dailyDownloadBytes = Array.from({ length: normalizedDayCount }, () => 0);
+  const indexByDay = new Map<string, number>();
+
+  if (!startKey) return { dailyDownloadBytes, indexByDay };
+
+  const startDayUtc = new Date(`${startKey}T00:00:00.000Z`);
+  for (let index = 0; index < normalizedDayCount; index += 1) {
+    const key = new Date(startDayUtc.getTime() + index * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    indexByDay.set(key, index);
+  }
+
+  return { dailyDownloadBytes, indexByDay };
+}
+
+export function aggregateRuijieHourly(
+  rows: RuijieHourlyRow[],
+  dayCount: number,
+  start: Date
+): CoreTrafficAggregate {
+  const { dailyDownloadBytes, indexByDay } = buildSastDayIndex(dayCount, start);
+  let downloadBytes = 0;
+  let uploadBytes = 0;
+  let averageBpsTotal = 0;
+  let averageBpsSamples = 0;
+  let peakBucketBytes: number | null = null;
+
+  for (const row of rows) {
+    const rowDownloadBytes = numberOrZero(row.total_rx_bytes);
+    downloadBytes += rowDownloadBytes;
+    uploadBytes += numberOrZero(row.total_tx_bytes);
+    peakBucketBytes = Math.max(peakBucketBytes ?? 0, rowDownloadBytes);
+
+    const averageBps = Number(row.avg_rx_bps);
+    if (Number.isFinite(averageBps)) {
+      averageBpsTotal += averageBps;
+      averageBpsSamples += 1;
+    }
+
+    const index = indexByDay.get(sastDayKey(row.captured_at) ?? '');
+    if (index !== undefined) dailyDownloadBytes[index] += rowDownloadBytes;
+  }
+
+  return {
+    downloadBytes,
+    uploadBytes,
+    avgDownKbps:
+      averageBpsSamples > 0
+        ? averageBpsTotal / averageBpsSamples / 1_000
+        : null,
+    peakBucketBytes,
+    dailyDownloadBytes,
+  };
+}
+
+export function aggregateInterstellioDaily(
+  entries: DataUsageEntry[],
+  dayCount: number,
+  start: Date
+): CoreTrafficAggregate {
+  const { dailyDownloadBytes, indexByDay } = buildSastDayIndex(dayCount, start);
+  let downloadBytes = 0;
+  let uploadBytes = 0;
+  let averageKbpsTotal = 0;
+  let averageKbpsSamples = 0;
+  const downloadBytesByDay = new Map<number, number>();
+
+  for (const entry of entries) {
+    const entryDownloadBytes =
+      numberOrZero(entry.download_kb) * BYTES_PER_INTERSTELLIO_KB;
+    downloadBytes += entryDownloadBytes;
+    uploadBytes += numberOrZero(entry.upload_kb) * BYTES_PER_INTERSTELLIO_KB;
+
+    if (entry.download_kbps !== undefined && Number.isFinite(entry.download_kbps)) {
+      averageKbpsTotal += entry.download_kbps;
+      averageKbpsSamples += 1;
+    }
+
+    const index = indexByDay.get(sastDayKey(entry.time) ?? '');
+    if (index !== undefined) {
+      downloadBytesByDay.set(
+        index,
+        (downloadBytesByDay.get(index) ?? 0) + entryDownloadBytes
+      );
+    }
+  }
+
+  for (const [index, bytes] of downloadBytesByDay) {
+    dailyDownloadBytes[index] = bytes;
+  }
+
+  return {
+    downloadBytes,
+    uploadBytes,
+    avgDownKbps:
+      averageKbpsSamples > 0 ? averageKbpsTotal / averageKbpsSamples : null,
+    peakBucketBytes:
+      downloadBytesByDay.size > 0
+        ? Math.max(...downloadBytesByDay.values())
+        : entries.length > 0
+          ? 0
+          : null,
+    dailyDownloadBytes,
+  };
+}
+
+export async function loadInterstellioSubscriberId(
+  supabase: SupabaseClient,
+  siteId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('corporate_sites')
+    .select('interstellio_subscriber_id')
+    .eq('id', siteId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return (data?.interstellio_subscriber_id as string | null | undefined) ?? null;
+}
+
+export async function loadRuijieHourlyRows(
+  supabase: SupabaseClient,
+  siteId: string,
+  startUtc: Date,
+  endUtc: Date
+): Promise<RuijieHourlyLoad> {
+  const { data: device, error: deviceError } = await supabase
+    .from('network_devices')
+    .select('ruijie_device_sn')
+    .eq('corporate_site_id', siteId)
+    .not('ruijie_device_sn', 'is', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (deviceError) throw deviceError;
+  const serial = device?.ruijie_device_sn as string | null | undefined;
+  if (!serial) return { groupId: null, rows: [] };
+
+  const { data: cachedDevice, error: cacheError } = await supabase
+    .from('ruijie_device_cache')
+    .select('group_id')
+    .eq('sn', serial)
+    .not('group_id', 'is', null)
+    .maybeSingle();
+
+  if (cacheError) throw cacheError;
+  const groupId = cachedDevice?.group_id as string | null | undefined;
+  if (!groupId) return { groupId: null, rows: [] };
+
+  const { data: rows, error: rollupError } = await supabase
+    .from('ruijie_traffic_rollups')
+    .select(
+      'captured_at,total_rx_bytes,total_tx_bytes,avg_rx_bps,peak_rx_bps'
+    )
+    .eq('group_id', groupId)
+    .eq('hours_window', 1)
+    .gte('captured_at', startUtc.toISOString())
+    .lte('captured_at', endUtc.toISOString())
+    .order('captured_at', { ascending: true });
+
+  if (rollupError) throw rollupError;
+  return { groupId, rows: (rows ?? []) as RuijieHourlyRow[] };
+}
+
+export async function loadInterstellioDailyEntries(
+  subscriberId: string,
+  period: ReportPeriod
+): Promise<DataUsageEntry[]> {
+  return getInterstellioClient().getSubscriberUsage(subscriberId, 'daily', {
+    start: period.startIso,
+    end: period.endIso,
+  });
+}
+
+export async function assembleCoreTraffic(
+  supabase: SupabaseClient,
+  siteId: string,
+  period: ReportPeriod
+): Promise<SiteUsageReportModel['core']> {
+  const [subscriberId, ruijie] = await Promise.all([
+    loadInterstellioSubscriberId(supabase, siteId),
+    period.isShortPeriod
+      ? loadRuijieHourlyRows(supabase, siteId, period.startUtc, period.endUtc)
+      : Promise.resolve<RuijieHourlyLoad>({ groupId: null, rows: [] }),
+  ]);
+
+  const source = selectCorePrimarySource({
+    isShortPeriod: period.isShortPeriod,
+    ruijieLinked: ruijie.groupId !== null,
+    ruijieCoversWindow: ruijie.rows.length > 0,
+    interstellioMapped: subscriberId !== null,
+  });
+
+  if (source === 'unavailable') {
+    return {
+      source,
+      sourceLabel: CORE_SOURCE_LABEL[source],
+      downloadBytes: 0,
+      uploadBytes: 0,
+      avgDownKbps: null,
+      peakBucketBytes: null,
+      dailyDownloadBytes: Array.from(
+        { length: period.inclusiveDayCount },
+        () => 0
+      ),
+      note: 'No permitted core traffic source is available for this period.',
+    };
+  }
+
+  if (source === 'interstellio_daily') {
+    const entries = await loadInterstellioDailyEntries(subscriberId!, period);
+    return {
+      source,
+      sourceLabel: CORE_SOURCE_LABEL[source],
+      ...aggregateInterstellioDaily(
+        entries,
+        period.inclusiveDayCount,
+        period.startUtc
+      ),
+      note: 'Interstellio daily subscriber usage (1 KB = 1,024 bytes).',
+    };
+  }
+
+  const primary = aggregateRuijieHourly(
+    ruijie.rows,
+    period.inclusiveDayCount,
+    period.startUtc
+  );
+  const secondaryEntries = shouldAttachSecondaryInterstellio({
+    isShortPeriod: period.isShortPeriod,
+    primary: source,
+    interstellioMapped: subscriberId !== null,
+  })
+    ? await loadInterstellioDailyEntries(subscriberId!, period)
+    : null;
+  const secondary = secondaryEntries
+    ? aggregateInterstellioDaily(
+        secondaryEntries,
+        period.inclusiveDayCount,
+        period.startUtc
+      )
+    : null;
+
+  return {
+    source,
+    sourceLabel: CORE_SOURCE_LABEL[source],
+    ...primary,
+    note:
+      'Totals include available hourly Ruijie rollups only; missing hours may undercount usage.',
+    ...(secondary
+      ? {
+          secondaryInterstellio: {
+            downloadBytes: secondary.downloadBytes,
+            uploadBytes: secondary.uploadBytes,
+          },
+        }
+      : {}),
+  };
+}

--- a/lib/usage-reports/csv.ts
+++ b/lib/usage-reports/csv.ts
@@ -1,0 +1,61 @@
+import { bytesToGb } from './bytes';
+import type { SiteUsageReportModel } from './types';
+
+const HEADERS = [
+  'site',
+  'period',
+  'core source',
+  'download GB',
+  'upload GB',
+  'staff total GB',
+  'staff download GB',
+  'staff upload GB',
+  'staff N/A reason',
+  'patient users',
+  'patient sessions',
+  'patient download GB',
+  'patient status',
+];
+
+function csvCell(value: string | number): string {
+  const text = String(value);
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+function gb(value: number): string {
+  return bytesToGb(value).toFixed(2);
+}
+
+export function reportModelToCsv(model: SiteUsageReportModel): string {
+  const staff = model.staff.kind === 'available'
+    ? [gb(model.staff.totalBytes), gb(model.staff.rxBytes), gb(model.staff.txBytes), '']
+    : [
+        '',
+        '',
+        '',
+        model.staff.kind === 'no_samples'
+          ? 'Not available — no Staff Wi-Fi samples in this period'
+          : 'Not available — AP not linked to site',
+      ];
+
+  const patient = model.patient.kind === 'available'
+    ? [
+        model.patient.uniqueUsers,
+        model.patient.loginSessions,
+        model.patient.downloadGb.toFixed(2),
+        '',
+      ]
+    : ['', '', '', 'Awaiting TDX export'];
+
+  const row = [
+    model.site.name,
+    model.period.label,
+    model.core.sourceLabel,
+    gb(model.core.downloadBytes),
+    gb(model.core.uploadBytes),
+    ...staff,
+    ...patient,
+  ];
+
+  return `${HEADERS.map(csvCell).join(',')}\r\n${row.map(csvCell).join(',')}\r\n`;
+}

--- a/lib/usage-reports/inclusion.ts
+++ b/lib/usage-reports/inclusion.ts
@@ -48,7 +48,7 @@ export async function fetchInclusionSiteRows(
   if (corporateAccountId) q = q.eq('corporate_id', corporateAccountId);
   const { data, error } = await q;
   if (error) throw error;
-  return ((data ?? []) as RawInclusionSiteRow[]).map((row) => ({
+  return ((data ?? []) as unknown as RawInclusionSiteRow[]).map((row) => ({
     id: row.id,
     name: row.site_name,
     account_number: row.account_number ?? '',

--- a/lib/usage-reports/inclusion.ts
+++ b/lib/usage-reports/inclusion.ts
@@ -1,0 +1,61 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface InclusionSiteRow {
+  id: string;
+  name: string;
+  account_number: string;
+  status: string;
+  service_id: string | null;
+  service_status: string | null;
+  corporate_code: string;
+  account_name: string;
+}
+
+export function filterEligibleSites(
+  rows: InclusionSiteRow[],
+  opts: { includeProvisioned: boolean; unjaniOnly?: boolean }
+): InclusionSiteRow[] {
+  const allowedStatus = new Set(
+    opts.includeProvisioned ? ['active', 'provisioned'] : ['active']
+  );
+  return rows.filter((r) => {
+    if (!allowedStatus.has(r.status)) return false;
+    if (r.service_id && r.service_status !== 'active') return false;
+    if (opts.unjaniOnly && r.corporate_code !== 'UNJ') return false;
+    return true;
+  });
+}
+
+interface RawInclusionSiteRow {
+  id: string;
+  site_name: string;
+  account_number: string | null;
+  status: string;
+  service_id: string | null;
+  customer_services: { status: string } | null;
+  corporate_accounts: { corporate_code: string; company_name: string } | null;
+}
+
+export async function fetchInclusionSiteRows(
+  supabase: SupabaseClient,
+  corporateAccountId?: string
+): Promise<InclusionSiteRow[]> {
+  let q = supabase.from('corporate_sites').select(`
+      id, site_name, account_number, status, service_id,
+      customer_services:service_id ( status ),
+      corporate_accounts:corporate_id ( corporate_code, company_name )
+    `);
+  if (corporateAccountId) q = q.eq('corporate_id', corporateAccountId);
+  const { data, error } = await q;
+  if (error) throw error;
+  return ((data ?? []) as RawInclusionSiteRow[]).map((row) => ({
+    id: row.id,
+    name: row.site_name,
+    account_number: row.account_number ?? '',
+    status: row.status,
+    service_id: row.service_id,
+    service_status: row.customer_services?.status ?? null,
+    corporate_code: row.corporate_accounts?.corporate_code ?? '',
+    account_name: row.corporate_accounts?.company_name ?? '',
+  }));
+}

--- a/lib/usage-reports/inclusion.ts
+++ b/lib/usage-reports/inclusion.ts
@@ -32,7 +32,6 @@ interface RawInclusionSiteRow {
   account_number: string | null;
   status: string;
   service_id: string | null;
-  customer_services: { status: string } | null;
   corporate_accounts: { corporate_code: string; company_name: string } | null;
 }
 
@@ -40,21 +39,41 @@ export async function fetchInclusionSiteRows(
   supabase: SupabaseClient,
   corporateAccountId?: string
 ): Promise<InclusionSiteRow[]> {
+  // No FK from corporate_sites.service_id → customer_services; load statuses separately.
   let q = supabase.from('corporate_sites').select(`
       id, site_name, account_number, status, service_id,
-      customer_services:service_id ( status ),
       corporate_accounts:corporate_id ( corporate_code, company_name )
     `);
   if (corporateAccountId) q = q.eq('corporate_id', corporateAccountId);
   const { data, error } = await q;
   if (error) throw error;
-  return ((data ?? []) as unknown as RawInclusionSiteRow[]).map((row) => ({
+
+  const rows = (data ?? []) as unknown as RawInclusionSiteRow[];
+  const serviceIds = [
+    ...new Set(rows.map((r) => r.service_id).filter((id): id is string => Boolean(id))),
+  ];
+
+  const statusByServiceId = new Map<string, string>();
+  if (serviceIds.length > 0) {
+    const { data: services, error: serviceError } = await supabase
+      .from('customer_services')
+      .select('id, status')
+      .in('id', serviceIds);
+    if (serviceError) throw serviceError;
+    for (const svc of services ?? []) {
+      statusByServiceId.set(String(svc.id), String(svc.status));
+    }
+  }
+
+  return rows.map((row) => ({
     id: row.id,
     name: row.site_name,
     account_number: row.account_number ?? '',
     status: row.status,
     service_id: row.service_id,
-    service_status: row.customer_services?.status ?? null,
+    service_status: row.service_id
+      ? statusByServiceId.get(row.service_id) ?? null
+      : null,
     corporate_code: row.corporate_accounts?.corporate_code ?? '',
     account_name: row.corporate_accounts?.company_name ?? '',
   }));

--- a/lib/usage-reports/patient-wifi.ts
+++ b/lib/usage-reports/patient-wifi.ts
@@ -1,0 +1,71 @@
+import type { PatientWifiState } from './types';
+
+export interface TdxPatientRow {
+  siteCode: string;
+  uniqueUsers: number;
+  loginSessions: number;
+  downloadGb: number;
+}
+
+const SITE_CODE_HEADERS = ['site code', 'account_number', 'account number'];
+const UNIQUE_USERS_HEADERS = ['unique users', 'users'];
+const SESSIONS_HEADERS = ['sessions', 'login sessions'];
+const DOWNLOAD_HEADERS = ['download gb', 'download (gb)'];
+
+function normalizeHeader(header: string): string {
+  return header.trim().toLowerCase();
+}
+
+function findColumnIndex(headers: string[], aliases: readonly string[]): number {
+  const normalized = headers.map(normalizeHeader);
+  for (const alias of aliases) {
+    const idx = normalized.indexOf(alias);
+    if (idx >= 0) return idx;
+  }
+  return -1;
+}
+
+function parseCsvLine(line: string): string[] {
+  return line.split(',').map((cell) => cell.trim());
+}
+
+export function parseTdxPatientCsv(csv: string): TdxPatientRow[] {
+  const lines = csv
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0);
+  if (lines.length < 2) return [];
+
+  const headers = parseCsvLine(lines[0]);
+  const siteIdx = findColumnIndex(headers, SITE_CODE_HEADERS);
+  const usersIdx = findColumnIndex(headers, UNIQUE_USERS_HEADERS);
+  const sessionsIdx = findColumnIndex(headers, SESSIONS_HEADERS);
+  const downloadIdx = findColumnIndex(headers, DOWNLOAD_HEADERS);
+  if (siteIdx < 0) return [];
+
+  const rows: TdxPatientRow[] = [];
+  for (let i = 1; i < lines.length; i += 1) {
+    const cols = parseCsvLine(lines[i]);
+    const siteCode = cols[siteIdx]?.trim();
+    if (!siteCode) continue;
+
+    rows.push({
+      siteCode,
+      uniqueUsers: usersIdx >= 0 ? Number(cols[usersIdx] || 0) : 0,
+      loginSessions: sessionsIdx >= 0 ? Number(cols[sessionsIdx] || 0) : 0,
+      downloadGb: downloadIdx >= 0 ? Number(cols[downloadIdx] || 0) : 0,
+    });
+  }
+
+  return rows;
+}
+
+export function resolvePatientWifi(row: TdxPatientRow | null): PatientWifiState {
+  if (!row) return { kind: 'awaiting_export' };
+  return {
+    kind: 'available',
+    uniqueUsers: row.uniqueUsers,
+    loginSessions: row.loginSessions,
+    downloadGb: row.downloadGb,
+  };
+}

--- a/lib/usage-reports/pdf-generator.ts
+++ b/lib/usage-reports/pdf-generator.ts
@@ -1,0 +1,313 @@
+import jsPDF from 'jspdf';
+import { circleTelLogoBase64 } from '@/lib/quotes/circletel-logo-base64';
+import { formatBytesAsGb, formatBytesAsMb } from './bytes';
+import type { SiteUsageReportModel } from './types';
+
+const COLORS = {
+  orange: '#F5831F',
+  dark: '#1F2937',
+  gray: '#6B7280',
+  muted: '#9CA3AF',
+  border: '#E5E7EB',
+  panel: '#F9FAFB',
+  white: '#FFFFFF',
+};
+
+const STAFF_FOOTNOTE =
+  'Sampled STA session telemetry (not accounting-grade); forward-only from sampler go-live; may undercount short sessions / gaps.';
+
+export interface SkipSlipInput {
+  siteLabel: string;
+  periodLabel: string;
+  reason: string;
+  generatedAtIso: string;
+}
+
+export interface WeekBand {
+  label: string;
+  start: number;
+  span: number;
+}
+
+export function buildWeekBands(periodStartIso: string, dayCount: number): WeekBand[] {
+  if (dayCount <= 0) return [];
+
+  const startDate = new Date(`${periodStartIso.slice(0, 10)}T00:00:00Z`);
+  const firstSpan = Math.min(dayCount, (8 - startDate.getUTCDay()) % 7 || 7);
+  const bands: WeekBand[] = [{ label: 'Week 1', start: 0, span: firstSpan }];
+  let start = firstSpan;
+
+  while (start < dayCount) {
+    bands.push({
+      label: `Week ${bands.length + 1}`,
+      start,
+      span: Math.min(7, dayCount - start),
+    });
+    start += 7;
+  }
+
+  return bands;
+}
+
+function outputBuffer(doc: jsPDF): ArrayBuffer {
+  return doc.output('arraybuffer');
+}
+
+function addLogo(doc: jsPDF, x: number, y: number, size: number): void {
+  try {
+    // Embedded representation of public/images/circletel-enclosed-logo.png.
+    doc.addImage(circleTelLogoBase64, 'PNG', x, y, size, size);
+  } catch {
+    doc.setFillColor(COLORS.orange);
+    doc.roundedRect(x, y, size, size, 2, 2, 'F');
+    doc.setTextColor(COLORS.white);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(13);
+    doc.text('CT', x + size / 2, y + size / 2 + 2, { align: 'center' });
+  }
+}
+
+function formatGeneratedAt(iso: string): string {
+  return new Intl.DateTimeFormat('en-ZA', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'Africa/Johannesburg',
+  }).format(new Date(iso));
+}
+
+function dayLabels(model: SiteUsageReportModel): number[] {
+  const startDate = new Date(`${model.period.startIso.slice(0, 10)}T00:00:00Z`);
+  return model.core.dailyDownloadBytes.map((_, index) => {
+    const date = new Date(startDate);
+    date.setUTCDate(startDate.getUTCDate() + index);
+    return date.getUTCDate();
+  });
+}
+
+function sectionTitle(doc: jsPDF, title: string, x: number, y: number): void {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  doc.setTextColor(COLORS.dark);
+  doc.text(title, x, y);
+}
+
+export function generateSiteUsageReportPdf(model: SiteUsageReportModel): ArrayBuffer {
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const margin = 15;
+  const contentWidth = pageWidth - margin * 2;
+
+  // 1. Logo + title + generated-at
+  addLogo(doc, margin, 14, 24);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(20);
+  doc.setTextColor(COLORS.dark);
+  doc.text('SITE NETWORK USAGE REPORT', pageWidth - margin, 23, { align: 'right' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(COLORS.gray);
+  doc.text(`Generated ${formatGeneratedAt(model.generatedAtIso)} SAST`, pageWidth - margin, 30, {
+    align: 'right',
+  });
+  doc.setDrawColor(COLORS.orange);
+  doc.setLineWidth(0.8);
+  doc.line(margin, 43, pageWidth - margin, 43);
+
+  // 2. Site / period
+  doc.setFontSize(7);
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(COLORS.gray);
+  doc.text('SITE', margin, 51);
+  doc.text('REPORT PERIOD', pageWidth - margin, 51, { align: 'right' });
+  doc.setFontSize(12);
+  doc.setTextColor(COLORS.dark);
+  doc.text(model.site.name, margin, 58);
+  doc.text(model.period.label, pageWidth - margin, 58, { align: 'right' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(COLORS.gray);
+  doc.text(`${model.site.corporateCode} · ${model.site.accountName}`, margin, 63);
+  doc.text(`${model.period.rangeLabel} · SAST`, pageWidth - margin, 63, { align: 'right' });
+
+  // 3. KPI strip
+  const kpiY = 70;
+  const kpiWidth = contentWidth / 4;
+  const kpis = [
+    ['DOWNLOADED', formatBytesAsGb(model.core.downloadBytes)],
+    ['UPLOADED', formatBytesAsGb(model.core.uploadBytes)],
+    ['AVG DL', model.core.avgDownKbps === null ? 'N/A' : `${model.core.avgDownKbps.toLocaleString('en-ZA')} Kbps`],
+    ['PEAK BUCKET', model.core.peakBucketBytes === null ? 'N/A' : formatBytesAsMb(model.core.peakBucketBytes)],
+  ];
+  doc.setFillColor(COLORS.panel);
+  doc.rect(margin, kpiY, contentWidth, 18, 'F');
+  kpis.forEach(([label, value], index) => {
+    const x = margin + index * kpiWidth + 3;
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(6.5);
+    doc.setTextColor(COLORS.gray);
+    doc.text(label, x, kpiY + 6);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9.5);
+    doc.setTextColor(COLORS.dark);
+    doc.text(value, x, kpiY + 13);
+  });
+
+  // 4. Core chart
+  sectionTitle(doc, 'Core site traffic', margin, 97);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(7);
+  doc.setTextColor(COLORS.gray);
+  doc.text(`Primary: ${model.core.sourceLabel}`, pageWidth - margin, 97, { align: 'right' });
+  const noteLines = doc.splitTextToSize(model.core.note, contentWidth);
+  doc.text(noteLines, margin, 102);
+
+  const chartX = margin + 4;
+  const chartY = 110;
+  const chartWidth = contentWidth - 8;
+  const chartHeight = 28;
+  const values = model.core.dailyDownloadBytes;
+  const maxValue = Math.max(1, ...values);
+  const barGap = values.length > 20 ? 0.4 : 0.8;
+  const barWidth = values.length ? chartWidth / values.length : chartWidth;
+  doc.setFillColor(COLORS.panel);
+  doc.setDrawColor(COLORS.border);
+  doc.roundedRect(margin, chartY - 3, contentWidth, 43, 1.5, 1.5, 'FD');
+  values.forEach((value, index) => {
+    const height = Math.max(0.8, (value / maxValue) * chartHeight);
+    doc.setFillColor(COLORS.orange);
+    doc.rect(
+      chartX + index * barWidth + barGap / 2,
+      chartY + chartHeight - height,
+      Math.max(0.3, barWidth - barGap),
+      height,
+      'F',
+    );
+  });
+  doc.setDrawColor(COLORS.border);
+  doc.line(chartX, chartY + chartHeight, chartX + chartWidth, chartY + chartHeight);
+  const labels = dayLabels(model);
+  doc.setFont('courier', 'normal');
+  doc.setFontSize(values.length > 31 ? 4.5 : 5.5);
+  doc.setTextColor(COLORS.gray);
+  labels.forEach((label, index) => {
+    doc.text(String(label), chartX + (index + 0.5) * barWidth, chartY + chartHeight + 4, {
+      align: 'center',
+    });
+  });
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(5.5);
+  buildWeekBands(model.period.startIso, values.length).forEach((band) => {
+    const center = chartX + (band.start + band.span / 2) * barWidth;
+    doc.text(band.label, center, chartY + chartHeight + 8, { align: 'center' });
+  });
+
+  // 5. Device identity
+  const deviceY = 157;
+  doc.setFillColor(COLORS.panel);
+  doc.setDrawColor(COLORS.border);
+  doc.roundedRect(margin, deviceY, contentWidth, 17, 1.5, 1.5, 'FD');
+  sectionTitle(doc, 'Device identity', margin + 4, deviceY + 6);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(7);
+  doc.setTextColor(COLORS.gray);
+  const deviceText = model.device
+    ? `${model.device.name} · ${model.device.model} · SN ${model.device.serial} · Group ${model.device.group} · ${model.device.status}`
+    : 'Not available';
+  doc.text(doc.splitTextToSize(deviceText, contentWidth - 8), margin + 4, deviceY + 12);
+
+  // 6. Unjani Staff + Patient blocks
+  if (model.unjani) {
+    sectionTitle(doc, 'Unjani Wi-Fi breakdown (separate sources — do not sum)', margin, 183);
+    const staffY = 188;
+    doc.setDrawColor(COLORS.border);
+    doc.roundedRect(margin, staffY, contentWidth, 30, 1.5, 1.5, 'S');
+    sectionTitle(doc, 'Staff Wi-Fi', margin + 4, staffY + 6);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7);
+    if (model.staff.kind === 'available') {
+      doc.setTextColor(COLORS.dark);
+      doc.text(`Total ${formatBytesAsGb(model.staff.totalBytes)}`, margin + 4, staffY + 13);
+      doc.text(`Download ${formatBytesAsGb(model.staff.rxBytes)}`, margin + 62, staffY + 13);
+      doc.text(`Upload ${formatBytesAsGb(model.staff.txBytes)}`, margin + 124, staffY + 13);
+      doc.setFontSize(6.2);
+      doc.setTextColor(COLORS.muted);
+      doc.text(doc.splitTextToSize(STAFF_FOOTNOTE, contentWidth - 8), margin + 4, staffY + 20);
+    } else {
+      doc.setTextColor(COLORS.gray);
+      doc.text(
+        model.staff.kind === 'no_samples'
+          ? 'Not available — no Staff Wi-Fi samples in this period'
+          : 'Not available — AP not linked to site',
+        margin + 4,
+        staffY + 14,
+      );
+    }
+
+    const patientY = 223;
+    doc.roundedRect(margin, patientY, contentWidth, 29, 1.5, 1.5, 'S');
+    sectionTitle(doc, 'Patient Free Wi-Fi', margin + 4, patientY + 6);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7);
+    if (model.patient.kind === 'available') {
+      doc.setTextColor(COLORS.dark);
+      doc.text(`Unique users ${model.patient.uniqueUsers.toLocaleString('en-ZA')}`, margin + 4, patientY + 13);
+      doc.text(`Login sessions ${model.patient.loginSessions.toLocaleString('en-ZA')}`, margin + 62, patientY + 13);
+      doc.text(`Download ${model.patient.downloadGb.toFixed(2)} GB`, margin + 124, patientY + 13);
+      doc.setFontSize(6.2);
+      doc.setTextColor(COLORS.muted);
+      doc.text('TDX anonymised analytics; numbers may be revised by TDX.', margin + 4, patientY + 21);
+    } else {
+      doc.setTextColor(COLORS.gray);
+      doc.text('Awaiting TDX export', margin + 4, patientY + 14);
+    }
+  }
+
+  // 7. Footer do-not-sum
+  doc.setDrawColor(COLORS.border);
+  doc.line(margin, pageHeight - 17, pageWidth - margin, pageHeight - 17);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(6.5);
+  doc.setTextColor(COLORS.muted);
+  doc.text(
+    `CircleTel · ${model.site.corporateCode} · Do not sum Patient + Staff + BNG · Page 1 of 1`,
+    pageWidth / 2,
+    pageHeight - 11,
+    { align: 'center' },
+  );
+
+  return outputBuffer(doc);
+}
+
+export function generateSkipSlipPdf(input: SkipSlipInput): ArrayBuffer {
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const margin = 20;
+
+  addLogo(doc, margin, 18, 26);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(19);
+  doc.setTextColor(COLORS.dark);
+  doc.text('SITE USAGE REPORT — NOT GENERATED', pageWidth - margin, 28, { align: 'right' });
+  doc.setDrawColor(COLORS.orange);
+  doc.setLineWidth(0.8);
+  doc.line(margin, 51, pageWidth - margin, 51);
+
+  doc.setFontSize(8);
+  doc.setTextColor(COLORS.gray);
+  doc.text('SITE', margin, 68);
+  doc.text('PERIOD', margin, 86);
+  doc.text('REASON', margin, 104);
+  doc.setFontSize(12);
+  doc.setTextColor(COLORS.dark);
+  doc.text(input.siteLabel, margin, 75);
+  doc.text(input.periodLabel, margin, 93);
+  doc.setFontSize(10);
+  doc.text(doc.splitTextToSize(input.reason, pageWidth - margin * 2), margin, 112);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(COLORS.gray);
+  doc.text(`Generated ${formatGeneratedAt(input.generatedAtIso)} SAST`, margin, 140);
+
+  return outputBuffer(doc);
+}

--- a/lib/usage-reports/periods.ts
+++ b/lib/usage-reports/periods.ts
@@ -1,0 +1,190 @@
+import { addDays, differenceInDays, format, subDays } from 'date-fns';
+import { displayDateRange, SAST_TIMEZONE, toSAST } from '@/lib/dates';
+import type { ReportPeriod, ReportPeriodPreset } from './types';
+
+export type { ReportPeriodPreset };
+
+const MAX_CUSTOM_DAYS = 90;
+const SAST_OFFSET = '+02:00';
+
+type SastDateParts = { year: number; month: number; day: number };
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function sastStartIso({ year, month, day }: SastDateParts): string {
+  return `${year}-${pad2(month)}-${pad2(day)}T00:00:00.000${SAST_OFFSET}`;
+}
+
+function sastEndIso({ year, month, day }: SastDateParts): string {
+  return `${year}-${pad2(month)}-${pad2(day)}T23:59:59.999${SAST_OFFSET}`;
+}
+
+function sastCalendarAnchor({ year, month, day }: SastDateParts): Date {
+  return new Date(`${year}-${pad2(month)}-${pad2(day)}T12:00:00${SAST_OFFSET}`);
+}
+
+function getSastDateParts(now: Date): SastDateParts & { dayOfWeek: number } {
+  const sast = toSAST(now);
+  if (!sast) {
+    throw new Error('Invalid reference date');
+  }
+
+  return {
+    year: sast.getUTCFullYear(),
+    month: sast.getUTCMonth() + 1,
+    day: sast.getUTCDate(),
+    dayOfWeek: sast.getUTCDay(),
+  };
+}
+
+function toSastPartsFromAnchor(anchor: Date): SastDateParts {
+  const sast = toSAST(anchor);
+  if (!sast) {
+    throw new Error('Invalid SAST date');
+  }
+
+  return {
+    year: sast.getUTCFullYear(),
+    month: sast.getUTCMonth() + 1,
+    day: sast.getUTCDate(),
+  };
+}
+
+function addSastDays(date: SastDateParts, days: number): SastDateParts {
+  return toSastPartsFromAnchor(addDays(sastCalendarAnchor(date), days));
+}
+
+function parseSastDateString(date: string): SastDateParts {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    throw new Error(`Invalid SAST date: ${date}`);
+  }
+
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+}
+
+function inclusiveDayCount(start: SastDateParts, end: SastDateParts): number {
+  return differenceInDays(sastCalendarAnchor(end), sastCalendarAnchor(start)) + 1;
+}
+
+function buildReportPeriod(
+  preset: ReportPeriodPreset,
+  start: SastDateParts,
+  end: SastDateParts,
+  label: string
+): ReportPeriod {
+  const startIso = sastStartIso(start);
+  const endIso = sastEndIso(end);
+  const dayCount = inclusiveDayCount(start, end);
+
+  return {
+    preset,
+    timezone: SAST_TIMEZONE,
+    startIso,
+    endIso,
+    startUtc: new Date(startIso),
+    endUtc: new Date(endIso),
+    label,
+    rangeLabel: displayDateRange(new Date(startIso), new Date(endIso)),
+    inclusiveDayCount: dayCount,
+    isShortPeriod: dayCount <= 7,
+  };
+}
+
+function resolveWeekly(now: Date): ReportPeriod {
+  const { dayOfWeek, ...today } = getSastDateParts(now);
+  const daysSinceMonday = (dayOfWeek + 6) % 7;
+  const thisMonday = addSastDays(today, -daysSinceMonday);
+  const lastSunday = addSastDays(thisMonday, -1);
+  const lastMonday = addSastDays(lastSunday, -6);
+
+  return buildReportPeriod(
+    'weekly',
+    lastMonday,
+    lastSunday,
+    `Last complete week (${format(sastCalendarAnchor(lastMonday), 'd MMM')} – ${format(
+      sastCalendarAnchor(lastSunday),
+      'd MMM yyyy'
+    )})`
+  );
+}
+
+function resolveMonthly(now: Date): ReportPeriod {
+  const { year, month } = getSastDateParts(now);
+  const firstOfThisMonth = sastCalendarAnchor({ year, month, day: 1 });
+  const lastDayPrevMonth = subDays(firstOfThisMonth, 1);
+  const sastEnd = toSAST(lastDayPrevMonth);
+  if (!sastEnd) {
+    throw new Error('Invalid monthly period end');
+  }
+
+  const end: SastDateParts = {
+    year: sastEnd.getUTCFullYear(),
+    month: sastEnd.getUTCMonth() + 1,
+    day: sastEnd.getUTCDate(),
+  };
+  const start: SastDateParts = { year: end.year, month: end.month, day: 1 };
+
+  return buildReportPeriod(
+    'monthly',
+    start,
+    end,
+    format(sastCalendarAnchor(start), 'MMMM yyyy')
+  );
+}
+
+function resolveSixtyDay(now: Date): ReportPeriod {
+  const today = getSastDateParts(now);
+  const end = addSastDays(today, -1);
+  const start = addSastDays(end, -59);
+
+  return buildReportPeriod('sixty_day', start, end, 'Last 60 days');
+}
+
+function resolveCustom(
+  custom: { startDate: string; endDate: string }
+): ReportPeriod {
+  const start = parseSastDateString(custom.startDate);
+  const end = parseSastDateString(custom.endDate);
+  const dayCount = inclusiveDayCount(start, end);
+
+  if (dayCount > MAX_CUSTOM_DAYS) {
+    throw new Error(`Custom period cannot exceed ${MAX_CUSTOM_DAYS} days`);
+  }
+
+  if (dayCount < 1) {
+    throw new Error('Custom period end date must be on or after start date');
+  }
+
+  return buildReportPeriod('custom', start, end, 'Custom period');
+}
+
+export function resolveReportPeriod(
+  preset: ReportPeriodPreset,
+  now: Date = new Date(),
+  custom?: { startDate: string; endDate: string }
+): ReportPeriod {
+  switch (preset) {
+    case 'weekly':
+      return resolveWeekly(now);
+    case 'monthly':
+      return resolveMonthly(now);
+    case 'sixty_day':
+      return resolveSixtyDay(now);
+    case 'custom':
+      if (!custom) {
+        throw new Error('Custom period requires startDate and endDate');
+      }
+      return resolveCustom(custom);
+    default: {
+      const _exhaustive: never = preset;
+      throw new Error(`Unknown preset: ${_exhaustive}`);
+    }
+  }
+}

--- a/lib/usage-reports/staff-wifi.ts
+++ b/lib/usage-reports/staff-wifi.ts
@@ -1,0 +1,44 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { RUIJIE_SSID_ROLLUP_ALLOWLIST } from '@/lib/ruijie/types';
+import type { StaffWifiState } from './types';
+
+export const STAFF_SSID = 'Unjani Clinic Staff'; // must stay in allowlist
+
+export function resolveStaffWifi(input: {
+  apLinkedToSite: boolean;
+  hourRows: Array<{ rx_bytes: number; tx_bytes: number }>;
+}): StaffWifiState {
+  if (!input.apLinkedToSite) return { kind: 'ap_unlinked' };
+  if (input.hourRows.length === 0) return { kind: 'no_samples' };
+  const rxBytes = input.hourRows.reduce((a, r) => a + Number(r.rx_bytes || 0), 0);
+  const txBytes = input.hourRows.reduce((a, r) => a + Number(r.tx_bytes || 0), 0);
+  return { kind: 'available', rxBytes, txBytes, totalBytes: rxBytes + txBytes };
+}
+
+export async function loadStaffHourRows(
+  supabase: SupabaseClient,
+  siteId: string,
+  startUtc: Date,
+  endUtc: Date
+) {
+  if (!RUIJIE_SSID_ROLLUP_ALLOWLIST.includes(STAFF_SSID)) {
+    throw new Error('Staff SSID not allow-listed');
+  }
+  const { data, error } = await supabase
+    .from('ruijie_ssid_traffic_rollups')
+    .select('rx_bytes, tx_bytes, hour_bucket')
+    .eq('corporate_site_id', siteId)
+    .eq('ssid', STAFF_SSID)
+    .gte('hour_bucket', startUtc.toISOString())
+    .lte('hour_bucket', endUtc.toISOString());
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function siteHasLinkedAp(supabase: SupabaseClient, siteId: string) {
+  const { count } = await supabase
+    .from('network_devices')
+    .select('id', { count: 'exact', head: true })
+    .eq('corporate_site_id', siteId);
+  return (count ?? 0) > 0;
+}

--- a/lib/usage-reports/storage.ts
+++ b/lib/usage-reports/storage.ts
@@ -1,0 +1,54 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const BUCKET = 'site-usage-reports';
+
+function storageError(action: string, error: { message: string }): Error {
+  return new Error(`Failed to ${action} report artifact: ${error.message}`);
+}
+
+export async function uploadReportArtifact(
+  supabase: SupabaseClient,
+  path: string,
+  bytes: Buffer,
+  contentType: string
+): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from(BUCKET)
+    .upload(path, bytes, {
+      contentType,
+      upsert: false,
+    });
+
+  if (error) {
+    throw storageError('upload', error);
+  }
+
+  return data.path;
+}
+
+export async function signedReportUrl(
+  supabase: SupabaseClient,
+  path: string,
+  expiresSec = 3600
+): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrl(path, expiresSec);
+
+  if (error) {
+    throw storageError('sign', error);
+  }
+
+  return data.signedUrl;
+}
+
+export async function deleteReportArtifact(
+  supabase: SupabaseClient,
+  path: string
+): Promise<void> {
+  const { error } = await supabase.storage.from(BUCKET).remove([path]);
+
+  if (error) {
+    throw storageError('delete', error);
+  }
+}

--- a/lib/usage-reports/types.ts
+++ b/lib/usage-reports/types.ts
@@ -1,0 +1,74 @@
+export type ReportPeriodPreset = 'weekly' | 'monthly' | 'sixty_day' | 'custom';
+
+export type CoreTrafficSource =
+  | 'ruijie_hourly'
+  | 'interstellio_daily'
+  | 'unavailable';
+
+export interface ReportPeriod {
+  preset: ReportPeriodPreset;
+  timezone: 'Africa/Johannesburg';
+  startIso: string; // offset-aware SAST
+  endIso: string;
+  startUtc: Date;
+  endUtc: Date;
+  label: string;
+  rangeLabel: string;
+  inclusiveDayCount: number;
+  /** true when inclusiveDayCount <= 7 — Ruijie-eligible primary */
+  isShortPeriod: boolean;
+}
+
+export type StaffWifiState =
+  | { kind: 'available'; totalBytes: number; rxBytes: number; txBytes: number }
+  | { kind: 'no_samples' }
+  | { kind: 'ap_unlinked' };
+
+export type PatientWifiState =
+  | {
+      kind: 'available';
+      uniqueUsers: number;
+      loginSessions: number;
+      downloadGb: number;
+    }
+  | { kind: 'awaiting_export' };
+
+export interface SiteUsageReportModel {
+  generatedAtIso: string;
+  site: {
+    id: string;
+    name: string;
+    accountNumber: string;
+    corporateCode: string;
+    accountName: string;
+  };
+  period: ReportPeriod;
+  core: {
+    source: CoreTrafficSource;
+    sourceLabel: string;
+    downloadBytes: number;
+    uploadBytes: number;
+    avgDownKbps: number | null;
+    peakBucketBytes: number | null;
+    dailyDownloadBytes: number[]; // length = inclusiveDayCount
+    note: string;
+    secondaryInterstellio?: {
+      downloadBytes: number;
+      uploadBytes: number;
+    };
+  };
+  device: {
+    name: string;
+    model: string;
+    serial: string;
+    group: string;
+    status: string;
+  } | null;
+  unjani: boolean;
+  staff: StaffWifiState;
+  patient: PatientWifiState;
+}
+
+export type AssembleSkipReason =
+  | 'core_unavailable'
+  | 'site_not_eligible';

--- a/scripts/smoke-sweetwaters-usage-report.ts
+++ b/scripts/smoke-sweetwaters-usage-report.ts
@@ -1,0 +1,76 @@
+/**
+ * One-off smoke: assemble + PDF for Unjani Sweetwaters (CT-UNJ-020).
+ * Usage:
+ *   set -a && source /home/circletel/.env.local && set +a && \
+ *     npx tsx scripts/smoke-sweetwaters-usage-report.ts
+ */
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { assembleSiteUsageReport } from '@/lib/usage-reports/assemble-report';
+import { generateSiteUsageReportPdf, generateSkipSlipPdf } from '@/lib/usage-reports/pdf-generator';
+import { resolveReportPeriod } from '@/lib/usage-reports/periods';
+import { bytesToGb } from '@/lib/usage-reports/bytes';
+
+const SWEETWATERS_ID = '2bcbdccf-f709-49bc-9078-e8a12d4046b3';
+
+async function smoke(preset: 'weekly' | 'monthly') {
+  const period = resolveReportPeriod(preset);
+  console.log(`\n=== Sweetwaters ${preset} ===`);
+  console.log(`Period: ${period.rangeLabel} (${period.inclusiveDayCount}d, short=${period.isShortPeriod})`);
+
+  const result = await assembleSiteUsageReport({
+    siteId: SWEETWATERS_ID,
+    period,
+    patientRow: null,
+  });
+
+  if (!result.ok) {
+    console.log(`SKIP: ${result.reason} — ${result.siteLabel}`);
+    const slip = generateSkipSlipPdf({
+      siteLabel: result.siteLabel,
+      periodLabel: `${period.label} · ${period.rangeLabel}`,
+      reason:
+        result.reason === 'core_unavailable'
+          ? 'No usable Ruijie or Interstellio source for this period'
+          : `Site not eligible (${result.reason})`,
+      generatedAtIso: new Date().toISOString(),
+    });
+    const out = resolve(`/tmp/sweetwaters-usage-${preset}-skip.pdf`);
+    writeFileSync(out, Buffer.from(slip));
+    console.log(`Wrote skip slip: ${out} (${slip.byteLength} bytes)`);
+    return { ok: false as const, reason: result.reason, out };
+  }
+
+  const m = result.model;
+  console.log(`Site: ${m.site.name} (${m.site.accountNumber})`);
+  console.log(`Core source: ${m.core.sourceLabel}`);
+  console.log(
+    `Core DL/UL: ${bytesToGb(m.core.downloadBytes)} / ${bytesToGb(m.core.uploadBytes)} GB`
+  );
+  console.log(`Device: ${m.device ? `${m.device.name} · ${m.device.serial}` : 'none'}`);
+  console.log(`Staff: ${m.staff.kind}${m.staff.kind === 'available' ? ` ${bytesToGb(m.staff.totalBytes)} GB` : ''}`);
+  console.log(`Patient: ${m.patient.kind}`);
+
+  const pdf = generateSiteUsageReportPdf(m);
+  const out = resolve(`/tmp/sweetwaters-usage-${preset}.pdf`);
+  writeFileSync(out, Buffer.from(pdf));
+  console.log(`Wrote PDF: ${out} (${pdf.byteLength} bytes, magic=${Buffer.from(pdf).subarray(0, 4).toString()})`);
+  return { ok: true as const, out, source: m.core.source, staff: m.staff.kind };
+}
+
+async function main() {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+  const weekly = await smoke('weekly');
+  const monthly = await smoke('monthly');
+  console.log('\n=== Summary ===');
+  console.log(JSON.stringify({ weekly, monthly }, null, 2));
+  if (!weekly.ok && !monthly.ok) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260801180000_site_usage_report_jobs.sql
+++ b/supabase/migrations/20260801180000_site_usage_report_jobs.sql
@@ -1,0 +1,40 @@
+-- Site usage report generation jobs and long-lived audit metadata.
+CREATE TABLE IF NOT EXISTS public.site_usage_report_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_by uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  status text NOT NULL CHECK (status IN ('queued', 'running', 'succeeded', 'failed')),
+  period_preset text NOT NULL,
+  period_start timestamptz NOT NULL,
+  period_end timestamptz NOT NULL,
+  site_ids uuid[] NOT NULL,
+  include_provisioned boolean NOT NULL DEFAULT false,
+  unjani_only boolean NOT NULL DEFAULT false,
+  include_csv boolean NOT NULL DEFAULT false,
+  patient_csv_path text,
+  primary_sources jsonb NOT NULL DEFAULT '{}'::jsonb,
+  outcome jsonb,
+  error_message text,
+  storage_path text,
+  content_type text,
+  byte_size bigint,
+  expires_at timestamptz DEFAULT (now() + interval '14 days'),
+  inngest_run_id text
+);
+
+CREATE INDEX IF NOT EXISTS idx_site_usage_report_jobs_created
+  ON public.site_usage_report_jobs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_site_usage_report_jobs_expires
+  ON public.site_usage_report_jobs (expires_at)
+  WHERE expires_at IS NOT NULL AND storage_path IS NOT NULL;
+
+ALTER TABLE public.site_usage_report_jobs ENABLE ROW LEVEL SECURITY;
+-- Service-role only: intentionally no anon or authenticated policies.
+
+-- Private artifact bucket. Service-role operations bypass storage object RLS;
+-- intentionally no anon or authenticated storage policies are created.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('site-usage-reports', 'site-usage-reports', false)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- Admin **Site Network Usage Reports** at `/admin/network/usage-reports` (nav + corporate site shortcut).
- Domain assemblers: SAST periods, active-site inclusion, period-gated Ruijie/Interstellio core (#669), Staff from `ruijie_ssid_traffic_rollups` (#682), Patient TDX CSV (#671).
- Layout A PDF + skip slips + optional CSV; sync generate (≤5 sites) / async Inngest ZIP (>5); audit jobs + 14-day storage purge.
- Implements plan `docs/superpowers/plans/2026-08-01-site-network-usage-reports.md` against locked `SPEC_OUTLINE.md`.

## Test plan
- [x] Jest usage-report suite (49 tests) on branch
- [x] Pre-push scoped type-check on changed TS files
- [ ] Apply migration `supabase/migrations/20260801180000_site_usage_report_jobs.sql` (+ private bucket `site-usage-reports`) to Supabase `agyjovdugmtopasyvlng`
- [ ] Authenticated smoke: Unjani monthly 1-site PDF; Staff/Patient states; 6+ site async ZIP
- [ ] Confirm Inngest registers `site-usage-report-zip` + `site-usage-report-purge`

## Residual
- Migration not applied in this PR workflow — required before generate works in prod/staging.
- No authenticated live Unjani smoke in CI.


Made with [Cursor](https://cursor.com)