### PR TITLE
Improve hardware inventory filters, pagination, and tab highlight

### DIFF
--- a/app/admin/network/hardware/page.tsx
+++ b/app/admin/network/hardware/page.tsx
@@ -10,6 +10,8 @@ import Link from 'next/link';
 import { Label, Pie, PieChart, Cell } from 'recharts';
 import {
   PiArrowsClockwiseBold,
+  PiCaretLeftBold,
+  PiCaretRightBold,
   PiDotsThreeBold,
   PiHardDrivesBold,
   PiLinkBold,
@@ -26,6 +28,7 @@ import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { cn } from '@/lib/utils';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -115,6 +118,10 @@ const SOURCE_LABEL: Record<HardwareSource, string> = {
   tarana: 'Tarana RN',
 };
 
+const PAGE_SIZE = 25;
+type StatusFilter = 'all' | 'online' | 'offline';
+type CardFilter = 'total' | 'linked' | 'unlinked' | 'online';
+
 const sourceChartConfig = {
   ruijie: { label: 'Ruijie', color: 'hsl(24 95% 53%)' },
   interstellio: { label: 'Interstellio', color: 'hsl(217 91% 60%)' },
@@ -180,9 +187,11 @@ export default function HardwareInstallationsPage() {
 
   const [source, setSource] = useState<string>('all');
   const [linked, setLinked] = useState<string>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [serviceStatus, setServiceStatus] = useState<string>('all');
   const [q, setQ] = useState('');
   const [searchInput, setSearchInput] = useState('');
+  const [page, setPage] = useState(1);
 
   const fetchData = useCallback(
     async (isRefresh = false) => {
@@ -220,6 +229,10 @@ export default function HardwareInstallationsPage() {
     fetchData();
   }, [fetchData]);
 
+  useEffect(() => {
+    setPage(1);
+  }, [source, linked, statusFilter, serviceStatus, q]);
+
   const rows = data?.rows || [];
   const totals = data?.totals;
 
@@ -235,6 +248,50 @@ export default function HardwareInstallationsPage() {
     () => rows.length - onlineCount - offlineCount,
     [rows.length, onlineCount, offlineCount]
   );
+
+  const filteredRows = useMemo(() => {
+    if (statusFilter === 'online') {
+      return rows.filter((r) => isOnlineStatus(r.hardware_status));
+    }
+    if (statusFilter === 'offline') {
+      return rows.filter((r) => isOfflineStatus(r.hardware_status));
+    }
+    return rows;
+  }, [rows, statusFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredRows.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const pageStart = (safePage - 1) * PAGE_SIZE;
+  const pageRows = filteredRows.slice(pageStart, pageStart + PAGE_SIZE);
+
+  const activeCard: CardFilter | null = useMemo(() => {
+    if (statusFilter === 'online') return 'online';
+    if (linked === 'linked') return 'linked';
+    if (linked === 'unlinked') return 'unlinked';
+    if (linked === 'all' && statusFilter === 'all') return 'total';
+    return null;
+  }, [linked, statusFilter]);
+
+  const applyCardFilter = (card: CardFilter) => {
+    setPage(1);
+    if (card === 'total') {
+      setLinked('all');
+      setStatusFilter('all');
+      return;
+    }
+    if (card === 'linked') {
+      setStatusFilter('all');
+      setLinked((prev) => (prev === 'linked' ? 'all' : 'linked'));
+      return;
+    }
+    if (card === 'unlinked') {
+      setStatusFilter('all');
+      setLinked((prev) => (prev === 'unlinked' ? 'all' : 'unlinked'));
+      return;
+    }
+    setLinked('all');
+    setStatusFilter((prev) => (prev === 'online' ? 'all' : 'online'));
+  };
 
   const sourcePieData = useMemo(
     () =>
@@ -325,62 +382,98 @@ export default function HardwareInstallationsPage() {
             }
           />
 
-          {/* KPI cards */}
+          {/* KPI cards — clickable filters */}
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-            <Card>
-              <CardHeader className="flex flex-row items-center justify-between pb-2">
-                <CardDescription>Total hardware</CardDescription>
-                <PiHardDrivesBold className="size-4 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold tracking-tight">{total}</div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  Across Ruijie, Interstellio & Tarana
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader className="flex flex-row items-center justify-between pb-2">
-                <CardDescription>Linked to service</CardDescription>
-                <PiLinkBold className="size-4 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold tracking-tight text-green-700">
-                  {totals?.linked ?? 0}
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {linkedPct}% of inventory mapped
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader className="flex flex-row items-center justify-between pb-2">
-                <CardDescription>Unlinked</CardDescription>
-                <PiLinkBreakBold className="size-4 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold tracking-tight">
-                  {totals?.unlinked ?? 0}
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  Needs install-register mapping
-                </p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader className="flex flex-row items-center justify-between pb-2">
-                <CardDescription>Online signal</CardDescription>
-                <PiWifiHighBold className="size-4 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold tracking-tight text-green-700">
-                  {onlineCount}
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {offlineCount} offline · {unknownCount} unknown
-                </p>
-              </CardContent>
-            </Card>
+            {(
+              [
+                {
+                  id: 'total' as const,
+                  label: 'Total hardware',
+                  value: total,
+                  hint: 'Across Ruijie, Interstellio & Tarana',
+                  icon: PiHardDrivesBold,
+                  valueClass: '',
+                },
+                {
+                  id: 'linked' as const,
+                  label: 'Linked to service',
+                  value: totals?.linked ?? 0,
+                  hint: `${linkedPct}% of inventory mapped`,
+                  icon: PiLinkBold,
+                  valueClass: 'text-green-700',
+                },
+                {
+                  id: 'unlinked' as const,
+                  label: 'Unlinked',
+                  value: totals?.unlinked ?? 0,
+                  hint: 'Needs install-register mapping',
+                  icon: PiLinkBreakBold,
+                  valueClass: '',
+                },
+                {
+                  id: 'online' as const,
+                  label: 'Online signal',
+                  value: onlineCount,
+                  hint: `${offlineCount} offline · ${unknownCount} unknown`,
+                  icon: PiWifiHighBold,
+                  valueClass: 'text-green-700',
+                },
+              ] as const
+            ).map((card) => {
+              const Icon = card.icon;
+              const isActive = activeCard === card.id;
+              return (
+                <Card
+                  key={card.id}
+                  role="button"
+                  tabIndex={0}
+                  aria-pressed={isActive}
+                  aria-label={`Filter by ${card.label}`}
+                  onClick={() => applyCardFilter(card.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      applyCardFilter(card.id);
+                    }
+                  }}
+                  className={cn(
+                    'cursor-pointer transition-all hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-circleTel-orange',
+                    isActive &&
+                      'border-circleTel-orange bg-orange-50/60 ring-2 ring-circleTel-orange'
+                  )}
+                >
+                  <CardHeader className="flex flex-row items-center justify-between pb-2">
+                    <CardDescription
+                      className={cn(isActive && 'text-circleTel-orange font-medium')}
+                    >
+                      {card.label}
+                    </CardDescription>
+                    <Icon
+                      className={cn(
+                        'size-4 text-muted-foreground',
+                        isActive && 'text-circleTel-orange'
+                      )}
+                    />
+                  </CardHeader>
+                  <CardContent>
+                    <div
+                      className={cn(
+                        'text-3xl font-bold tracking-tight',
+                        card.valueClass
+                      )}
+                    >
+                      {card.value}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {card.hint}
+                      <span className="ml-1 text-muted-foreground/80">
+                        · click to filter
+                      </span>
+                    </p>
+                  </CardContent>
+                </Card>
+              );
+            })}
           </div>
 
           {/* Charts */}
@@ -573,11 +666,28 @@ export default function HardwareInstallationsPage() {
                 onValueChange={setSource}
                 className="w-full"
               >
-                <TabsList className="flex h-auto flex-wrap justify-start">
-                  <TabsTrigger value="all">All</TabsTrigger>
-                  <TabsTrigger value="ruijie">Ruijie</TabsTrigger>
-                  <TabsTrigger value="interstellio">Interstellio</TabsTrigger>
-                  <TabsTrigger value="tarana">Tarana RN</TabsTrigger>
+                <TabsList className="inline-flex h-auto w-full flex-wrap justify-start gap-1 rounded-lg bg-muted p-1">
+                  {(
+                    [
+                      { value: 'all', label: 'All' },
+                      { value: 'ruijie', label: 'Ruijie' },
+                      { value: 'interstellio', label: 'Interstellio' },
+                      { value: 'tarana', label: 'Tarana RN' },
+                    ] as const
+                  ).map((tab) => (
+                    <TabsTrigger
+                      key={tab.value}
+                      value={tab.value}
+                      className={cn(
+                        'rounded-md px-3 py-1.5 text-sm font-medium',
+                        'data-[state=inactive]:text-muted-foreground',
+                        'data-[state=active]:bg-circleTel-orange data-[state=active]:text-white data-[state=active]:shadow-sm',
+                        'data-[state=active]:hover:bg-circleTel-orange'
+                      )}
+                    >
+                      {tab.label}
+                    </TabsTrigger>
+                  ))}
                 </TabsList>
               </Tabs>
 
@@ -606,7 +716,11 @@ export default function HardwareInstallationsPage() {
                 <ToggleGroup
                   type="single"
                   value={linked}
-                  onValueChange={(v) => v && setLinked(v)}
+                  onValueChange={(v) => {
+                    if (!v) return;
+                    setLinked(v);
+                    if (v !== 'all') setStatusFilter('all');
+                  }}
                   variant="outline"
                   size="sm"
                 >
@@ -654,7 +768,7 @@ export default function HardwareInstallationsPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {rows.length === 0 ? (
+                    {filteredRows.length === 0 ? (
                       <TableRow>
                         <TableCell colSpan={8} className="h-40">
                           <EmptyState
@@ -665,7 +779,7 @@ export default function HardwareInstallationsPage() {
                         </TableCell>
                       </TableRow>
                     ) : (
-                      rows.map((row) => {
+                      pageRows.map((row) => {
                         const href = detailHref(row);
                         return (
                           <TableRow
@@ -848,6 +962,53 @@ export default function HardwareInstallationsPage() {
                   </TableBody>
                 </Table>
               </div>
+
+              {filteredRows.length > 0 && (
+                <div className="flex flex-col gap-3 border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-sm text-muted-foreground">
+                    Showing{' '}
+                    <span className="font-medium text-foreground">
+                      {pageStart + 1}
+                    </span>
+                    –
+                    <span className="font-medium text-foreground">
+                      {Math.min(pageStart + PAGE_SIZE, filteredRows.length)}
+                    </span>{' '}
+                    of{' '}
+                    <span className="font-medium text-foreground">
+                      {filteredRows.length}
+                    </span>
+                    {statusFilter !== 'all' ? ' (status filter)' : ''}
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={safePage <= 1}
+                      onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    >
+                      <PiCaretLeftBold className="mr-1 size-4" />
+                      Previous
+                    </Button>
+                    <span className="min-w-[5.5rem] text-center text-sm text-muted-foreground">
+                      Page {safePage} of {totalPages}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={safePage >= totalPages}
+                      onClick={() =>
+                        setPage((p) => Math.min(totalPages, p + 1))
+                      }
+                    >
+                      Next
+                      <PiCaretRightBold className="ml-1 size-4" />
+                    </Button>
+                  </div>
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- Make Total / Linked / Unlinked / Online KPI cards clickable filters (with clear active state)
- Add client-side pagination (25 rows/page) with Previous/Next controls
- Highlight the selected source tab (All / Ruijie / Interstellio / Tarana RN) with orange active styling

## Test plan
- [ ] Open `/admin/network/hardware` and confirm KPI cards filter the table when clicked
- [ ] Click an active Linked/Unlinked/Online card again to clear that filter
- [ ] Confirm source tabs show a clear orange selected state
- [ ] Verify pagination shows 25 rows max and Previous/Next update the range label
- [ ] Change filters/search and confirm page resets to 1


Made with [Cursor](https://cursor.com)