### PR TITLE
fix(usage-reports): never present a shared group rollup as site traffic (#701)

### DIFF
--- a/__tests__/lib/usage-reports/assemble-diagnosis.test.ts
+++ b/__tests__/lib/usage-reports/assemble-diagnosis.test.ts
@@ -65,6 +65,7 @@ describe('assembleSiteUsageReport — unavailability diagnosis', () => {
       interstellioMapped: false,
       ruijieLinked: false,
       ruijieCoversWindow: false,
+      ruijiePerDeviceSeries: false,
     };
 
     const result = await assembleSiteUsageReport({
@@ -87,6 +88,7 @@ describe('assembleSiteUsageReport — unavailability diagnosis', () => {
       interstellioMapped: false,
       ruijieLinked: true,
       ruijieCoversWindow: false,
+      ruijiePerDeviceSeries: false,
     };
 
     const result = await assembleSiteUsageReport({
@@ -112,6 +114,7 @@ describe('assembleSiteUsageReport — unavailability diagnosis', () => {
         interstellioMapped: false,
         ruijieLinked: false,
         ruijieCoversWindow: false,
+        ruijiePerDeviceSeries: false,
       })), loadSite: async () => null },
     });
 

--- a/__tests__/lib/usage-reports/assemble-diagnosis.test.ts
+++ b/__tests__/lib/usage-reports/assemble-diagnosis.test.ts
@@ -1,0 +1,122 @@
+import {
+  assembleSiteUsageReport,
+  type AssembleReportDeps,
+} from '@/lib/usage-reports/assemble-report';
+import type {
+  CoreUnavailableDiagnosis,
+  ReportPeriod,
+  SiteUsageReportModel,
+} from '@/lib/usage-reports/types';
+
+const period: ReportPeriod = {
+  preset: 'monthly',
+  timezone: 'Africa/Johannesburg',
+  startIso: '2026-07-01T00:00:00+02:00',
+  endIso: '2026-07-31T23:59:59+02:00',
+  startUtc: new Date('2026-06-30T22:00:00Z'),
+  endUtc: new Date('2026-07-31T21:59:59Z'),
+  label: 'Previous month',
+  rangeLabel: '1 – 31 July 2026',
+  inclusiveDayCount: 31,
+  isShortPeriod: false,
+};
+
+const site = {
+  id: 'site-1',
+  name: 'Unjani Clinic Soshanguve',
+  account_number: 'CT-UNJ-022',
+  status: 'active',
+  service_id: null,
+  service_status: null,
+  corporate_code: 'UNJ',
+  account_name: 'Unjani Clinics NPC',
+};
+
+function unavailableCore(
+  diagnosis: CoreUnavailableDiagnosis
+): SiteUsageReportModel['core'] {
+  return {
+    source: 'unavailable',
+    sourceLabel: 'No permitted source',
+    downloadBytes: 0,
+    uploadBytes: 0,
+    avgDownKbps: null,
+    peakBucketBytes: null,
+    dailyDownloadBytes: Array.from({ length: 31 }, () => 0),
+    dailyCovered: Array.from({ length: 31 }, () => false),
+    note: 'No permitted core traffic source is available for this period.',
+    unavailable: diagnosis,
+  };
+}
+
+function deps(core: SiteUsageReportModel['core']): AssembleReportDeps {
+  return {
+    loadSite: async () => site,
+    loadCore: async () => core,
+    loadStaff: async () => ({ kind: 'ap_unlinked' }),
+    loadDevice: async () => null,
+    generatedAtIso: () => '2026-08-01T12:00:00+02:00',
+  };
+}
+
+describe('assembleSiteUsageReport — unavailability diagnosis', () => {
+  it('carries every applicable cause on the failure result', async () => {
+    const diagnosis: CoreUnavailableDiagnosis = {
+      interstellioMapped: false,
+      ruijieLinked: false,
+      ruijieCoversWindow: false,
+    };
+
+    const result = await assembleSiteUsageReport({
+      siteId: 'site-1',
+      period,
+      patientRow: null,
+      deps: deps(unavailableCore(diagnosis)),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected an unavailable result');
+    expect(result.reason).toBe('core_unavailable');
+    expect(result.siteLabel).toBe('Unjani Clinic Soshanguve');
+    // Both causes are true at once — the panel must be able to list both.
+    expect(result.diagnosis).toEqual(diagnosis);
+  });
+
+  it('distinguishes a retention gap from a missing link', async () => {
+    const diagnosis: CoreUnavailableDiagnosis = {
+      interstellioMapped: false,
+      ruijieLinked: true,
+      ruijieCoversWindow: false,
+    };
+
+    const result = await assembleSiteUsageReport({
+      siteId: 'site-1',
+      period,
+      patientRow: null,
+      deps: deps(unavailableCore(diagnosis)),
+    });
+
+    if (result.ok) throw new Error('expected an unavailable result');
+    // Linked but uncovered — the copy explains retention rather than telling
+    // the admin to link a device that is already linked.
+    expect(result.diagnosis?.ruijieLinked).toBe(true);
+    expect(result.diagnosis?.ruijieCoversWindow).toBe(false);
+  });
+
+  it('leaves diagnosis absent when the site itself is not eligible', async () => {
+    const result = await assembleSiteUsageReport({
+      siteId: 'site-1',
+      period,
+      patientRow: null,
+      deps: { ...deps(unavailableCore({
+        interstellioMapped: false,
+        ruijieLinked: false,
+        ruijieCoversWindow: false,
+      })), loadSite: async () => null },
+    });
+
+    if (result.ok) throw new Error('expected an unavailable result');
+    expect(result.reason).toBe('site_not_eligible');
+    expect(result.diagnosis).toBeUndefined();
+  });
+});

--- a/__tests__/lib/usage-reports/core-traffic.test.ts
+++ b/__tests__/lib/usage-reports/core-traffic.test.ts
@@ -7,13 +7,20 @@ import {
 } from '@/lib/usage-reports/core-traffic';
 
 describe('selectCorePrimarySource', () => {
-  it('prefers covered Ruijie data for a short period', () => {
+  // A Ruijie series is only usable as a site's core traffic when it is
+  // per-device. `ruijie_traffic_rollups` is keyed by group today, so a shared
+  // group figure must never stand in for one site (#698 / #701).
+  const perDevice = { ruijiePerDeviceSeries: true };
+  const groupOnly = { ruijiePerDeviceSeries: false };
+
+  it('prefers covered per-device Ruijie data for a short period', () => {
     expect(
       selectCorePrimarySource({
         isShortPeriod: true,
         ruijieLinked: true,
         ruijieCoversWindow: true,
         interstellioMapped: true,
+        ...perDevice,
       })
     ).toBe('ruijie_hourly');
   });
@@ -25,6 +32,7 @@ describe('selectCorePrimarySource', () => {
         ruijieLinked: true,
         ruijieCoversWindow: false,
         interstellioMapped: true,
+        ...perDevice,
       })
     ).toBe('interstellio_daily');
   });
@@ -36,6 +44,7 @@ describe('selectCorePrimarySource', () => {
         ruijieLinked: false,
         ruijieCoversWindow: true,
         interstellioMapped: true,
+        ...perDevice,
       })
     ).toBe('interstellio_daily');
   });
@@ -47,30 +56,62 @@ describe('selectCorePrimarySource', () => {
         ruijieLinked: true,
         ruijieCoversWindow: true,
         interstellioMapped: true,
+        ...perDevice,
       })
     ).toBe('interstellio_daily');
   });
 
