### PR TITLE
feat(usage-reports): read-only preview endpoint with coverage and diagnosis (#690)

### DIFF
--- a/__tests__/lib/usage-reports/assemble-diagnosis.test.ts
+++ b/__tests__/lib/usage-reports/assemble-diagnosis.test.ts
@@ -1,0 +1,122 @@
+import {
+  assembleSiteUsageReport,
+  type AssembleReportDeps,
+} from '@/lib/usage-reports/assemble-report';
+import type {
+  CoreUnavailableDiagnosis,
+  ReportPeriod,
+  SiteUsageReportModel,
+} from '@/lib/usage-reports/types';
+
+const period: ReportPeriod = {
+  preset: 'monthly',
+  timezone: 'Africa/Johannesburg',
+  startIso: '2026-07-01T00:00:00+02:00',
+  endIso: '2026-07-31T23:59:59+02:00',
+  startUtc: new Date('2026-06-30T22:00:00Z'),
+  endUtc: new Date('2026-07-31T21:59:59Z'),
+  label: 'Previous month',
+  rangeLabel: '1 – 31 July 2026',
+  inclusiveDayCount: 31,
+  isShortPeriod: false,
+};
+
+const site = {
+  id: 'site-1',
+  name: 'Unjani Clinic Soshanguve',
+  account_number: 'CT-UNJ-022',
+  status: 'active',
+  service_id: null,
+  service_status: null,
+  corporate_code: 'UNJ',
+  account_name: 'Unjani Clinics NPC',
+};
+
+function unavailableCore(
+  diagnosis: CoreUnavailableDiagnosis
+): SiteUsageReportModel['core'] {
+  return {
+    source: 'unavailable',
+    sourceLabel: 'No permitted source',
+    downloadBytes: 0,
+    uploadBytes: 0,
+    avgDownKbps: null,
+    peakBucketBytes: null,
+    dailyDownloadBytes: Array.from({ length: 31 }, () => 0),
+    dailyCovered: Array.from({ length: 31 }, () => false),
+    note: 'No permitted core traffic source is available for this period.',
+    unavailable: diagnosis,
+  };
+}
+
+function deps(core: SiteUsageReportModel['core']): AssembleReportDeps {
+  return {
+    loadSite: async () => site,
+    loadCore: async () => core,
+    loadStaff: async () => ({ kind: 'ap_unlinked' }),
+    loadDevice: async () => null,
+    generatedAtIso: () => '2026-08-01T12:00:00+02:00',
+  };
+}
+
+describe('assembleSiteUsageReport — unavailability diagnosis', () => {
+  it('carries every applicable cause on the failure result', async () => {
+    const diagnosis: CoreUnavailableDiagnosis = {
+      interstellioMapped: false,
+      ruijieLinked: false,
+      ruijieCoversWindow: false,
+    };
+
+    const result = await assembleSiteUsageReport({
+      siteId: 'site-1',
+      period,
+      patientRow: null,
+      deps: deps(unavailableCore(diagnosis)),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected an unavailable result');
+    expect(result.reason).toBe('core_unavailable');
+    expect(result.siteLabel).toBe('Unjani Clinic Soshanguve');
+    // Both causes are true at once — the panel must be able to list both.
+    expect(result.diagnosis).toEqual(diagnosis);
+  });
+
+  it('distinguishes a retention gap from a missing link', async () => {
+    const diagnosis: CoreUnavailableDiagnosis = {
+      interstellioMapped: false,
+      ruijieLinked: true,
+      ruijieCoversWindow: false,
+    };
+
+    const result = await assembleSiteUsageReport({
+      siteId: 'site-1',
+      period,
+      patientRow: null,
+      deps: deps(unavailableCore(diagnosis)),
+    });
+
+    if (result.ok) throw new Error('expected an unavailable result');
+    // Linked but uncovered — the copy explains retention rather than telling
+    // the admin to link a device that is already linked.
+    expect(result.diagnosis?.ruijieLinked).toBe(true);
+    expect(result.diagnosis?.ruijieCoversWindow).toBe(false);
+  });
+
+  it('leaves diagnosis absent when the site itself is not eligible', async () => {
+    const result = await assembleSiteUsageReport({
+      siteId: 'site-1',
+      period,
+      patientRow: null,
+      deps: { ...deps(unavailableCore({
+        interstellioMapped: false,
+        ruijieLinked: false,
+        ruijieCoversWindow: false,
+      })), loadSite: async () => null },
+    });
+
+    if (result.ok) throw new Error('expected an unavailable result');
+    expect(result.reason).toBe('site_not_eligible');
+    expect(result.diagnosis).toBeUndefined();
+  });
+});

--- a/__tests__/lib/usage-reports/core-traffic.test.ts
+++ b/__tests__/lib/usage-reports/core-traffic.test.ts
@@ -142,6 +142,7 @@ describe('aggregateRuijieHourly', () => {
       avgDownKbps: 6_000,
       peakBucketBytes: 1_000_000_000,
       dailyDownloadBytes: [1_000_000_000, 500_000_000],
+      dailyCovered: [true, true],
     });
   });
 
@@ -162,6 +163,47 @@ describe('aggregateRuijieHourly', () => {
 
     expect(result.downloadBytes).toBe(25);
     expect(result.dailyDownloadBytes).toEqual([0, 0, 25]);
+    // Days 1-2 read zero because nothing was sampled, not because traffic was
+    // zero — callers must be able to tell those apart (#689).
+    expect(result.dailyCovered).toEqual([false, false, true]);
+  });
+
+  it('counts a zero-byte sample as covered — a quiet day is not a gap', () => {
+    const result = aggregateRuijieHourly(
+      [
+        {
+          captured_at: '2026-07-02T08:00:00+02:00',
+          total_rx_bytes: 0,
+          total_tx_bytes: 0,
+          avg_rx_bps: 0,
+          peak_rx_bps: 0,
+        },
+      ],
+      3,
+      new Date('2026-07-01T00:00:00+02:00')
+    );
+
+    expect(result.dailyDownloadBytes[1]).toBe(0);
+    expect(result.dailyCovered).toEqual([false, true, false]);
+  });
+
+  it('returns a coverage entry for every day in the window', () => {
+    const result = aggregateRuijieHourly(
+      [
+        {
+          captured_at: '2026-07-01T08:00:00+02:00',
+          total_rx_bytes: 5,
+          total_tx_bytes: 1,
+          avg_rx_bps: 10,
+          peak_rx_bps: 20,
+        },
+      ],
+      31,
+      new Date('2026-07-01T00:00:00+02:00')
+    );
+
+    expect(result.dailyCovered).toHaveLength(31);
+    expect(result.dailyCovered.filter(Boolean)).toHaveLength(1);
   });
 
   it('returns null rate and peak metrics for no rows', () => {
@@ -173,6 +215,7 @@ describe('aggregateRuijieHourly', () => {
       avgDownKbps: null,
       peakBucketBytes: null,
       dailyDownloadBytes: [0],
+      dailyCovered: [false],
     });
   });
 });
