### PR TITLE
feat(network): alert on Ruijie sync health before data becomes unrecoverable

### DIFF
--- a/__tests__/lib/network/ruijie-sync-health.test.ts
+++ b/__tests__/lib/network/ruijie-sync-health.test.ts
@@ -1,0 +1,113 @@
+import {
+  evaluateRuijieSyncHealth,
+  RUIJIE_SOURCE_RETENTION_HOURS,
+  type RuijieSyncHealthInput,
+} from '@/lib/network/ruijie-sync-health';
+
+const NOW = new Date('2026-08-02T12:00:00Z');
+
+function hoursAgo(hours: number): string {
+  return new Date(NOW.getTime() - hours * 3_600_000).toISOString();
+}
+
+const healthy: RuijieSyncHealthInput = {
+  now: NOW,
+  newestRollupAt: hoursAgo(0.5),
+  devicesReportingRecently: 22,
+  devicesExpected: 22,
+  newestStaffRollupAt: hoursAgo(1),
+};
+
+describe('evaluateRuijieSyncHealth', () => {
+  it('is healthy when the sync is current and every device is reporting', () => {
+    const result = evaluateRuijieSyncHealth(healthy);
+
+    expect(result.status).toBe('healthy');
+    expect(result.checks.every((check) => check.status === 'pass')).toBe(true);
+  });
+
+  it('warns before the loss window, not after it', () => {
+    // The whole point: Ruijie holds ~3 days, so a warning at 4h leaves ~68h to
+    // act. Warning only once data was already lost would be useless.
+    const result = evaluateRuijieSyncHealth({ ...healthy, newestRollupAt: hoursAgo(4) });
+    const freshness = result.checks.find((c) => c.name === 'rollup_freshness');
+
+    expect(freshness?.status).toBe('warn');
+    expect(result.status).toBe('warning');
+    expect(RUIJIE_SOURCE_RETENTION_HOURS).toBeGreaterThan(48);
+  });
+
+  it('escalates to critical well inside the unrecoverable window', () => {
+    const result = evaluateRuijieSyncHealth({ ...healthy, newestRollupAt: hoursAgo(10) });
+    const freshness = result.checks.find((c) => c.name === 'rollup_freshness');
+
+    expect(freshness?.status).toBe('fail');
+    expect(result.status).toBe('critical');
+    // Must still leave meaningful runway before the ~72h cliff.
+    expect(result.hoursUntilUnrecoverable).toBeGreaterThan(24);
+  });
+
+  it('reports how much runway is left before data is unrecoverable', () => {
+    const result = evaluateRuijieSyncHealth({ ...healthy, newestRollupAt: hoursAgo(24) });
+
+    expect(result.hoursUntilUnrecoverable).toBeCloseTo(
+      RUIJIE_SOURCE_RETENTION_HOURS - 24,
+      1
+    );
+  });
+
+  it('flags a collapse back to one device per group', () => {
+    // The #702 regression shape: collection silently reverts to a single
+    // representative AP, so rows keep arriving and freshness looks fine.
+    const result = evaluateRuijieSyncHealth({
+      ...healthy,
+      devicesReportingRecently: 3,
+      devicesExpected: 22,
+    });
+    const coverage = result.checks.find((c) => c.name === 'device_coverage');
+
+    expect(coverage?.status).toBe('fail');
+    expect(result.status).toBe('critical');
+  });
+
+  it('tolerates a few devices being offline', () => {
+    const result = evaluateRuijieSyncHealth({
+      ...healthy,
+      devicesReportingRecently: 20,
+      devicesExpected: 22,
+    });
+
+    expect(result.checks.find((c) => c.name === 'device_coverage')?.status).toBe('pass');
+  });
+
+  it('treats never having collected as critical, not healthy', () => {
+    const result = evaluateRuijieSyncHealth({ ...healthy, newestRollupAt: null });
+
+    expect(result.checks.find((c) => c.name === 'rollup_freshness')?.status).toBe('fail');
+    expect(result.status).toBe('critical');
+    expect(result.hoursUntilUnrecoverable).toBe(0);
+  });
+
+  it('warns on stale Staff Wi-Fi without escalating the whole check', () => {
+    // Staff sampling is thinner and less critical than core flow — it should be
+    // visible but must not mask or inflate a core-traffic problem.
+    const result = evaluateRuijieSyncHealth({
+      ...healthy,
+      newestStaffRollupAt: hoursAgo(20),
+    });
+
+    expect(result.checks.find((c) => c.name === 'staff_freshness')?.status).toBe('warn');
+    expect(result.status).toBe('warning');
+  });
+
+  it('does not divide by zero when no devices are enrolled', () => {
+    const result = evaluateRuijieSyncHealth({
+      ...healthy,
+      devicesReportingRecently: 0,
+      devicesExpected: 0,
+    });
+
+    expect(result.checks.find((c) => c.name === 'device_coverage')?.status).toBe('warn');
+    expect(Number.isFinite(result.deviceCoveragePercent)).toBe(true);
+  });
+});