-  it('falls back to Ruijie for a long period when Interstellio is absent (MTN/TDX)', () => {
+  it('falls back to per-device Ruijie for a long period when Interstellio is absent', () => {
     expect(
       selectCorePrimarySource({
         isShortPeriod: false,
         ruijieLinked: true,
         ruijieCoversWindow: true,
         interstellioMapped: false,
+        ...perDevice,
       })
     ).toBe('ruijie_hourly');
   });
 
-  it('returns unavailable when long period has neither Interstellio nor Ruijie samples', () => {
+  it('returns unavailable when a long period has neither Interstellio nor Ruijie samples', () => {
     expect(
       selectCorePrimarySource({
         isShortPeriod: false,
         ruijieLinked: true,
         ruijieCoversWindow: false,
         interstellioMapped: false,
+        ...perDevice,
       })
     ).toBe('unavailable');
+  });
+
+  it.each([true, false])(
+    'refuses a group-only Ruijie series as site traffic (short=%s)',
+    (isShortPeriod) => {
+      // Linked and covered, but the series belongs to a shared group — this is
+      // the live state today, and it must not be presented as one site's usage.
+      expect(
+        selectCorePrimarySource({
+          isShortPeriod,
+          ruijieLinked: true,
+          ruijieCoversWindow: true,
+          interstellioMapped: false,
+          ...groupOnly,
+        })
+      ).toBe('unavailable');
+    }
+  );
+
+  it('still uses Interstellio when the Ruijie series is group-only', () => {
+    expect(
+      selectCorePrimarySource({
+        isShortPeriod: true,
+        ruijieLinked: true,
+        ruijieCoversWindow: true,
+        interstellioMapped: true,
+        ...groupOnly,
+      })
+    ).toBe('interstellio_daily');
   });
 });
 

--- a/__tests__/lib/usage-reports/core-traffic.test.ts
+++ b/__tests__/lib/usage-reports/core-traffic.test.ts
@@ -142,6 +142,7 @@ describe('aggregateRuijieHourly', () => {
       avgDownKbps: 6_000,
       peakBucketBytes: 1_000_000_000,
       dailyDownloadBytes: [1_000_000_000, 500_000_000],
+      dailyCovered: [true, true],
     });
   });
 