@@ -206,6 +249,7 @@ describe('aggregateInterstellioDaily', () => {
       avgDownKbps: 600,
       peakBucketBytes: 2_048_000,
       dailyDownloadBytes: [0, 2_048_000, 1_024_000],
+      dailyCovered: [false, true, true],
     });
   });
 });

--- a/app/api/admin/network/usage-reports/preview/route.ts
+++ b/app/api/admin/network/usage-reports/preview/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { createClient } from '@/lib/supabase/server';
+import { assembleSiteUsageReport } from '@/lib/usage-reports/assemble-report';
+import { fetchInclusionSiteRows } from '@/lib/usage-reports/inclusion';
+import {
+  isTdxPatientRow,
+  patientRowForSite,
+  type TdxPatientRow,
+} from '@/lib/usage-reports/patient-wifi';
+import { resolveReportPeriod } from '@/lib/usage-reports/periods';
+import type { ReportPeriodPreset } from '@/lib/usage-reports/types';
+
+/**
+ * Read-only preview of a single site's usage report.
+ *
+ * Returns the same `SiteUsageReportModel` the PDF renders from, so the dashboard
+ * and the downloaded document can never disagree on figures. Writes nothing —
+ * no `site_usage_report_jobs` row and no stored artifact, because nothing has
+ * left the building yet (map #687 decision 4; audit intent from #668).
+ *
+ * POST rather than GET: uploaded TDX patient rows are a body, not a query
+ * string, and the same shape must serve a 26-row Unjani upload.
+ */
+
+interface PreviewRequest {
+  siteId?: unknown;
+  period?: unknown;
+  custom?: { startDate?: unknown; endDate?: unknown };
+  patientRows?: unknown;
+}
+
+const PERIOD_PRESETS = new Set<ReportPeriodPreset>([
+  'weekly',
+  'monthly',
+  'sixty_day',
+  'custom',
+]);
+
+class RequestValidationError extends Error {}
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) return authResult.response;
+
+  try {
+    const body = (await request.json()) as PreviewRequest;
+
+    if (typeof body.siteId !== 'string' || body.siteId.trim() === '') {
+      return NextResponse.json({ error: 'siteId is required' }, { status: 400 });
+    }
+    if (
+      typeof body.period !== 'string' ||
+      !PERIOD_PRESETS.has(body.period as ReportPeriodPreset)
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid report period preset' },
+        { status: 400 }
+      );
+    }
+
+    const patientRows: TdxPatientRow[] = Array.isArray(body.patientRows)
+      ? body.patientRows.filter(isTdxPatientRow)
+      : [];
+    if (
+      Array.isArray(body.patientRows) &&
+      patientRows.length !== body.patientRows.length
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid patientRows payload' },
+        { status: 400 }
+      );
+    }
+
+    const custom =
+      typeof body.custom?.startDate === 'string' &&
+      typeof body.custom?.endDate === 'string'
+        ? { startDate: body.custom.startDate, endDate: body.custom.endDate }
+        : undefined;
+
+    let period: ReturnType<typeof resolveReportPeriod>;
+    try {
+      period = resolveReportPeriod(
+        body.period as ReportPeriodPreset,
+        new Date(),
+        custom
+      );
+    } catch (error) {
+      throw new RequestValidationError(
+        error instanceof Error ? error.message : 'Invalid report period'
+      );
+    }
+
+    const siteId = body.siteId;
+    const supabase = await createClient();
+    const siteRow = (await fetchInclusionSiteRows(supabase)).find(
+      (row) => row.id === siteId
+    );
+
+    const result = await assembleSiteUsageReport({
+      siteId,
+      period,
+      patientRow: siteRow
+        ? patientRowForSite(patientRows, siteRow.account_number)
+        : null,
+    });
+
+    if (!result.ok) {
+      // A site with no permitted source is a legitimate answer, not a failure:
+      // 200 with the diagnosis so the dashboard can name each cause and its
+      // unlock step (#689) instead of rendering an error.
+      return NextResponse.json(
+        {
+          ok: false,
+          reason: result.reason,
+          siteId: result.siteId,
+          siteLabel: result.siteLabel,
+          diagnosis: result.diagnosis ?? null,
+          period: {
+            preset: period.preset,
+            label: period.label,
+            rangeLabel: period.rangeLabel,
+          },
+        },
+        { headers: { 'Cache-Control': 'private, no-store' } }
+      );
+    }
+
+    return NextResponse.json(
+      { ok: true, model: result.model },
+      { headers: { 'Cache-Control': 'private, no-store' } }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[UsageReportsPreview] Preview failed:', error);
+    const status =
+      error instanceof RequestValidationError || error instanceof SyntaxError
+        ? 400
+        : 500;
+    return NextResponse.json(
+      { error: status === 400 ? message : 'Failed to build report preview' },
+      { status }
+    );
+  }
+}

