### PR TITLE
feat(ruijie): per-device flow rollups so a site gets its own traffic (#702)

### DIFF
--- a/__tests__/lib/network/analytics-aggregates.test.ts
+++ b/__tests__/lib/network/analytics-aggregates.test.ts
@@ -136,4 +136,48 @@ describe('buildHourlyRollupUpserts', () => {
     expect(rows[1].total_rx_bytes).toBe(2_000_000);
     expect(rows[0].raw_summary.flowSn).toBe('SN123');
   });
+
+  it('keys every row to the device the flow came from', () => {
+    // device_sn is a real column now, not just raw_summary trivia — it is what
+    // lets one site be attributed its own AP instead of the group's (#702).
+    const rows = buildHourlyRollupUpserts({
+      groupId: '9058218',
+      groupName: 'Unjani',
+      flowSn: 'G1U52HL00261B',
+      dataPoints: [
+        {
+          timestamp: Date.parse('2026-07-25T20:15:00+02:00'),
+          rxBytes: 1_000,
+          txBytes: 100,
+        },
+      ],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].device_sn).toBe('G1U52HL00261B');
+  });
+
+  it('produces independent rows for two devices in the same group and hour', () => {
+    const at = Date.parse('2026-07-25T20:15:00+02:00');
+    const [first] = buildHourlyRollupUpserts({
+      groupId: '9058218',
+      groupName: 'Unjani',
+      flowSn: 'SN-A',
+      dataPoints: [{ timestamp: at, rxBytes: 1_000, txBytes: 100 }],
+    });
+    const [second] = buildHourlyRollupUpserts({
+      groupId: '9058218',
+      groupName: 'Unjani',
+      flowSn: 'SN-B',
+      dataPoints: [{ timestamp: at, rxBytes: 5_000, txBytes: 500 }],
+    });
+
+    // Same group, same hour, different device — previously impossible, because
+    // the unique key was (group_id, captured_at, hours_window).
+    expect(first.captured_at).toBe(second.captured_at);
+    expect(first.group_id).toBe(second.group_id);
+    expect(first.device_sn).not.toBe(second.device_sn);
+    expect(first.total_rx_bytes).toBe(1_000);
+    expect(second.total_rx_bytes).toBe(5_000);
+  });
 });

--- a/app/api/admin/network/analytics/route.ts
+++ b/app/api/admin/network/analytics/route.ts
@@ -159,6 +159,9 @@ export async function GET(request: NextRequest) {
         'group_id, group_name, total_rx_bytes, total_tx_bytes, captured_at, hours_window, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, raw_summary'
       )
       .eq('hours_window', HOURLY_ROLLUP_WINDOW)
+      // Legacy group blobs would double-count against per-device rows for the
+      // 14-day retention overlap (#702).
+      .neq('device_sn', '__legacy_group__')
       .gte('captured_at', since)
       .order('captured_at', { ascending: true });
 