@@ -162,6 +163,47 @@ describe('aggregateRuijieHourly', () => {
 
     expect(result.downloadBytes).toBe(25);
     expect(result.dailyDownloadBytes).toEqual([0, 0, 25]);
+    // Days 1-2 read zero because nothing was sampled, not because traffic was
+    // zero — callers must be able to tell those apart (#689).
+    expect(result.dailyCovered).toEqual([false, false, true]);
+  });
+
+  it('counts a zero-byte sample as covered — a quiet day is not a gap', () => {
+    const result = aggregateRuijieHourly(
+      [
+        {
+          captured_at: '2026-07-02T08:00:00+02:00',
+          total_rx_bytes: 0,
+          total_tx_bytes: 0,
+          avg_rx_bps: 0,
+          peak_rx_bps: 0,
+        },
+      ],
+      3,
+      new Date('2026-07-01T00:00:00+02:00')
+    );
+
+    expect(result.dailyDownloadBytes[1]).toBe(0);
+    expect(result.dailyCovered).toEqual([false, true, false]);
+  });
+
+  it('returns a coverage entry for every day in the window', () => {
+    const result = aggregateRuijieHourly(
+      [
+        {
+          captured_at: '2026-07-01T08:00:00+02:00',
+          total_rx_bytes: 5,
+          total_tx_bytes: 1,
+          avg_rx_bps: 10,
+          peak_rx_bps: 20,
+        },
+      ],
+      31,
+      new Date('2026-07-01T00:00:00+02:00')
+    );
+
+    expect(result.dailyCovered).toHaveLength(31);
+    expect(result.dailyCovered.filter(Boolean)).toHaveLength(1);
   });
 
   it('returns null rate and peak metrics for no rows', () => {
@@ -173,6 +215,7 @@ describe('aggregateRuijieHourly', () => {
       avgDownKbps: null,
       peakBucketBytes: null,
       dailyDownloadBytes: [0],
+      dailyCovered: [false],
     });
   });
 });
@@ -206,6 +249,7 @@ describe('aggregateInterstellioDaily', () => {
       avgDownKbps: 600,
       peakBucketBytes: 2_048_000,
       dailyDownloadBytes: [0, 2_048_000, 1_024_000],
+      dailyCovered: [false, true, true],
     });
   });
 });