--- a/lib/usage-reports/artifacts.ts
+++ b/lib/usage-reports/artifacts.ts
@@ -6,7 +6,7 @@ import {
   type AssembleSiteUsageReportInput,
 } from './assemble-report';
 import { reportModelToCsv } from './csv';
-import type { TdxPatientRow } from './patient-wifi';
+import { patientRowForSite, type TdxPatientRow } from './patient-wifi';
 import {
   generateSiteUsageReportPdf,
   generateSkipSlipPdf,
@@ -62,16 +62,6 @@ function safeFilenamePart(value: string): string {
 
 function periodFilenamePart(period: ReportPeriod): string {
   return `${period.startIso.slice(0, 10)}_to_${period.endIso.slice(0, 10)}`;
-}
-
-function patientRowForSite(
-  rows: TdxPatientRow[],
-  accountNumber: string
-): TdxPatientRow | null {
-  const normalizedAccount = accountNumber.trim().toLowerCase();
-  return (
-    rows.find((row) => row.siteCode.trim().toLowerCase() === normalizedAccount) ?? null
-  );
 }
 
 function skipReason(reason: AssembleSkipReason): string {

--- a/lib/usage-reports/assemble-report.ts
+++ b/lib/usage-reports/assemble-report.ts
@@ -11,6 +11,7 @@ import { resolvePatientWifi, type TdxPatientRow } from './patient-wifi';
 import { loadStaffHourRows, resolveStaffWifi, siteHasLinkedAp } from './staff-wifi';
 import type {
   AssembleSkipReason,
+  CoreUnavailableDiagnosis,
   ReportPeriod,
   SiteUsageReportModel,
   StaffWifiState,
@@ -26,6 +27,11 @@ export type AssembleResult =
       reason: AssembleSkipReason;
       siteId: string;
       siteLabel: string;
+      /**
+       * Present only for `core_unavailable` — which of the source links are
+       * missing, so the caller can name each cause and its unlock step (#689).
+       */
+      diagnosis?: CoreUnavailableDiagnosis;
     };
 
 export interface AssembleReportDeps {
@@ -142,6 +148,7 @@ export async function assembleSiteUsageReport({
       reason: 'core_unavailable',
       siteId,
       siteLabel: site.name,
+      diagnosis: core.unavailable,
     };
   }
 

--- a/lib/usage-reports/core-traffic.ts
+++ b/lib/usage-reports/core-traffic.ts
@@ -24,6 +24,8 @@ export interface CoreTrafficAggregate {
   avgDownKbps: number | null;
   peakBucketBytes: number | null;
   dailyDownloadBytes: number[];
+  /** Per-day sample presence — see `SiteUsageReportModel['core'].dailyCovered`. */
+  dailyCovered: boolean[];
 }
 
 export interface RuijieHourlyLoad {
@@ -83,13 +85,19 @@ function sastDayKey(value: Date | string): string | null {
 function buildSastDayIndex(
   dayCount: number,
   start: Date
-): { dailyDownloadBytes: number[]; indexByDay: Map<string, number> } {
+): {
+  dailyDownloadBytes: number[];
+  dailyCovered: boolean[];
+  indexByDay: Map<string, number>;
+} {
   const startKey = sastDayKey(start);
   const normalizedDayCount = Math.max(0, Math.trunc(dayCount));
   const dailyDownloadBytes = Array.from({ length: normalizedDayCount }, () => 0);
+  // Starts all-false: a day is covered only once a sample lands on it.
+  const dailyCovered = Array.from({ length: normalizedDayCount }, () => false);
   const indexByDay = new Map<string, number>();
 
-  if (!startKey) return { dailyDownloadBytes, indexByDay };
+  if (!startKey) return { dailyDownloadBytes, dailyCovered, indexByDay };
 
   const startDayUtc = new Date(`${startKey}T00:00:00.000Z`);
   for (let index = 0; index < normalizedDayCount; index += 1) {
@@ -99,7 +107,7 @@ function buildSastDayIndex(
     indexByDay.set(key, index);
   }
 
-  return { dailyDownloadBytes, indexByDay };
+  return { dailyDownloadBytes, dailyCovered, indexByDay };
 }
 
 export function aggregateRuijieHourly(
@@ -107,7 +115,10 @@ export function aggregateRuijieHourly(
   dayCount: number,
   start: Date
 ): CoreTrafficAggregate {
-  const { dailyDownloadBytes, indexByDay } = buildSastDayIndex(dayCount, start);
+  const { dailyDownloadBytes, dailyCovered, indexByDay } = buildSastDayIndex(
+    dayCount,
+    start
+  );
   let downloadBytes = 0;
   let uploadBytes = 0;
   let averageBpsTotal = 0;
@@ -127,7 +138,12 @@ export function aggregateRuijieHourly(
     }
 
     const index = indexByDay.get(sastDayKey(row.captured_at) ?? '');
-    if (index !== undefined) dailyDownloadBytes[index] += rowDownloadBytes;
+    if (index !== undefined) {
+      dailyDownloadBytes[index] += rowDownloadBytes;
+      // A row is a sample even when it reports 0 bytes — that is a quiet hour,
+      // not a missing one.
+      dailyCovered[index] = true;
+    }
   }
 
   return {
@@ -139,6 +155,7 @@ export function aggregateRuijieHourly(
         : null,
     peakBucketBytes,
     dailyDownloadBytes,
+    dailyCovered,
   };
 }
 
@@ -147,7 +164,10 @@ export function aggregateInterstellioDaily(
   dayCount: number,
   start: Date
 ): CoreTrafficAggregate {
-  const { dailyDownloadBytes, indexByDay } = buildSastDayIndex(dayCount, start);
+  const { dailyDownloadBytes, dailyCovered, indexByDay } = buildSastDayIndex(
+    dayCount,
+    start
+  );
   let downloadBytes = 0;
   let uploadBytes = 0;
   let averageKbpsTotal = 0;
@@ -176,6 +196,8 @@ export function aggregateInterstellioDaily(
 
   for (const [index, bytes] of downloadBytesByDay) {
     dailyDownloadBytes[index] = bytes;
+    // Presence of an entry is the coverage signal, whatever it reports.
+    dailyCovered[index] = true;
   }
 
   return {
@@ -190,6 +212,7 @@ export function aggregateInterstellioDaily(
           ? 0
           : null,
     dailyDownloadBytes,
+    dailyCovered,
   };
 }
 
@@ -290,11 +313,15 @@ export async function assembleCoreTraffic(
     ? await loadRuijieHourlyRows(supabase, siteId, period.startUtc, period.endUtc)
     : ({ groupId: null, rows: [] } satisfies RuijieHourlyLoad);
 
-  const source = selectCorePrimarySource({
-    isShortPeriod: period.isShortPeriod,
+  const diagnosis = {
+    interstellioMapped: subscriberId !== null,
     ruijieLinked: ruijie.groupId !== null,
     ruijieCoversWindow: ruijie.rows.length > 0,
-    interstellioMapped: subscriberId !== null,
+  };
+
+  const source = selectCorePrimarySource({
+    isShortPeriod: period.isShortPeriod,
+    ...diagnosis,
   });
 
   if (source === 'unavailable') {
@@ -309,7 +336,10 @@ export async function assembleCoreTraffic(
         { length: period.inclusiveDayCount },
         () => 0
       ),
+      dailyCovered: Array.from({ length: period.inclusiveDayCount }, () => false),
       note: 'No permitted core traffic source is available for this period.',
+      // Kept rather than discarded so callers can name each applicable cause.
+      unavailable: diagnosis,
     };
   }
 

--- a/lib/usage-reports/patient-wifi.ts
+++ b/lib/usage-reports/patient-wifi.ts
@@ -7,6 +7,36 @@ export interface TdxPatientRow {
   downloadGb: number;
 }
 
+/**
+ * Match an uploaded TDX row to a site by account number. Shared so preview and
+ * download resolve the same row — a preview that matched differently would show
+ * figures the downloaded PDF does not contain.
+ */
+export function patientRowForSite(
+  rows: TdxPatientRow[],
+  accountNumber: string
+): TdxPatientRow | null {
+  const normalizedAccount = accountNumber.trim().toLowerCase();
+  return (
+    rows.find((row) => row.siteCode.trim().toLowerCase() === normalizedAccount) ??
+    null
+  );
+}
+
+/** Runtime guard for rows arriving over the wire from the admin UI. */
+export function isTdxPatientRow(value: unknown): value is TdxPatientRow {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  const nonNegativeNumber = (input: unknown) =>
+    typeof input === 'number' && Number.isFinite(input) && input >= 0;
+  return (
+    typeof row.siteCode === 'string' &&
+    nonNegativeNumber(row.uniqueUsers) &&
+    nonNegativeNumber(row.loginSessions) &&
+    nonNegativeNumber(row.downloadGb)
+  );
+}
+
 const SITE_CODE_HEADERS = ['site code', 'account_number', 'account number'];
 const UNIQUE_USERS_HEADERS = ['unique users', 'users'];
 const SESSIONS_HEADERS = ['sessions', 'login sessions'];

--- a/lib/usage-reports/types.ts
+++ b/lib/usage-reports/types.ts
@@ -19,6 +19,23 @@ export interface ReportPeriod {
   isShortPeriod: boolean;
 }
 
+/**
+ * Why no core traffic source was permitted. Every flag is already computed by
+ * `assembleCoreTraffic` while choosing a source — surfaced so the UI can name
+ * each applicable cause instead of one generic message (#689).
+ *
+ * More than one cause can be true at once (no AP linked AND no subscriber
+ * mapping); consumers should list every false flag, not just the first.
+ */
+export interface CoreUnavailableDiagnosis {
+  /** `corporate_sites.interstellio_subscriber_id` is set. */
+  interstellioMapped: boolean;
+  /** Site resolves to a Ruijie device with a `group_id` in the cache. */
+  ruijieLinked: boolean;
+  /** That group has at least one rollup row inside the report window. */
+  ruijieCoversWindow: boolean;
+}
+
 export type StaffWifiState =
   | { kind: 'available'; totalBytes: number; rxBytes: number; txBytes: number }
   | { kind: 'no_samples' }
@@ -51,7 +68,16 @@ export interface SiteUsageReportModel {
     avgDownKbps: number | null;
     peakBucketBytes: number | null;
     dailyDownloadBytes: number[]; // length = inclusiveDayCount
+    /**
+     * Whether each day carried at least one sample — same length and order as
+     * `dailyDownloadBytes`. A day can be covered and read 0 bytes (a quiet day);
+     * an uncovered day has no data at all and must never be drawn as a zero
+     * (#689). Ruijie retention (~14 days) makes this routine on long periods.
+     */
+    dailyCovered: boolean[];
     note: string;
+    /** Present only when `source === 'unavailable'`. */
+    unavailable?: CoreUnavailableDiagnosis;
     secondaryInterstellio?: {
       downloadBytes: number;
       uploadBytes: number;


### PR DESCRIPTION
Closes #690. Part of wayfinder map #687.

## What

`POST /api/admin/network/usage-reports/preview` returns the assembled `SiteUsageReportModel` as JSON — the same model the PDF renders from, so the dashboard and the downloaded document cannot disagree on figures.

**Writes nothing.** No `site_usage_report_jobs` row, no stored artifact. Preview is a read; the #668 audit trail is for artifacts that left the building.

An unavailable site returns **200 with a diagnosis**, not an error — "no permitted source" is a legitimate answer the dashboard has to render, not a failure.

## Model additions (both additive, required by #689)

| Field | Why |
|---|---|
| `core.dailyCovered: boolean[]` | `dailyDownloadBytes` is zero-filled, so an uncovered day was indistinguishable from a genuine zero. A gap is not a quiet day. |
| `core.unavailable` | `assembleCoreTraffic` already computed `interstellioMapped` / `ruijieLinked` / `ruijieCoversWindow` and threw them away. Carried through `AssembleResult.diagnosis` so each cause can name its own unlock step. |

The jsPDF renderer is untouched — how a gap is *drawn* is #692's call.

Also lifts `patientRowForSite` from `artifacts.ts` into `patient-wifi.ts` so preview and download match sites identically (a preview matching differently would show figures the PDF doesn't contain), with `isTdxPatientRow` beside it for wire validation.

## Verification

- `jest __tests__/lib/usage-reports/` — **47 passed, 9 suites**. Coverage assertions folded into the existing `core-traffic.test.ts` rather than a parallel file; new `assemble-diagnosis.test.ts` covers the pass-through.
- `tsc --noEmit` — no errors in any `usage-reports` path (repo carries a known pre-existing backlog elsewhere).
- Smoked against **live Supabase + Interstellio** across 6 real sites on weekly and monthly periods.

## What the smoke run exposed

Live data immediately justified `dailyCovered`: a **July report covers 7 of 31 days**. Without the flag that renders as 24 zero-bars and a "19.7 GB month" that is really 7 days of samples.

It also surfaced a defect that is **not fixed here** and needs its own decision — see the linked issue: every Unjani clinic resolves to the same Ruijie `group_id`, so per-site core traffic is currently group-wide, identical across clinics.