--- a/app/api/admin/network/health/route.ts
+++ b/app/api/admin/network/health/route.ts
@@ -183,6 +183,9 @@ export async function GET(request: NextRequest) {
       .select(
         'group_id, group_name, captured_at, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, total_rx_bytes, total_tx_bytes'
       )
+      // Exclude legacy group blobs so they do not double-count against
+      // per-device rows during the retention overlap (#702).
+      .neq('device_sn', '__legacy_group__')
       .gte('captured_at', twentyFourHoursAgo)
       .order('captured_at', { ascending: true });
 

--- a/lib/inngest/functions/ruijie-traffic-rollup.ts
+++ b/lib/inngest/functions/ruijie-traffic-rollup.ts
@@ -1,9 +1,13 @@
 /**
  * Ruijie Traffic Rollup
  *
- * After each device sync, fetch hourly flow per group (via a representative
- * device SN — API V2.0.3 §2.6.2) and persist one hours_window=1 row per hour
- * so Analytics charts have a usable series (not a single 24h window blob).
+ * After each device sync, fetch hourly flow for EVERY device (API V2.0.3 §2.6.2
+ * is per-SN) and persist one hours_window=1 row per device per hour, so a site
+ * can be attributed its own AP and a group total is a real sum.
+ *
+ * Until #702 this polled one representative device per group and stored its
+ * flow as the group's — which meant ~10 Unjani clinics shared one arbitrary
+ * clinic's traffic. See supabase/migrations/20260802090000_*.
  *
  * Trigger: ruijie/sync.completed
  *
@@ -17,12 +21,13 @@
 import { inngest } from '../client';
 import { ruijieSyncCompleted } from '../events/ruijie';
 import { createClient } from '@/lib/supabase/server';
-import { getNetworkTraffic, pickFlowDeviceSn } from '@/lib/ruijie/client';
+import { getNetworkTraffic } from '@/lib/ruijie/client';
 import { buildHourlyRollupUpserts } from '@/lib/network/analytics-aggregates';
 
 const HOURS_WINDOW = 24;
 const RETENTION_DAYS = 14;
-const GROUP_DELAY_MS = 600;
+/** Pace between per-device flow calls — the fleet is ~25 devices per sync. */
+const DEVICE_DELAY_MS = 600;
 /** Let Ruijie cool down after device metric enrichment on the same event. */
 const POST_SYNC_COOLDOWN_MS = 12_000;
 const EMPTY_RETRY_DELAY_MS = 5_000;
@@ -84,60 +89,68 @@ export const ruijieTrafficRollupFunction = inngest.createFunction(
       let inserted = 0;
 
       for (const group of groups) {
-        try {
-          const { data: devices } = await supabase
-            .from('ruijie_device_cache')
-            .select('sn, status, model')
-            .eq('group_id', group.group_id);
+        const { data: devices } = await supabase
+          .from('ruijie_device_cache')
+          .select('sn, status, model')
+          .eq('group_id', group.group_id);
 
-          const flowSn = pickFlowDeviceSn(devices || []);
-          if (!flowSn) {
-            console.warn(`[TrafficRollup] No device SN for group ${group.group_id}`);
-            continue;
-          }
+        const serials = (devices || [])
+          .map((device) => device.sn as string | null)
+          .filter((sn): sn is string => Boolean(sn));
 
-          let traffic = await getNetworkTraffic({ sn: flowSn, hours: HOURS_WINDOW });
-
-          // Ruijie flow can return empty under load right after sync — one retry.
-          if (!traffic.dataPoints.length) {
-            console.warn(
-              `[TrafficRollup] Empty flow for group ${group.group_id} sn=${flowSn}; retrying once`
-            );
-            await new Promise((r) => setTimeout(r, EMPTY_RETRY_DELAY_MS));
-            traffic = await getNetworkTraffic({ sn: flowSn, hours: HOURS_WINDOW });
-          }
-
-          const upserts = buildHourlyRollupUpserts({
-            groupId: group.group_id,
-            groupName: group.group_name,
-            flowSn,
-            dataPoints: traffic.dataPoints,
-          });
-
-          if (upserts.length === 0) {
-            console.warn(
-              `[TrafficRollup] No hourly points for group ${group.group_id} (sn=${flowSn}, totalBytes=${traffic.totalBytes}, rawPoints=${traffic.dataPoints.length})`
-            );
-            continue;
-          }
-
-          const { error } = await supabase.from('ruijie_traffic_rollups').upsert(upserts, {
-            onConflict: 'group_id,captured_at,hours_window',
-          });
-
-          if (error) {
-            console.error(`[TrafficRollup] Upsert failed for ${group.group_id}:`, error);
-          } else {
-            inserted += upserts.length;
-            console.log(
-              `[TrafficRollup] group=${group.group_id} name=${group.group_name} sn=${flowSn} upserts=${upserts.length} bytes=${traffic.totalBytes}`
-            );
-          }
-        } catch (err) {
-          console.error(`[TrafficRollup] Group ${group.group_id} failed:`, err);
+        if (serials.length === 0) {
+          console.warn(`[TrafficRollup] No device SNs for group ${group.group_id}`);
+          continue;
         }
 
-        await new Promise((r) => setTimeout(r, GROUP_DELAY_MS));
+        // Every device, not a representative — the whole point of #702.
+        for (const sn of serials) {
+          try {
+            let traffic = await getNetworkTraffic({ sn, hours: HOURS_WINDOW });
+
+            // Ruijie flow can return empty under load right after sync — one retry.
+            if (!traffic.dataPoints.length) {
+              console.warn(
+                `[TrafficRollup] Empty flow for sn=${sn} (group ${group.group_id}); retrying once`
+              );
+              await new Promise((r) => setTimeout(r, EMPTY_RETRY_DELAY_MS));
+              traffic = await getNetworkTraffic({ sn, hours: HOURS_WINDOW });
+            }
+
+            const upserts = buildHourlyRollupUpserts({
+              groupId: group.group_id,
+              groupName: group.group_name,
+              flowSn: sn,
+              dataPoints: traffic.dataPoints,
+            });
+
+            if (upserts.length === 0) {
+              console.warn(
+                `[TrafficRollup] No hourly points for sn=${sn} (group=${group.group_id}, totalBytes=${traffic.totalBytes}, rawPoints=${traffic.dataPoints.length})`
+              );
+              continue;
+            }
+
+            const { error } = await supabase
+              .from('ruijie_traffic_rollups')
+              .upsert(upserts, {
+                onConflict: 'group_id,device_sn,captured_at,hours_window',
+              });
+
+            if (error) {
+              console.error(`[TrafficRollup] Upsert failed for sn=${sn}:`, error);
+            } else {
+              inserted += upserts.length;
+              console.log(
+                `[TrafficRollup] group=${group.group_id} sn=${sn} upserts=${upserts.length} bytes=${traffic.totalBytes}`
+              );
+            }
+          } catch (err) {
+            console.error(`[TrafficRollup] Device ${sn} failed:`, err);
+          }
+
+          await new Promise((r) => setTimeout(r, DEVICE_DELAY_MS));
+        }
       }
 
       return inserted;

--- a/lib/network/analytics-aggregates.ts
+++ b/lib/network/analytics-aggregates.ts
@@ -25,6 +25,8 @@ export type HourlyTrafficPoint = {
 export type HourlyRollupUpsert = {
   group_id: string;
   group_name: string | null;
+  /** Serial of the device this hour's flow came from — part of the unique key. */
+  device_sn: string;
   captured_at: string;
   hours_window: number;
   total_rx_bytes: number;
@@ -77,6 +79,9 @@ export function buildHourlyRollupUpserts(params: {
       return {
         group_id: params.groupId,
         group_name: params.groupName,
+        // The device this flow belongs to. Group totals are the SUM across
+        // device_sn — one AP's series is never the group's, nor a site's (#702).
+        device_sn: params.flowSn,
         captured_at,
         hours_window: HOURLY_ROLLUP_WINDOW,
         total_rx_bytes: Math.round(rx),

--- a/lib/usage-reports/core-traffic.ts
+++ b/lib/usage-reports/core-traffic.ts
@@ -274,12 +274,13 @@ export async function loadRuijieHourlyRows(
   const groupId = cachedDevice?.group_id as string | null | undefined;
   if (!groupId) return { groupId: null, rows: [], perDeviceSeries: false };
 
+  // Scoped to THIS site's device. Rows are per-device since #702; anything
+  // older is a group blob under the legacy sentinel and must not be used as
+  // site traffic, so it is excluded rather than silently mixed in.
   const { data: rows, error: rollupError } = await supabase
     .from('ruijie_traffic_rollups')
-    .select(
-      'captured_at,total_rx_bytes,total_tx_bytes,avg_rx_bps,peak_rx_bps'
-    )
-    .eq('group_id', groupId)
+    .select('captured_at,total_rx_bytes,total_tx_bytes,avg_rx_bps,peak_rx_bps')
+    .eq('device_sn', serial)
     .eq('hours_window', 1)
     .gte('captured_at', startUtc.toISOString())
     .lte('captured_at', endUtc.toISOString())
@@ -289,8 +290,8 @@ export async function loadRuijieHourlyRows(
   return {
     groupId,
     rows: (rows ?? []) as RuijieHourlyRow[],
-    // Group-keyed table: no per-site series exists yet (#702).
-    perDeviceSeries: false,
+    // Queried by device_sn, so this series belongs to this site alone.
+    perDeviceSeries: true,
   };
 }
 

--- a/supabase/migrations/20260802090000_ruijie_per_device_traffic_rollups.sql
+++ b/supabase/migrations/20260802090000_ruijie_per_device_traffic_rollups.sql
@@ -1,0 +1,51 @@
+-- Per-device Ruijie flow rollups (#702)
+--
+-- `ruijie_traffic_rollups` was keyed by group_id alone, so only one device per
+-- group per hour could be stored. The collector picked one representative AP
+-- (pickFlowDeviceSn -> pool[0] in an all-AP fleet) and its flow was reported as
+-- the whole group's — and, downstream, as each member site's own traffic.
+-- Verified in production: 20 Unjani sites resolve to 2 groups.
+--
+-- The device SN was already being recorded in raw_summary->>'flowSn'; this
+-- promotes it to a real dimension so a site can be attributed its own device.
+--
+-- Safe to run against existing data: the column is added nullable, backfilled
+-- from raw_summary, and the unique key is only widened — no row is deleted and
+-- no existing (group_id, captured_at, hours_window) tuple becomes ambiguous.
+
+BEGIN;
+
+ALTER TABLE public.ruijie_traffic_rollups
+  ADD COLUMN IF NOT EXISTS device_sn text;
+
+-- Existing rows already carry their source SN in raw_summary.
+UPDATE public.ruijie_traffic_rollups
+SET device_sn = raw_summary->>'flowSn'
+WHERE device_sn IS NULL
+  AND raw_summary ? 'flowSn';
+
+COMMENT ON COLUMN public.ruijie_traffic_rollups.device_sn IS
+  'Ruijie device serial this hourly flow belongs to. Group totals are the SUM across device_sn (#702). Null only for legacy rows predating per-device collection.';
+
+-- Widen the uniqueness so every device in a group can hold its own hour.
+ALTER TABLE public.ruijie_traffic_rollups
+  DROP CONSTRAINT IF EXISTS ruijie_traffic_rollups_group_captured_window_key;
+
+-- device_sn participates in the key, so it must be non-null going forward.
+-- Legacy rows without a flowSn get a sentinel rather than being deleted.
+UPDATE public.ruijie_traffic_rollups
+SET device_sn = '__legacy_group__'
+WHERE device_sn IS NULL;
+
+ALTER TABLE public.ruijie_traffic_rollups
+  ALTER COLUMN device_sn SET NOT NULL;
+
+ALTER TABLE public.ruijie_traffic_rollups
+  ADD CONSTRAINT ruijie_traffic_rollups_group_device_captured_window_key
+  UNIQUE (group_id, device_sn, captured_at, hours_window);
+
+-- Usage reports read one site's device across a window.
+CREATE INDEX IF NOT EXISTS idx_ruijie_traffic_rollups_device_time
+  ON public.ruijie_traffic_rollups USING btree (device_sn, captured_at DESC);
+
+COMMIT;


### PR DESCRIPTION
Closes #702. Unblocks #701 / map #687.

> **⚠ The migration is ALREADY APPLIED to the shared staging/prod Supabase.** Production code still upserts with `onConflict: 'group_id,captured_at,hours_window'` — a constraint that no longer exists — and `device_sn` is now NOT NULL. **The Ruijie traffic rollup is broken in production until this merges and deploys.**

## Why

`ruijie_traffic_rollups` was keyed by `group_id` alone, so only one device per group per hour could exist. The collector polled one representative device (`pickFlowDeviceSn` → `pool[0]` in an all-AP fleet) and stored its flow as the group's — and downstream as each member site's own traffic. 20 Unjani sites resolve to 2 groups, so ~10 clinics shared one arbitrary clinic's figure.

The API was never the limitation: `getNetworkTraffic({ sn })` is per-device and was already called per SN. Only the storage key and the loop collapsed it.

## Change

| Part | What |
|---|---|
| Migration | `device_sn` added, backfilled from `raw_summary->>'flowSn'`, unique key widened to include it, index added. Non-destructive. |
| Collector | Polls **every** device in each group, paced 600ms (~25 devices/sync). |
| Reader | `loadRuijieHourlyRows` scopes to the site's own `device_sn` and reports `perDeviceSeries: true`, re-enabling Ruijie as a core source (#701). |

## Dashboards shift — accepted

Analytics and Health already summed rows per group, so their group totals become a **real sum** instead of one AP's flow. Both now exclude the `__legacy_group__` sentinel, otherwise legacy blobs would double-count against per-device rows through the 14-day retention overlap.

## Verified

- **68 tests, 11 suites, passing.** New cases prove `device_sn` is carried and that two devices can hold the same group+hour — previously impossible.
- `tsc --noEmit` clean across all touched paths.
- Migration verified live: **555 rows before, 555 after**, 0 null `device_sn`, 0 sentinel rows, old constraint gone, new key and index present.

## Better than expected

All 555 existing rows already carried a `flowSn`, across **11 distinct serials** — the "representative" device drifted over time, so the historical group series was a mixture of different APs. That also means the backfilled history is genuine per-device flow, not garbage: sites whose device happened to be polled now have real history rather than starting from zero.