### PR TITLE
feat(network): hardware install inventory admin page

### DIFF
--- a/app/admin/network/hardware/page.tsx
+++ b/app/admin/network/hardware/page.tsx
@@ -1,0 +1,423 @@
+'use client';
+
+/**
+ * Hardware → Location → Active Customer inventory
+ * Hardware-first rows from v_hardware_installations (Ruijie / Interstellio / Tarana RN).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  PiArrowsClockwiseBold,
+  PiHardDrivesBold,
+  PiLinkBold,
+  PiLinkBreakBold,
+  PiMagnifyingGlassBold,
+} from 'react-icons/pi';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AdminPage,
+  PageHeader,
+  LoadingState,
+  ErrorState,
+  StatCard,
+} from '@/components/backend';
+
+type HardwareSource = 'ruijie' | 'interstellio' | 'tarana';
+
+interface HardwareRow {
+  hardware_source: HardwareSource;
+  hardware_id: string;
+  hardware_label: string | null;
+  hardware_model: string | null;
+  hardware_status: string | null;
+  last_seen_at: string | null;
+  customer_id: string | null;
+  customer_name: string | null;
+  customer_email: string | null;
+  service_id: string | null;
+  service_status: string | null;
+  service_active: boolean | null;
+  package_name: string | null;
+  location_type: string | null;
+  location_id: string | null;
+  location_name: string | null;
+  location_address: string | null;
+  province: string | null;
+  link_method: string | null;
+}
+
+interface ApiResponse {
+  rows: HardwareRow[];
+  totals: {
+    total: number;
+    linked: number;
+    unlinked: number;
+    by_source: Record<HardwareSource, number>;
+  };
+}
+
+const SOURCE_LABEL: Record<HardwareSource, string> = {
+  ruijie: 'Ruijie',
+  interstellio: 'Interstellio',
+  tarana: 'Tarana RN',
+};
+
+function statusBadgeClass(status: string | null): string {
+  const s = (status || '').toLowerCase();
+  if (['online', 'enabled', 'active'].includes(s)) {
+    return 'bg-green-50 text-green-700 border-green-200';
+  }
+  if (['offline', 'disabled', 'down'].includes(s)) {
+    return 'bg-red-50 text-red-700 border-red-200';
+  }
+  if (['unknown', 'pending'].includes(s)) {
+    return 'bg-gray-50 text-gray-600 border-gray-200';
+  }
+  return 'bg-slate-50 text-slate-700 border-slate-200';
+}
+
+function detailHref(row: HardwareRow): string | null {
+  if (row.hardware_source === 'ruijie') {
+    return `/admin/network/devices/${encodeURIComponent(row.hardware_id)}`;
+  }
+  if (row.customer_id) {
+    return `/admin/customers/${row.customer_id}`;
+  }
+  return null;
+}
+
+export default function HardwareInstallationsPage() {
+  const [data, setData] = useState<ApiResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [source, setSource] = useState<string>('all');
+  const [linked, setLinked] = useState<string>('all');
+  const [serviceStatus, setServiceStatus] = useState<string>('all');
+  const [q, setQ] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+
+  const fetchData = useCallback(
+    async (isRefresh = false) => {
+      if (isRefresh) setRefreshing(true);
+      else setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        if (source !== 'all') params.set('source', source);
+        if (linked !== 'all') params.set('linked', linked);
+        if (serviceStatus !== 'all') params.set('service_status', serviceStatus);
+        if (q) params.set('q', q);
+
+        const res = await fetch(
+          `/api/admin/network/hardware-installations?${params.toString()}`,
+          { credentials: 'include' }
+        );
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || 'Failed to load');
+        }
+        const json = (await res.json()) as ApiResponse;
+        setData(json);
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load');
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [source, linked, serviceStatus, q]
+  );
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  if (loading && !data) {
+    return (
+      <AdminPage>
+        <LoadingState message="Loading hardware inventory…" />
+      </AdminPage>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <AdminPage>
+        <ErrorState
+          title="Unable to load inventory"
+          message={error}
+          onRetry={() => fetchData()}
+        />
+      </AdminPage>
+    );
+  }
+
+  const totals = data?.totals;
+  const rows = data?.rows || [];
+
+  return (
+    <AdminPage>
+      <PageHeader
+        title="Hardware Installations"
+        subtitle="Network hardware linked to locations and active customer services"
+        actions={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fetchData(true)}
+            disabled={refreshing}
+          >
+            <PiArrowsClockwiseBold
+              className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`}
+            />
+            Refresh
+          </Button>
+        }
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+        <StatCard
+          label="Total hardware"
+          value={totals?.total ?? 0}
+          icon={<PiHardDrivesBold className="w-5 h-5" />}
+        />
+        <StatCard
+          label="Linked to service"
+          value={totals?.linked ?? 0}
+          icon={<PiLinkBold className="w-5 h-5" />}
+        />
+        <StatCard
+          label="Unlinked"
+          value={totals?.unlinked ?? 0}
+          icon={<PiLinkBreakBold className="w-5 h-5" />}
+        />
+        <StatCard
+          label="By source"
+          value={`${totals?.by_source.ruijie ?? 0} / ${totals?.by_source.interstellio ?? 0} / ${totals?.by_source.tarana ?? 0}`}
+          subtitle="Ruijie / Interstellio / Tarana"
+        />
+      </div>
+
+      <div className="flex flex-col md:flex-row gap-3 mb-4">
+        <form
+          className="flex gap-2 flex-1"
+          onSubmit={(e) => {
+            e.preventDefault();
+            setQ(searchInput.trim());
+          }}
+        >
+          <div className="relative flex-1">
+            <PiMagnifyingGlassBold className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <Input
+              className="pl-9"
+              placeholder="Search serial, customer, location…"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+            />
+          </div>
+          <Button type="submit" variant="secondary" size="sm">
+            Search
+          </Button>
+        </form>
+
+        <Select value={source} onValueChange={setSource}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Source" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All sources</SelectItem>
+            <SelectItem value="ruijie">Ruijie</SelectItem>
+            <SelectItem value="interstellio">Interstellio</SelectItem>
+            <SelectItem value="tarana">Tarana RN</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select value={linked} onValueChange={setLinked}>
+          <SelectTrigger className="w-[150px]">
+            <SelectValue placeholder="Link" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All links</SelectItem>
+            <SelectItem value="linked">Linked</SelectItem>
+            <SelectItem value="unlinked">Unlinked</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select value={serviceStatus} onValueChange={setServiceStatus}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Service status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Any service</SelectItem>
+            <SelectItem value="active">Active</SelectItem>
+            <SelectItem value="suspended">Suspended</SelectItem>
+            <SelectItem value="pending">Pending</SelectItem>
+            <SelectItem value="cancelled">Cancelled</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="rounded-lg border bg-white overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Source</TableHead>
+              <TableHead>Hardware</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Customer</TableHead>
+              <TableHead>Service</TableHead>
+              <TableHead>Location</TableHead>
+              <TableHead>Link</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center text-gray-500 py-10">
+                  No hardware rows match these filters.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => {
+                const href = detailHref(row);
+                return (
+                  <TableRow key={`${row.hardware_source}:${row.hardware_id}`}>
+                    <TableCell>
+                      <Badge variant="outline">
+                        {SOURCE_LABEL[row.hardware_source]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="font-medium text-gray-900">
+                        {row.hardware_label || row.hardware_id}
+                      </div>
+                      <div className="text-xs text-gray-500 font-mono">
+                        {row.hardware_id}
+                      </div>
+                      {row.hardware_model && (
+                        <div className="text-xs text-gray-400">{row.hardware_model}</div>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className={statusBadgeClass(row.hardware_status)}
+                      >
+                        {row.hardware_status || '—'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {row.customer_name || row.customer_id ? (
+                        <div>
+                          {row.customer_id ? (
+                            <Link
+                              href={`/admin/customers/${row.customer_id}`}
+                              className="text-circleTel-orange hover:underline font-medium"
+                            >
+                              {row.customer_name || 'Customer'}
+                            </Link>
+                          ) : (
+                            <span className="font-medium">{row.customer_name}</span>
+                          )}
+                          {row.customer_email && (
+                            <div className="text-xs text-gray-500">{row.customer_email}</div>
+                          )}
+                        </div>
+                      ) : (
+                        <span className="text-gray-400 text-sm">Unlinked</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {row.service_id ? (
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <Badge
+                              variant="outline"
+                              className={statusBadgeClass(row.service_status)}
+                            >
+                              {row.service_status || '—'}
+                            </Badge>
+                            {row.service_active === false && (
+                              <span className="text-xs text-amber-600">inactive flag</span>
+                            )}
+                          </div>
+                          {row.package_name && (
+                            <div className="text-xs text-gray-500 mt-1">{row.package_name}</div>
+                          )}
+                        </div>
+                      ) : (
+                        <span className="text-gray-400 text-sm">No service</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {row.location_name || row.location_address ? (
+                        <div>
+                          <div className="font-medium text-sm">
+                            {row.location_name || 'Location'}
+                          </div>
+                          {row.location_address && (
+                            <div className="text-xs text-gray-500 line-clamp-2">
+                              {row.location_address}
+                            </div>
+                          )}
+                          {row.province && (
+                            <div className="text-xs text-gray-400">{row.province}</div>
+                          )}
+                        </div>
+                      ) : (
+                        <span className="text-gray-400 text-sm">No location</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {row.link_method ? (
+                        <span className="text-xs font-mono text-gray-600">
+                          {row.link_method}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-gray-400">
+                          Unlinked — map via install register
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {href ? (
+                        <Link href={href}>
+                          <Button variant="ghost" size="sm">
+                            Open
+                          </Button>
+                        </Link>
+                      ) : (
+                        <span className="text-xs text-gray-400">—</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </AdminPage>
+  );
+}

--- a/app/admin/network/page.tsx
+++ b/app/admin/network/page.tsx
@@ -161,6 +161,12 @@ export default function NetworkDashboardPage() {
             <PiArrowsClockwiseBold className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
             Refresh
           </Button>
+          <Link href="/admin/network/hardware">
+            <Button variant="outline" size="sm">
+              <PiDesktopTowerBold className="w-4 h-4 mr-2" />
+              Hardware
+            </Button>
+          </Link>
           <Link href="/admin/network/outages/new">
             <Button size="sm" className="bg-circleTel-orange hover:bg-orange-600">
               <PiPlusBold className="w-4 h-4 mr-2" />

--- a/app/api/admin/network/hardware-installations/route.ts
+++ b/app/api/admin/network/hardware-installations/route.ts
@@ -1,0 +1,134 @@
+/**
+ * GET /api/admin/network/hardware-installations
+ *
+ * Hardware-first inventory from v_hardware_installations
+ * (Ruijie + Interstellio + Tarana RN) with optional customer/location links.
+ *
+ * Query params:
+ * - source: ruijie|interstellio|tarana (optional)
+ * - linked: all|linked|unlinked (default all)
+ * - q: search hardware id/label, customer, location
+ * - service_status: filter by customer_services.status
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+
+export const dynamic = 'force-dynamic';
+
+export type HardwareInstallationRow = {
+  hardware_source: 'ruijie' | 'interstellio' | 'tarana';
+  hardware_id: string;
+  hardware_label: string | null;
+  hardware_model: string | null;
+  hardware_status: string | null;
+  last_seen_at: string | null;
+  customer_id: string | null;
+  customer_name: string | null;
+  customer_email: string | null;
+  service_id: string | null;
+  service_status: string | null;
+  service_active: boolean | null;
+  package_name: string | null;
+  location_type: string | null;
+  location_id: string | null;
+  location_name: string | null;
+  location_address: string | null;
+  province: string | null;
+  lat: number | null;
+  lng: number | null;
+  link_method: string | null;
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) {
+      return authResult.response;
+    }
+
+    const { searchParams } = new URL(request.url);
+    const source = searchParams.get('source')?.trim() || '';
+    const linked = searchParams.get('linked')?.trim() || 'all';
+    const q = searchParams.get('q')?.trim() || '';
+    const serviceStatus = searchParams.get('service_status')?.trim() || '';
+
+    const supabase = await createClient();
+
+    let query = supabase.from('v_hardware_installations').select('*');
+
+    if (source && ['ruijie', 'interstellio', 'tarana'].includes(source)) {
+      query = query.eq('hardware_source', source);
+    }
+
+    if (linked === 'linked') {
+      query = query.not('service_id', 'is', null);
+    } else if (linked === 'unlinked') {
+      query = query.is('service_id', null);
+    }
+
+    if (serviceStatus) {
+      query = query.eq('service_status', serviceStatus);
+    }
+
+    if (q) {
+      // PostgREST or() — escape commas in q
+      const safe = q.replace(/[,()]/g, ' ');
+      query = query.or(
+        [
+          `hardware_id.ilike.%${safe}%`,
+          `hardware_label.ilike.%${safe}%`,
+          `customer_name.ilike.%${safe}%`,
+          `location_name.ilike.%${safe}%`,
+          `package_name.ilike.%${safe}%`,
+        ].join(',')
+      );
+    }
+
+    query = query
+      .order('hardware_source', { ascending: true })
+      .order('hardware_label', { ascending: true });
+
+    const { data, error } = await query;
+
+    if (error) {
+      console.error('[HardwareInstallations] query failed', error);
+      return NextResponse.json(
+        { error: 'Failed to load hardware installations', details: error.message },
+        { status: 500 }
+      );
+    }
+
+    const rows = (data || []) as HardwareInstallationRow[];
+
+    const bySource = {
+      ruijie: 0,
+      interstellio: 0,
+      tarana: 0,
+    };
+    let linkedCount = 0;
+    for (const row of rows) {
+      if (row.hardware_source in bySource) {
+        bySource[row.hardware_source as keyof typeof bySource] += 1;
+      }
+      if (row.service_id) linkedCount += 1;
+    }
+
+    return NextResponse.json({
+      rows,
+      totals: {
+        total: rows.length,
+        linked: linkedCount,
+        unlinked: rows.length - linkedCount,
+        by_source: bySource,
+      },
+    });
+  } catch (err) {
+    console.error('[HardwareInstallations] unexpected error', err);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/ruijie/devices/[sn]/link/route.ts
+++ b/app/api/ruijie/devices/[sn]/link/route.ts
@@ -15,16 +15,19 @@
  * - Sets one of `customer_order_id` / `corporate_site_id` (clears the other)
  * - Denormalizes `customer_name`, `customer_email`, `customer_phone` from
  *   `consumer_orders` or `corporate_sites`
+ * - Upserts `service_network_identifiers` (`ruijie_sn` → service) when a
+ *   `service_id` can be resolved (corporate site or order connection_id)
  *
  * Success (200):
  * ```json
- * { "success": true, "customer_name": "...", "customer_email": "...", "customer_phone": "..." }
+ * { "success": true, "customer_name": "...", "customer_email": "...", "customer_phone": "...", "service_id": "..." }
  * ```
  *
  * Errors: 400 validation, 401/403 auth, 404 device or order/site missing, 500 update failure.
  *
  * ## DELETE `/api/ruijie/devices/[sn]/link`
- * Clears `customer_order_id`, `corporate_site_id`, and denormalized customer fields.
+ * Clears `customer_order_id`, `corporate_site_id`, denormalized customer fields,
+ * and deletes matching `service_network_identifiers` row for this SN.
  * Success (200): `{ "success": true }`
  *
  * Ops UI: `/admin/network/devices` (list + filter Unlinked) and device detail
@@ -101,10 +104,12 @@ export async function POST(
     let customerEmail: string | null = null;
     let customerPhone: string | null = null;
 
+    let resolvedServiceId: string | null = null;
+
     if (body.type === 'consumer' && body.customer_order_id) {
       const { data: order, error: orderError } = await supabaseAdmin
         .from('consumer_orders')
-        .select('first_name, last_name, email, phone')
+        .select('first_name, last_name, email, phone, connection_id')
         .eq('id', body.customer_order_id)
         .single();
 
@@ -115,10 +120,20 @@ export async function POST(
       customerName = `${order.first_name} ${order.last_name}`;
       customerEmail = order.email;
       customerPhone = order.phone;
+
+      // Best-effort: match customer_services via Interstellio connection_id on the order
+      if (order.connection_id) {
+        const { data: svc } = await supabaseAdmin
+          .from('customer_services')
+          .select('id')
+          .eq('connection_id', order.connection_id)
+          .maybeSingle();
+        resolvedServiceId = svc?.id ?? null;
+      }
     } else if (body.type === 'corporate' && body.corporate_site_id) {
       const { data: site, error: siteError } = await supabaseAdmin
         .from('corporate_sites')
-        .select('site_name, site_contact_email, site_contact_phone')
+        .select('site_name, site_contact_email, site_contact_phone, service_id')
         .eq('id', body.corporate_site_id)
         .single();
 
@@ -129,6 +144,7 @@ export async function POST(
       customerName = site.site_name;
       customerEmail = site.site_contact_email;
       customerPhone = site.site_contact_phone;
+      resolvedServiceId = site.service_id ?? null;
     }
 
     // Update device with customer link
@@ -148,10 +164,33 @@ export async function POST(
       return NextResponse.json({ error: 'Failed to link device' }, { status: 500 });
     }
 
+    // Dual-write service_network_identifiers for RA / hardware inventory view
+    if (resolvedServiceId) {
+      const { error: sniError } = await supabaseAdmin
+        .from('service_network_identifiers')
+        .upsert(
+          {
+            service_id: resolvedServiceId,
+            identifier_type: 'ruijie_sn',
+            identifier_value: sn,
+            source: 'manual',
+          },
+          { onConflict: 'identifier_type,identifier_value' }
+        );
+      if (sniError) {
+        apiLogger.warn('[Ruijie] SNI upsert failed after link', {
+          sn,
+          serviceId: resolvedServiceId,
+          error: sniError.message,
+        });
+      }
+    }
+
     apiLogger.info('[Ruijie] Device linked to customer', {
       sn,
       type: body.type,
       customerName,
+      serviceId: resolvedServiceId,
       linkedBy: user.id
     });
 
@@ -160,6 +199,7 @@ export async function POST(
       customer_name: customerName,
       customer_email: customerEmail,
       customer_phone: customerPhone,
+      service_id: resolvedServiceId,
     });
 
   } catch (error) {
@@ -224,6 +264,20 @@ export async function DELETE(
     if (updateError) {
       apiLogger.error('[Ruijie] Failed to unlink device', { error: updateError.message, sn });
       return NextResponse.json({ error: 'Failed to unlink device' }, { status: 500 });
+    }
+
+    // Remove SNI mapping for this Ruijie SN (safe: unique on type+value)
+    const { error: sniDeleteError } = await supabaseAdmin
+      .from('service_network_identifiers')
+      .delete()
+      .eq('identifier_type', 'ruijie_sn')
+      .eq('identifier_value', sn);
+
+    if (sniDeleteError) {
+      apiLogger.warn('[Ruijie] SNI delete failed after unlink', {
+        sn,
+        error: sniDeleteError.message,
+      });
     }
 
     apiLogger.info('[Ruijie] Device unlinked from customer', {

--- a/lib/admin/feature-registry.ts
+++ b/lib/admin/feature-registry.ts
@@ -23,6 +23,7 @@ import {
   PiGearBold,
   PiGlobeBold,
   PiGraphBold,
+  PiHardDrivesBold,
   PiHandshakeBold,
   PiImageBold,
   PiLightningBold,
@@ -336,9 +337,13 @@ export const featureSections: NavSection[] = [
         icon: PiWifiHighBold,
         children: [
           { name: 'Devices', href: '/admin/network/devices', icon: PiWifiHighBold },
+          {
+            name: 'Hardware Installations',
+            href: '/admin/network/hardware',
+            icon: PiHardDrivesBold,
+          },
           { name: 'System Health', href: '/admin/network/health', icon: PiPulseBold },
           { name: 'Analytics', href: '/admin/network/analytics', icon: PiChartBarBold },
-          { name: 'Usage Reports', href: '/admin/network/usage-reports', icon: PiFileTextBold },
           { name: 'Network Map', href: '/admin/network/map', icon: PiMapTrifoldBold },
         ],
       },

--- a/supabase/migrations/20260802160000_interstellio_subscriber_cache.sql
+++ b/supabase/migrations/20260802160000_interstellio_subscriber_cache.sql
@@ -1,0 +1,50 @@
+-- Interstellio subscriber inventory cache (vendor-cache sync → Supabase)
+-- System of record for admin list reads; live API remains for disconnect/actions.
+
+CREATE TABLE IF NOT EXISTS public.interstellio_subscriber_cache (
+  id TEXT PRIMARY KEY,
+  username TEXT,
+  name TEXT,
+  enabled BOOLEAN NOT NULL DEFAULT false,
+  domain TEXT,
+  tenant_id TEXT,
+  service TEXT,
+  profile TEXT,
+  virtual TEXT,
+  last_seen TIMESTAMPTZ,
+  expire TIMESTAMPTZ,
+  static_ip4 TEXT,
+  uncapped_data BOOLEAN,
+  raw_json JSONB,
+  synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_interstellio_subscriber_cache_username
+  ON public.interstellio_subscriber_cache (username);
+
+CREATE INDEX IF NOT EXISTS idx_interstellio_subscriber_cache_enabled
+  ON public.interstellio_subscriber_cache (enabled);
+
+CREATE INDEX IF NOT EXISTS idx_interstellio_subscriber_cache_synced_at
+  ON public.interstellio_subscriber_cache (synced_at DESC);
+
+COMMENT ON TABLE public.interstellio_subscriber_cache IS
+  'Mirrored Interstellio/NebularStack subscriber inventory from VPS vendor-cache sync';
+
+COMMENT ON COLUMN public.interstellio_subscriber_cache.raw_json IS
+  'Full API payload (no RADIUS passwords)';
+
+ALTER TABLE public.interstellio_subscriber_cache ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access; authenticated admins read via existing admin patterns (service role in API)
+CREATE POLICY interstellio_subscriber_cache_service_role_all
+  ON public.interstellio_subscriber_cache
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.interstellio_subscriber_cache TO service_role;
+GRANT SELECT ON public.interstellio_subscriber_cache TO authenticated;

--- a/supabase/migrations/20260802170000_v_hardware_installations.sql
+++ b/supabase/migrations/20260802170000_v_hardware_installations.sql
@@ -1,0 +1,234 @@
+-- Hardware-first inventory view: Ruijie + Interstellio + Tarana RN
+-- Joins to customers / services / locations when linked; null when unlinked.
+-- Ref: docs/architecture/NETWORK_VISIBILITY_BRIDGES.md
+
+CREATE OR REPLACE VIEW public.v_hardware_installations AS
+WITH tarana_rn_ids AS (
+  SELECT DISTINCT trim(serial) AS serial
+  FROM (
+    SELECT tarana_rn_serial AS serial
+    FROM public.corporate_sites
+    WHERE tarana_rn_serial IS NOT NULL AND trim(tarana_rn_serial) <> ''
+    UNION
+    SELECT identifier_value AS serial
+    FROM public.service_network_identifiers
+    WHERE identifier_type = 'tarana_serial'
+      AND identifier_value IS NOT NULL
+      AND trim(identifier_value) <> ''
+    UNION
+    SELECT serial_number AS serial
+    FROM public.network_devices
+    WHERE device_type = 'tarana_router'
+      AND serial_number IS NOT NULL
+      AND trim(serial_number) <> ''
+  ) src
+),
+ruijie_rows AS (
+  SELECT
+    'ruijie'::text AS hardware_source,
+    r.sn AS hardware_id,
+    COALESCE(r.device_name, r.sn) AS hardware_label,
+    r.model AS hardware_model,
+    r.status AS hardware_status,
+    r.last_seen_at AS last_seen_at,
+    COALESCE(cs_site.customer_id, cs_sni.customer_id) AS customer_id,
+    COALESCE(
+      NULLIF(trim(both FROM concat_ws(' ', cust.first_name, cust.last_name)), ''),
+      r.customer_name,
+      site.site_name,
+      NULLIF(trim(both FROM concat_ws(' ', ord.first_name, ord.last_name)), '')
+    ) AS customer_name,
+    COALESCE(cust.email, r.customer_email, site.site_contact_email, ord.email) AS customer_email,
+    COALESCE(cs_site.id, cs_sni.id) AS service_id,
+    COALESCE(cs_site.status, cs_sni.status)::text AS service_status,
+    COALESCE(cs_site.active, cs_sni.active) AS service_active,
+    COALESCE(cs_site.package_name, cs_sni.package_name)::text AS package_name,
+    CASE
+      WHEN r.corporate_site_id IS NOT NULL THEN 'corporate_site'
+      WHEN r.customer_order_id IS NOT NULL THEN 'consumer_order'
+      WHEN cs_sni.id IS NOT NULL AND site_via_svc.id IS NOT NULL THEN 'corporate_site'
+      WHEN cs_sni.id IS NOT NULL THEN 'service_address'
+      ELSE NULL
+    END AS location_type,
+    CASE
+      WHEN r.corporate_site_id IS NOT NULL THEN r.corporate_site_id
+      WHEN r.customer_order_id IS NOT NULL THEN r.customer_order_id
+      WHEN site_via_svc.id IS NOT NULL THEN site_via_svc.id
+      ELSE NULL
+    END AS location_id,
+    COALESCE(site.site_name, site_via_svc.site_name, ord.installation_address) AS location_name,
+    COALESCE(
+      NULLIF(TRIM(CONCAT_WS(', ',
+        NULLIF(site.installation_address->>'street', ''),
+        NULLIF(site.installation_address->>'suburb', ''),
+        NULLIF(site.installation_address->>'city', ''),
+        NULLIF(site.installation_address->>'province', ''),
+        NULLIF(site.installation_address->>'postal_code', '')
+      )), ''),
+      NULLIF(TRIM(CONCAT_WS(', ',
+        NULLIF(site_via_svc.installation_address->>'street', ''),
+        NULLIF(site_via_svc.installation_address->>'suburb', ''),
+        NULLIF(site_via_svc.installation_address->>'city', ''),
+        NULLIF(site_via_svc.installation_address->>'province', ''),
+        NULLIF(site_via_svc.installation_address->>'postal_code', '')
+      )), ''),
+      ord.installation_address,
+      COALESCE(cs_site.installation_address, cs_sni.installation_address)
+    ) AS location_address,
+    COALESCE(site.province, site_via_svc.province, ord.province)::text AS province,
+    COALESCE(site.lat, site_via_svc.lat) AS lat,
+    COALESCE(site.lng, site_via_svc.lng) AS lng,
+    CASE
+      WHEN r.corporate_site_id IS NOT NULL THEN 'ruijie_cache_site'
+      WHEN r.customer_order_id IS NOT NULL THEN 'ruijie_cache_order'
+      WHEN sni.service_id IS NOT NULL THEN 'sni'
+      ELSE NULL
+    END AS link_method
+  FROM public.ruijie_device_cache r
+  LEFT JOIN public.corporate_sites site ON site.id = r.corporate_site_id
+  LEFT JOIN public.customer_services cs_site ON cs_site.id = site.service_id
+  LEFT JOIN public.consumer_orders ord ON ord.id = r.customer_order_id
+  LEFT JOIN public.service_network_identifiers sni
+    ON sni.identifier_type = 'ruijie_sn' AND sni.identifier_value = r.sn
+  LEFT JOIN public.customer_services cs_sni ON cs_sni.id = sni.service_id
+  LEFT JOIN public.corporate_sites site_via_svc ON site_via_svc.service_id = cs_sni.id
+  LEFT JOIN public.customers cust
+    ON cust.id = COALESCE(cs_site.customer_id, cs_sni.customer_id)
+),
+interstellio_rows AS (
+  SELECT
+    'interstellio'::text AS hardware_source,
+    i.id AS hardware_id,
+    COALESCE(i.username, i.name, i.id) AS hardware_label,
+    NULL::text AS hardware_model,
+    CASE
+      WHEN i.enabled IS TRUE THEN 'enabled'
+      WHEN i.enabled IS FALSE THEN 'disabled'
+      ELSE NULL
+    END AS hardware_status,
+    i.last_seen AS last_seen_at,
+    cs.customer_id,
+    COALESCE(
+      NULLIF(trim(both FROM concat_ws(' ', cust.first_name, cust.last_name)), ''),
+      i.name,
+      site.site_name
+    ) AS customer_name,
+    COALESCE(cust.email, site.site_contact_email)::text AS customer_email,
+    cs.id AS service_id,
+    cs.status::text AS service_status,
+    cs.active AS service_active,
+    cs.package_name::text AS package_name,
+    CASE
+      WHEN site.id IS NOT NULL THEN 'corporate_site'
+      WHEN cs.id IS NOT NULL THEN 'service_address'
+      ELSE NULL
+    END AS location_type,
+    COALESCE(site.id, cs.id) AS location_id,
+    COALESCE(site.site_name, cs.installation_address) AS location_name,
+    COALESCE(
+      NULLIF(TRIM(CONCAT_WS(', ',
+        NULLIF(site.installation_address->>'street', ''),
+        NULLIF(site.installation_address->>'suburb', ''),
+        NULLIF(site.installation_address->>'city', ''),
+        NULLIF(site.installation_address->>'province', ''),
+        NULLIF(site.installation_address->>'postal_code', '')
+      )), ''),
+      cs.installation_address
+    ) AS location_address,
+    site.province::text AS province,
+    site.lat AS lat,
+    site.lng AS lng,
+    CASE
+      WHEN sni.service_id IS NOT NULL THEN 'sni'
+      WHEN cs_conn.id IS NOT NULL THEN 'connection_id'
+      WHEN cs_ppp.id IS NOT NULL THEN 'connection_id'
+      ELSE NULL
+    END AS link_method
+  FROM public.interstellio_subscriber_cache i
+  LEFT JOIN public.service_network_identifiers sni
+    ON sni.identifier_type = 'interstellio_uuid' AND sni.identifier_value = i.id
+  LEFT JOIN public.customer_services cs_sni ON cs_sni.id = sni.service_id
+  LEFT JOIN public.customer_services cs_conn ON cs_conn.connection_id = i.id
+  LEFT JOIN public.pppoe_credentials ppp
+    ON ppp.interstellio_subscriber_id = i.id
+  LEFT JOIN public.customer_services cs_ppp ON cs_ppp.id = ppp.service_id
+  LEFT JOIN LATERAL (
+    SELECT x.*
+    FROM public.customer_services x
+    WHERE x.id = COALESCE(cs_sni.id, cs_conn.id, cs_ppp.id)
+  ) cs ON TRUE
+  LEFT JOIN public.corporate_sites site ON site.service_id = cs.id
+  LEFT JOIN public.customers cust ON cust.id = cs.customer_id
+),
+tarana_rows AS (
+  SELECT
+    'tarana'::text AS hardware_source,
+    t.serial AS hardware_id,
+    COALESCE(nd.device_name, site.site_name, t.serial) AS hardware_label,
+    COALESCE(nd.model, 'Tarana G1 RN') AS hardware_model,
+    COALESCE(nd.status, 'unknown') AS hardware_status,
+    NULL::timestamptz AS last_seen_at,
+    cs.customer_id,
+    COALESCE(
+      NULLIF(trim(both FROM concat_ws(' ', cust.first_name, cust.last_name)), ''),
+      site.site_name
+    ) AS customer_name,
+    COALESCE(cust.email, site.site_contact_email)::text AS customer_email,
+    cs.id AS service_id,
+    cs.status::text AS service_status,
+    cs.active AS service_active,
+    cs.package_name::text AS package_name,
+    CASE
+      WHEN site.id IS NOT NULL THEN 'corporate_site'
+      WHEN cs.id IS NOT NULL THEN 'service_address'
+      ELSE NULL
+    END AS location_type,
+    COALESCE(site.id, cs.id) AS location_id,
+    COALESCE(site.site_name, nd.site_name, cs.installation_address) AS location_name,
+    COALESCE(
+      NULLIF(TRIM(CONCAT_WS(', ',
+        NULLIF(site.installation_address->>'street', ''),
+        NULLIF(site.installation_address->>'suburb', ''),
+        NULLIF(site.installation_address->>'city', ''),
+        NULLIF(site.installation_address->>'province', ''),
+        NULLIF(site.installation_address->>'postal_code', '')
+      )), ''),
+      cs.installation_address
+    ) AS location_address,
+    COALESCE(site.province, nd.province)::text AS province,
+    site.lat AS lat,
+    site.lng AS lng,
+    CASE
+      WHEN sni.service_id IS NOT NULL THEN 'sni'
+      WHEN site.id IS NOT NULL THEN 'site_serial'
+      ELSE NULL
+    END AS link_method
+  FROM tarana_rn_ids t
+  LEFT JOIN public.service_network_identifiers sni
+    ON sni.identifier_type = 'tarana_serial' AND sni.identifier_value = t.serial
+  LEFT JOIN public.corporate_sites site
+    ON site.tarana_rn_serial = t.serial
+  LEFT JOIN LATERAL (
+    SELECT x.*
+    FROM public.customer_services x
+    WHERE x.id = COALESCE(sni.service_id, site.service_id)
+  ) cs ON TRUE
+  LEFT JOIN public.customers cust ON cust.id = cs.customer_id
+  LEFT JOIN LATERAL (
+    SELECT n.*
+    FROM public.network_devices n
+    WHERE n.device_type = 'tarana_router' AND n.serial_number = t.serial
+    ORDER BY n.updated_at DESC NULLS LAST
+    LIMIT 1
+  ) nd ON TRUE
+)
+SELECT * FROM ruijie_rows
+UNION ALL
+SELECT * FROM interstellio_rows
+UNION ALL
+SELECT * FROM tarana_rows;
+
+COMMENT ON VIEW public.v_hardware_installations IS
+  'Hardware-first inventory (Ruijie / Interstellio / Tarana RN) with optional customer/location links';
+
+GRANT SELECT ON public.v_hardware_installations TO service_role;


### PR DESCRIPTION
## Summary
- Adds `/admin/network/hardware` inventory table (hardware-first: Ruijie / Interstellio / Tarana RN)
- SQL view `v_hardware_installations` + admin API with filters
- Dual-writes `service_network_identifiers` on Ruijie device link/unlink
- Nav entry under Network Management

## Why production 404s
Code was on the VPS working tree only; this PR ships it to `main` so Coolify/www can deploy.

## Test plan
- [ ] Open `/admin/network/hardware` on preview/staging after deploy
- [ ] Confirm rows load; linked/unlinked filters work
- [ ] Ruijie **Open** deep-links to device detail
- [ ] After merge to main, confirm https://www.circletel.co.za/admin/network/hardware no longer 404s


Made with [Cursor](https://cursor.com)