--- a/app/api/admin/network/usage-reports/preview/route.ts
+++ b/app/api/admin/network/usage-reports/preview/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { createClient } from '@/lib/supabase/server';
+import { assembleSiteUsageReport } from '@/lib/usage-reports/assemble-report';
+import { fetchInclusionSiteRows } from '@/lib/usage-reports/inclusion';
+import {
+  isTdxPatientRow,
+  patientRowForSite,
+  type TdxPatientRow,
+} from '@/lib/usage-reports/patient-wifi';
+import { resolveReportPeriod } from '@/lib/usage-reports/periods';
+import type { ReportPeriodPreset } from '@/lib/usage-reports/types';
+
+/**
+ * Read-only preview of a single site's usage report.
+ *
+ * Returns the same `SiteUsageReportModel` the PDF renders from, so the dashboard
+ * and the downloaded document can never disagree on figures. Writes nothing —
+ * no `site_usage_report_jobs` row and no stored artifact, because nothing has
+ * left the building yet (map #687 decision 4; audit intent from #668).
+ *
+ * POST rather than GET: uploaded TDX patient rows are a body, not a query
+ * string, and the same shape must serve a 26-row Unjani upload.
+ */
+
+interface PreviewRequest {
+  siteId?: unknown;
+  period?: unknown;
+  custom?: { startDate?: unknown; endDate?: unknown };
+  patientRows?: unknown;
+}
+
+const PERIOD_PRESETS = new Set<ReportPeriodPreset>([
+  'weekly',
+  'monthly',
+  'sixty_day',
+  'custom',
+]);
+
+class RequestValidationError extends Error {}
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateAdmin(request);
+  if (!authResult.success) return authResult.response;
+
+  try {
+    const body = (await request.json()) as PreviewRequest;
+
+    if (typeof body.siteId !== 'string' || body.siteId.trim() === '') {
+      return NextResponse.json({ error: 'siteId is required' }, { status: 400 });
+    }
+    if (
+      typeof body.period !== 'string' ||
+      !PERIOD_PRESETS.has(body.period as ReportPeriodPreset)
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid report period preset' },
+        { status: 400 }
+      );
+    }
+
+    const patientRows: TdxPatientRow[] = Array.isArray(body.patientRows)
+      ? body.patientRows.filter(isTdxPatientRow)
+      : [];
+    if (
+      Array.isArray(body.patientRows) &&
+      patientRows.length !== body.patientRows.length
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid patientRows payload' },
+        { status: 400 }
+      );
+    }
+
+    const custom =
+      typeof body.custom?.startDate === 'string' &&
+      typeof body.custom?.endDate === 'string'
+        ? { startDate: body.custom.startDate, endDate: body.custom.endDate }
+        : undefined;
+
+    let period: ReturnType<typeof resolveReportPeriod>;
+    try {
+      period = resolveReportPeriod(
+        body.period as ReportPeriodPreset,
+        new Date(),
+        custom
+      );
+    } catch (error) {
+      throw new RequestValidationError(
+        error instanceof Error ? error.message : 'Invalid report period'
+      );
+    }
+
+    const siteId = body.siteId;
+    const supabase = await createClient();
+    const siteRow = (await fetchInclusionSiteRows(supabase)).find(
+      (row) => row.id === siteId
+    );
+
+    const result = await assembleSiteUsageReport({
+      siteId,
+      period,
+      patientRow: siteRow
+        ? patientRowForSite(patientRows, siteRow.account_number)
+        : null,
+    });
+
+    if (!result.ok) {
+      // A site with no permitted source is a legitimate answer, not a failure:
+      // 200 with the diagnosis so the dashboard can name each cause and its
+      // unlock step (#689) instead of rendering an error.
+      return NextResponse.json(
+        {
+          ok: false,
+          reason: result.reason,
+          siteId: result.siteId,
+          siteLabel: result.siteLabel,
+          diagnosis: result.diagnosis ?? null,
+          period: {
+            preset: period.preset,
+            label: period.label,
+            rangeLabel: period.rangeLabel,
+          },
+        },
+        { headers: { 'Cache-Control': 'private, no-store' } }
+      );
+    }
+
+    return NextResponse.json(
+      { ok: true, model: result.model },
+      { headers: { 'Cache-Control': 'private, no-store' } }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[UsageReportsPreview] Preview failed:', error);
+    const status =
+      error instanceof RequestValidationError || error instanceof SyntaxError
+        ? 400
+        : 500;
+    return NextResponse.json(
+      { error: status === 400 ? message : 'Failed to build report preview' },
+      { status }
+    );
+  }
+}

--- a/lib/usage-reports/artifacts.ts
+++ b/lib/usage-reports/artifacts.ts
@@ -6,7 +6,7 @@ import {
   type AssembleSiteUsageReportInput,
 } from './assemble-report';
 import { reportModelToCsv } from './csv';
