### PR TITLE
chore(ruijie): retain traffic rollups for 90 days, not 14

### DIFF
--- a/lib/inngest/functions/ruijie-traffic-rollup.ts
+++ b/lib/inngest/functions/ruijie-traffic-rollup.ts
@@ -25,7 +25,20 @@ import { getNetworkTraffic } from '@/lib/ruijie/client';
 import { buildHourlyRollupUpserts } from '@/lib/network/analytics-aggregates';
 
 const HOURS_WINDOW = 24;
-const RETENTION_DAYS = 14;
+/**
+ * 90 days, matching the longest report period the spec allows (custom ranges are
+ * capped at 90 inclusive days).
+ *
+ * This table is the system of record, not a cache. Ruijie Cloud itself only
+ * serves ~3 days of per-device flow — measured 2026-08-02: four APs all cut off
+ * at the same instant, and a 90-day request returns a full 12,960-point grid
+ * that is 88% zero-padded rather than truncated. So anything pruned here is
+ * gone for good; there is nothing upstream to re-fetch it from.
+ *
+ * Cost is negligible: ~22 devices x 24 hourly rows = ~530 rows/day, so 90 days
+ * is roughly 48k rows.
+ */
+const RETENTION_DAYS = 90;
 /** Pace between per-device flow calls — the fleet is ~25 devices per sync. */
 const DEVICE_DELAY_MS = 600;
 /** Let Ruijie cool down after device metric enrichment on the same event. */


### PR DESCRIPTION
`RETENTION_DAYS` 14 → 90 in `lib/inngest/functions/ruijie-traffic-rollup.ts`.

## Why now

This table stopped being a cache the moment per-device collection landed (#702) — it is the **system of record**.

Measured today against live Ruijie Cloud: it serves only **~3 days** of per-device flow. Four Unjani APs all cut off at the identical instant (`2026-07-29T22:00:00Z`, midnight SAST), and the boundary is date-aligned rather than rolling. A 90-day request does not truncate or error — it returns a full 12,960-point grid that is **88% zero-padded**, indistinguishable from genuinely idle buckets.

So anything this prune deletes is gone permanently; there is nothing upstream to re-fetch it from.

A 14-day window also capped every report period at 14 days no matter how much history accumulated, which directly contradicts the spec's 90-day custom range.

## Cost

~22 devices × 24 hourly rows ≈ **530 rows/day**, so 90 days is roughly **48k rows**. Negligible.

## Verification

- `tsc --noEmit` clean.
- 18 tests across 2 suites in `__tests__/lib/network/` pass.
- Prune logic itself is unchanged — only the constant moves, and it is already covered by the existing cutoff arithmetic.

## Related, not changed here

- `ruijie_ssid_traffic_rollups` (Staff Wi-Fi) has **no prune at all** — it already retains indefinitely. Worth a deliberate decision rather than leaving it implicit, but out of scope for this change.
- The oldest rollups (25–31 Jul) are pre-#702 group blobs, unusable as site traffic and unrepairable. This change stops them being deleted around 8 Aug; they can be cleared deliberately if preferred.