### PR TITLE
fix(network): recover from Ruijie token expiry, never prune cache on zero-device fetch

### DIFF
--- a/lib/inngest/functions/ruijie-sync.ts
+++ b/lib/inngest/functions/ruijie-sync.ts
@@ -136,9 +136,19 @@ export const ruijieSyncFunction = inngest.createFunction(
       return result;
     });
 
-    // Step 5b: Remove cache rows outside the active window
+    // Step 5b: Remove cache rows outside the active window.
+    // A zero-device fetch means the API call failed (auth, outage), not that
+    // the fleet vanished — pruning against an empty keep-set would wipe the
+    // whole cache (happened 2026-08-02: token expired server-side, 22 devices deleted).
+    const fetchedCount = (activeDevices as unknown as RuijieDevice[]).length;
     const pruneResult = await step.run('prune-inactive-devices', async () => {
       const keepSns = (enrichedDevices as unknown as RuijieDevice[]).map((d) => d.sn);
+      if (keepSns.length === 0) {
+        console.error(
+          '[RuijieSync] Fetched 0 devices — skipping prune to protect existing cache'
+        );
+        return { deleted: 0, deletedSns: [] };
+      }
       const result = await pruneDevicesNotInSet(keepSns);
       if (result.deleted > 0) {
         console.log(
@@ -151,10 +161,18 @@ export const ruijieSyncFunction = inngest.createFunction(
     // Step 6: Update sync log
     const duration = Date.now() - startTime;
     await step.run('update-sync-log', async () => {
+      const errors =
+        fetchedCount === 0
+          ? [
+              ...syncResult.errors,
+              'Fetched 0 devices from Ruijie API — likely auth failure or outage; cache preserved',
+            ]
+          : syncResult.errors;
       await logSyncRun(
         {
           ...syncResult,
-          devicesFetched: (activeDevices as unknown as RuijieDevice[]).length,
+          errors,
+          devicesFetched: fetchedCount,
           durationMs: duration,
         },
         triggeredBy,

--- a/lib/ruijie/__tests__/client-auth-retry.test.ts
+++ b/lib/ruijie/__tests__/client-auth-retry.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Ruijie reports an expired server-side session as HTTP 200 + {"code":3,"msg":"Login timeout"}.
+ * On 2026-08-02 this was treated as a valid "no groups" response: the sync fetched
+ * 0 devices and pruned all 22 cached rows. These tests pin the recovery behaviour:
+ * re-authenticate and retry once on code 3, and never prune with an empty keep-set.
+ */
+
+const AUTH_OK = {
+  code: 0,
+  msg: 'OK.',
+  accessToken: '',
+  refreshToken: '',
+};
+
+const GROUP_TREE_OK = {
+  code: 0,
+  msg: 'OK.',
+  groupTree: {
+    id: 0,
+    name: 'dumy',
+    children: [
+      { id: 111, name: 'Unjani' },
+      { id: 222, name: 'Consumer' },
+    ],
+  },
+};
+
+const LOGIN_TIMEOUT = { code: 3, msg: 'Login timeout' };
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('ruijieFetch auth recovery (via getAllGroups)', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.RUIJIE_APP_ID = 'test-app-id';
+    process.env.RUIJIE_SECRET = 'test-secret';
+    process.env.RUIJIE_MOCK_MODE = 'false';
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('re-authenticates and retries once when the API returns code 3 (Login timeout)', async () => {
+    let tokenCounter = 0;
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('/oauth20/client/access_token')) {
+        tokenCounter += 1;
+        return jsonResponse({ ...AUTH_OK, accessToken: `token-${tokenCounter}` });
+      }
+      if (url.includes('/maint/groups')) {
+        // First groups call carries the stale token — expire it server-side.
+        if (url.includes('access_token=token-1')) {
+          return jsonResponse(LOGIN_TIMEOUT);
+        }
+        return jsonResponse(GROUP_TREE_OK);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const { getAllGroups } = await import('../client');
+    const groups = await getAllGroups();
+
+    expect(groups).toEqual([111, 222]);
+    // auth, groups(code 3), re-auth, groups(ok)
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const lastUrl = String(fetchMock.mock.calls[3][0]);
+    expect(lastUrl).toContain('access_token=token-2');
+  });
+
+  it('does not retry forever when re-authentication still yields Login timeout', async () => {
+    let tokenCounter = 0;
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('/oauth20/client/access_token')) {
+        tokenCounter += 1;
+        return jsonResponse({ ...AUTH_OK, accessToken: `token-${tokenCounter}` });
+      }
+      return jsonResponse(LOGIN_TIMEOUT);
+    });
+
+    const { getAllGroups } = await import('../client');
+    // getAllGroups swallows the thrown error and returns [] — the sync-level
+    // zero-fetch guard is what protects the cache in this case.
+    const groups = await getAllGroups();
+
+    expect(groups).toEqual([]);
+    // auth, groups(code 3), re-auth, groups(code 3) — then stop, no third attempt.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('pruneDevicesNotInSet empty keep-set guard', () => {
+  it('refuses to prune when the keep-set is empty', async () => {
+    jest.resetModules();
+    // createClient must never be reached — a DB call here would mean the guard failed.
+    jest.doMock('@/lib/supabase/server', () => ({
+      createClient: jest.fn(() => {
+        throw new Error('createClient should not be called for an empty keep-set');
+      }),
+    }));
+
+    const { pruneDevicesNotInSet } = await import('../sync-service');
+    const result = await pruneDevicesNotInSet([]);
+
+    expect(result).toEqual({ deleted: 0, deletedSns: [] });
+  });
+});

--- a/lib/ruijie/client.ts
+++ b/lib/ruijie/client.ts
@@ -7,7 +7,7 @@
  * IMPORTANT: Ruijie API uses access_token as query param, NOT Bearer header
  */
 
-import { getAccessToken } from './auth';
+import { getAccessToken, clearRuijieAuth } from './auth';
 import { getMockDevices, getMockDevice, createMockTunnel } from './mock';
 import { RuijieDevice, RuijieTunnel } from './types';
 import {
@@ -67,13 +67,21 @@ function mergeAbortSignals(signals: AbortSignal[]): AbortSignal | undefined {
 // =============================================================================
 
 /**
+ * Ruijie reports an expired server-side session as HTTP 200 with code 3
+ * ("Login timeout"). The token can die well before our 30-day cache expiry,
+ * so this must trigger a re-auth, not be treated as a valid response.
+ */
+const RUIJIE_CODE_LOGIN_TIMEOUT = 3;
+
+/**
  * Make authenticated API request to Ruijie Cloud
  * Note: Ruijie uses access_token as query param, not Authorization header
  */
 async function ruijieFetch<T>(
   endpoint: string,
   options: RequestInit = {},
-  baseUrl: string = RUIJIE_BASE_URL
+  baseUrl: string = RUIJIE_BASE_URL,
+  isAuthRetry = false
 ): Promise<T> {
   const token = await getAccessToken();
 
@@ -101,7 +109,19 @@ async function ruijieFetch<T>(
     throw new Error(`Ruijie API error: ${response.status} - ${error}`);
   }
 
-  return response.json();
+  const data = (await response.json()) as T;
+
+  const code = (data as { code?: number }).code;
+  if (code === RUIJIE_CODE_LOGIN_TIMEOUT) {
+    if (isAuthRetry) {
+      throw new Error('Ruijie API error: Login timeout persisted after re-authentication');
+    }
+    console.warn('[Ruijie] Access token expired server-side, re-authenticating...');
+    clearRuijieAuth();
+    return ruijieFetch<T>(endpoint, options, baseUrl, true);
+  }
+
+  return data;
 }
 
 /** Authenticated fetch against the logbiz agent (CPU/mem, STA, flow). */

--- a/lib/ruijie/sync-service.ts
+++ b/lib/ruijie/sync-service.ts
@@ -169,6 +169,13 @@ export async function upsertDevices(
 export async function pruneDevicesNotInSet(
   keepSns: string[]
 ): Promise<{ deleted: number; deletedSns: string[] }> {
+  // An empty keep-set would delete every cached device. That only happens when
+  // the upstream fetch failed, so refuse rather than destroy the cache.
+  if (keepSns.length === 0) {
+    console.error('[RuijieSync] Refusing to prune with empty keep-set — cache preserved');
+    return { deleted: 0, deletedSns: [] };
+  }
+
   const supabase = await createClient();
   const keep = new Set(keepSns);
 


### PR DESCRIPTION
## Incident

2026-08-02 15:30 SAST: the Ruijie sync cron fetched 0 devices and pruned **all 22 rows** in `ruijie_device_cache`, logging the run as "completed, 0 errors". `/admin/network/devices` lost all Ruijie live status. The prod token had been invalidated server-side ~1h after issue — Ruijie returns HTTP 200 + `{"code":3,"msg":"Login timeout"}`, which the client treated as a valid empty response. The in-memory cache assumes 30-day validity, so every subsequent sync reused the dead token.

Ruled out by live testing: new-token-invalidates-old (6 concurrent tokens all stayed valid), token cap eviction. The real TTL is undocumented; the client must recover regardless.

## Fix (three layers)

1. `ruijieFetch` detects `code: 3`, clears the token cache, re-authenticates and retries **once**
2. The sync skips pruning when the fetch returns 0 devices and logs the run as `completed_with_errors`
3. `pruneDevicesNotInSet` refuses an empty keep-set outright

## Tests

`lib/ruijie/__tests__/client-auth-retry.test.ts` — 3 passing: retry-once success path (asserts the retried call carries the fresh token), give-up-after-one-retry path, empty keep-set guard (asserts no DB client is ever constructed).

Deploying this restarts the container, which also recovers the current outage (fresh boot → fresh token → cache repopulates on next sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WLyCcHJPJJ8diVXgcuLuL