### PR TITLE
feat(network): Usage Reports dashboard — preview on screen, then download (#693)

### DIFF
--- a/__tests__/lib/usage-reports/unavailable-copy.test.ts
+++ b/__tests__/lib/usage-reports/unavailable-copy.test.ts
@@ -1,0 +1,88 @@
+import { describeCoreUnavailable } from '@/lib/usage-reports/unavailable-copy';
+import type { CoreUnavailableDiagnosis } from '@/lib/usage-reports/types';
+
+const ok: CoreUnavailableDiagnosis = {
+  interstellioMapped: true,
+  ruijieLinked: true,
+  ruijieCoversWindow: true,
+  ruijiePerDeviceSeries: true,
+};
+
+describe('describeCoreUnavailable', () => {
+  it('names the missing AP link and points at a screen that can fix it', () => {
+    const causes = describeCoreUnavailable({
+      ...ok,
+      interstellioMapped: false,
+      ruijieLinked: false,
+    });
+
+    const apLink = causes.find((cause) => cause.key === 'no_ap_link');
+    expect(apLink).toBeDefined();
+    expect(apLink?.href).toBe('/admin/network/devices');
+  });
+
+  it('does not offer a link for the Interstellio mapping — no admin screen exists', () => {
+    const [cause] = describeCoreUnavailable({ ...ok, interstellioMapped: false });
+
+    expect(cause.key).toBe('no_interstellio');
+    expect(cause.href).toBeUndefined();
+    // Naming the column is the honest way to hand an ops person the real fix.
+    expect(cause.unlock).toMatch(/interstellio_subscriber_id/);
+  });
+
+  it('lists every applicable cause, not just the first', () => {
+    const causes = describeCoreUnavailable({
+      interstellioMapped: false,
+      ruijieLinked: false,
+      ruijieCoversWindow: false,
+      ruijiePerDeviceSeries: false,
+    });
+
+    expect(causes.map((cause) => cause.key)).toEqual(
+      expect.arrayContaining(['no_interstellio', 'no_ap_link'])
+    );
+  });
+
+  it('explains retention rather than instructing, since no admin can fix it', () => {
+    const causes = describeCoreUnavailable({
+      ...ok,
+      interstellioMapped: false,
+      ruijieCoversWindow: false,
+    });
+
+    const retention = causes.find((cause) => cause.key === 'window_uncovered');
+    expect(retention).toBeDefined();
+    expect(retention?.href).toBeUndefined();
+    expect(retention?.actionable).toBe(false);
+  });
+
+  it('distinguishes a shared group series from an unlinked device', () => {
+    const causes = describeCoreUnavailable({
+      ...ok,
+      interstellioMapped: false,
+      ruijiePerDeviceSeries: false,
+    });
+
+    const shared = causes.find((cause) => cause.key === 'group_only');
+    expect(shared).toBeDefined();
+    // The device IS linked — telling someone to link one would be wrong.
+    expect(causes.some((cause) => cause.key === 'no_ap_link')).toBe(false);
+    expect(shared?.actionable).toBe(false);
+  });
+
+  it('returns nothing when every source is healthy', () => {
+    expect(describeCoreUnavailable(ok)).toEqual([]);
+  });
+
+  it('says nothing about Ruijie when Interstellio is mapped and would be used', () => {
+    // Interstellio mapped means the report has a source; Ruijie gaps are moot.
+    const causes = describeCoreUnavailable({
+      ...ok,
+      ruijieLinked: false,
+      ruijieCoversWindow: false,
+      ruijiePerDeviceSeries: false,
+    });
+
+    expect(causes).toEqual([]);
+  });
+});

--- a/app/admin/network/usage-reports/page.tsx
+++ b/app/admin/network/usage-reports/page.tsx
@@ -1,6 +1,4 @@
-import { PiFileTextBold } from 'react-icons/pi';
-
-import { UsageReportBuilder } from '@/components/admin/network/usage-reports/UsageReportBuilder';
+import { UsageReportDashboard } from '@/components/admin/network/usage-reports/dashboard/UsageReportDashboard';
 
 interface UsageReportsPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -14,28 +12,11 @@ export default async function UsageReportsPage({
   searchParams,
 }: UsageReportsPageProps) {
   const params = await searchParams;
-  const initialSiteId = firstParam(params.siteId);
-  const initialUnjaniOnly = firstParam(params.unjani) === '1';
 
   return (
-    <div className="mx-auto max-w-5xl space-y-6">
-      <div className="flex items-start gap-4">
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-orange-100 text-orange-700">
-          <PiFileTextBold className="h-6 w-6" />
-        </div>
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900">Site Usage Reports</h1>
-          <p className="mt-1 text-sm text-slate-600">
-            Generate CircleTel-branded network usage reports for eligible corporate
-            sites.
-          </p>
-        </div>
-      </div>
-
-      <UsageReportBuilder
-        initialSiteId={initialSiteId}
-        initialUnjaniOnly={initialUnjaniOnly}
-      />
-    </div>
+    <UsageReportDashboard
+      initialSiteId={firstParam(params.siteId)}
+      initialUnjaniOnly={firstParam(params.unjani) === '1'}
+    />
   );
 }

--- a/components/admin/network/usage-reports/dashboard/NotAvailablePanel.tsx
+++ b/components/admin/network/usage-reports/dashboard/NotAvailablePanel.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+/**
+ * The not-available state (#689), drawn as the sample PDF's orange callout.
+ *
+ * Until per-device history builds up (#702) this is what most sites show, so it
+ * is the main surface of the page rather than an edge case — it has to be
+ * genuinely useful, not an apology.
+ */
+
+import Link from 'next/link';
+import { PiArrowSquareOutBold, PiWarningBold } from 'react-icons/pi';
+
+import { describeCoreUnavailable } from '@/lib/usage-reports/unavailable-copy';
+import type { CoreUnavailableDiagnosis } from '@/lib/usage-reports/types';
+
+interface NotAvailablePanelProps {
+  siteLabel: string;
+  periodLabel: string;
+  reason: 'core_unavailable' | 'site_not_eligible';
+  diagnosis: CoreUnavailableDiagnosis | null;
+}
+
+export function NotAvailablePanel({
+  siteLabel,
+  periodLabel,
+  reason,
+  diagnosis,
+}: NotAvailablePanelProps) {
+  const causes = diagnosis ? describeCoreUnavailable(diagnosis) : [];
+
+  return (
+    <article className="mx-auto max-w-3xl bg-white px-6 py-7 shadow-sm ring-1 ring-slate-200 sm:px-10 sm:py-9">
+      <header className="flex items-start justify-between gap-6">
+        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border-2 border-orange-500 text-xs font-bold text-orange-600">
+          CT
+        </div>
+        <div className="text-right">
+          <h2 className="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl">
+            Site Network Usage Report
+          </h2>
+          <p className="mt-1 text-xs text-slate-500">
+            {siteLabel} · {periodLabel}
+          </p>
+        </div>
+      </header>
+      <div className="mt-4 h-[3px] w-full bg-orange-500" />
+
+      <div className="mt-6 rounded-md border-2 border-orange-500 bg-orange-50/40 px-5 py-4">
+        <div className="flex items-start gap-2">
+          <PiWarningBold className="mt-0.5 h-4 w-4 shrink-0 text-orange-600" />
+          <p className="text-sm font-bold text-orange-700">
+            {reason === 'site_not_eligible'
+              ? 'This site is not eligible for usage reporting'
+              : 'Core traffic not available for this period'}
+          </p>
+        </div>
+
+        {reason === 'site_not_eligible' ? (
+          <p className="mt-2 text-xs text-slate-700">
+            Only active corporate sites are reported. A site that is pending or
+            whose linked service is not active is excluded.
+          </p>
+        ) : causes.length === 0 ? (
+          <p className="mt-2 text-xs text-slate-700">
+            No permitted traffic source covers this period.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-3">
+            {causes.map((cause) => (
+              <li key={cause.key}>
+                <p className="text-xs font-bold text-slate-900">{cause.title}</p>
+                <p className="mt-0.5 text-xs text-slate-700">{cause.detail}</p>
+                <p className="mt-1 text-xs text-slate-600">
+                  {cause.href ? (
+                    <Link
+                      href={cause.href}
+                      className="inline-flex items-center gap-1 font-medium text-orange-700 underline underline-offset-2"
+                    >
+                      {cause.unlock}
+                      <PiArrowSquareOutBold className="h-3 w-3" />
+                    </Link>
+                  ) : (
+                    cause.unlock
+                  )}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <p className="mt-4 text-[11px] text-orange-700">
+          No figure is shown rather than a wrong one. In a bulk ZIP this site
+          becomes a skip slip.
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/components/admin/network/usage-reports/dashboard/ReportDocument.tsx
+++ b/components/admin/network/usage-reports/dashboard/ReportDocument.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+/**
+ * The report canvas — Variant B from #688, drawn in the sample PDF's grammar so
+ * the screen and the printed document read as the same artefact: brand mark
+ * left with the title right, thick orange rule, uppercase micro-labels, a KPI
+ * row with no card boxes, flat bars on a grey panel, grey inline device panel,
+ * bordered Wi-Fi panels, centred footer.
+ */
+
+import { PiArrowDownBold, PiArrowUpBold, PiDatabaseBold, PiLightningBold } from 'react-icons/pi';
+
+import { formatBytesAsGb } from '@/lib/usage-reports/bytes';
+import type { SiteUsageReportModel } from '@/lib/usage-reports/types';
+
+import { TrafficChart } from './TrafficChart';
+
+function MicroLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-[10px] font-medium uppercase tracking-wider text-slate-400">
+      {children}
+    </p>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div>
+      <MicroLabel>{label}</MicroLabel>
+      <p className="mt-0.5 text-xl font-bold text-slate-900">{value}</p>
+      <span className="mt-1 inline-flex">{icon}</span>
+    </div>
+  );
+}
+
+function Panel({
+  title,
+  source,
+  children,
+}: {
+  title: string;
+  source: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-md border border-slate-200 px-4 py-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <p className="text-sm font-bold text-slate-900">{title}</p>
+        <span className="text-[11px] text-slate-500">{source}</span>
+      </div>
+      <div className="mt-2">{children}</div>
+    </div>
+  );
+}
+
+function formatMbps(kbps: number | null): string {
+  return kbps == null ? '—' : `${(kbps / 1000).toFixed(1)} Mbps`;
+}
+
+function formatGeneratedAt(iso: string): string {
+  const date = new Date(iso);
+  return `${date.toLocaleDateString('en-ZA', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'Africa/Johannesburg',
+  })}, ${date.toLocaleTimeString('en-ZA', {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Africa/Johannesburg',
+  })} SAST`;
+}
+
+export function ReportDocument({ model }: { model: SiteUsageReportModel }) {
+  const { site, period, core, device, staff, patient, unjani } = model;
+
+  return (
+    <article className="mx-auto max-w-3xl bg-white px-6 py-7 shadow-sm ring-1 ring-slate-200 sm:px-10 sm:py-9">
+      <header className="flex items-start justify-between gap-6">
+        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border-2 border-orange-500 text-xs font-bold text-orange-600">
+          CT
+        </div>
+        <div className="text-right">
+          <h2 className="text-xl font-bold tracking-tight text-slate-900 sm:text-2xl">
+            Site Network Usage Report
+          </h2>
+          <p className="mt-1 text-xs text-slate-500">
+            Generated {formatGeneratedAt(model.generatedAtIso)}
+          </p>
+        </div>
+      </header>
+      <div className="mt-4 h-[3px] w-full bg-orange-500" />
+
+      <section className="mt-6 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <MicroLabel>Site</MicroLabel>
+          <p className="text-lg font-bold text-slate-900">{site.name}</p>
+          <p className="text-xs text-slate-500">
+            {site.accountNumber} · {site.accountName}
+          </p>
+        </div>
+        <div className="text-right">
+          <MicroLabel>Report period</MicroLabel>
+          <p className="text-lg font-bold text-slate-900">{period.label}</p>
+          <p className="text-xs text-slate-500">{period.rangeLabel} · SAST</p>
+        </div>
+      </section>
+
+      <section className="mt-6 grid grid-cols-2 gap-6 sm:grid-cols-4">
+        <Kpi
+          label="Downloaded"
+          value={formatBytesAsGb(core.downloadBytes)}
+          icon={<PiArrowDownBold className="h-3.5 w-3.5 text-emerald-600" />}
+        />
+        <Kpi
+          label="Uploaded"
+          value={formatBytesAsGb(core.uploadBytes)}
+          icon={<PiArrowUpBold className="h-3.5 w-3.5 text-blue-600" />}
+        />
+        <Kpi
+          label="Avg DL"
+          value={formatMbps(core.avgDownKbps)}
+          icon={<PiLightningBold className="h-3.5 w-3.5 text-orange-500" />}
+        />
+        <Kpi
+          label="Peak bucket"
+          value={formatBytesAsGb(core.peakBucketBytes ?? 0)}
+          icon={<PiDatabaseBold className="h-3.5 w-3.5 text-slate-400" />}
+        />
+      </section>
+
+      <section className="mt-7 border-t border-slate-200 pt-5">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <h3 className="text-sm font-bold text-slate-900">Core site traffic</h3>
+          <span className="text-xs text-slate-500">Primary: {core.sourceLabel}</span>
+        </div>
+        <p className="mt-1 text-xs text-slate-500">{core.note}</p>
+        <div className="mt-3">
+          <TrafficChart
+            dailyDownloadBytes={core.dailyDownloadBytes}
+            dailyCovered={core.dailyCovered}
+            periodStartIso={period.startIso}
+          />
+        </div>
+        {core.secondaryInterstellio && (
+          <p className="mt-2 text-[11px] text-slate-400">
+            BNG / Interstellio, same period:{' '}
+            {formatBytesAsGb(core.secondaryInterstellio.downloadBytes)} down ·{' '}
+            {formatBytesAsGb(core.secondaryInterstellio.uploadBytes)} up — shown for
+            comparison, never summed with the primary.
+          </p>
+        )}
+      </section>
+
+      {device && (
+        <section className="mt-6 rounded-md bg-slate-50 px-4 py-3">
+          <p className="text-xs font-bold text-slate-900">Device identity</p>
+          <p className="mt-1 text-xs text-slate-500">
+            {[
+              device.name,
+              device.model,
+              device.serial && `SN ${device.serial}`,
+              device.group && `Group ${device.group}`,
+              device.status,
+            ]
+              .filter(Boolean)
+              .join(' · ')}
+          </p>
+        </section>
+      )}
+
+      {unjani && (
+        <section className="mt-7">
+          <h3 className="text-sm font-bold text-slate-900">
+            Unjani Wi-Fi breakdown{' '}
+            <span className="font-normal text-slate-500">
+              (separate sources — do not sum)
+            </span>
+          </h3>
+
+          <div className="mt-3 space-y-3">
+            <Panel
+              title="Staff Wi-Fi"
+              source="Source: CircleTel radio (SSID period bytes)"
+            >
+              {staff.kind === 'available' ? (
+                <>
+                  <div className="flex flex-wrap gap-x-8 gap-y-1 text-sm text-slate-900">
+                    <span>Total: {formatBytesAsGb(staff.totalBytes)}</span>
+                    <span>Download: {formatBytesAsGb(staff.rxBytes)}</span>
+                    <span>Upload: {formatBytesAsGb(staff.txBytes)}</span>
+                  </div>
+                  <p className="mt-2 text-[11px] text-slate-400">
+                    Sampled STA session telemetry — not accounting-grade;
+                    forward-only from sampler go-live and may undercount short
+                    sessions.
+                  </p>
+                </>
+              ) : (
+                <p className="text-sm text-slate-500">
+                  {staff.kind === 'no_samples'
+                    ? 'Not available — no Staff Wi-Fi samples in this period.'
+                    : 'Not available — this site has no access point linked to it.'}
+                </p>
+              )}
+            </Panel>
+
+            <Panel
+              title="Patient Free Wi-Fi"
+              source="Source: TDX/ThinkWiFi (manual Looker export)"
+            >
+              {patient.kind === 'available' ? (
+                <>
+                  <div className="flex flex-wrap gap-x-8 gap-y-1 text-sm text-slate-900">
+                    <span>Unique users: {patient.uniqueUsers.toLocaleString()}</span>
+                    <span>
+                      Login sessions: {patient.loginSessions.toLocaleString()}
+                    </span>
+                    <span>Download: {patient.downloadGb} GB</span>
+                  </div>
+                  <p className="mt-2 text-[11px] text-slate-400">
+                    Aggregate / anonymised · may be revised by TDX · do not sum with
+                    Staff or BNG totals.
+                  </p>
+                </>
+              ) : (
+                <p className="text-sm text-slate-500">Awaiting TDX export.</p>
+              )}
+            </Panel>
+          </div>
+        </section>
+      )}
+
+      <footer className="mt-8 border-t border-slate-100 pt-4 text-center text-[11px] text-slate-400">
+        CircleTel · {site.accountNumber} · Generated{' '}
+        {formatGeneratedAt(model.generatedAtIso)} · Figures are from the labelled
+        source only
+      </footer>
+    </article>
+  );
+}

--- a/components/admin/network/usage-reports/dashboard/SitePicker.tsx
+++ b/components/admin/network/usage-reports/dashboard/SitePicker.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+/**
+ * Searchable site picker (#695). A plain dropdown does not survive 26 sites,
+ * and #688 ruled out a persistent rail — so selection lives in a command
+ * palette and focus lives in the cards above the document.
+ *
+ * Deliberately shows no availability badge: the map rules out a per-site
+ * telemetry probe on list load.
+ */
+
+import { useMemo, useState } from 'react';
+import { PiBuildingsBold, PiCaretDownBold, PiCheckBold } from 'react-icons/pi';
+
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+import {
+  filterUsageReportSites,
+  type UsageReportSite,
+} from '../SiteMultiSelect';
+
+interface SitePickerProps {
+  sites: UsageReportSite[];
+  selectedIds: string[];
+  loading: boolean;
+  onChange: (siteIds: string[]) => void;
+}
+
+export function SitePicker({
+  sites,
+  selectedIds,
+  loading,
+  onChange,
+}: SitePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  // Reuses the shipped filter so search behaviour is inherited, not reinvented.
+  const filtered = useMemo(
+    () => filterUsageReportSites(sites, query),
+    [sites, query]
+  );
+
+  const toggle = (siteId: string) =>
+    onChange(
+      selectedIds.includes(siteId)
+        ? selectedIds.filter((id) => id !== siteId)
+        : [...selectedIds, siteId]
+    );
+
+  // Select-all applies to what is on screen, so "UNJ" + select all is the
+  // Unjani preset without needing a special case.
+  const selectFiltered = () => {
+    const merged = new Set(selectedIds);
+    for (const site of filtered) merged.add(site.id);
+    onChange(Array.from(merged));
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="gap-2 font-normal" disabled={loading}>
+          <PiBuildingsBold className="h-4 w-4 text-slate-400" />
+          {loading
+            ? 'Loading sites…'
+            : selectedIds.length === 0
+              ? 'Choose sites'
+              : `${selectedIds.length} site${selectedIds.length === 1 ? '' : 's'}`}
+          <PiCaretDownBold className="h-3.5 w-3.5 text-slate-400" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-0">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Search site, account or corporate…"
+            value={query}
+            onValueChange={setQuery}
+          />
+          <CommandList>
+            <CommandEmpty>No eligible site matches.</CommandEmpty>
+            <CommandGroup>
+              {filtered.map((site) => {
+                const isSelected = selectedIds.includes(site.id);
+                return (
+                  <CommandItem
+                    key={site.id}
+                    value={site.id}
+                    onSelect={() => toggle(site.id)}
+                    className="gap-2"
+                  >
+                    <PiCheckBold
+                      className={cn(
+                        'h-4 w-4 shrink-0',
+                        isSelected ? 'text-orange-600' : 'text-transparent'
+                      )}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm">{site.name}</span>
+                      <span className="block text-xs text-slate-500">
+                        {site.account_number}
+                      </span>
+                    </span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+          <div className="flex items-center justify-between border-t border-slate-100 px-2 py-1.5">
+            <Button variant="ghost" size="sm" onClick={selectFiltered}>
+              Select {query ? 'these' : 'all'} ({filtered.length})
+            </Button>
+            <Button variant="ghost" size="sm" onClick={() => onChange([])}>
+              Clear
+            </Button>
+          </div>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/admin/network/usage-reports/dashboard/TrafficChart.tsx
+++ b/components/admin/network/usage-reports/dashboard/TrafficChart.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+/**
+ * Core traffic chart (#692): hatched gap band + coverage ribbon.
+ *
+ * Two rules it exists to honour:
+ * - An uncovered day is drawn as a gap, never a zero-height bar. Retention
+ *   means most long periods are mostly gap, and a zero bar claims the network
+ *   was idle (#689).
+ * - Chrome stays minimal to match the printed report — bars on a plain grey
+ *   panel, no gridlines, no y-axis, day-of-month ticks only (#667).
+ */
+
+import { Bar, BarChart, ReferenceArea, ResponsiveContainer, XAxis } from 'recharts';
+
+const ORANGE = '#E87A1E';
+const GAP_INK = '#94A3B8';
+const GAP_PATTERN_ID = 'usage-report-gap-hatch';
+
+export interface TrafficChartProps {
+  /** Bytes per day, in period order. */
+  dailyDownloadBytes: number[];
+  /** Sample presence per day — same length and order. */
+  dailyCovered: boolean[];
+  /** SAST start of the period, used for day-of-month labels. */
+  periodStartIso: string;
+}
+
+const BYTES_PER_GB = 1024 ** 3;
+
+/** Contiguous runs of uncovered days as inclusive index pairs. */
+export function gapRanges(covered: boolean[]): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let start: number | null = null;
+
+  covered.forEach((isCovered, index) => {
+    if (!isCovered && start === null) start = index;
+    if (isCovered && start !== null) {
+      ranges.push([start, index - 1]);
+      start = null;
+    }
+  });
+  if (start !== null) ranges.push([start, covered.length - 1]);
+
+  return ranges;
+}
+
+/** Fewer ticks as the period grows so labels never collide in a 768px column. */
+export function tickInterval(dayCount: number): number {
+  if (dayCount <= 7) return 0;
+  if (dayCount <= 31) return 2;
+  if (dayCount <= 60) return 5;
+  return 8;
+}
+
+export function TrafficChart({
+  dailyDownloadBytes,
+  dailyCovered,
+  periodStartIso,
+}: TrafficChartProps) {
+  const start = new Date(periodStartIso);
+  const data = dailyDownloadBytes.map((bytes, index) => {
+    const day = new Date(start.getTime() + index * 86_400_000);
+    return {
+      index: index + 1,
+      dayOfMonth: day.getUTCDate(),
+      downloadGb: Number((bytes / BYTES_PER_GB).toFixed(2)),
+      covered: dailyCovered[index] ?? false,
+    };
+  });
+
+  const gaps = gapRanges(dailyCovered);
+  const coveredCount = dailyCovered.filter(Boolean).length;
+
+  return (
+    <div>
+      <div className="rounded-md bg-slate-50 p-3">
+        <ResponsiveContainer width="100%" height={150}>
+          <BarChart data={data} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
+            <defs>
+              <pattern
+                id={GAP_PATTERN_ID}
+                width={6}
+                height={6}
+                patternTransform="rotate(45)"
+                patternUnits="userSpaceOnUse"
+              >
+                <rect width={6} height={6} fill="#EEF2F7" />
+                <line x1={0} y1={0} x2={0} y2={6} stroke={GAP_INK} strokeWidth={1.2} />
+              </pattern>
+            </defs>
+
+            {gaps.map(([from, to]) => (
+              <ReferenceArea
+                key={`${from}-${to}`}
+                x1={data[from].index}
+                x2={data[to].index}
+                fill={`url(#${GAP_PATTERN_ID})`}
+                fillOpacity={1}
+              />
+            ))}
+
+            <XAxis
+              dataKey="dayOfMonth"
+              tickLine={false}
+              axisLine={false}
+              interval={tickInterval(data.length)}
+              tickMargin={6}
+              fontSize={9}
+              stroke="#94A3B8"
+            />
+            {/* Animation off: a mid-animation render shows axes with no bars,
+                which screenshot-based checks read as a working empty chart. */}
+            <Bar
+              dataKey="downloadGb"
+              fill={ORANGE}
+              radius={1}
+              isAnimationActive={false}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Coverage ribbon — per-day precision the hatching alone cannot give. */}
+      <div
+        className="mt-1.5 flex h-1.5 w-full overflow-hidden rounded-full"
+        role="img"
+        aria-label={`${coveredCount} of ${dailyCovered.length} days have samples`}
+      >
+        {dailyCovered.map((isCovered, index) => (
+          <div
+            key={index}
+            className={isCovered ? 'bg-orange-500' : 'bg-slate-300'}
+            style={{ width: `${100 / dailyCovered.length}%` }}
+          />
+        ))}
+      </div>
+      <p className="mt-1.5 text-[11px] text-slate-400">
+        Daily download (GB) · {coveredCount} of {dailyCovered.length} days sampled ·
+        hatched days have no data
+      </p>
+    </div>
+  );
+}

--- a/components/admin/network/usage-reports/dashboard/UsageReportDashboard.tsx
+++ b/components/admin/network/usage-reports/dashboard/UsageReportDashboard.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+/**
+ * Usage Reports dashboard (#693) — Variant B "report-first" from #688.
+ *
+ * Page chrome follows /admin/network/analytics (breadcrumb, right-aligned
+ * toolbar, source + freshness line, selectable cards); the canvas follows the
+ * printed report. Preview is a pure read — the endpoint writes nothing — so
+ * looking costs no audit row and no stored artifact (#690).
+ *
+ * Download still uses the shipped generate/jobs routes; the split control, CSV
+ * retirement and Patient CSV rebind are #694.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  PiArrowClockwiseBold,
+  PiCaretDownBold,
+  PiClockBold,
+  PiDownloadSimpleBold,
+  PiSpinnerGapBold,
+} from 'react-icons/pi';
+
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Label } from '@/components/ui/label';
+import { formatBytesAsGb } from '@/lib/usage-reports/bytes';
+import type {
+  CoreUnavailableDiagnosis,
+  ReportPeriodPreset,
+  SiteUsageReportModel,
+} from '@/lib/usage-reports/types';
+
+import { JobProgress } from '../JobProgress';
+import type { UsageReportSite } from '../SiteMultiSelect';
+import { NotAvailablePanel } from './NotAvailablePanel';
+import { ReportDocument } from './ReportDocument';
+import { SitePicker } from './SitePicker';
+
+const PERIOD_LABELS: Record<ReportPeriodPreset, string> = {
+  weekly: 'Last complete week',
+  monthly: 'Previous month',
+  sixty_day: 'Last 60 days',
+  custom: 'Custom range',
+};
+
+type PreviewResult =
+  | { ok: true; model: SiteUsageReportModel }
+  | {
+      ok: false;
+      reason: 'core_unavailable' | 'site_not_eligible';
+      siteLabel: string;
+      diagnosis: CoreUnavailableDiagnosis | null;
+      period: { label: string; rangeLabel: string };
+    };
+
+interface UsageReportDashboardProps {
+  initialSiteId?: string;
+  initialUnjaniOnly?: boolean;
+}
+
+export function UsageReportDashboard({
+  initialSiteId,
+  initialUnjaniOnly = false,
+}: UsageReportDashboardProps) {
+  const [period, setPeriod] = useState<ReportPeriodPreset>('monthly');
+  const [includeProvisioned, setIncludeProvisioned] = useState(true);
+  const [unjaniOnly, setUnjaniOnly] = useState(initialUnjaniOnly);
+
+  const [sites, setSites] = useState<UsageReportSite[]>([]);
+  const [sitesLoading, setSitesLoading] = useState(true);
+  const [selectedIds, setSelectedIds] = useState<string[]>(
+    initialSiteId ? [initialSiteId] : []
+  );
+  const [focusedId, setFocusedId] = useState<string | null>(initialSiteId ?? null);
+
+  const [preview, setPreview] = useState<PreviewResult | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [loadedAt, setLoadedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [jobId, setJobId] = useState<string | null>(null);
+
+  /**
+   * Session cache per (site, period): re-focusing a site you have already
+   * looked at is free. Long periods hit the Interstellio API per site, so
+   * clicking back and forth would otherwise re-pay that every time.
+   */
+  const cache = useRef(new Map<string, { result: PreviewResult; at: string }>());
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadSites = async () => {
+      setSitesLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        if (includeProvisioned) params.set('includeProvisioned', '1');
+        if (unjaniOnly) params.set('unjaniOnly', '1');
+        const response = await fetch(
+          `/api/admin/network/usage-reports/sites?${params.toString()}`,
+          { credentials: 'include', cache: 'no-store', signal: controller.signal }
+        );
+        const data = (await response.json()) as {
+          sites?: UsageReportSite[];
+          error?: string;
+        };
+        if (!response.ok) throw new Error(data.error || 'Failed to load eligible sites');
+
+        const next = data.sites ?? [];
+        const eligible = new Set(next.map((site) => site.id));
+        setSites(next);
+        setSelectedIds((current) => current.filter((id) => eligible.has(id)));
+        setFocusedId((current) => (current && eligible.has(current) ? current : null));
+      } catch (loadError) {
+        if (controller.signal.aborted) return;
+        setSites([]);
+        setError(
+          loadError instanceof Error ? loadError.message : 'Failed to load eligible sites'
+        );
+      } finally {
+        if (!controller.signal.aborted) setSitesLoading(false);
+      }
+    };
+
+    void loadSites();
+    return () => controller.abort();
+  }, [includeProvisioned, unjaniOnly]);
+
+  const loadPreview = useCallback(
+    async (siteId: string, { force = false } = {}) => {
+      const key = `${siteId}:${period}`;
+      const cached = cache.current.get(key);
+      if (cached && !force) {
+        setPreview(cached.result);
+        setLoadedAt(cached.at);
+        return;
+      }
+
+      setPreviewLoading(true);
+      setError(null);
+      try {
+        const response = await fetch('/api/admin/network/usage-reports/preview', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ siteId, period }),
+        });
+        const data = (await response.json()) as PreviewResult & { error?: string };
+        if (!response.ok) throw new Error(data.error || 'Failed to load preview');
+
+        const at = new Date().toLocaleTimeString('en-ZA', {
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+        cache.current.set(key, { result: data, at });
+        setPreview(data);
+        setLoadedAt(at);
+      } catch (previewError) {
+        setPreview(null);
+        setError(
+          previewError instanceof Error ? previewError.message : 'Failed to load preview'
+        );
+      } finally {
+        setPreviewLoading(false);
+      }
+    },
+    [period]
+  );
+
+  // Focusing a site, or changing the period, reloads what is on screen.
+  useEffect(() => {
+    if (!focusedId) {
+      setPreview(null);
+      return;
+    }
+    void loadPreview(focusedId);
+  }, [focusedId, loadPreview]);
+
+  // A different period invalidates every cached model.
+  useEffect(() => {
+    cache.current.clear();
+  }, [period]);
+
+  const handleSelectionChange = (ids: string[]) => {
+    setSelectedIds(ids);
+    if (ids.length > 0 && (!focusedId || !ids.includes(focusedId))) {
+      setFocusedId(ids[0]);
+    }
+    if (ids.length === 0) setFocusedId(null);
+  };
+
+  const handleDownload = async () => {
+    if (selectedIds.length === 0) return;
+    setSubmitting(true);
+    setJobId(null);
+    setError(null);
+
+    const payload = { siteIds: selectedIds, period, includeCsv: false, patientRows: [] };
+    try {
+      if (selectedIds.length <= 5) {
+        const response = await fetch('/api/admin/network/usage-reports/generate', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          const data = (await response.json().catch(() => ({}))) as { error?: string };
+          throw new Error(data.error || 'Failed to generate usage report');
+        }
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download =
+          response.headers
+            .get('content-disposition')
+            ?.match(/filename="([^"]+)"/i)?.[1] ?? 'CircleTel_Usage_Report.pdf';
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        window.setTimeout(() => window.URL.revokeObjectURL(url), 0);
+      } else {
+        const response = await fetch('/api/admin/network/usage-reports/jobs', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = (await response.json()) as { jobId?: string; error?: string };
+        if (!response.ok || !data.jobId) {
+          throw new Error(data.error || 'Failed to queue usage report job');
+        }
+        setJobId(data.jobId);
+      }
+    } catch (downloadError) {
+      setError(
+        downloadError instanceof Error
+          ? downloadError.message
+          : 'Failed to generate usage report'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (jobId) {
+    return <JobProgress jobId={jobId} onReset={() => setJobId(null)} />;
+  }
+
+  const selectedSites = sites.filter((site) => selectedIds.includes(site.id));
+  const focusedSite = sites.find((site) => site.id === focusedId) ?? null;
+
+  return (
+    <div className="space-y-6">
+      {/* Page chrome — Analytics grammar */}
+      <div>
+        <p className="text-xs text-slate-400">Activity / Infrastructure / Usage Reports</p>
+        <div className="mt-1 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900">Site Usage Reports</h1>
+            <p className="mt-0.5 text-sm text-slate-500">
+              Preview a site&apos;s report, then download it or the whole selection
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <SitePicker
+              sites={sites}
+              selectedIds={selectedIds}
+              loading={sitesLoading}
+              onChange={handleSelectionChange}
+            />
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="gap-2 font-normal">
+                  {PERIOD_LABELS[period]}
+                  <PiCaretDownBold className="h-3.5 w-3.5 text-slate-400" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Report period (SAST)</DropdownMenuLabel>
+                {(['weekly', 'monthly', 'sixty_day'] as const).map((preset) => (
+                  <DropdownMenuCheckboxItem
+                    key={preset}
+                    checked={period === preset}
+                    onCheckedChange={() => setPeriod(preset)}
+                  >
+                    {PERIOD_LABELS[preset]}
+                  </DropdownMenuCheckboxItem>
+                ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="font-normal text-xs text-slate-400">
+                  Custom ranges: use the generate flow
+                </DropdownMenuLabel>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <Button
+              variant="outline"
+              className="gap-2 font-normal"
+              disabled={!focusedId || previewLoading}
+              onClick={() => focusedId && void loadPreview(focusedId, { force: true })}
+            >
+              {previewLoading ? (
+                <PiSpinnerGapBold className="h-4 w-4 animate-spin" />
+              ) : (
+                <PiArrowClockwiseBold className="h-4 w-4" />
+              )}
+              Refresh
+            </Button>
+
+            <Button
+              onClick={() => void handleDownload()}
+              disabled={submitting || selectedIds.length === 0}
+            >
+              {submitting ? (
+                <PiSpinnerGapBold className="mr-2 h-4 w-4 animate-spin" />
+              ) : selectedIds.length > 5 ? (
+                <PiClockBold className="mr-2 h-4 w-4" />
+              ) : (
+                <PiDownloadSimpleBold className="mr-2 h-4 w-4" />
+              )}
+              {selectedIds.length > 5
+                ? `Queue ${selectedIds.length} (ZIP)`
+                : 'Download'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs">
+          {preview?.ok && (
+            <span className="rounded-md bg-slate-100 px-2 py-1 font-medium text-slate-700">
+              {preview.model.core.sourceLabel}
+            </span>
+          )}
+          <span className="text-slate-400">
+            {focusedSite ? focusedSite.name : 'No site selected'}
+            {loadedAt && ` · loaded ${loadedAt}`}
+          </span>
+          <span className="ml-auto flex items-center gap-4">
+            <label className="flex items-center gap-2 text-slate-600">
+              <Checkbox
+                id="include-provisioned"
+                checked={includeProvisioned}
+                onCheckedChange={(checked) => setIncludeProvisioned(checked === true)}
+              />
+              <Label htmlFor="include-provisioned" className="cursor-pointer font-normal">
+                Include provisioned
+              </Label>
+            </label>
+            <label className="flex items-center gap-2 text-slate-600">
+              <Checkbox
+                id="unjani-only"
+                checked={unjaniOnly}
+                onCheckedChange={(checked) => setUnjaniOnly(checked === true)}
+              />
+              <Label htmlFor="unjani-only" className="cursor-pointer font-normal">
+                Unjani only
+              </Label>
+            </label>
+          </span>
+        </div>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Selected sites — Analytics' Group Traffic card pattern */}
+      {selectedSites.length > 0 && (
+        <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-sm font-semibold text-slate-900">Selected sites</h2>
+          <p className="mt-0.5 text-xs text-slate-500">
+            Click a site to preview its report — download acts on the whole selection
+          </p>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {selectedSites.map((site) => {
+              const isFocused = site.id === focusedId;
+              const cached = cache.current.get(`${site.id}:${period}`)?.result;
+              return (
+                <button
+                  key={site.id}
+                  type="button"
+                  onClick={() => setFocusedId(site.id)}
+                  className={`rounded-lg border px-4 py-3 text-left transition ${
+                    isFocused
+                      ? 'border-orange-500 bg-orange-50/50'
+                      : 'border-slate-200 bg-white hover:border-slate-300'
+                  }`}
+                >
+                  <span className="block truncate text-sm font-medium text-slate-900">
+                    {site.name}
+                  </span>
+                  <span className="mt-1 block text-lg font-semibold text-slate-900">
+                    {cached?.ok
+                      ? formatBytesAsGb(cached.model.core.downloadBytes)
+                      : cached
+                        ? '—'
+                        : '·'}
+                  </span>
+                  <span className="mt-0.5 block truncate text-xs text-slate-500">
+                    {cached?.ok
+                      ? site.account_number
+                      : cached
+                        ? 'Not available'
+                        : site.account_number}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* The document */}
+      {!focusedId ? (
+        <div className="rounded-xl border border-dashed border-slate-300 bg-white py-16 text-center">
+          <p className="text-sm font-medium text-slate-900">No site selected</p>
+          <p className="mt-1 text-sm text-slate-500">
+            Choose one or more sites to preview a report.
+          </p>
+        </div>
+      ) : previewLoading && !preview ? (
+        <div className="rounded-xl border border-slate-200 bg-white py-16 text-center">
+          <PiSpinnerGapBold className="mx-auto h-6 w-6 animate-spin text-orange-600" />
+          <p className="mt-3 text-sm text-slate-500">Assembling report…</p>
+        </div>
+      ) : preview?.ok ? (
+        <ReportDocument model={preview.model} />
+      ) : preview ? (
+        <NotAvailablePanel
+          siteLabel={preview.siteLabel}
+          periodLabel={preview.period.rangeLabel}
+          reason={preview.reason}
+          diagnosis={preview.diagnosis}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/lib/usage-reports/unavailable-copy.ts
+++ b/lib/usage-reports/unavailable-copy.ts
@@ -1,0 +1,90 @@
+import type { CoreUnavailableDiagnosis } from './types';
+
+/**
+ * Turns a core-traffic diagnosis into the causes an admin should read (#689).
+ *
+ * Rules this encodes:
+ * - Every applicable cause is listed, not just the first — a site can be
+ *   missing an AP link AND a subscriber mapping at once.
+ * - A cause only offers a link when a screen exists that can actually fix it.
+ *   Pointing at a page that cannot do the job is worse than saying so.
+ * - Retention explains rather than instructs, because no admin can change it.
+ * - "Shared group series" is distinct from "no AP linked": the device IS
+ *   linked, so telling someone to link one would send them in circles (#701).
+ */
+
+export type CoreUnavailableCauseKey =
+  | 'no_interstellio'
+  | 'no_ap_link'
+  | 'window_uncovered'
+  | 'group_only';
+
+export interface CoreUnavailableCause {
+  key: CoreUnavailableCauseKey;
+  title: string;
+  detail: string;
+  unlock: string;
+  /** Present only where a screen can genuinely resolve it. */
+  href?: string;
+  /** False when nothing an admin does will fix it — explain, don't instruct. */
+  actionable: boolean;
+}
+
+export function describeCoreUnavailable(
+  diagnosis: CoreUnavailableDiagnosis
+): CoreUnavailableCause[] {
+  // A mapped subscriber means the report has a working source; any Ruijie
+  // shortcoming is irrelevant and mentioning it would just be noise.
+  if (diagnosis.interstellioMapped) return [];
+
+  const causes: CoreUnavailableCause[] = [
+    {
+      key: 'no_interstellio',
+      title: 'No Interstellio subscriber mapping',
+      detail:
+        'Periods longer than a week are billed from BNG subscriber accounting, and this site is not mapped to a subscriber.',
+      unlock:
+        'No admin screen sets this yet — ops must populate corporate_sites.interstellio_subscriber_id for the site.',
+      actionable: false,
+    },
+  ];
+
+  if (!diagnosis.ruijieLinked) {
+    causes.push({
+      key: 'no_ap_link',
+      title: 'No access point linked to this site',
+      detail:
+        'Without a linked device there is no Ruijie series to fall back on for short periods.',
+      unlock: 'Link a device to this site from the network devices page.',
+      href: '/admin/network/devices',
+      actionable: true,
+    });
+    return causes;
+  }
+
+  if (!diagnosis.ruijieCoversWindow) {
+    causes.push({
+      key: 'window_uncovered',
+      title: 'No Ruijie samples in this period',
+      detail:
+        'Ruijie rollups reach back roughly two weeks, so they cannot cover this window.',
+      unlock: 'Choose a shorter period, or wait for subscriber mapping.',
+      actionable: false,
+    });
+    return causes;
+  }
+
+  if (!diagnosis.ruijiePerDeviceSeries) {
+    causes.push({
+      key: 'group_only',
+      title: 'Traffic is only available for the shared network group',
+      detail:
+        'This site’s access point is linked and reporting, but its traffic is recorded against a network group shared with other sites — so it is not this site’s own usage.',
+      unlock:
+        'Per-device collection is now running; this resolves itself once enough per-device history exists for the period.',
+      actionable: false,
+    });
+  }
+
+  return causes;
+}


### PR DESCRIPTION
Closes #693. Map #687.

Replaces the blind three-card form. Until now an admin could configure and download a **client-facing** report without ever seeing a number.

## Shape

Variant B "report-first" from #688, with the two references doing different jobs:

- **`/admin/network/analytics` → page chrome.** Breadcrumb, right-aligned toolbar, source + freshness line, and selectable cards using its Group Traffic pattern.
- **Sample PDF → canvas.** Orange rule, uppercase micro-labels, boxless KPI row, flat bars on a grey panel, grey device panel, centred footer — so screen and print read as the same artefact.

## Decisions carried in

| From | What |
|---|---|
| #690 | Reads the preview endpoint — a pure read, so looking costs no audit row and no stored artifact |
| #692 | Hatched gap band + coverage ribbon; animation disabled; an uncovered day is never a zero-height bar |
| #695 | Searchable command palette, reusing the shipped `filterUsageReportSites` |
| #689 / #701 | `describeCoreUnavailable` — pure, unit-tested; lists every applicable cause, links only where a screen can genuinely fix it, explains retention rather than instructing |

Session cache per (site, period): long periods hit Interstellio per site, so re-focusing a site you have already opened is free. Refresh forces a reload.

**#692 and #695 were decided by delegation**, not deliberation — both are recorded as revisable on their tickets.

## Verification

- **57 tests, 10 suites.** New `unavailable-copy.test.ts` covers the copy matrix, including that the Interstellio cause offers no link (no admin screen exists) and that a shared-group series is not reported as an unlinked device.
- `tsc --noEmit` clean across all touched paths.
- Rendered at **1440px and 375px against live data with a real admin session** via the #691 harness — no admin API call denied.

## What it shows today

Core traffic is **not available** for every site, because per-device collection only began this morning (#702). The screenshot below is the honest current state, and it is why the not-available panel got the design attention it did — it is the main surface of the page until history accumulates.

Download keeps the shipped generate/jobs behaviour; the split control, CSV retirement and Patient CSV rebind are #694.