--- a/app/api/cron/ruijie-sync-health/route.ts
+++ b/app/api/cron/ruijie-sync-health/route.ts
@@ -1,0 +1,182 @@
+/**
+ * Ruijie Sync Health Cron
+ *
+ * Guards the per-device traffic sync (#702). `ruijie_traffic_rollups` is the
+ * system of record — Ruijie Cloud itself serves only ~3 days of per-device flow
+ * (measured 2026-08-02), so a sync outage longer than that is permanent,
+ * unrecoverable data loss. Nothing watched this before.
+ *
+ * Runs every 4 hours, which detects a stall with ~60h of runway remaining.
+ *
+ * Sends from notify.circletel.co.za — the ONLY domain verified in Resend
+ * (checked 2026-08-02). Other senders in this codebase use unverified domains
+ * and fail silently, which is exactly the failure an alert must not have.
+ *
+ * @module app/api/cron/ruijie-sync-health/route
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { cronLogger } from '@/lib/logging';
+import { createClient } from '@/lib/supabase/server';
+import {
+  evaluateRuijieSyncHealth,
+  RUIJIE_SOURCE_RETENTION_HOURS,
+  type RuijieSyncHealthResult,
+} from '@/lib/network/ruijie-sync-health';
+
+const ALERT_EMAIL =
+  process.env.NETWORK_ALERT_EMAIL || process.env.ALERT_EMAIL_TO || 'dev@circletel.co.za';
+const RESEND_API_KEY = process.env.RESEND_API_KEY;
+const ALERT_FROM = 'CircleTel Alerts <alerts@notify.circletel.co.za>';
+
+/** Window for "is the fleet still reporting per-device?" */
+const COVERAGE_WINDOW_HOURS = 6;
+
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const supabase = await createClient();
+    const now = new Date();
+    const coverageSince = new Date(
+      now.getTime() - COVERAGE_WINDOW_HOURS * 3_600_000
+    ).toISOString();
+
+    const [newestRollup, recentRows, enrolledDevices, newestStaff] = await Promise.all([
+      supabase
+        .from('ruijie_traffic_rollups')
+        .select('captured_at')
+        .order('captured_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from('ruijie_traffic_rollups')
+        .select('device_sn')
+        .gte('captured_at', coverageSince),
+      supabase
+        .from('ruijie_device_cache')
+        .select('sn')
+        .not('group_id', 'is', null),
+      supabase
+        .from('ruijie_ssid_traffic_rollups')
+        .select('hour_bucket')
+        .order('hour_bucket', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+
+    const devicesReportingRecently = new Set(
+      (recentRows.data ?? [])
+        .map((row) => row.device_sn as string | null)
+        // The legacy sentinel is not a real device — counting it would mask a
+        // regression to group-only collection.
+        .filter((sn): sn is string => Boolean(sn) && sn !== '__legacy_group__')
+    ).size;
+
+    const result = evaluateRuijieSyncHealth({
+      now,
+      newestRollupAt: (newestRollup.data?.captured_at as string | undefined) ?? null,
+      devicesReportingRecently,
+      devicesExpected: (enrolledDevices.data ?? []).length,
+      newestStaffRollupAt: (newestStaff.data?.hour_bucket as string | undefined) ?? null,
+    });
+
+    let emailSent = false;
+    if (result.status !== 'healthy') {
+      emailSent = await sendAlert(result);
+      cronLogger.warn('[RuijieSyncHealth] Unhealthy', {
+        status: result.status,
+        hoursUntilUnrecoverable: result.hoursUntilUnrecoverable,
+        emailSent,
+      });
+    }
+
+    return NextResponse.json({
+      status: result.status,
+      checks: result.checks,
+      hoursUntilUnrecoverable: Number(result.hoursUntilUnrecoverable.toFixed(1)),
+      sourceRetentionHours: RUIJIE_SOURCE_RETENTION_HOURS,
+      alertSent: emailSent,
+      timestamp: now.toISOString(),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    cronLogger.error('[RuijieSyncHealth] Check failed', { error: message });
+    return NextResponse.json(
+      { error: 'Ruijie sync health check failed', details: message },
+      { status: 500 }
+    );
+  }
+}
+
+async function sendAlert(result: RuijieSyncHealthResult): Promise<boolean> {
+  if (!RESEND_API_KEY) return false;
+
+  const rows = result.checks
+    .map(
+      (check) => `
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #eee;">${check.name}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #eee;font-weight:600;color:${
+            check.status === 'fail'
+              ? '#b91c1c'
+              : check.status === 'warn'
+                ? '#b45309'
+                : '#15803d'
+          };">${check.status.toUpperCase()}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #eee;">${check.value}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #eee;color:#475569;">${check.message}</td>
+        </tr>`
+    )
+    .join('');
+
+  const runway = result.hoursUntilUnrecoverable;
+  const html = `
+    <div style="font-family:system-ui,sans-serif;max-width:720px;">
+      <h2 style="color:#0f172a;">Ruijie sync ${result.status.toUpperCase()}</h2>
+      <div style="border-left:4px solid #E87A1E;background:#fff7ed;padding:12px 16px;margin:16px 0;">
+        <strong>Roughly ${runway.toFixed(0)} hours before this becomes unrecoverable.</strong><br/>
+        Ruijie Cloud retains only about ${RUIJIE_SOURCE_RETENTION_HOURS} hours of per-device flow.
+        Anything not collected inside that window cannot be backfilled from any source —
+        <code>ruijie_traffic_rollups</code> is the system of record, not a cache.
+      </div>
+      <table style="border-collapse:collapse;width:100%;font-size:14px;">
+        <thead>
+          <tr style="text-align:left;background:#f8fafc;">
+            <th style="padding:8px 12px;">Check</th><th style="padding:8px 12px;">Status</th>
+            <th style="padding:8px 12px;">Value</th><th style="padding:8px 12px;">Detail</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+      <p style="color:#64748b;font-size:12px;margin-top:20px;">
+        The sync runs on an Inngest cron every 30 minutes
+        (<code>ruijie-sync</code> → <code>ruijie-traffic-rollup</code>).
+        If it has stalled, re-register with
+        <code>curl -X PUT https://www.circletel.co.za/api/inngest</code> and check the Inngest dashboard.
+      </p>
+    </div>`;
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: ALERT_FROM,
+      to: [ALERT_EMAIL],
+      subject: `[${result.status.toUpperCase()}] Ruijie sync — ${runway.toFixed(0)}h before data loss`,
+      html,
+    }),
+  });
+
+  return response.ok;
+}

