### PR TITLE
feat(network): device report export (PDF/Excel) on device detail page

### DIFF
--- a/app/admin/network/devices/[sn]/page.tsx
+++ b/app/admin/network/devices/[sn]/page.tsx
@@ -32,7 +32,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { UnderlineTabs, TabPanel, SectionCard } from '@/components/admin/shared';
-import { DeviceHeader, DeviceStatCards, DeviceSupportNotes, DeviceCustomerLink, DeviceClientList, DeviceActivityLog, DeviceSystemHealth, DeviceTrafficPanel, formatUptime } from '@/components/admin/network/detail';
+import { DeviceHeader, DeviceStatCards, DeviceSupportNotes, DeviceCustomerLink, DeviceClientList, DeviceActivityLog, DeviceSystemHealth, DeviceTrafficPanel, DeviceExportMenu, formatUptime } from '@/components/admin/network/detail';
 import type { DeviceSystemHealthData } from '@/components/admin/network/detail/DeviceSystemHealth';
 import { formatLatency, scoreTone } from '@/components/admin/network/detail/telemetry-format';
 import type { StaDeviceExperience } from '@/lib/ruijie/performance-metrics';
@@ -210,6 +210,8 @@ export default function RuijieDeviceDetailPage({
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>('overview');
+  // Mirrors DeviceTrafficPanel's window selection so exports cover the same period.
+  const [trafficHours, setTrafficHours] = useState(24);
 
   // Tunnel state
   const [tunnelLoading, setTunnelLoading] = useState(false);
@@ -438,6 +440,7 @@ export default function RuijieDeviceDetailPage({
         onLaunchTunnel={handleLaunchTunnel}
         onRefresh={handleRefresh}
         refreshing={refreshing}
+        actions={<DeviceExportMenu sn={sn} hours={trafficHours} />}
       />
 
       {/* Main Content */}
@@ -612,7 +615,7 @@ export default function RuijieDeviceDetailPage({
 
         {/* TRAFFIC TAB */}
         <TabPanel id="traffic" activeTab={activeTab} className="mt-6">
-          <DeviceTrafficPanel sn={sn} />
+          <DeviceTrafficPanel sn={sn} onHoursChange={setTrafficHours} />
         </TabPanel>
 
         {/* TUNNEL TAB */}

--- a/app/api/ruijie/devices/[sn]/export/route.ts
+++ b/app/api/ruijie/devices/[sn]/export/route.ts
@@ -1,0 +1,113 @@
+/**
+ * Device Report Export API
+ * GET /api/ruijie/devices/[sn]/export?hours=24&format=pdf|excel
+ *
+ * Streams a full device dossier — summary, traffic window, clients, logs —
+ * as a PDF or Excel attachment. Data is gathered server-side via the same
+ * lib/ruijie functions the tab APIs use.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClientWithSession, createClient } from '@/lib/supabase/server';
+import { apiLogger } from '@/lib/logging/logger';
+import {
+  buildDeviceExportModel,
+  clampHours,
+  exportFilename,
+} from '@/lib/ruijie/device-export';
+import { generateDeviceReportPdf } from '@/lib/ruijie/device-report-pdf';
+import { generateDeviceReportExcel } from '@/lib/ruijie/device-report-excel';
+
+export const dynamic = 'force-dynamic';
+
+const EXCEL_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ sn: string }> }
+) {
+  try {
+    const { sn } = await context.params;
+
+    // Use session client for authentication (reads cookies)
+    const supabase = await createClientWithSession();
+
+    // Verify admin access
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Use service role client for admin check (bypasses RLS)
+    const supabaseAdmin = await createClient();
+    const { data: adminUser } = await supabaseAdmin
+      .from('admin_users')
+      .select('id, role')
+      .eq('id', user.id)
+      .eq('is_active', true)
+      .single();
+
+    if (!adminUser) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const format = searchParams.get('format');
+    if (format !== 'pdf' && format !== 'excel') {
+      return NextResponse.json(
+        { error: "format must be 'pdf' or 'excel'" },
+        { status: 400 }
+      );
+    }
+    const hours = clampHours(Number(searchParams.get('hours')));
+
+    const model = await buildDeviceExportModel(sn, hours);
+    if (!model) {
+      return NextResponse.json({ error: 'Device not found' }, { status: 404 });
+    }
+
+    // Audit log — same pattern as the manual sync trigger
+    const clientIp =
+      request.headers.get('x-forwarded-for') ||
+      request.headers.get('x-real-ip') ||
+      'unknown';
+    await supabaseAdmin.from('ruijie_audit_log').insert({
+      admin_user_id: adminUser.id,
+      device_sn: sn,
+      action: 'export',
+      action_detail: { format, hours },
+      ip_address: clientIp,
+      status: 'success',
+    });
+
+    if (format === 'pdf') {
+      const pdf = generateDeviceReportPdf(model);
+      return new NextResponse(pdf, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/pdf',
+          'Content-Disposition': `attachment; filename="${exportFilename(sn, hours, 'pdf')}"`,
+          'Content-Length': String(pdf.byteLength),
+          'Cache-Control': 'private, no-store',
+        },
+      });
+    }
+
+    const workbook = await generateDeviceReportExcel(model);
+    return new NextResponse(new Uint8Array(workbook), {
+      status: 200,
+      headers: {
+        'Content-Type': EXCEL_MIME,
+        'Content-Disposition': `attachment; filename="${exportFilename(sn, hours, 'xlsx')}"`,
+        'Content-Length': String(workbook.byteLength),
+        'Cache-Control': 'private, no-store',
+      },
+    });
+  } catch (error) {
+    apiLogger.error('Ruijie device export API error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json({ error: 'Failed to generate device report' }, { status: 500 });
+  }
+}

--- a/components/admin/network/detail/DeviceExportMenu.tsx
+++ b/components/admin/network/detail/DeviceExportMenu.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+/**
+ * Download dropdown for the device detail header — exports the device dossier
+ * (summary, current traffic window, clients, logs) as PDF or Excel via
+ * /api/ruijie/devices/[sn]/export.
+ */
+
+import { useState } from 'react';
+import {
+  PiCaretDownBold,
+  PiDownloadSimpleBold,
+  PiFilePdfBold,
+  PiFileXlsBold,
+  PiSpinnerGapBold,
+} from 'react-icons/pi';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface DeviceExportMenuProps {
+  sn: string;
+  /** Traffic window the report covers — follows the Traffic tab's selection. */
+  hours: number;
+}
+
+export function DeviceExportMenu({ sn, hours }: DeviceExportMenuProps) {
+  const [downloading, setDownloading] = useState<'pdf' | 'excel' | null>(null);
+
+  const handleDownload = async (format: 'pdf' | 'excel') => {
+    setDownloading(format);
+    try {
+      const response = await fetch(
+        `/api/ruijie/devices/${encodeURIComponent(sn)}/export?hours=${hours}&format=${format}`,
+        { credentials: 'include' }
+      );
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error || `Export failed (${response.status})`);
+      }
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download =
+        response.headers
+          .get('content-disposition')
+          ?.match(/filename="([^"]+)"/i)?.[1] ??
+        `CircleTel_Device_${sn}.${format === 'pdf' ? 'pdf' : 'xlsx'}`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => window.URL.revokeObjectURL(url), 0);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : `Failed to download ${format.toUpperCase()} report`
+      );
+    } finally {
+      setDownloading(null);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" className="gap-2" disabled={downloading !== null}>
+          {downloading ? (
+            <PiSpinnerGapBold className="w-4 h-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <PiDownloadSimpleBold className="w-4 h-4" aria-hidden="true" />
+          )}
+          Download
+          <PiCaretDownBold className="w-3.5 h-3.5" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onClick={() => handleDownload('pdf')}
+          disabled={downloading !== null}
+        >
+          <PiFilePdfBold className="mr-2 h-4 w-4" aria-hidden="true" />
+          PDF report
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => handleDownload('excel')}
+          disabled={downloading !== null}
+        >
+          <PiFileXlsBold className="mr-2 h-4 w-4" aria-hidden="true" />
+          Excel workbook
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/admin/network/detail/DeviceHeader.tsx
+++ b/components/admin/network/detail/DeviceHeader.tsx
@@ -29,6 +29,8 @@ interface DeviceHeaderProps {
   onLaunchTunnel: () => void;
   onRefresh: () => void;
   refreshing?: boolean;
+  /** Extra header actions (e.g. the report download menu), rendered before the icon buttons. */
+  actions?: React.ReactNode;
 }
 
 export function DeviceHeader({
@@ -40,6 +42,7 @@ export function DeviceHeader({
   onLaunchTunnel,
   onRefresh,
   refreshing,
+  actions,
 }: DeviceHeaderProps) {
   const statusConfig = isOnline
     ? { className: 'bg-emerald-50 text-emerald-700', label: 'Online', icon: PiWifiHighBold }
@@ -75,6 +78,7 @@ export function DeviceHeader({
 
           {/* Action Buttons */}
           <div className="flex flex-wrap items-center gap-2">
+            {actions}
             {/* Grouped icon buttons */}
             <div className="flex border border-slate-200 rounded-lg overflow-hidden bg-white">
               <button

--- a/components/admin/network/detail/DeviceTrafficPanel.tsx
+++ b/components/admin/network/detail/DeviceTrafficPanel.tsx
@@ -32,6 +32,8 @@ interface TrafficHistory {
 
 interface DeviceTrafficPanelProps {
   sn: string;
+  /** Reports window changes so the page can share the selection (e.g. with the export menu). */
+  onHoursChange?: (hours: number) => void;
 }
 
 const WINDOWS = [
@@ -65,7 +67,7 @@ function Tile({ label, value, hint }: { label: string; value: string; hint?: str
   );
 }
 
-export function DeviceTrafficPanel({ sn }: DeviceTrafficPanelProps) {
+export function DeviceTrafficPanel({ sn, onHoursChange }: DeviceTrafficPanelProps) {
   const [hours, setHours] = useState<number>(24);
   const [history, setHistory] = useState<TrafficHistory | null>(null);
   const [loading, setLoading] = useState(true);
@@ -120,7 +122,10 @@ export function DeviceTrafficPanel({ sn }: DeviceTrafficPanelProps) {
             <button
               key={w.hours}
               type="button"
-              onClick={() => setHours(w.hours)}
+              onClick={() => {
+                setHours(w.hours);
+                onHoursChange?.(w.hours);
+              }}
               aria-pressed={hours === w.hours}
               className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
                 hours === w.hours

--- a/components/admin/network/detail/index.ts
+++ b/components/admin/network/detail/index.ts
@@ -6,3 +6,4 @@ export { DeviceClientList } from './DeviceClientList';
 export { DeviceActivityLog } from './DeviceActivityLog';
 export { DeviceSystemHealth, formatUptime } from './DeviceSystemHealth';
 export { DeviceTrafficPanel } from './DeviceTrafficPanel';
+export { DeviceExportMenu } from './DeviceExportMenu';

--- a/lib/ruijie/__tests__/device-export.test.ts
+++ b/lib/ruijie/__tests__/device-export.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Device report export — model builder, PDF and Excel generators.
+ * Ruijie client + Supabase are mocked; fixtures mimic live response shapes.
+ */
+
+import ExcelJS from 'exceljs';
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+  createClientWithSession: jest.fn(),
+}));
+
+jest.mock('../client', () => ({
+  getDeviceMetrics: jest.fn(),
+  getDeviceClients: jest.fn(),
+  getDeviceLogs: jest.fn(),
+  getNetworkTraffic: jest.fn(),
+}));
+
+import { createClient } from '@/lib/supabase/server';
+import {
+  getDeviceMetrics,
+  getDeviceClients,
+  getDeviceLogs,
+  getNetworkTraffic,
+} from '../client';
+import {
+  buildDeviceExportModel,
+  clampHours,
+  exportFilename,
+  type DeviceExportModel,
+} from '../device-export';
+import { generateDeviceReportPdf } from '../device-report-pdf';
+import { generateDeviceReportExcel } from '../device-report-excel';
+
+const DEVICE_ROW = {
+  sn: 'G1U52HL044467',
+  device_name: 'UNJANICLINICTHOKOZA',
+  model: 'RAP2200(F)',
+  group_id: '9058218',
+  group_name: 'Unjani',
+  management_ip: '10.0.0.2',
+  wan_ip: '105.0.0.1',
+  egress_ip: '105.0.0.1',
+  status: 'online',
+  config_status: 'Synced',
+  firmware_version: 'ReyeeOS 1.55',
+  mac_address: 'AA:BB:CC:DD:EE:FF',
+  cpu_usage: 12,
+  memory_usage: 44,
+  uptime_seconds: 86_400,
+  online_clients: 2,
+  synced_at: '2026-08-02T14:11:43.751Z',
+};
+
+const TRAFFIC = {
+  totalRxBytes: 14_800_000_000,
+  totalTxBytes: 4_600_000_000,
+  totalBytes: 19_400_000_000,
+  avgRxRate: 210_500,
+  avgTxRate: 64_900,
+  peakRxBytes: 702_100_000,
+  peakTxBytes: 88_000_000,
+  dataPoints: Array.from({ length: 144 }, (_, i) => ({
+    timestamp: 1_754_000_000_000 + i * 600_000,
+    timeString: `2026-08-01 ${String(Math.floor(i / 6)).padStart(2, '0')}:${String((i % 6) * 10).padStart(2, '0')}:00`,
+    rxBytes: 100_000_000 + i,
+    txBytes: 30_000_000 + i,
+    rxPkts: 1000,
+    txPkts: 400,
+    buildingId: 0,
+    sn: 'G1U52HL044467',
+  })),
+};
+
+const CLIENTS = [
+  {
+    mac: '11:22:33:44:55:66',
+    userIp: '192.168.110.21',
+    ssid: 'Unjani-Staff',
+    rssi: -48,
+    band: '5G',
+    channel: 36,
+    sn: 'G1U52HL044467',
+    signalQuality: 'excellent' as const,
+    utilization: null,
+    uplinkRate: 12_000_000,
+    downlinkRate: 86_000_000,
+    pktLoseRate: null,
+    latencyMs: 4,
+    score: 98,
+    scoreReason: null,
+    hostname: 'clinic-laptop',
+    vendor: 'HP',
+    sessionBytes: 1_400_000_000,
+    sessionMs: 5_600_000,
+  },
+];
+
+const LOGS = [
+  {
+    id: 1,
+    sn: 'G1U52HL044467',
+    logType: 'onoffline',
+    logSubType: 'ON',
+    logDetail: 'AP came online',
+    operateTime: 1_754_100_000_000,
+  },
+];
+
+const METRICS = {
+  cpu_usage: 14,
+  memory_usage: 41,
+  uptime_seconds: 90_000,
+  online_clients: 2,
+  radio_2g_channel: 6,
+  radio_5g_channel: 36,
+  radio_2g_utilization: 20,
+  radio_5g_utilization: 12,
+  system: {},
+  experience: {},
+};
+
+function mockSupabaseDeviceRow(row: typeof DEVICE_ROW | null) {
+  (createClient as jest.Mock).mockResolvedValue({
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          single: jest.fn(async () => ({ data: row, error: row ? null : { message: 'not found' } })),
+        })),
+      })),
+    })),
+  });
+}
+
+function fullFixtureModel(): DeviceExportModel {
+  return {
+    device: { ...DEVICE_ROW },
+    metrics: METRICS as unknown as DeviceExportModel['metrics'],
+    traffic: TRAFFIC,
+    clients: CLIENTS,
+    logs: LOGS,
+    hours: 168,
+    generatedAtIso: '2026-08-02T15:00:00.000Z',
+    unavailable: {},
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('clampHours', () => {
+  it('accepts the four traffic windows and defaults everything else to 24', () => {
+    expect(clampHours(6)).toBe(6);
+    expect(clampHours(168)).toBe(168);
+    expect(clampHours(999)).toBe(24);
+    expect(clampHours(NaN)).toBe(24);
+    expect(clampHours(null)).toBe(24);
+  });
+});
+
+describe('exportFilename', () => {
+  it('embeds SN, SAST date and window', () => {
+    const name = exportFilename('G1U52HL044467', 168, 'pdf');
+    expect(name).toMatch(/^CircleTel_Device_G1U52HL044467_\d{4}-\d{2}-\d{2}_168h\.pdf$/);
+  });
+});
+
+describe('buildDeviceExportModel', () => {
+  it('assembles all sections when every source succeeds', async () => {
+    mockSupabaseDeviceRow(DEVICE_ROW);
+    (getDeviceMetrics as jest.Mock).mockResolvedValue(METRICS);
+    (getNetworkTraffic as jest.Mock).mockResolvedValue(TRAFFIC);
+    (getDeviceClients as jest.Mock).mockResolvedValue(CLIENTS);
+    (getDeviceLogs as jest.Mock).mockResolvedValue(LOGS);
+
+    const model = await buildDeviceExportModel('G1U52HL044467', 168);
+
+    expect(model).not.toBeNull();
+    expect(model!.device.device_name).toBe('UNJANICLINICTHOKOZA');
+    expect(model!.traffic!.dataPoints).toHaveLength(144);
+    expect(model!.clients).toHaveLength(1);
+    expect(model!.logs).toHaveLength(1);
+    expect(model!.unavailable).toEqual({});
+    expect(getDeviceClients).toHaveBeenCalledWith('G1U52HL044467', '9058218');
+  });
+
+  it('degrades failed sections to unavailable notes instead of throwing', async () => {
+    mockSupabaseDeviceRow(DEVICE_ROW);
+    (getDeviceMetrics as jest.Mock).mockResolvedValue(METRICS);
+    (getNetworkTraffic as jest.Mock).mockResolvedValue(TRAFFIC);
+    (getDeviceClients as jest.Mock).mockRejectedValue(new Error('STA timeout'));
+    (getDeviceLogs as jest.Mock).mockRejectedValue(new Error('logs 500'));
+
+    const model = await buildDeviceExportModel('G1U52HL044467', 24);
+
+    expect(model!.clients).toEqual([]);
+    expect(model!.logs).toEqual([]);
+    expect(model!.unavailable.clients).toBe('STA timeout');
+    expect(model!.unavailable.logs).toBe('logs 500');
+  });
+
+  it('flags an empty traffic window as unavailable but keeps the summary', async () => {
+    mockSupabaseDeviceRow(DEVICE_ROW);
+    (getDeviceMetrics as jest.Mock).mockResolvedValue(METRICS);
+    (getNetworkTraffic as jest.Mock).mockResolvedValue({ ...TRAFFIC, dataPoints: [] });
+    (getDeviceClients as jest.Mock).mockResolvedValue([]);
+    (getDeviceLogs as jest.Mock).mockResolvedValue([]);
+
+    const model = await buildDeviceExportModel('G1U52HL044467', 24);
+
+    expect(model!.traffic).not.toBeNull();
+    expect(model!.unavailable.traffic).toMatch(/No traffic samples/);
+  });
+
+  it('returns null for an unknown device', async () => {
+    mockSupabaseDeviceRow(null);
+    const model = await buildDeviceExportModel('NOPE', 24);
+    expect(model).toBeNull();
+    expect(getNetworkTraffic).not.toHaveBeenCalled();
+  });
+});
+
+describe('generateDeviceReportPdf', () => {
+  it('produces a PDF from a full model', () => {
+    const output = generateDeviceReportPdf(fullFixtureModel());
+    const magic = Buffer.from(output.slice(0, 4)).toString('ascii');
+    expect(magic).toBe('%PDF');
+    expect(output.byteLength).toBeGreaterThan(5_000);
+  });
+
+  it('still renders when traffic, clients and logs are all unavailable', () => {
+    const model: DeviceExportModel = {
+      ...fullFixtureModel(),
+      traffic: { ...TRAFFIC, dataPoints: [], totalRxBytes: 0, totalTxBytes: 0 },
+      clients: [],
+      logs: [],
+      unavailable: {
+        traffic: 'No traffic samples returned for this window',
+        clients: 'Not available — device offline',
+        logs: 'Ruijie timeout',
+      },
+    };
+    const output = generateDeviceReportPdf(model);
+    expect(Buffer.from(output.slice(0, 4)).toString('ascii')).toBe('%PDF');
+  });
+});
+
+describe('generateDeviceReportExcel', () => {
+  it('produces a 4-sheet workbook with raw traffic buckets', async () => {
+    const buffer = await generateDeviceReportExcel(fullFixtureModel());
+
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer as unknown as ArrayBuffer);
+
+    expect(workbook.worksheets.map((sheet) => sheet.name)).toEqual([
+      'Overview',
+      'Traffic',
+      'Clients',
+      'Logs',
+    ]);
+
+    const trafficSheet = workbook.getWorksheet('Traffic')!;
+    // header + 144 buckets + totals row
+    expect(trafficSheet.rowCount).toBe(1 + 144 + 1);
+    expect(trafficSheet.getRow(1).getCell(1).value).toBe('Timestamp (SAST)');
+    const totalsRow = trafficSheet.getRow(trafficSheet.rowCount);
+    expect(totalsRow.getCell(1).value).toBe('TOTAL');
+    expect(totalsRow.getCell(2).value).toBe(TRAFFIC.totalRxBytes);
+
+    const overview = workbook.getWorksheet('Overview')!;
+    expect(overview.getRow(1).getCell(2).value).toBe('UNJANICLINICTHOKOZA');
+
+    const clients = workbook.getWorksheet('Clients')!;
+    expect(clients.getRow(2).getCell(1).value).toBe('clinic-laptop');
+
+    const logs = workbook.getWorksheet('Logs')!;
+    expect(logs.getRow(2).getCell(4).value).toBe('AP came online');
+  });
+});

--- a/lib/ruijie/device-export.ts
+++ b/lib/ruijie/device-export.ts
@@ -1,0 +1,163 @@
+/**
+ * Device report export model.
+ *
+ * Assembles everything the device detail page knows about one AP — cached
+ * identity, live metrics, traffic window, connected clients, management logs —
+ * into a single model that the PDF and Excel generators render. Sections that
+ * fail upstream (offline device, Ruijie timeout) degrade to "unavailable"
+ * rather than failing the whole export.
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import {
+  getDeviceMetrics,
+  getDeviceClients,
+  getDeviceLogs,
+  getNetworkTraffic,
+  type DeviceMetrics,
+  type RuijieClient,
+  type RuijieLogEntry,
+  type TrafficSummary,
+} from './client';
+
+export const EXPORT_WINDOW_HOURS = [6, 24, 72, 168] as const;
+
+/** Snap an arbitrary hours value onto the windows the traffic panel offers. */
+export function clampHours(value: number | null | undefined): number {
+  return value != null && (EXPORT_WINDOW_HOURS as readonly number[]).includes(value)
+    ? value
+    : 24;
+}
+
+export function windowLabel(hours: number): string {
+  if (hours % 24 === 0 && hours >= 24) return `Last ${hours / 24} day${hours > 24 ? 's' : ''}`;
+  return `Last ${hours} hours`;
+}
+
+/** Identity fields as cached in ruijie_device_cache (the page's own source). */
+export interface DeviceExportDevice {
+  sn: string;
+  device_name: string;
+  model: string | null;
+  group_id: string | null;
+  group_name: string | null;
+  management_ip: string | null;
+  wan_ip: string | null;
+  egress_ip: string | null;
+  status: string;
+  config_status: string | null;
+  firmware_version: string | null;
+  mac_address: string | null;
+  cpu_usage: number | null;
+  memory_usage: number | null;
+  uptime_seconds: number | null;
+  online_clients: number | null;
+  synced_at: string | null;
+}
+
+export interface DeviceExportModel {
+  device: DeviceExportDevice;
+  metrics: DeviceMetrics | null;
+  traffic: TrafficSummary | null;
+  clients: RuijieClient[];
+  logs: RuijieLogEntry[];
+  hours: number;
+  generatedAtIso: string;
+  unavailable: {
+    metrics?: string;
+    traffic?: string;
+    clients?: string;
+    logs?: string;
+  };
+}
+
+function reasonFrom(rejection: PromiseRejectedResult): string {
+  const cause = rejection.reason;
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+/**
+ * Build the export model for one device.
+ * Returns null when the SN is not in the device cache (route turns this into 404).
+ */
+export async function buildDeviceExportModel(
+  sn: string,
+  hours: number
+): Promise<DeviceExportModel | null> {
+  const supabase = await createClient();
+  const { data: device } = await supabase
+    .from('ruijie_device_cache')
+    .select(
+      'sn, device_name, model, group_id, group_name, management_ip, wan_ip, egress_ip, status, config_status, firmware_version, mac_address, cpu_usage, memory_usage, uptime_seconds, online_clients, synced_at'
+    )
+    .eq('sn', sn)
+    .single();
+
+  if (!device) return null;
+
+  const window = clampHours(hours);
+  const unavailable: DeviceExportModel['unavailable'] = {};
+
+  const [metricsResult, trafficResult, clientsResult, logsResult] = await Promise.allSettled([
+    getDeviceMetrics(sn, device.group_id ?? undefined),
+    getNetworkTraffic({ sn, hours: window }),
+    device.group_id
+      ? getDeviceClients(sn, device.group_id)
+      : Promise.resolve([] as RuijieClient[]),
+    getDeviceLogs(sn),
+  ]);
+
+  let metrics: DeviceMetrics | null = null;
+  if (metricsResult.status === 'fulfilled') {
+    metrics = metricsResult.value;
+  } else {
+    unavailable.metrics = reasonFrom(metricsResult);
+  }
+
+  let traffic: TrafficSummary | null = null;
+  if (trafficResult.status === 'fulfilled') {
+    traffic = trafficResult.value;
+    // getNetworkTraffic swallows upstream errors into an empty summary — an
+    // empty window on an online device still renders, just with a note.
+    if (traffic.dataPoints.length === 0) {
+      unavailable.traffic = 'No traffic samples returned for this window';
+    }
+  } else {
+    unavailable.traffic = reasonFrom(trafficResult);
+  }
+
+  let clients: RuijieClient[] = [];
+  if (clientsResult.status === 'fulfilled') {
+    clients = clientsResult.value;
+  } else {
+    unavailable.clients = reasonFrom(clientsResult);
+  }
+  if (!device.group_id && !unavailable.clients) {
+    unavailable.clients = 'Device has no Ruijie group — client list requires one';
+  }
+
+  let logs: RuijieLogEntry[] = [];
+  if (logsResult.status === 'fulfilled') {
+    logs = logsResult.value;
+  } else {
+    unavailable.logs = reasonFrom(logsResult);
+  }
+
+  return {
+    device: device as DeviceExportDevice,
+    metrics,
+    traffic,
+    clients,
+    logs,
+    hours: window,
+    generatedAtIso: new Date().toISOString(),
+    unavailable,
+  };
+}
+
+export function exportFilename(sn: string, hours: number, extension: 'pdf' | 'xlsx'): string {
+  const date = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Africa/Johannesburg',
+  }).format(new Date());
+  return `CircleTel_Device_${sn}_${date}_${hours}h.${extension}`;
+}

--- a/lib/ruijie/device-report-excel.ts
+++ b/lib/ruijie/device-report-excel.ts
@@ -1,0 +1,178 @@
+/**
+ * Device dossier Excel workbook (exceljs).
+ *
+ * Four sheets — Overview, Traffic, Clients, Logs — carrying the same data as
+ * the PDF but in analyst-friendly raw form: the Traffic sheet keeps every
+ * 10-minute bucket so totals can be re-derived and pivoted.
+ */
+
+import ExcelJS from 'exceljs';
+import { windowLabel, type DeviceExportModel } from './device-export';
+
+const HEADER_FILL: ExcelJS.Fill = {
+  type: 'pattern',
+  pattern: 'solid',
+  fgColor: { argb: 'FFF3F4F6' },
+};
+
+function sastTimestamp(input: string | number): string {
+  return new Intl.DateTimeFormat('en-ZA', {
+    timeZone: 'Africa/Johannesburg',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(new Date(input));
+}
+
+function styleHeaderRow(row: ExcelJS.Row): void {
+  row.font = { bold: true };
+  row.eachCell((cell) => {
+    cell.fill = HEADER_FILL;
+  });
+}
+
+export async function generateDeviceReportExcel(model: DeviceExportModel): Promise<Buffer> {
+  const { device, traffic } = model;
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'CircleTel';
+  workbook.created = new Date(model.generatedAtIso);
+
+  // --- Overview ---
+  const overview = workbook.addWorksheet('Overview');
+  overview.columns = [
+    { key: 'label', width: 26 },
+    { key: 'value', width: 42 },
+  ];
+  const overviewRows: Array<[string, string | number]> = [
+    ['Device name', device.device_name],
+    ['Serial number', device.sn],
+    ['Model', device.model ?? '—'],
+    ['Group', device.group_name ?? '—'],
+    ['Status', device.status],
+    ['Config status', device.config_status ?? '—'],
+    ['Management IP', device.management_ip ?? '—'],
+    ['WAN IP', device.wan_ip ?? '—'],
+    ['Egress IP', device.egress_ip ?? '—'],
+    ['MAC address', device.mac_address ?? '—'],
+    ['Firmware', device.firmware_version ?? '—'],
+    ['CPU usage (%)', model.metrics?.cpu_usage ?? device.cpu_usage ?? '—'],
+    ['Memory usage (%)', model.metrics?.memory_usage ?? device.memory_usage ?? '—'],
+    ['Uptime (seconds)', model.metrics?.uptime_seconds ?? device.uptime_seconds ?? '—'],
+    ['Connected clients', model.metrics?.online_clients ?? device.online_clients ?? 0],
+    ['Last synced (SAST)', device.synced_at ? sastTimestamp(device.synced_at) : '—'],
+    ['Report period', windowLabel(model.hours)],
+    ['Generated (SAST)', sastTimestamp(model.generatedAtIso)],
+  ];
+  overviewRows.forEach(([label, value]) => {
+    const row = overview.addRow({ label, value });
+    row.getCell(1).font = { bold: true };
+  });
+  const unavailableNotes = Object.entries(model.unavailable);
+  if (unavailableNotes.length > 0) {
+    overview.addRow({});
+    unavailableNotes.forEach(([section, reason]) => {
+      const row = overview.addRow({ label: `Note — ${section}`, value: reason });
+      row.getCell(1).font = { bold: true, color: { argb: 'FF9CA3AF' } };
+      row.getCell(2).font = { color: { argb: 'FF9CA3AF' } };
+    });
+  }
+
+  // --- Traffic (raw 10-minute buckets) ---
+  const trafficSheet = workbook.addWorksheet('Traffic');
+  trafficSheet.columns = [
+    { header: 'Timestamp (SAST)', key: 'time', width: 22 },
+    { header: 'Download bytes', key: 'rx', width: 18 },
+    { header: 'Upload bytes', key: 'tx', width: 18 },
+  ];
+  styleHeaderRow(trafficSheet.getRow(1));
+  (traffic?.dataPoints ?? []).forEach((point) => {
+    trafficSheet.addRow({
+      time: sastTimestamp(point.timestamp),
+      rx: point.rxBytes,
+      tx: point.txBytes,
+    });
+  });
+  if (traffic && traffic.dataPoints.length > 0) {
+    const totals = trafficSheet.addRow({
+      time: 'TOTAL',
+      rx: traffic.totalRxBytes,
+      tx: traffic.totalTxBytes,
+    });
+    totals.font = { bold: true };
+  } else {
+    trafficSheet.addRow({ time: model.unavailable.traffic ?? 'No traffic samples' });
+  }
+  trafficSheet.getColumn('rx').numFmt = '#,##0';
+  trafficSheet.getColumn('tx').numFmt = '#,##0';
+
+  // --- Clients ---
+  const clientsSheet = workbook.addWorksheet('Clients');
+  clientsSheet.columns = [
+    { header: 'Hostname', key: 'hostname', width: 24 },
+    { header: 'MAC', key: 'mac', width: 18 },
+    { header: 'IP', key: 'ip', width: 15 },
+    { header: 'SSID', key: 'ssid', width: 20 },
+    { header: 'Band', key: 'band', width: 8 },
+    { header: 'Channel', key: 'channel', width: 9 },
+    { header: 'RSSI (dBm)', key: 'rssi', width: 11 },
+    { header: 'Quality', key: 'quality', width: 11 },
+    { header: 'Down rate (bps)', key: 'down', width: 15 },
+    { header: 'Up rate (bps)', key: 'up', width: 15 },
+    { header: 'Session bytes', key: 'sessionBytes', width: 15 },
+    { header: 'Latency (ms)', key: 'latency', width: 12 },
+    { header: 'Score', key: 'score', width: 8 },
+  ];
+  styleHeaderRow(clientsSheet.getRow(1));
+  model.clients.forEach((client) => {
+    clientsSheet.addRow({
+      hostname: client.hostname ?? '—',
+      mac: client.mac,
+      ip: client.userIp,
+      ssid: client.ssid,
+      band: client.band,
+      channel: client.channel,
+      rssi: client.rssi,
+      quality: client.signalQuality,
+      down: client.downlinkRate,
+      up: client.uplinkRate,
+      sessionBytes: client.sessionBytes,
+      latency: client.latencyMs,
+      score: client.score,
+    });
+  });
+  if (model.clients.length === 0) {
+    clientsSheet.addRow({
+      hostname:
+        model.unavailable.clients ??
+        (device.status === 'online' ? 'No clients connected' : 'Not available — device offline'),
+    });
+  }
+
+  // --- Logs ---
+  const logsSheet = workbook.addWorksheet('Logs');
+  logsSheet.columns = [
+    { header: 'Time (SAST)', key: 'time', width: 22 },
+    { header: 'Type', key: 'type', width: 12 },
+    { header: 'Subtype', key: 'subtype', width: 10 },
+    { header: 'Detail', key: 'detail', width: 70 },
+  ];
+  styleHeaderRow(logsSheet.getRow(1));
+  model.logs.forEach((log) => {
+    logsSheet.addRow({
+      time: sastTimestamp(log.operateTime),
+      type: log.logType,
+      subtype: log.logSubType ?? '',
+      detail: log.logDetail,
+    });
+  });
+  if (model.logs.length === 0) {
+    logsSheet.addRow({ time: model.unavailable.logs ?? 'No log entries returned' });
+  }
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return Buffer.from(buffer);
+}

--- a/lib/ruijie/device-report-pdf.ts
+++ b/lib/ruijie/device-report-pdf.ts
@@ -1,0 +1,356 @@
+/**
+ * Device dossier PDF.
+ *
+ * Renders a DeviceExportModel with jsPDF: identity summary, traffic window
+ * (KPIs + stacked bar chart drawn with rect()), connected clients and recent
+ * management logs as autoTable tables. Layout and palette mirror
+ * lib/usage-reports/pdf-generator.ts; its helpers are module-private there,
+ * so the small ones are replicated here.
+ */
+
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { circleTelLogoBase64 } from '@/lib/quotes/circletel-logo-base64';
+import { windowLabel, type DeviceExportModel } from './device-export';
+import type { TrafficDataPoint } from './client';
+
+const COLORS = {
+  orange: '#F5831F',
+  navy: '#1B2A4A',
+  dark: '#1F2937',
+  gray: '#6B7280',
+  muted: '#9CA3AF',
+  border: '#E5E7EB',
+  panel: '#F9FAFB',
+  white: '#FFFFFF',
+};
+
+const MAX_CHART_BARS = 84;
+const MAX_LOG_ROWS = 30;
+
+function addLogo(doc: jsPDF, x: number, y: number, size: number): void {
+  try {
+    doc.addImage(circleTelLogoBase64, 'PNG', x, y, size, size);
+  } catch {
+    doc.setFillColor(COLORS.orange);
+    doc.roundedRect(x, y, size, size, 2, 2, 'F');
+    doc.setTextColor(COLORS.white);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(13);
+    doc.text('CT', x + size / 2, y + size / 2 + 2, { align: 'center' });
+  }
+}
+
+function formatGeneratedAt(iso: string): string {
+  return new Intl.DateTimeFormat('en-ZA', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'Africa/Johannesburg',
+  }).format(new Date(iso));
+}
+
+function sectionTitle(doc: jsPDF, title: string, x: number, y: number): void {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  doc.setTextColor(COLORS.dark);
+  doc.text(title, x, y);
+}
+
+function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes) || bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
+}
+
+function formatBps(bps: number | null | undefined): string {
+  if (bps == null || !Number.isFinite(bps) || bps === 0) return '0 bps';
+  const units = ['bps', 'Kbps', 'Mbps', 'Gbps'];
+  const i = Math.min(Math.floor(Math.log(bps) / Math.log(1000)), units.length - 1);
+  return `${(bps / Math.pow(1000, i)).toFixed(1)} ${units[i]}`;
+}
+
+function formatUptime(seconds: number | null | undefined): string {
+  if (seconds == null || seconds <= 0) return '—';
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function formatSastTime(timestampMs: number, hours: number): string {
+  return new Intl.DateTimeFormat('en-ZA', {
+    timeZone: 'Africa/Johannesburg',
+    ...(hours <= 24
+      ? { hour: '2-digit', minute: '2-digit' }
+      : { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' }),
+  }).format(new Date(timestampMs));
+}
+
+/** Merge consecutive 10-minute buckets so a 7-day window stays readable at A4 width. */
+function resampleForChart(
+  points: TrafficDataPoint[]
+): Array<{ timestamp: number; rxBytes: number; txBytes: number }> {
+  if (points.length <= MAX_CHART_BARS) {
+    return points.map((p) => ({ timestamp: p.timestamp, rxBytes: p.rxBytes, txBytes: p.txBytes }));
+  }
+  const groupSize = Math.ceil(points.length / MAX_CHART_BARS);
+  const bars: Array<{ timestamp: number; rxBytes: number; txBytes: number }> = [];
+  for (let start = 0; start < points.length; start += groupSize) {
+    const group = points.slice(start, start + groupSize);
+    bars.push({
+      timestamp: group[0].timestamp,
+      rxBytes: group.reduce((sum, p) => sum + p.rxBytes, 0),
+      txBytes: group.reduce((sum, p) => sum + p.txBytes, 0),
+    });
+  }
+  return bars;
+}
+
+export function generateDeviceReportPdf(model: DeviceExportModel): ArrayBuffer {
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const margin = 15;
+  const contentWidth = pageWidth - margin * 2;
+  const { device, traffic } = model;
+
+  // Header
+  addLogo(doc, margin, 14, 24);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(20);
+  doc.setTextColor(COLORS.dark);
+  doc.text('DEVICE REPORT', pageWidth - margin, 23, { align: 'right' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(COLORS.gray);
+  doc.text(`Generated ${formatGeneratedAt(model.generatedAtIso)} SAST`, pageWidth - margin, 30, {
+    align: 'right',
+  });
+  doc.setDrawColor(COLORS.orange);
+  doc.setLineWidth(0.8);
+  doc.line(margin, 43, pageWidth - margin, 43);
+
+  // Device identity row
+  doc.setFontSize(7);
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(COLORS.gray);
+  doc.text('DEVICE', margin, 51);
+  doc.text('REPORT PERIOD', pageWidth - margin, 51, { align: 'right' });
+  doc.setFontSize(12);
+  doc.setTextColor(COLORS.dark);
+  doc.text(device.device_name, margin, 58);
+  doc.text(windowLabel(model.hours), pageWidth - margin, 58, { align: 'right' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(COLORS.gray);
+  doc.text(
+    [device.model, `SN ${device.sn}`, device.group_name].filter(Boolean).join(' · '),
+    margin,
+    63
+  );
+  doc.text('Times in SAST', pageWidth - margin, 63, { align: 'right' });
+
+  // Device summary grid
+  const summaryY = 70;
+  const summaryRows: Array<[string, string]> = [
+    ['Status', device.status === 'online' ? 'Online' : 'Offline'],
+    ['Config', device.config_status ?? '—'],
+    ['Management IP', device.management_ip ?? '—'],
+    ['WAN IP', device.wan_ip ?? '—'],
+    ['MAC address', device.mac_address ?? '—'],
+    ['Firmware', device.firmware_version ?? '—'],
+    ['Uptime', formatUptime(model.metrics?.uptime_seconds ?? device.uptime_seconds)],
+    [
+      'CPU / Memory',
+      `${model.metrics?.cpu_usage ?? device.cpu_usage ?? '—'}% / ${model.metrics?.memory_usage ?? device.memory_usage ?? '—'}%`,
+    ],
+    ['Connected clients', String(model.metrics?.online_clients ?? device.online_clients ?? 0)],
+    [
+      'Last synced',
+      device.synced_at ? `${formatGeneratedAt(device.synced_at)} SAST` : '—',
+    ],
+  ];
+  const summaryRowHeight = 6;
+  const summaryHeight = Math.ceil(summaryRows.length / 2) * summaryRowHeight + 10;
+  doc.setFillColor(COLORS.panel);
+  doc.setDrawColor(COLORS.border);
+  doc.roundedRect(margin, summaryY, contentWidth, summaryHeight, 1.5, 1.5, 'FD');
+  sectionTitle(doc, 'Device summary', margin + 4, summaryY + 6);
+  const colWidth = contentWidth / 2;
+  summaryRows.forEach(([label, value], index) => {
+    const col = index % 2;
+    const row = Math.floor(index / 2);
+    const x = margin + 4 + col * colWidth;
+    const y = summaryY + 12 + row * summaryRowHeight;
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7);
+    doc.setTextColor(COLORS.gray);
+    doc.text(label, x, y);
+    doc.setFont('helvetica', 'bold');
+    doc.setTextColor(COLORS.dark);
+    doc.text(value, x + 32, y);
+  });
+
+  // Traffic KPI strip
+  const kpiY = summaryY + summaryHeight + 8;
+  sectionTitle(doc, `Traffic — ${windowLabel(model.hours).toLowerCase()}`, margin, kpiY - 2);
+  const kpis: Array<[string, string]> = [
+    ['DOWNLOADED', formatBytes(traffic?.totalRxBytes)],
+    ['UPLOADED', formatBytes(traffic?.totalTxBytes)],
+    ['AVG RATE', formatBps(traffic?.avgRxRate)],
+    ['BUSIEST BUCKET', formatBytes(traffic?.peakRxBytes)],
+  ];
+  const kpiWidth = contentWidth / 4;
+  doc.setFillColor(COLORS.panel);
+  doc.rect(margin, kpiY, contentWidth, 18, 'F');
+  kpis.forEach(([label, value], index) => {
+    const x = margin + index * kpiWidth + 3;
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(6.5);
+    doc.setTextColor(COLORS.gray);
+    doc.text(label, x, kpiY + 6);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9.5);
+    doc.setTextColor(COLORS.dark);
+    doc.text(value, x, kpiY + 13);
+  });
+
+  // Traffic chart — download orange, upload navy stacked on top
+  const chartBoxY = kpiY + 22;
+  const chartHeight = 28;
+  const bars = resampleForChart(traffic?.dataPoints ?? []);
+  doc.setFillColor(COLORS.panel);
+  doc.setDrawColor(COLORS.border);
+  doc.roundedRect(margin, chartBoxY, contentWidth, 44, 1.5, 1.5, 'FD');
+  if (bars.length === 0) {
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(8);
+    doc.setTextColor(COLORS.gray);
+    doc.text(
+      model.unavailable.traffic ?? 'No traffic samples in this window',
+      pageWidth / 2,
+      chartBoxY + 23,
+      { align: 'center' }
+    );
+  } else {
+    const chartX = margin + 4;
+    const chartY = chartBoxY + 5;
+    const chartWidth = contentWidth - 8;
+    const maxValue = Math.max(1, ...bars.map((bar) => bar.rxBytes + bar.txBytes));
+    const barWidth = chartWidth / bars.length;
+    const barGap = bars.length > 40 ? 0.3 : 0.6;
+    bars.forEach((bar, index) => {
+      const x = chartX + index * barWidth + barGap / 2;
+      const width = Math.max(0.3, barWidth - barGap);
+      const rxHeight = (bar.rxBytes / maxValue) * chartHeight;
+      const txHeight = (bar.txBytes / maxValue) * chartHeight;
+      const total = Math.max(0.5, rxHeight + txHeight);
+      doc.setFillColor(COLORS.orange);
+      doc.rect(x, chartY + chartHeight - rxHeight, width, rxHeight, 'F');
+      doc.setFillColor(COLORS.navy);
+      doc.rect(x, chartY + chartHeight - total, width, txHeight, 'F');
+    });
+    doc.setDrawColor(COLORS.border);
+    doc.line(chartX, chartY + chartHeight, chartX + chartWidth, chartY + chartHeight);
+    // Five evenly spaced time labels
+    doc.setFont('courier', 'normal');
+    doc.setFontSize(5.5);
+    doc.setTextColor(COLORS.gray);
+    for (let i = 0; i < 5; i++) {
+      const barIndex = Math.min(bars.length - 1, Math.round((i / 4) * (bars.length - 1)));
+      const x = chartX + (barIndex + 0.5) * barWidth;
+      doc.text(formatSastTime(bars[barIndex].timestamp, model.hours), x, chartY + chartHeight + 4, {
+        align: 'center',
+      });
+    }
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(5.5);
+    doc.setTextColor(COLORS.gray);
+    doc.text('Download (orange) + Upload (navy), stacked', chartX, chartY + chartHeight + 8);
+  }
+
+  // Connected clients table
+  const clientsStartY = chartBoxY + 52;
+  sectionTitle(doc, `Connected clients (${model.clients.length})`, margin, clientsStartY);
+  if (model.clients.length === 0) {
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7.5);
+    doc.setTextColor(COLORS.gray);
+    doc.text(
+      model.unavailable.clients ??
+        (device.status === 'online' ? 'No clients connected right now' : 'Not available — device offline'),
+      margin,
+      clientsStartY + 6
+    );
+  } else {
+    autoTable(doc, {
+      startY: clientsStartY + 3,
+      margin: { left: margin, right: margin },
+      head: [['Hostname', 'IP', 'SSID', 'Band', 'RSSI', 'Quality', 'Down', 'Up']],
+      body: model.clients.map((client) => [
+        client.hostname ?? client.mac,
+        client.userIp,
+        client.ssid,
+        client.band,
+        `${client.rssi} dBm`,
+        client.signalQuality,
+        formatBps(client.downlinkRate),
+        formatBps(client.uplinkRate),
+      ]),
+      theme: 'plain',
+      styles: { fontSize: 7, cellPadding: 1.8, textColor: COLORS.dark, lineColor: COLORS.border, lineWidth: 0.2 },
+      headStyles: { fillColor: COLORS.panel, textColor: COLORS.gray, fontStyle: 'bold' },
+    });
+  }
+
+  // Recent logs table
+  const afterClientsY =
+    (doc as jsPDF & { lastAutoTable?: { finalY: number } }).lastAutoTable?.finalY ??
+    clientsStartY + 10;
+  const logs = model.logs.slice(0, MAX_LOG_ROWS);
+  const logsTitleY = afterClientsY + 10 > pageHeight - 30 ? (doc.addPage(), 20) : afterClientsY + 10;
+  sectionTitle(doc, `Recent device logs${model.logs.length > MAX_LOG_ROWS ? ` (latest ${MAX_LOG_ROWS} of ${model.logs.length})` : ` (${model.logs.length})`}`, margin, logsTitleY);
+  if (logs.length === 0) {
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7.5);
+    doc.setTextColor(COLORS.gray);
+    doc.text(model.unavailable.logs ?? 'No log entries returned', margin, logsTitleY + 6);
+  } else {
+    autoTable(doc, {
+      startY: logsTitleY + 3,
+      margin: { left: margin, right: margin },
+      head: [['Time (SAST)', 'Type', 'Detail']],
+      body: logs.map((log) => [
+        formatGeneratedAt(new Date(log.operateTime).toISOString()),
+        log.logSubType ? `${log.logType}/${log.logSubType}` : log.logType,
+        log.logDetail,
+      ]),
+      theme: 'plain',
+      styles: { fontSize: 7, cellPadding: 1.8, textColor: COLORS.dark, lineColor: COLORS.border, lineWidth: 0.2 },
+      headStyles: { fillColor: COLORS.panel, textColor: COLORS.gray, fontStyle: 'bold' },
+      columnStyles: { 0: { cellWidth: 38 }, 1: { cellWidth: 28 } },
+    });
+  }
+
+  // Footer on every page
+  const pageCount = doc.getNumberOfPages();
+  for (let page = 1; page <= pageCount; page++) {
+    doc.setPage(page);
+    doc.setDrawColor(COLORS.border);
+    doc.line(margin, pageHeight - 14, pageWidth - margin, pageHeight - 14);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(6.5);
+    doc.setTextColor(COLORS.muted);
+    doc.text(
+      `CircleTel · ${device.sn} · ${windowLabel(model.hours)} · Page ${page} of ${pageCount}`,
+      pageWidth / 2,
+      pageHeight - 9,
+      { align: 'center' }
+    );
+  }
+
+  return doc.output('arraybuffer');
+}


### PR DESCRIPTION
## What

Adds a **Download** dropdown to the `/admin/network/devices/[sn]` header exporting a full device dossier — device summary, traffic for the currently selected window (6h/24h/3d/7d), connected clients, recent logs — as a **PDF report** (jsPDF, styled after the usage-report generator) or a **4-sheet Excel workbook** (first use of the already-installed `exceljs`; **no new dependencies**).

## How

- `GET /api/ruijie/devices/[sn]/export?hours=&format=pdf|excel` — same session+`admin_users` auth as sibling device routes; gathers data server-side via existing `lib/ruijie/client.ts` functions (`Promise.allSettled`); writes a `ruijie_audit_log` row per export
- Sections degrade to "unavailable" notes on upstream failure (offline device, Ruijie timeout) — the export never hard-fails after the device is found
- Excel: Overview | Traffic (raw 10-min buckets + totals) | Clients | Logs, SAST timestamps
- Traffic window selection lifted from `DeviceTrafficPanel` via optional `onHoursChange` — exports follow the Traffic tab's period

## Verified

- 9/9 unit tests (`lib/ruijie/__tests__/device-export.test.ts`): model builder degradation paths, PDF magic bytes, Excel workbook re-read with sheet/cell assertions
- Live against dev server + real Ruijie data for `G1U52HL044467`: 401 unauthenticated, 400 bad format, both downloads ~2.7s with correct MIME/filenames; **PDF traffic KPIs match the Traffic tab exactly** (14.8 GB / 4.6 GB / 210.8 Kbps / 702.1 MB); real clients + logs render
- `verify-admin-page.ts` harness: Download button renders in header at 1440px and 375px, no admin API denied; hydration warning confirmed pre-existing (also on untouched control page)
- Pre-push scoped type-check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WLyCcHJPJJ8diVXgcuLuL