### PR TITLE
fix(network): alert fallback recipient was a hard-bouncing address

### DIFF
--- a/app/api/cron/ruijie-sync-health/route.ts
+++ b/app/api/cron/ruijie-sync-health/route.ts
@@ -25,8 +25,16 @@ import {
   type RuijieSyncHealthResult,
 } from '@/lib/network/ruijie-sync-health';
 
+/**
+ * The fallback must be a mailbox that actually exists. `dev@circletel.co.za` —
+ * the default copied from payment-sync-monitor — HARD BOUNCES (verified via the
+ * Resend API 2026-08-02), so every alert relying on it is delivered nowhere.
+ * An alert with a bouncing recipient is worse than no alert: it reports success.
+ */
 const ALERT_EMAIL =
-  process.env.NETWORK_ALERT_EMAIL || process.env.ALERT_EMAIL_TO || 'dev@circletel.co.za';
+  process.env.NETWORK_ALERT_EMAIL ||
+  process.env.ALERT_EMAIL_TO ||
+  'jeffrey.de.wee@circletel.co.za';
 const RESEND_API_KEY = process.env.RESEND_API_KEY;
 const ALERT_FROM = 'CircleTel Alerts <alerts@notify.circletel.co.za>';
 


### PR DESCRIPTION
Found by actually testing the alert (thresholds temporarily lowered locally against production data — never committed).

## What happened

The alert fired correctly and reported `alertSent: true`. The email **hard-bounced**.

```
11:52:58  bounced    to=dev@circletel.co.za    [CRITICAL] Ruijie sync — 71h before data loss
11:31:30  delivered  to=delivered@resend.dev   [TEST] sender check
```

Resend: *"The recipient's email provider sent a hard bounce message… We recommend removing the recipient's email address from your mailing list."*

**`dev@circletel.co.za` does not exist.** All three recipient env vars were unset, so the code fell through to that hardcoded default — copied from `payment-sync-monitor` without questioning it.

Everything else was right: correct thresholds, verified sender domain, armed on the host crontab. It would have fired into a void on the first real outage **while reporting success**. An alert with a bouncing recipient is worse than no alert.

## Fix

Fallback is now `jeffrey.de.wee@circletel.co.za`, confirmed delivering today. `NETWORK_ALERT_EMAIL` still takes precedence and has now been set on the production app in Coolify, so the fallback is belt-and-braces rather than the primary path.

## Verification

- `tsc --noEmit` clean; 27 tests across 3 suites pass.
- Sender domain (`notify.circletel.co.za`) already proven end to end.
- Recipient proven by inspecting real Resend delivery events, not assumed.

## Same defect elsewhere

`payment-sync-monitor` and other alert paths share the `dev@circletel.co.za` default **and** send from unverified domains — so they may be failing at both ends. Out of scope here, worth a follow-up.