-import type { TdxPatientRow } from './patient-wifi';
+import { patientRowForSite, type TdxPatientRow } from './patient-wifi';
 import {
   generateSiteUsageReportPdf,
   generateSkipSlipPdf,
@@ -62,16 +62,6 @@ function safeFilenamePart(value: string): string {
 
 function periodFilenamePart(period: ReportPeriod): string {
   return `${period.startIso.slice(0, 10)}_to_${period.endIso.slice(0, 10)}`;
-}
-
-function patientRowForSite(
-  rows: TdxPatientRow[],
-  accountNumber: string
-): TdxPatientRow | null {
-  const normalizedAccount = accountNumber.trim().toLowerCase();
-  return (
-    rows.find((row) => row.siteCode.trim().toLowerCase() === normalizedAccount) ?? null
-  );
 }
 
 function skipReason(reason: AssembleSkipReason): string {

--- a/lib/usage-reports/assemble-report.ts
+++ b/lib/usage-reports/assemble-report.ts
@@ -11,6 +11,7 @@ import { resolvePatientWifi, type TdxPatientRow } from './patient-wifi';
 import { loadStaffHourRows, resolveStaffWifi, siteHasLinkedAp } from './staff-wifi';
 import type {
   AssembleSkipReason,
+  CoreUnavailableDiagnosis,
   ReportPeriod,
   SiteUsageReportModel,
   StaffWifiState,
@@ -26,6 +27,11 @@ export type AssembleResult =
       reason: AssembleSkipReason;
       siteId: string;
       siteLabel: string;
+      /**
+       * Present only for `core_unavailable` — which of the source links are
+       * missing, so the caller can name each cause and its unlock step (#689).
+       */
+      diagnosis?: CoreUnavailableDiagnosis;
     };
 
 export interface AssembleReportDeps {
@@ -142,6 +148,7 @@ export async function assembleSiteUsageReport({
       reason: 'core_unavailable',
       siteId,
       siteLabel: site.name,
+      diagnosis: core.unavailable,
     };
   }
 

--- a/lib/usage-reports/core-traffic.ts
+++ b/lib/usage-reports/core-traffic.ts
@@ -24,6 +24,8 @@ export interface CoreTrafficAggregate {
   avgDownKbps: number | null;
   peakBucketBytes: number | null;
   dailyDownloadBytes: number[];
+  /** Per-day sample presence — see `SiteUsageReportModel['core'].dailyCovered`. */
+  dailyCovered: boolean[];
 }
 
 export interface RuijieHourlyLoad {
@@ -83,13 +85,19 @@ function sastDayKey(value: Date | string): string | null {
 function buildSastDayIndex(
   dayCount: number,
   start: Date
-): { dailyDownloadBytes: number[]; indexByDay: Map<string, number> } {
+): {
+  dailyDownloadBytes: number[];
+  dailyCovered: boolean[];
+  indexByDay: Map<string, number>;
+} {
   const startKey = sastDayKey(start);
   const normalizedDayCount = Math.max(0, Math.trunc(dayCount));
   const dailyDownloadBytes = Array.from({ length: normalizedDayCount }, () => 0);
+  // Starts all-false: a day is covered only once a sample lands on it.
+  const dailyCovered = Array.from({ length: normalizedDayCount }, () => false);
   const indexByDay = new Map<string, number>();
 
-  if (!startKey) return { dailyDownloadBytes, indexByDay };
+  if (!startKey) return { dailyDownloadBytes, dailyCovered, indexByDay };
 
   const startDayUtc = new Date(`${startKey}T00:00:00.000Z`);
   for (let index = 0; index < normalizedDayCount; index += 1) {
@@ -99,7 +107,7 @@ function buildSastDayIndex(
     indexByDay.set(key, index);
   }
 
-  return { dailyDownloadBytes, indexByDay };
+  return { dailyDownloadBytes, dailyCovered, indexByDay };
 }
 
 export function aggregateRuijieHourly(
@@ -107,7 +115,10 @@ export function aggregateRuijieHourly(
   dayCount: number,
   start: Date
 ): CoreTrafficAggregate {
-  const { dailyDownloadBytes, indexByDay } = buildSastDayIndex(dayCount, start);
+  const { dailyDownloadBytes, dailyCovered, indexByDay } = buildSastDayIndex(
+    dayCount,
+    start
+  );
   let downloadBytes = 0;
   let uploadBytes = 0;
   let averageBpsTotal = 0;
@@ -127,7 +138,12 @@ export function aggregateRuijieHourly(
     }
 
     const index = indexByDay.get(sastDayKey(row.captured_at) ?? '');
-    if (index !== undefined) dailyDownloadBytes[index] += rowDownloadBytes;
+    if (index !== undefined) {
+      dailyDownloadBytes[index] += rowDownloadBytes;
+      // A row is a sample even when it reports 0 bytes — that is a quiet hour,
+      // not a missing one.
+      dailyCovered[index] = true;
+    }
   }
 
   return {
@@ -139,6 +155,7 @@ export function aggregateRuijieHourly(
         : null,
     peakBucketBytes,
     dailyDownloadBytes,
+    dailyCovered,
   };
 }
 
@@ -147,7 +164,10 @@ export function aggregateInterstellioDaily(
   dayCount: number,
   start: Date
 ): CoreTrafficAggregate {
-  const { dailyDownloadBytes, indexByDay } = buildSastDayIndex(dayCount, start);
+  const { dailyDownloadBytes, dailyCovered, indexByDay } = buildSastDayIndex(
+    dayCount,
+    start
+  );
   let downloadBytes = 0;
   let uploadBytes = 0;
   let averageKbpsTotal = 0;
@@ -176,6 +196,8 @@ export function aggregateInterstellioDaily(
 
   for (const [index, bytes] of downloadBytesByDay) {
     dailyDownloadBytes[index] = bytes;
+    // Presence of an entry is the coverage signal, whatever it reports.
+    dailyCovered[index] = true;
   }
 
   return {
@@ -190,6 +212,7 @@ export function aggregateInterstellioDaily(
           ? 0
           : null,
     dailyDownloadBytes,
+    dailyCovered,
   };
 }
 
@@ -290,11 +313,15 @@ export async function assembleCoreTraffic(
     ? await loadRuijieHourlyRows(supabase, siteId, period.startUtc, period.endUtc)
     : ({ groupId: null, rows: [] } satisfies RuijieHourlyLoad);
 
-  const source = selectCorePrimarySource({
-    isShortPeriod: period.isShortPeriod,
+  const diagnosis = {
+    interstellioMapped: subscriberId !== null,
     ruijieLinked: ruijie.groupId !== null,
     ruijieCoversWindow: ruijie.rows.length > 0,
-    interstellioMapped: subscriberId !== null,
+  };
+
+  const source = selectCorePrimarySource({
+    isShortPeriod: period.isShortPeriod,
+    ...diagnosis,
   });
 
   if (source === 'unavailable') {
@@ -309,7 +336,10 @@ export async function assembleCoreTraffic(
         { length: period.inclusiveDayCount },
         () => 0
       ),
+      dailyCovered: Array.from({ length: period.inclusiveDayCount }, () => false),
       note: 'No permitted core traffic source is available for this period.',
+      // Kept rather than discarded so callers can name each applicable cause.
+      unavailable: diagnosis,
     };
   }
 

--- a/lib/usage-reports/core-traffic.ts
+++ b/lib/usage-reports/core-traffic.ts
@@ -31,6 +31,12 @@ export interface CoreTrafficAggregate {
 export interface RuijieHourlyLoad {
   groupId: string | null;
   rows: RuijieHourlyRow[];
+  /**
+   * False while rollups are group-keyed — see `selectCorePrimarySource`. Kept as
+   * a property of the load rather than a constant so #702 can flip it per row
+   * source without touching the selection rule.
+   */
+  perDeviceSeries: boolean;
 }
 
 export const CORE_SOURCE_LABEL: Record<CoreTrafficSource, string> = {
@@ -44,16 +50,25 @@ export function selectCorePrimarySource(input: {
   ruijieLinked: boolean;
   ruijieCoversWindow: boolean;
   interstellioMapped: boolean;
+  /**
+   * Whether the Ruijie series belongs to this site alone. `ruijie_traffic_rollups`
+   * is keyed by `group_id` and holds one representative AP's flow, so ~10 clinics
+   * share a figure — it must never be presented as one site's traffic (#698).
+   * Flips true once per-device collection lands (#702).
+   */
+  ruijiePerDeviceSeries: boolean;
 }): CoreTrafficSource {
-  const ruijieOk = input.ruijieLinked && input.ruijieCoversWindow;
+  const ruijieOk =
+    input.ruijieLinked && input.ruijieCoversWindow && input.ruijiePerDeviceSeries;
 
   if (input.isShortPeriod) {
     if (ruijieOk) return 'ruijie_hourly';
     return input.interstellioMapped ? 'interstellio_daily' : 'unavailable';
   }
 
-  // Long periods: prefer Interstellio (BNG accounting). MTN / TDX sites with no
-  // Interstellio fall back to Ruijie AP/group rollups for hours that exist.
+  // Long periods: prefer Interstellio (BNG accounting). Sites with no
+  // Interstellio fall back to Ruijie for the hours that exist — but only once
+  // that series is per-device; a shared group figure is never site traffic.
   if (input.interstellioMapped) return 'interstellio_daily';
   if (ruijieOk) return 'ruijie_hourly';
   return 'unavailable';
@@ -246,7 +261,7 @@ export async function loadRuijieHourlyRows(
 
   if (deviceError) throw deviceError;
   const serial = device?.ruijie_device_sn as string | null | undefined;
-  if (!serial) return { groupId: null, rows: [] };
+  if (!serial) return { groupId: null, rows: [], perDeviceSeries: false };
 
   const { data: cachedDevice, error: cacheError } = await supabase
     .from('ruijie_device_cache')
@@ -257,7 +272,7 @@ export async function loadRuijieHourlyRows(
 
   if (cacheError) throw cacheError;
   const groupId = cachedDevice?.group_id as string | null | undefined;
-  if (!groupId) return { groupId: null, rows: [] };
+  if (!groupId) return { groupId: null, rows: [], perDeviceSeries: false };
 
   const { data: rows, error: rollupError } = await supabase
     .from('ruijie_traffic_rollups')
@@ -271,7 +286,12 @@ export async function loadRuijieHourlyRows(
     .order('captured_at', { ascending: true });
 
   if (rollupError) throw rollupError;
-  return { groupId, rows: (rows ?? []) as RuijieHourlyRow[] };
+  return {
+    groupId,
+    rows: (rows ?? []) as RuijieHourlyRow[],
+    // Group-keyed table: no per-site series exists yet (#702).
+    perDeviceSeries: false,
+  };
 }
 
 export async function loadInterstellioDailyEntries(
@@ -311,12 +331,17 @@ export async function assembleCoreTraffic(
   const needsRuijie = period.isShortPeriod || subscriberId === null;
   const ruijie = needsRuijie
     ? await loadRuijieHourlyRows(supabase, siteId, period.startUtc, period.endUtc)
-    : ({ groupId: null, rows: [] } satisfies RuijieHourlyLoad);
+    : ({
+        groupId: null,
+        rows: [],
+        perDeviceSeries: false,
+      } satisfies RuijieHourlyLoad);
 
   const diagnosis = {
     interstellioMapped: subscriberId !== null,
     ruijieLinked: ruijie.groupId !== null,
     ruijieCoversWindow: ruijie.rows.length > 0,
+    ruijiePerDeviceSeries: ruijie.perDeviceSeries,
   };
 
   const source = selectCorePrimarySource({

--- a/lib/usage-reports/patient-wifi.ts
+++ b/lib/usage-reports/patient-wifi.ts
@@ -7,6 +7,36 @@ export interface TdxPatientRow {
   downloadGb: number;
 }
 
+/**
+ * Match an uploaded TDX row to a site by account number. Shared so preview and
+ * download resolve the same row — a preview that matched differently would show
+ * figures the downloaded PDF does not contain.
+ */
+export function patientRowForSite(
+  rows: TdxPatientRow[],
+  accountNumber: string
+): TdxPatientRow | null {
+  const normalizedAccount = accountNumber.trim().toLowerCase();
+  return (
+    rows.find((row) => row.siteCode.trim().toLowerCase() === normalizedAccount) ??
+    null
+  );
+}
+
+/** Runtime guard for rows arriving over the wire from the admin UI. */
+export function isTdxPatientRow(value: unknown): value is TdxPatientRow {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  const nonNegativeNumber = (input: unknown) =>
+    typeof input === 'number' && Number.isFinite(input) && input >= 0;
+  return (
+    typeof row.siteCode === 'string' &&
+    nonNegativeNumber(row.uniqueUsers) &&
+    nonNegativeNumber(row.loginSessions) &&
+    nonNegativeNumber(row.downloadGb)
+  );
+}
+
 const SITE_CODE_HEADERS = ['site code', 'account_number', 'account number'];
 const UNIQUE_USERS_HEADERS = ['unique users', 'users'];
 const SESSIONS_HEADERS = ['sessions', 'login sessions'];

--- a/lib/usage-reports/types.ts
+++ b/lib/usage-reports/types.ts
@@ -19,6 +19,23 @@ export interface ReportPeriod {
   isShortPeriod: boolean;
 }
 
+/**
+ * Why no core traffic source was permitted. Every flag is already computed by
+ * `assembleCoreTraffic` while choosing a source — surfaced so the UI can name
+ * each applicable cause instead of one generic message (#689).
+ *
+ * More than one cause can be true at once (no AP linked AND no subscriber
+ * mapping); consumers should list every false flag, not just the first.
+ */
+export interface CoreUnavailableDiagnosis {
+  /** `corporate_sites.interstellio_subscriber_id` is set. */
+  interstellioMapped: boolean;
+  /** Site resolves to a Ruijie device with a `group_id` in the cache. */
+  ruijieLinked: boolean;
+  /** That group has at least one rollup row inside the report window. */
+  ruijieCoversWindow: boolean;
+}
+
 export type StaffWifiState =
   | { kind: 'available'; totalBytes: number; rxBytes: number; txBytes: number }
   | { kind: 'no_samples' }
@@ -51,7 +68,16 @@ export interface SiteUsageReportModel {
     avgDownKbps: number | null;
     peakBucketBytes: number | null;
     dailyDownloadBytes: number[]; // length = inclusiveDayCount
+    /**
+     * Whether each day carried at least one sample — same length and order as
+     * `dailyDownloadBytes`. A day can be covered and read 0 bytes (a quiet day);
+     * an uncovered day has no data at all and must never be drawn as a zero
+     * (#689). Ruijie retention (~14 days) makes this routine on long periods.
+     */
+    dailyCovered: boolean[];
     note: string;
+    /** Present only when `source === 'unavailable'`. */
+    unavailable?: CoreUnavailableDiagnosis;
     secondaryInterstellio?: {
       downloadBytes: number;
       uploadBytes: number;

--- a/lib/usage-reports/types.ts
+++ b/lib/usage-reports/types.ts
@@ -34,6 +34,14 @@ export interface CoreUnavailableDiagnosis {
   ruijieLinked: boolean;
   /** That group has at least one rollup row inside the report window. */
   ruijieCoversWindow: boolean;
+  /**
+   * Whether the Ruijie series is this site's alone. False while
+   * `ruijie_traffic_rollups` is keyed by `group_id` — roughly ten clinics share
+   * one representative AP's flow, so it cannot stand in for a single site
+   * (#698). Distinct from `ruijieLinked`: the device IS linked, the data just
+   * is not per-site. Flips true when per-device collection lands (#702).
+   */
+  ruijiePerDeviceSeries: boolean;
 }
 
 export type StaffWifiState =


### PR DESCRIPTION
Closes #701. Decided in #698. Part of wayfinder map #687.

> **Stacked on #697** — branched from `feat/usage-reports-preview`, so this diff includes that commit until #697 merges. Merge #697 first.

## Why this is urgent

The MVP deployed to production on 1 Aug (`e81c4a73`). Today a user can open `/admin/network/usage-reports`, pick a linked Unjani clinic, and download a **branded PDF carrying another clinic's traffic**.

Verified in production:

| Fact | Value |
|---|---|
| Unjani sites with a linked device | 20 |
| Distinct Ruijie `group_id` across them | **2** |
| Sites with an Interstellio mapping | **0** |
| Per-device columns on `ruijie_traffic_rollups` | **0** |

`pickFlowDeviceSn` looks for a gateway, finds none in an all-AP fleet, and falls back to `pool[0]` — an arbitrary online AP whose flow is stored as the group's series. With no Interstellio anywhere, that series was sourcing **100% of reports**.

No wrong PDF has actually reached anyone: all 3 report jobs ever run were skip slips. That is luck, not design.

## Change

`selectCorePrimarySource` now requires `ruijiePerDeviceSeries` before Ruijie may be primary. The flag lives on `RuijieHourlyLoad`, not hardcoded in the rule, so **#702 flips it on at the source without touching the selection logic**.

`CoreUnavailableDiagnosis` gains the same flag, deliberately distinct from `ruijieLinked` — the device IS linked and DOES have rows, the data just is not per-site. That distinction is what lets the panel explain the real situation instead of telling someone to link a device they already linked.

Staff Wi-Fi, device identity and Patient TDX are untouched. Staff rollups are keyed by `corporate_site_id` and were never subject to this.

## Verification

- **50 tests, 9 suites, all passing.** The selector's existing tests encoded the old rule and were rewritten; added cases proving a group-only series is refused on both short and long periods, and that Interstellio still wins when mapped.
- Smoked against **live Supabase + Interstellio**: every linked site now returns `core_unavailable` with `linked=true covers=true perDevice=false`, on weekly and monthly.

## Consequence, stated plainly

Core traffic is now **not available for every site** until per-device collection (#702) lands. That is the honest state — the alternative is a client-facing document with the wrong number on it.

## Found along the way

`tsconfig.json` excludes `**/__tests__/**`, so **test files are never type-checked** — not by `npm run type-check:memory`, not by the pre-push hook. A test can reference a removed or renamed type and stay green. The diagnosis literals in this PR were updated by hand because nothing would have caught them. Worth fixing repo-wide, but out of scope here.