--- a/docs/architecture/CRON_SCHEDULE.md
+++ b/docs/architecture/CRON_SCHEDULE.md
@@ -46,6 +46,7 @@ Keep Inngest functions as event-triggered step functions. Remove their cron sche
 | `0 21 * * *` | 23:00 | `ar-snapshot` | Finance | Accounts receivable snapshot |
 | `0 0,6,12,18 * * *` | 4x/day | `diagnostics-health-check` | Ops | System health |
 | `0 2,6,10,14,18,22 * * *` | 6x/day | `payment-sync-monitor` | Billing | Monitor payment sync |
+| `20 */4 * * *` | 6x/day | `ruijie-sync-health` | Ops | Alert before Ruijie flow data becomes unrecoverable (~3d source retention) |
 | `0 */4 * * *` | 6x/day | `payment-sync-retry` | Billing | Retry failed syncs |
 | `*/15 * * * *` | every 15m | `zoho-books-retry` | Integration | Retry failed Zoho syncs |
 | `*/30 * * * *` | every 30m | `integrations-health-check` | Ops | Integration health |

--- a/lib/network/ruijie-sync-health.ts
+++ b/lib/network/ruijie-sync-health.ts
@@ -1,0 +1,159 @@
+/**
+ * Health evaluation for the Ruijie per-device traffic sync.
+ *
+ * Why this exists: `ruijie_traffic_rollups` is the system of record, not a
+ * cache. Measured 2026-08-02 against live Ruijie Cloud, the source serves only
+ * ~3 days of per-device flow — four APs all cut off at the same instant, and a
+ * 90-day request returns a zero-padded grid rather than an error. So a sync
+ * outage lasting longer than that window is **permanent, unrecoverable data
+ * loss**: there is nothing upstream to backfill from.
+ *
+ * Thresholds are therefore set to alert with days of runway, not hours of it.
+ */
+
+/** Measured, not assumed — see the module docblock. Deliberately conservative. */
+export const RUIJIE_SOURCE_RETENTION_HOURS = 72;
+
+/** Sync runs every 30 min, so 4h is 8 missed cycles — signal, not noise. */
+const FRESHNESS_WARN_HOURS = 4;
+/** Still ~62h of runway at this point. */
+const FRESHNESS_FAIL_HOURS = 10;
+/** Staff SSID sampling is thinner; visible but never the headline. */
+const STAFF_WARN_HOURS = 12;
+/** Some APs are legitimately offline; a real collapse is far below this. */
+const DEVICE_COVERAGE_FAIL_PERCENT = 60;
+
+export type CheckStatus = 'pass' | 'warn' | 'fail';
+export type HealthStatus = 'healthy' | 'warning' | 'critical';
+
+export interface RuijieSyncHealthInput {
+  now: Date;
+  /** Newest `captured_at` in ruijie_traffic_rollups, or null if none exists. */
+  newestRollupAt: string | null;
+  /** Distinct device_sn seen in the recent window. */
+  devicesReportingRecently: number;
+  /** Devices enrolled in the cache with a group — what we expect to hear from. */
+  devicesExpected: number;
+  /** Newest `hour_bucket` in ruijie_ssid_traffic_rollups, or null. */
+  newestStaffRollupAt: string | null;
+}
+
+export interface HealthCheck {
+  name: 'rollup_freshness' | 'device_coverage' | 'staff_freshness';
+  status: CheckStatus;
+  value: string;
+  threshold: string;
+  message: string;
+}
+
+export interface RuijieSyncHealthResult {
+  status: HealthStatus;
+  checks: HealthCheck[];
+  /** Hours before the un-collected window passes out of Ruijie for good. */
+  hoursUntilUnrecoverable: number;
+  deviceCoveragePercent: number;
+}
+
+function ageHours(now: Date, iso: string | null): number | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return null;
+  return (now.getTime() - then) / 3_600_000;
+}
+
+function worst(statuses: CheckStatus[]): HealthStatus {
+  if (statuses.includes('fail')) return 'critical';
+  if (statuses.includes('warn')) return 'warning';
+  return 'healthy';
+}
+
+export function evaluateRuijieSyncHealth(
+  input: RuijieSyncHealthInput
+): RuijieSyncHealthResult {
+  const checks: HealthCheck[] = [];
+
+  // 1. Freshness — the check that guards against silent, permanent loss.
+  const rollupAge = ageHours(input.now, input.newestRollupAt);
+  if (rollupAge === null) {
+    checks.push({
+      name: 'rollup_freshness',
+      status: 'fail',
+      value: 'no rollups',
+      threshold: `${FRESHNESS_WARN_HOURS}h`,
+      message:
+        'No traffic rollups exist at all. Nothing is being collected, and Ruijie only holds ~3 days.',
+    });
+  } else {
+    const status: CheckStatus =
+      rollupAge >= FRESHNESS_FAIL_HOURS
+        ? 'fail'
+        : rollupAge >= FRESHNESS_WARN_HOURS
+          ? 'warn'
+          : 'pass';
+    checks.push({
+      name: 'rollup_freshness',
+      status,
+      value: `${rollupAge.toFixed(1)}h old`,
+      threshold: `warn ${FRESHNESS_WARN_HOURS}h / fail ${FRESHNESS_FAIL_HOURS}h`,
+      message:
+        status === 'pass'
+          ? 'Traffic rollups are current.'
+          : `Newest rollup is ${rollupAge.toFixed(1)}h old. Ruijie retains roughly ${RUIJIE_SOURCE_RETENTION_HOURS}h, after which the gap cannot be backfilled.`,
+    });
+  }
+
+  // 2. Device coverage — catches a silent regression to one AP per group, which
+  //    freshness alone would miss because rows keep arriving.
+  const coveragePercent =
+    input.devicesExpected > 0
+      ? (input.devicesReportingRecently / input.devicesExpected) * 100
+      : 0;
+
+  if (input.devicesExpected === 0) {
+    checks.push({
+      name: 'device_coverage',
+      status: 'warn',
+      value: 'no devices enrolled',
+      threshold: `${DEVICE_COVERAGE_FAIL_PERCENT}%`,
+      message: 'No Ruijie devices are enrolled with a group, so nothing can be collected.',
+    });
+  } else {
+    const status: CheckStatus =
+      coveragePercent < DEVICE_COVERAGE_FAIL_PERCENT ? 'fail' : 'pass';
+    checks.push({
+      name: 'device_coverage',
+      status,
+      value: `${input.devicesReportingRecently}/${input.devicesExpected} (${coveragePercent.toFixed(0)}%)`,
+      threshold: `${DEVICE_COVERAGE_FAIL_PERCENT}%`,
+      message:
+        status === 'pass'
+          ? 'Per-device collection is reporting across the fleet.'
+          : `Only ${input.devicesReportingRecently} of ${input.devicesExpected} devices reported. A drop to one device per group means per-site attribution has silently regressed.`,
+    });
+  }
+
+  // 3. Staff SSID — informational; must not mask a core-traffic problem.
+  const staffAge = ageHours(input.now, input.newestStaffRollupAt);
+  const staffStatus: CheckStatus =
+    staffAge === null || staffAge >= STAFF_WARN_HOURS ? 'warn' : 'pass';
+  checks.push({
+    name: 'staff_freshness',
+    status: staffStatus,
+    value: staffAge === null ? 'no samples' : `${staffAge.toFixed(1)}h old`,
+    threshold: `${STAFF_WARN_HOURS}h`,
+    message:
+      staffStatus === 'pass'
+        ? 'Staff Wi-Fi SSID samples are current.'
+        : 'Staff Wi-Fi SSID sampling is stale — Unjani Staff sections will show no data for this period.',
+  });
+
+  return {
+    status: worst(checks.map((check) => check.status)),
+    checks,
+    hoursUntilUnrecoverable:
+      rollupAge === null
+        ? 0
+        : Math.max(0, RUIJIE_SOURCE_RETENTION_HOURS - rollupAge),
+    deviceCoveragePercent: coveragePercent,
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -73,6 +73,10 @@
       "maxDuration": 120,
       "memory": 512
     },
+    "app/api/cron/ruijie-sync-health/route.ts": {
+      "maxDuration": 60,
+      "memory": 512
+    },
     "app/api/cron/payment-sync-monitor/route.ts": {
       "maxDuration": 60,
       "memory": 512
@@ -186,6 +190,10 @@
     {
       "path": "/api/cron/payment-sync-retry",
       "schedule": "0 */4 * * *"
+    },
+    {
+      "path": "/api/cron/ruijie-sync-health",
+      "schedule": "20 */4 * * *"
     },
     {
       "path": "/api/cron/payment-sync-monitor",


### PR DESCRIPTION
Closes the gap opened by #702.

## Why

`ruijie_traffic_rollups` stopped being a cache when per-device collection landed — it is now the **system of record**, and #706 extended it to 90 days. Nothing watched it.

Ruijie Cloud serves only **~3 days** of per-device flow. Measured today: four APs cut off at the identical instant (`2026-07-29T22:00:00Z`), and a 90-day request returns a full 12,960-point grid that is **88% zero-padded** rather than erroring. So a sync outage longer than that window is **permanent, unrecoverable loss** — there is nothing upstream to backfill from.

## Checks

Cron every 4 hours (`20 */4 * * *`), detecting a stall with roughly **60 hours of runway** remaining.

| Check | Thresholds | Catches |
|---|---|---|
| `rollup_freshness` | warn 4h (8 missed cycles), fail 10h | The sync stopping |
| `device_coverage` | fail below 60% of enrolled devices | A silent regression to one AP per group — which freshness alone would **miss**, because rows keep arriving |
| `staff_freshness` | warn only, 12h | Staff SSID sampling stalling, without masking a core-traffic problem |

The alert leads with hours-until-unrecoverable rather than a status word, because that is the number that determines urgency.

## The sender matters here

Checked the Resend API today: **`notify.circletel.co.za` is the only verified domain.**

`payment-sync-monitor` sends from `alerts@notifications.circletelsa.co.za`, and other paths use `alerts@circletel.co.za`, `orders@`, `finance@`, `devadmin@notifications.circletelsa.co.za` — **none verified**. Those alerts have been failing silently, which is the one failure mode an alert must never have. This one uses the verified domain, and I confirmed end to end that Resend accepts it (test send to `delivered@resend.dev`, accepted with an ID — no human mailed).

Worth fixing the others separately; out of scope here.

## Verification

- **9 unit tests** on the pure threshold logic, including that the warning fires *inside* the loss window rather than after it, that a collapse to 3-of-22 devices is critical, and that no-data-ever is critical rather than healthy.
- 27 tests across 3 suites in `__tests__/lib/network/` pass; `tsc --noEmit` clean.
- `vercel.json` edit validated as parseable JSON.
- **Smoked against live data**: `healthy`, 22/22 devices, freshness 0.5h, 71.5h runway.

## Config

`NETWORK_ALERT_EMAIL` (falls back to `ALERT_EMAIL_TO`, then `dev@circletel.co.za`). Currently resolves to `dev@circletel.co.za`.