### PR TITLE
feat(network): PDF/Excel download dropdown on usage reports dashboard

### DIFF
--- a/app/api/admin/network/usage-reports/generate/route.ts
+++ b/app/api/admin/network/usage-reports/generate/route.ts
@@ -15,6 +15,7 @@ interface GenerateRequest {
   custom?: { startDate?: unknown; endDate?: unknown };
   includeCsv?: unknown;
   patientRows?: unknown;
+  format?: unknown;
 }
 
 const PERIOD_PRESETS = new Set<ReportPeriodPreset>([
@@ -64,6 +65,10 @@ export async function POST(request: NextRequest) {
     if (typeof body.period !== 'string' || !PERIOD_PRESETS.has(body.period as ReportPeriodPreset)) {
       return NextResponse.json({ error: 'Invalid report period preset' }, { status: 400 });
     }
+    const format = body.format ?? 'pdf';
+    if (format !== 'pdf' && format !== 'excel') {
+      return NextResponse.json({ error: "format must be 'pdf' or 'excel'" }, { status: 400 });
+    }
     const patientRows = Array.isArray(body.patientRows)
       ? body.patientRows.filter(isPatientRow)
       : [];
@@ -94,6 +99,7 @@ export async function POST(request: NextRequest) {
       period,
       patientRows,
       includeCsv: body.includeCsv === true,
+      format,
     });
 
     const createdAt = new Date();

--- a/components/admin/network/usage-reports/dashboard/UsageReportDashboard.tsx
+++ b/components/admin/network/usage-reports/dashboard/UsageReportDashboard.tsx
@@ -8,8 +8,9 @@
  * printed report. Preview is a pure read — the endpoint writes nothing — so
  * looking costs no audit row and no stored artifact (#690).
  *
- * Download still uses the shipped generate/jobs routes; the split control, CSV
- * retirement and Patient CSV rebind are #694.
+ * Download uses the shipped generate/jobs routes; the button is a PDF/Excel
+ * format dropdown (Excel is sync-path only — up to 5 sites). CSV retirement
+ * and the Patient CSV rebind remain #694.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -18,6 +19,8 @@ import {
   PiCaretDownBold,
   PiClockBold,
   PiDownloadSimpleBold,
+  PiFilePdfBold,
+  PiFileXlsBold,
   PiSpinnerGapBold,
 } from 'react-icons/pi';
 
@@ -27,6 +30,7 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -200,13 +204,19 @@ export function UsageReportDashboard({
     if (ids.length === 0) setFocusedId(null);
   };
 
-  const handleDownload = async () => {
+  const handleDownload = async (format: 'pdf' | 'excel') => {
     if (selectedIds.length === 0) return;
     setSubmitting(true);
     setJobId(null);
     setError(null);
 
-    const payload = { siteIds: selectedIds, period, includeCsv: false, patientRows: [] };
+    const payload = {
+      siteIds: selectedIds,
+      period,
+      includeCsv: false,
+      patientRows: [],
+      format,
+    };
     try {
       if (selectedIds.length <= 5) {
         const response = await fetch('/api/admin/network/usage-reports/generate', {
@@ -226,7 +236,8 @@ export function UsageReportDashboard({
         anchor.download =
           response.headers
             .get('content-disposition')
-            ?.match(/filename="([^"]+)"/i)?.[1] ?? 'CircleTel_Usage_Report.pdf';
+            ?.match(/filename="([^"]+)"/i)?.[1] ??
+          `CircleTel_Usage_Report.${format === 'excel' ? 'xlsx' : 'pdf'}`;
         document.body.appendChild(anchor);
         anchor.click();
         anchor.remove();
@@ -321,21 +332,44 @@ export function UsageReportDashboard({
               Refresh
             </Button>
 
-            <Button
-              onClick={() => void handleDownload()}
-              disabled={submitting || selectedIds.length === 0}
-            >
-              {submitting ? (
-                <PiSpinnerGapBold className="mr-2 h-4 w-4 animate-spin" />
-              ) : selectedIds.length > 5 ? (
-                <PiClockBold className="mr-2 h-4 w-4" />
-              ) : (
-                <PiDownloadSimpleBold className="mr-2 h-4 w-4" />
-              )}
-              {selectedIds.length > 5
-                ? `Queue ${selectedIds.length} (ZIP)`
-                : 'Download'}
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button disabled={submitting || selectedIds.length === 0}>
+                  {submitting ? (
+                    <PiSpinnerGapBold className="mr-2 h-4 w-4 animate-spin" />
+                  ) : selectedIds.length > 5 ? (
+                    <PiClockBold className="mr-2 h-4 w-4" />
+                  ) : (
+                    <PiDownloadSimpleBold className="mr-2 h-4 w-4" />
+                  )}
+                  {selectedIds.length > 5
+                    ? `Queue ${selectedIds.length} (ZIP)`
+                    : 'Download'}
+                  <PiCaretDownBold className="ml-2 h-3.5 w-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={() => void handleDownload('pdf')}
+                  disabled={submitting}
+                >
+                  <PiFilePdfBold className="mr-2 h-4 w-4" aria-hidden="true" />
+                  PDF report
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => void handleDownload('excel')}
+                  disabled={submitting || selectedIds.length > 5}
+                >
+                  <PiFileXlsBold className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Excel workbook
+                </DropdownMenuItem>
+                {selectedIds.length > 5 && (
+                  <DropdownMenuLabel className="font-normal text-xs text-slate-400">
+                    Excel is available for up to 5 sites
+                  </DropdownMenuLabel>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
 

--- a/lib/usage-reports/__tests__/excel-artifact.test.ts
+++ b/lib/usage-reports/__tests__/excel-artifact.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Excel format for site usage reports: the workbook generator itself, and the
+ * artifact builder's format routing (single-site xlsx, multi-site zip of xlsx,
+ * skip slips staying PDF).
+ */
+
+import ExcelJS from 'exceljs';
+import JSZip from 'jszip';
+
+import {
+  buildUsageReportArtifact,
+  EXCEL_CONTENT_TYPE,
+  type UsageReportArtifactDeps,
+} from '../artifacts';
+import { generateSiteUsageReportExcel } from '../excel';
+import type { ReportPeriod, SiteUsageReportModel } from '../types';
+
+const PERIOD: ReportPeriod = {
+  preset: 'weekly',
+  timezone: 'Africa/Johannesburg',
+  startIso: '2026-07-27T00:00:00+02:00',
+  endIso: '2026-08-02T23:59:59+02:00',
+  startUtc: new Date('2026-07-26T22:00:00Z'),
+  endUtc: new Date('2026-08-02T21:59:59Z'),
+  label: 'Last complete week',
+  rangeLabel: '27 Jul – 2 Aug 2026',
+  inclusiveDayCount: 7,
+  isShortPeriod: true,
+};
+
+function fixtureModel(overrides?: Partial<SiteUsageReportModel['core']>): SiteUsageReportModel {
+  return {
+    generatedAtIso: '2026-08-02T15:00:00.000Z',
+    site: {
+      id: 'site-1',
+      name: 'Unjani Clinic Thokoza',
+      accountNumber: 'CT-UNJ-014',
+      corporateCode: 'UNJANI',
+      accountName: 'Unjani Clinics NPC',
+    },
+    period: PERIOD,
+    core: {
+      source: 'ruijie_hourly',
+      sourceLabel: 'Ruijie AP hourly flow',
+      downloadBytes: 14_800_000_000,
+      uploadBytes: 4_600_000_000,
+      avgDownKbps: 210,
+      peakBucketBytes: 702_100_000,
+      dailyDownloadBytes: [1e9, 2e9, 0, 3e9, 4e9, 2.4e9, 2.4e9],
+      dailyCovered: [true, true, false, true, true, true, true],
+      note: 'Ruijie per-device rollups.',
+      ...overrides,
+    },
+    device: {
+      name: 'UNJANICLINICTHOKOZA',
+      model: 'RAP2200(F)',
+      serial: 'G1U52HL044467',
+      group: 'Unjani',
+      status: 'online',
+    },
+    unjani: true,
+    staff: { kind: 'available', totalBytes: 5e9, rxBytes: 4e9, txBytes: 1e9 },
+    patient: { kind: 'available', uniqueUsers: 120, loginSessions: 340, downloadGb: 88.4 },
+  };
+}
+
+describe('generateSiteUsageReportExcel', () => {
+  it('produces Overview + Daily traffic sheets with uncovered days left EMPTY, not zero', async () => {
+    const buffer = await generateSiteUsageReportExcel(fixtureModel());
+
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer as unknown as ArrayBuffer);
+
+    expect(workbook.worksheets.map((sheet) => sheet.name)).toEqual([
+      'Overview',
+      'Daily traffic',
+    ]);
+
+    const overview = workbook.getWorksheet('Overview')!;
+    expect(overview.getRow(1).getCell(2).value).toBe('Unjani Clinic Thokoza');
+
+    const daily = workbook.getWorksheet('Daily traffic')!;
+    // header + 7 days + totals
+    expect(daily.rowCount).toBe(1 + 7 + 1);
+    // Day 3 (index 2) is uncovered: bytes cell empty, coverage says "no data".
+    const uncovered = daily.getRow(4);
+    expect(uncovered.getCell(2).value).toBeNull();
+    expect(uncovered.getCell(3).value).toBe('no data');
+    // A covered zero-byte day would still show 0 — but here day 1 has data.
+    expect(daily.getRow(2).getCell(2).value).toBe(1e9);
+    // Totals row carries the period total.
+    const totals = daily.getRow(daily.rowCount);
+    expect(totals.getCell(1).value).toBe('TOTAL');
+    expect(totals.getCell(2).value).toBe(14_800_000_000);
+    // Dates follow the period start.
+    expect(daily.getRow(2).getCell(1).value).toBe('2026-07-27');
+    expect(daily.getRow(8).getCell(1).value).toBe('2026-08-02');
+  });
+});
+
+describe('buildUsageReportArtifact format routing', () => {
+  const model = fixtureModel();
+
+  function stubDeps(): UsageReportArtifactDeps {
+    return {
+      assemble: jest.fn(async () => ({ ok: true as const, model })),
+      reportPdf: jest.fn(() => new TextEncoder().encode('%PDF-fake').buffer),
+      reportExcel: jest.fn(async () => Buffer.from('PK-fake-xlsx')),
+      skipPdf: jest.fn(() => new TextEncoder().encode('%PDF-skip').buffer),
+      csv: jest.fn(() => 'a,b\r\n'),
+    };
+  }
+
+  const input = {
+    period: PERIOD,
+    patientRows: [],
+    includeCsv: false,
+  };
+
+  it('single site + excel → xlsx artifact', async () => {
+    const deps = stubDeps();
+    const artifact = await buildUsageReportArtifact(
+      { ...input, sites: [{ id: 'site-1', accountNumber: 'CT-UNJ-014' }], format: 'excel' },
+      deps
+    );
+    expect(artifact.contentType).toBe(EXCEL_CONTENT_TYPE);
+    expect(artifact.filename).toMatch(/\.xlsx$/);
+    expect(deps.reportExcel).toHaveBeenCalledTimes(1);
+    expect(deps.reportPdf).not.toHaveBeenCalled();
+  });
+
+  it('single site with no format → pdf artifact (backwards compatible)', async () => {
+    const deps = stubDeps();
+    const artifact = await buildUsageReportArtifact(
+      { ...input, sites: [{ id: 'site-1', accountNumber: 'CT-UNJ-014' }] },
+      deps
+    );
+    expect(artifact.contentType).toBe('application/pdf');
+    expect(artifact.filename).toMatch(/\.pdf$/);
+    expect(deps.reportExcel).not.toHaveBeenCalled();
+  });
+
+  it('multiple sites + excel → zip of xlsx files', async () => {
+    const deps = stubDeps();
+    // Distinct account numbers per site — the filename comes from the model.
+    (deps.assemble as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, model })
+      .mockResolvedValueOnce({
+        ok: true,
+        model: { ...model, site: { ...model.site, accountNumber: 'CT-UNJ-015' } },
+      });
+    const artifact = await buildUsageReportArtifact(
+      {
+        ...input,
+        sites: [
+          { id: 'site-1', accountNumber: 'CT-UNJ-014' },
+          { id: 'site-2', accountNumber: 'CT-UNJ-015' },
+        ],
+        format: 'excel',
+      },
+      deps
+    );
+    expect(artifact.contentType).toBe('application/zip');
+    const zip = await JSZip.loadAsync(artifact.bytes);
+    const names = Object.keys(zip.files);
+    expect(names).toHaveLength(2);
+    expect(names.every((name) => name.endsWith('.xlsx'))).toBe(true);
+  });
+
+  it('skipped site + excel → skip slip stays a PDF inside the zip', async () => {
+    const deps = stubDeps();
+    (deps.assemble as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, model })
+      .mockResolvedValueOnce({
+        ok: false,
+        reason: 'core_unavailable',
+        siteLabel: 'CT-UNJ-016',
+      });
+    const artifact = await buildUsageReportArtifact(
+      {
+        ...input,
+        sites: [
+          { id: 'site-1', accountNumber: 'CT-UNJ-014' },
+          { id: 'site-3', accountNumber: 'CT-UNJ-016' },
+        ],
+        format: 'excel',
+      },
+      deps
+    );
+    const zip = await JSZip.loadAsync(artifact.bytes);
+    const names = Object.keys(zip.files);
+    expect(names.some((name) => name.endsWith('.xlsx'))).toBe(true);
+    expect(names.some((name) => name.endsWith('_SKIPPED.pdf'))).toBe(true);
+    expect(deps.skipPdf).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/usage-reports/artifacts.ts
+++ b/lib/usage-reports/artifacts.ts
@@ -6,6 +6,7 @@ import {
   type AssembleSiteUsageReportInput,
 } from './assemble-report';
 import { reportModelToCsv } from './csv';
+import { generateSiteUsageReportExcel } from './excel';
 import { patientRowForSite, type TdxPatientRow } from './patient-wifi';
 import {
   generateSiteUsageReportPdf,
@@ -23,23 +24,31 @@ export interface UsageReportArtifactSite {
   accountNumber: string;
 }
 
+export type UsageReportFormat = 'pdf' | 'excel';
+
+export const EXCEL_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
 export interface UsageReportArtifactInput {
   sites: UsageReportArtifactSite[];
   period: ReportPeriod;
   patientRows: TdxPatientRow[];
   includeCsv: boolean;
+  /** Report file format — skip slips stay PDF in either case. Default 'pdf'. */
+  format?: UsageReportFormat;
 }
 
 export interface UsageReportArtifactDeps {
   assemble(input: AssembleSiteUsageReportInput): Promise<AssembleResult>;
   reportPdf(model: SiteUsageReportModel): ArrayBuffer;
+  reportExcel(model: SiteUsageReportModel): Promise<Buffer>;
   skipPdf(input: SkipSlipInput): ArrayBuffer;
   csv(model: SiteUsageReportModel): string;
 }
 
 export interface UsageReportArtifact {
   bytes: Buffer;
-  contentType: 'application/pdf' | 'application/zip';
+  contentType: 'application/pdf' | 'application/zip' | typeof EXCEL_CONTENT_TYPE;
   filename: string;
   primarySources: Record<string, string>;
   outcome: {
@@ -51,6 +60,7 @@ export interface UsageReportArtifact {
 const defaultDeps: UsageReportArtifactDeps = {
   assemble: assembleSiteUsageReport,
   reportPdf: generateSiteUsageReportPdf,
+  reportExcel: generateSiteUsageReportExcel,
   skipPdf: generateSkipSlipPdf,
   csv: reportModelToCsv,
 };
@@ -112,8 +122,19 @@ export async function buildUsageReportArtifact(
     generated.map(({ siteId, model }) => [siteId, model.core.source])
   );
 
+  const format: UsageReportFormat = input.format ?? 'pdf';
+
   if (generated.length === 1 && skipped.length === 0 && !input.includeCsv) {
     const report = generated[0];
+    if (format === 'excel') {
+      return {
+        bytes: await deps.reportExcel(report.model),
+        contentType: EXCEL_CONTENT_TYPE,
+        filename: `CircleTel_Usage_${report.filenameBase}_${periodPart}.xlsx`,
+        primarySources,
+        outcome,
+      };
+    }
     return {
       bytes: Buffer.from(deps.reportPdf(report.model)),
       contentType: 'application/pdf',
@@ -126,7 +147,11 @@ export async function buildUsageReportArtifact(
   const zip = new JSZip();
   for (const report of generated) {
     const base = `CircleTel_Usage_${report.filenameBase}_${periodPart}`;
-    zip.file(`${base}.pdf`, Buffer.from(deps.reportPdf(report.model)));
+    if (format === 'excel') {
+      zip.file(`${base}.xlsx`, await deps.reportExcel(report.model));
+    } else {
+      zip.file(`${base}.pdf`, Buffer.from(deps.reportPdf(report.model)));
+    }
     if (input.includeCsv) {
       zip.file(`${base}.csv`, deps.csv(report.model));
     }

--- a/lib/usage-reports/excel.ts
+++ b/lib/usage-reports/excel.ts
@@ -1,0 +1,128 @@
+/**
+ * Site usage report as an Excel workbook (exceljs).
+ *
+ * Two sheets: Overview (everything the PDF summarises) and Daily traffic
+ * (per-day download bytes with coverage). An uncovered day keeps an EMPTY
+ * bytes cell — never a zero — matching the chart rule in types.ts (#689).
+ */
+
+import ExcelJS from 'exceljs';
+import type { SiteUsageReportModel } from './types';
+
+const HEADER_FILL: ExcelJS.Fill = {
+  type: 'pattern',
+  pattern: 'solid',
+  fgColor: { argb: 'FFF3F4F6' },
+};
+
+function sastTimestamp(iso: string): string {
+  return new Intl.DateTimeFormat('en-ZA', {
+    timeZone: 'Africa/Johannesburg',
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(iso));
+}
+
+/** Calendar date of day `index` of the period, matching the PDF's day labels. */
+function dayDate(periodStartIso: string, index: number): string {
+  const start = new Date(`${periodStartIso.slice(0, 10)}T00:00:00Z`);
+  const date = new Date(start);
+  date.setUTCDate(start.getUTCDate() + index);
+  return date.toISOString().slice(0, 10);
+}
+
+function staffLabel(staff: SiteUsageReportModel['staff']): string {
+  if (staff.kind === 'available') {
+    return `Total ${staff.totalBytes} bytes (down ${staff.rxBytes} / up ${staff.txBytes})`;
+  }
+  return staff.kind === 'no_samples'
+    ? 'Not available — no Staff Wi-Fi samples in this period'
+    : 'Not available — AP not linked to site';
+}
+
+function patientLabel(patient: SiteUsageReportModel['patient']): string {
+  if (patient.kind === 'available') {
+    return `${patient.uniqueUsers} unique users, ${patient.loginSessions} sessions, ${patient.downloadGb.toFixed(2)} GB down`;
+  }
+  return 'Awaiting TDX export';
+}
+
+export async function generateSiteUsageReportExcel(
+  model: SiteUsageReportModel
+): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'CircleTel';
+  workbook.created = new Date(model.generatedAtIso);
+
+  // --- Overview ---
+  const overview = workbook.addWorksheet('Overview');
+  overview.columns = [
+    { key: 'label', width: 26 },
+    { key: 'value', width: 52 },
+  ];
+  const deviceLabel = model.device
+    ? `${model.device.name} · ${model.device.model} · SN ${model.device.serial} · ${model.device.status}`
+    : 'Not available';
+  const rows: Array<[string, string | number]> = [
+    ['Site', model.site.name],
+    ['Account number', model.site.accountNumber],
+    ['Corporate code', model.site.corporateCode],
+    ['Account name', model.site.accountName],
+    ['Report period', model.period.label],
+    ['Range (SAST)', model.period.rangeLabel],
+    ['Core source', model.core.sourceLabel],
+    ['Downloaded bytes', model.core.downloadBytes],
+    ['Uploaded bytes', model.core.uploadBytes],
+    ['Avg download (Kbps)', model.core.avgDownKbps ?? 'N/A'],
+    ['Peak bucket bytes', model.core.peakBucketBytes ?? 'N/A'],
+    ['Staff Wi-Fi', staffLabel(model.staff)],
+    ['Patient Free Wi-Fi', patientLabel(model.patient)],
+    ['Device', deviceLabel],
+    ['Generated (SAST)', sastTimestamp(model.generatedAtIso)],
+    ['Note', model.core.note],
+  ];
+  rows.forEach(([label, value]) => {
+    const row = overview.addRow({ label, value });
+    row.getCell(1).font = { bold: true };
+  });
+  if (model.unjani) {
+    const warning = overview.addRow({
+      label: 'Warning',
+      value: 'Patient + Staff + core are separate sources — do not sum.',
+    });
+    warning.getCell(1).font = { bold: true, color: { argb: 'FFB45309' } };
+    warning.getCell(2).font = { color: { argb: 'FFB45309' } };
+  }
+
+  // --- Daily traffic ---
+  const daily = workbook.addWorksheet('Daily traffic');
+  daily.columns = [
+    { header: 'Date', key: 'date', width: 14 },
+    { header: 'Download bytes', key: 'download', width: 18 },
+    { header: 'Coverage', key: 'coverage', width: 14 },
+  ];
+  const headerRow = daily.getRow(1);
+  headerRow.font = { bold: true };
+  headerRow.eachCell((cell) => {
+    cell.fill = HEADER_FILL;
+  });
+  model.core.dailyDownloadBytes.forEach((bytes, index) => {
+    const covered = model.core.dailyCovered[index] === true;
+    daily.addRow({
+      date: dayDate(model.period.startIso, index),
+      // An uncovered day has no data — an empty cell, never a zero.
+      download: covered ? bytes : null,
+      coverage: covered ? 'covered' : 'no data',
+    });
+  });
+  const totals = daily.addRow({
+    date: 'TOTAL',
+    download: model.core.downloadBytes,
+    coverage: '',
+  });
+  totals.font = { bold: true };
+  daily.getColumn('download').numFmt = '#,##0';
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return Buffer.from(buffer);
+}


### PR DESCRIPTION
## What

Brings the device-page download pattern to `/admin/network/usage-reports`: the **Download** button is now a dropdown offering the existing **PDF report** or a new **Excel workbook** (exceljs — already installed, **no new dependencies**).

## How

- `lib/usage-reports/excel.ts` — 2-sheet workbook per site: **Overview** (site, period, core totals, staff/patient Wi-Fi states, do-not-sum warning for Unjani sites) and **Daily traffic** (per-day download bytes; an uncovered day keeps an **empty cell, never a zero** — same rule as the chart, #689)
- `artifacts.ts` — `format: 'pdf' | 'excel'` routing: single site → `.xlsx`, 2–5 sites → zip of `.xlsx`; **skip slips stay PDF** in both formats; default `'pdf'` keeps the jobs pipeline and all existing callers unchanged
- Generate route accepts and validates `format`
- **Excel is sync-path only (≤5 sites)** — the >5-site queued-ZIP flow stays PDF with the Excel item disabled and captioned (extending it would need a jobs-table migration; deliberately out of scope)

## Verified

- 5 new tests (workbook shape, empty-not-zero coverage cells, format routing, zip composition, skip-slip format); **all 66 usage-reports tests green**
- Live against dev server: `format=excel` accepted, invalid format → 400, skip case returns a correct zip; dropdown renders on the dashboard toolbar with no denied admin API calls
- Pre-push scoped type-check passed

Note: no site generates a real report yet — per-device traffic collection started 2026-08-02, so the first populated reports (and first real xlsx) appear ~8 Aug. The full xlsx content path is pinned by unit tests against the real generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WLyCcHJPJJ8diVXgcuLuL