### PR TITLE
chore(dev): harness for verifying a populated admin page (#691)

### DIFF
--- a/.claude/rules/admin-page-verification.md
+++ b/.claude/rules/admin-page-verification.md
@@ -1,0 +1,61 @@
+# Verifying a Populated Admin Page
+
+**Trigger**: About to claim an `/admin/*` page works, renders data, or looks right; screenshotting an admin page; "verify the dashboard"
+**Scope**: Seeing admin UI with real data before calling it done
+**Source**: Wayfinder #691 (Usage Reports dashboard, 2026-08-01)
+
+---
+
+## The trap
+
+`ALLOW_DEV_ADMIN_BYPASS` covers `/admin/*` **pages only**. Every `/api/admin/*` route uses
+`authenticateAdmin()` (`lib/auth/admin-api-auth.ts`), which has **no bypass**.
+
+So with the bypass on and no session, the page shell renders, every data fetch 401s, and the
+screenshot looks like a working page displaying nothing. Silent, and easy to mistake for success.
+
+**A rendered admin page is not evidence its data works.** Check the network calls.
+
+---
+
+## The path
+
+`authenticateAdmin()` accepts a Bearer token *or* a cookie session — so no bypass and no
+service-role impersonation is needed. Log in as a real admin.
+
+`.env.local` already carries `ADMIN_TEST_USERNAME` / `ADMIN_TEST_PASSWORD` (an active
+`super_admin`).
+
+```bash
+# dev server first, on a port that is open in ufw (3002 = "circletel dev preview")
+ALLOW_DEV_ADMIN_BYPASS=true node --max-old-space-size=8192 \
+  ./node_modules/next/dist/bin/next dev -p 3002 &
+
+set -a && source .env.local && set +a && \
+  npx tsx scripts/verify-admin-page.ts /admin/network/usage-reports
+```
+
+`scripts/verify-admin-page.ts` logs in through `/admin/login`, captures the page at 1440px and
+375px, and **exits non-zero if any `/api/admin/*` call returned 401/403** — so an unpopulated page
+fails instead of quietly screenshotting an empty shell.
+
+Options: `--base=`, `--out=` (default `.claude/scratch/verify`, gitignored), `--widths=1440,375`.
+
+---
+
+## Gotchas this encodes
+
+| Gotcha | Why it bites |
+|---|---|
+| Cold `next dev` compiles a route on first hit | Blows Playwright's 30s default; the script uses 180s |
+| Sidebar covers the page below `lg` | `AdminLayoutClient` starts `sidebarOpen: true`, so a 375px screenshot shows only the nav. The script clicks the backdrop — near the **right edge**, since the 256px sidebar (z-50) sits above the z-40 backdrop and eats a centre click |
+| Sidebar "closes" but stays visible | It slides out via `-translate-x-full`, so Playwright still calls it visible. Wait for its bounding box to leave the viewport, not for `state: 'hidden'` |
+| Public IP won't work for the bypass | `handleAdminAuth` requires a `localhost` / `127.0.0.1` Host header. Use an SSH tunnel (`ssh -L 3002:localhost:3002`) to browse from your own machine — do not weaken the check |
+
+---
+
+## Don't
+
+- Don't add a dev bypass to `authenticateAdmin()` — the page-level guard is deliberately narrow.
+- Don't send admin credentials over plain HTTP to the public IP; tunnel instead.
+- Don't claim a page renders correctly from a screenshot alone — confirm no admin API call was denied.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,7 @@ All detailed patterns are in `.claude/rules/`:
 | `invoice-pdf-patterns.md` | VAT calc (excl-VAT multiply), fetch/blob download, print:hidden, jsPDF patterns |
 | `pre-push-hook.md` | Shared `.githooks/pre-push` — build-config + scoped type-check, escape hatches |
 | `icon-system.md` | Phosphor UI icons, Iconify brand logos, local hosting, licensing, and accessibility |
+| `admin-page-verification.md` | Seeing an admin page with real data — the API-bypass trap, login harness, mobile sidebar |
 
 ---
 

--- a/scripts/verify-admin-page.ts
+++ b/scripts/verify-admin-page.ts
@@ -1,0 +1,197 @@
+/**
+ * Verify a populated admin page against a real admin session.
+ *
+ * Why this exists (#691): `ALLOW_DEV_ADMIN_BYPASS` covers `/admin/*` PAGES only.
+ * `/api/admin/*` uses `authenticateAdmin()`, which has no bypass — so a bypassed
+ * page renders its shell while every data fetch 401s, and the page *looks* fine
+ * while showing nothing real. This logs in properly instead, so what you see is
+ * what an admin sees.
+ *
+ * It fails loudly rather than screenshotting an empty page: any 401/403 on an
+ * `/api/admin/*` call, a redirect back to the login screen, or a page error all
+ * exit non-zero.
+ *
+ * Usage (dev server must already be running):
+ *   set -a && source .env.local && set +a && \
+ *     npx tsx scripts/verify-admin-page.ts /admin/network/usage-reports
+ *
+ * Options:
+ *   --base=http://localhost:3002   dev server origin (default)
+ *   --out=<dir>                    screenshot directory (default .claude/scratch/verify)
+ *   --widths=1440,375              viewport widths to capture (default)
+ */
+import { mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { chromium, type Browser, type Page } from 'playwright';
+
+interface Options {
+  path: string;
+  base: string;
+  out: string;
+  widths: number[];
+}
+
+function parseArgs(argv: string[]): Options {
+  const positional = argv.filter((arg) => !arg.startsWith('--'));
+  const flag = (name: string): string | undefined =>
+    argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
+
+  const path = positional[0];
+  if (!path || !path.startsWith('/')) {
+    throw new Error('Pass an admin path, e.g. /admin/network/usage-reports');
+  }
+
+  return {
+    path,
+    base: flag('base') ?? 'http://localhost:3002',
+    out: flag('out') ?? '.claude/scratch/verify',
+    widths: (flag('widths') ?? '1440,375')
+      .split(',')
+      .map((value) => Number(value.trim()))
+      .filter((value) => Number.isFinite(value) && value > 0),
+  };
+}
+
+function requireCredentials(): { email: string; password: string } {
+  const email = process.env.ADMIN_TEST_USERNAME;
+  const password = process.env.ADMIN_TEST_PASSWORD;
+  if (!email || !password) {
+    throw new Error(
+      'ADMIN_TEST_USERNAME and ADMIN_TEST_PASSWORD must be set — source .env.local first'
+    );
+  }
+  return { email, password };
+}
+
+async function signIn(page: Page, base: string): Promise<void> {
+  const { email, password } = requireCredentials();
+  // Generous: a cold `next dev` compiles the login route on first hit, which
+  // routinely exceeds Playwright's 30s default.
+  await page.goto(`${base}/admin/login`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 180_000,
+  });
+  await page.locator('#email').fill(email, { timeout: 60_000 });
+  await page.locator('#password').fill(password);
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await page.waitForURL((url) => !url.pathname.startsWith('/admin/login'), {
+    timeout: 60_000,
+  });
+}
+
+interface Findings {
+  deniedApiCalls: string[];
+  pageErrors: string[];
+  consoleErrors: string[];
+}
+
+function watch(page: Page, findings: Findings): void {
+  page.on('response', (response) => {
+    const url = response.url();
+    if (!url.includes('/api/admin/')) return;
+    if (response.status() === 401 || response.status() === 403) {
+      findings.deniedApiCalls.push(`${response.status()} ${new URL(url).pathname}`);
+    }
+  });
+  page.on('pageerror', (error) => {
+    findings.pageErrors.push(String(error).slice(0, 200));
+  });
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      findings.consoleErrors.push(message.text().slice(0, 200));
+    }
+  });
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const outDir = resolve(process.cwd(), options.out);
+  mkdirSync(outDir, { recursive: true });
+
+  const slug = options.path.replace(/^\/|\/$/g, '').replace(/[^a-z0-9]+/gi, '-');
+  const findings: Findings = {
+    deniedApiCalls: [],
+    pageErrors: [],
+    consoleErrors: [],
+  };
+
+  let browser: Browser | null = null;
+  try {
+    browser = await chromium.launch();
+    // One context — the session cookies are reused across every viewport.
+    const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+    const loginPage = await context.newPage();
+    await signIn(loginPage, options.base);
+    await loginPage.close();
+
+    for (const width of options.widths) {
+      const page = await context.newPage();
+      await page.setViewportSize({ width, height: width < 768 ? 900 : 1000 });
+      watch(page, findings);
+
+      await page.goto(`${options.base}${options.path}`, {
+        waitUntil: 'networkidle',
+        timeout: 180_000,
+      });
+
+      if (new URL(page.url()).pathname.startsWith('/admin/login')) {
+        throw new Error(`Bounced to login at ${width}px — session did not hold`);
+      }
+
+      // AdminLayoutClient starts with `sidebarOpen: true`, so below the `lg`
+      // breakpoint the nav covers the page and a screenshot shows only the menu.
+      // Dismiss it via the backdrop the layout renders for exactly that purpose,
+      // otherwise mobile can never be assessed (the trap that blocked #688).
+      if (width < 1024) {
+        const backdrop = page.locator('div.fixed.inset-0.z-40').first();
+        if (await backdrop.isVisible().catch(() => false)) {
+          // Click near the right edge: the backdrop spans the viewport but the
+          // 256px sidebar sits above it (z-50), so a default centre click lands
+          // on the nav instead of dismissing it.
+          await backdrop.click({ position: { x: width - 16, y: 300 } });
+          // It slides out via `-translate-x-full` rather than unmounting, so it
+          // stays "visible" to Playwright — wait for it to actually leave the
+          // viewport instead.
+          await page.waitForFunction(
+            () => {
+              const nav = document.querySelector('[data-testid="sidebar"]');
+              return !nav || nav.getBoundingClientRect().right <= 1;
+            },
+            undefined,
+            { timeout: 10_000 }
+          );
+        }
+      }
+
+      const file = resolve(outDir, `${slug}-${width}.png`);
+      await page.screenshot({ path: file, fullPage: width >= 768 });
+      const textLength = (await page.locator('body').innerText()).length;
+      console.log(`${width}px → ${file}  (${textLength} chars of text)`);
+      await page.close();
+    }
+  } finally {
+    await browser?.close();
+  }
+
+  const denied = [...new Set(findings.deniedApiCalls)];
+  const errors = [...new Set([...findings.pageErrors, ...findings.consoleErrors])];
+
+  if (errors.length > 0) {
+    console.log('\nconsole / page errors:');
+    for (const error of errors.slice(0, 10)) console.log(`  ${error}`);
+  }
+
+  if (denied.length > 0) {
+    console.error('\nFAILED — admin API calls were denied, so the page is not populated:');
+    for (const call of denied) console.error(`  ${call}`);
+    process.exit(1);
+  }
+
+  console.log('\nOK — no admin API call was denied; screenshots show real data.');
+}
+
+main().catch((error) => {
+  console.error('verify-admin-page failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/verify-admin-page.ts
+++ b/scripts/verify-admin-page.ts
@@ -19,6 +19,9 @@
  *   --base=http://localhost:3002   dev server origin (default)
  *   --out=<dir>                    screenshot directory (default .claude/scratch/verify)
  *   --widths=1440,375              viewport widths to capture (default)
+ *   --settle=8000                  extra ms to wait after networkidle, for pages
+ *                                  whose data lands after the network goes quiet
+ *                                  (skeletons otherwise screenshot as "done")
  */
 import { mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -30,6 +33,7 @@ interface Options {
   base: string;
   out: string;
   widths: number[];
+  settleMs: number;
 }
 
 function parseArgs(argv: string[]): Options {
@@ -50,6 +54,7 @@ function parseArgs(argv: string[]): Options {
       .split(',')
       .map((value) => Number(value.trim()))
       .filter((value) => Number.isFinite(value) && value > 0),
+    settleMs: Number(flag('settle') ?? 0) || 0,
   };
 }
 
@@ -163,6 +168,10 @@ async function main(): Promise<void> {
           );
         }
       }
+
+      // networkidle can resolve while a page is still showing skeletons, so an
+      // unpopulated capture passes silently. Give slow dashboards time to land.
+      if (options.settleMs > 0) await page.waitForTimeout(options.settleMs);
 
       const file = resolve(outDir, `${slug}-${width}.png`);
       await page.screenshot({ path: file, fullPage: width >= 768 });


### PR DESCRIPTION
Closes #691. Part of wayfinder map #687.

## The trap this closes

`ALLOW_DEV_ADMIN_BYPASS` covers `/admin/*` **pages only**. Every `/api/admin/*` route uses `authenticateAdmin()`, which has **no bypass**. With the bypass on and no session, the shell renders, every fetch 401s, and the screenshot looks like a working page displaying nothing.

That is exactly what blocked mobile assessment in #688, and it would have silently undermined sign-off on the reshell (#693) — a page whose entire purpose is rendering data.

## The path chosen

`authenticateAdmin()` already accepts a cookie session, and `.env.local` already carries `ADMIN_TEST_USERNAME` / `ADMIN_TEST_PASSWORD` for an active `super_admin`. So the harness **logs in properly** — no bypass widened, no service-role impersonation, no code change to auth.

```bash
set -a && source .env.local && set +a && \
  npx tsx scripts/verify-admin-page.ts /admin/network/usage-reports
```

Captures 1440px and 375px, and **exits non-zero if any `/api/admin/*` call returned 401/403** — an unpopulated page fails rather than quietly producing an empty screenshot.

## Traps encoded while building it

| Trap | Handling |
|---|---|
| Cold `next dev` compiles a route on first hit | 180s navigation timeout, not Playwright's 30s default |
| Sidebar covers the page below `lg` (`sidebarOpen: true`) | Clicks the backdrop **near the right edge** — the 256px sidebar (z-50) sits above the z-40 backdrop and eats a centre click |
| Sidebar "closes" but stays visible | Slides out via `-translate-x-full`; waits for its box to leave the viewport, not `state: 'hidden'` |

Also documented in `.claude/rules/admin-page-verification.md` (registered in the CLAUDE.md rules table) so this is not rediscovered.

## Verification

Run against two unrelated admin pages, both passing with real data and no denied calls:

- `/admin/network/usage-reports` — 1440px / 375px
- `/admin/network/devices` — 1440px / 375px

**Not exercised:** the failure path. The 401/403 detection is a response listener and was never triggered, because every run authenticated correctly. Worth remembering before trusting it as a gate.

Screenshots default to `.claude/scratch/verify` (gitignored).