### PR TITLE
Restore vendor SQLite cache and VPS cron runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -330,6 +330,12 @@ RUIJIE_BASE_URL=https://cloud-eu.ruijienetworks.com/service/api
 RUIJIE_MOCK_MODE=false
 
 # =============================================================================
+# Vendor SQLite staging cache (VPS pull → SQLite → Supabase)
+# =============================================================================
+# Default: data/vendor-cache/vendor-cache.db (gitignored). Override for Coolify volume.
+VENDOR_CACHE_DB_PATH=
+
+# =============================================================================
 # WhatsApp Cloud API / Flows
 # =============================================================================
 # Existing WA vars (phone number, access token, WABA, webhook) live in Coolify/.env.local

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ next-env.d.ts
 # Code Review Graph (knowledge graph database)
 .code-review-graph/
 
+# VPS-local vendor SQLite staging (Ruijie / Tarana / Interstellio)
+data/vendor-cache/
+
 # Temporary files
 *.tmp
 *.temp

--- a/docs/architecture/CRON_SCHEDULE.md
+++ b/docs/architecture/CRON_SCHEDULE.md
@@ -52,6 +52,46 @@ Keep Inngest functions as event-triggered step functions. Remove their cron sche
 | `*/30 * * * *` | every 30m | `integrations-health-check` | Ops | Integration health |
 | `0 3 * * 0` | Sun 05:00 | `cleanup-webhook-logs` | Ops | Weekly cleanup |
 
+## Vendor SQLite Staging → Supabase (VPS scripts)
+
+**Canonical path**: Coolify VPS crontab runs `tsx` sync scripts that pull vendor APIs → local SQLite (`VENDOR_CACHE_DB_PATH` / `data/vendor-cache/vendor-cache.db`) → upsert Supabase. Admin/UI reads Supabase only.
+
+```bash
+# Preferred (same path as crontab):
+ops/scheduler/run-vendor-cache.sh ruijie
+ops/scheduler/run-vendor-cache.sh tarana
+ops/scheduler/run-vendor-cache.sh interstellio
+
+# Or from app root:
+# Flags: --dry-run | --publish-only | --delete-stale | --usage-days=N
+npm run vendor-cache:sync:ruijie
+npm run vendor-cache:sync:tarana
+npm run vendor-cache:sync:interstellio
+
+# Regenerate host crontab (includes vendor-cache lines):
+ops/scheduler/generate-crontab.sh | crontab -
+```
+
+| Schedule (UTC) | SAST | Command | Domain | Notes |
+|----------------|------|---------|--------|-------|
+| `*/30 * * * *` | every 30m | `sync.ts --vendor=ruijie` | Network | Stages devices; publishes `ruijie_device_cache`; emits `ruijie/sync.completed` for Inngest fan-out |
+| `0 22 * * *` | 00:00+1 | `sync.ts --vendor=tarana` | Network | NQS BN inventory → `tarana_base_stations` / counts / logs |
+| `0 * * * *` | hourly | `sync.ts --vendor=interstellio` | Network | Subscriber cache + last-2-days usage → `usage_history` |
+
+**Cutover (2026-08-02)**: Inngest Cloud `cron:` removed from `ruijie-sync` and `tarana-sync` (event triggers + fan-out handlers retained). Canonical schedule is host-local via `ops/scheduler/generate-crontab.sh` → `ops/scheduler/run-vendor-cache.sh` (not `$APP_URL` curl — SQLite must stay on the VPS). Logs: `/var/log/circletel-vendor-cache.log`.
+
+**Verification**
+
+```bash
+npm run vendor-cache:sync:ruijie -- --dry-run
+npm run vendor-cache:sync:tarana -- --dry-run
+npm run vendor-cache:sync:interstellio -- --dry-run
+# Then live publish (requires credentials + migration for interstellio_subscriber_cache)
+npm run vendor-cache:sync:ruijie
+```
+
+Apply migration: `supabase/migrations/20260802160000_interstellio_subscriber_cache.sql`
+
 ## Inngest-Only Functions (Need Crontab Routes)
 
 These functions currently only fire via Inngest Cloud cron. They need `/api/cron/*` routes so crontab can trigger them:
@@ -60,7 +100,7 @@ These functions currently only fire via Inngest Cloud cron. They need `/api/cron
 |----------------|------|------------------|--------|----------|
 | `*/15 * * * *` | every 15m | `tarana-metrics-collection` | Network | HIGH — monitoring |
 | `*/30 * * * *` | every 30m | `mikrotik-sync` | Network | HIGH — device sync |
-| `*/30 * * * *` | every 30m | `ruijie-sync` | Network | HIGH — device sync |
+| ~~`*/30 * * * *`~~ | — | `ruijie-sync` | Network | CUTOVER — Inngest cron removed; use host `run-vendor-cache.sh ruijie` |
 | `*/45 * * * *` | every 45m | `zoho-desk-token-refresh` | Integration | MEDIUM |
 | `0 * * * *` | hourly | `ruijie-tunnel-cleanup` | Network | MEDIUM |
 | `0 0 * * *` | 02:00 | `dfa-sync` | Network | MEDIUM |
@@ -68,7 +108,7 @@ These functions currently only fire via Inngest Cloud cron. They need `/api/cron
 | `0 3 */7 * *` | every 7d 05:00 | `ruijie-token-refresh` | Network | LOW |
 | `0 6 * * *` | 08:00 | `whatsapp-campaign-report` | Marketing | LOW |
 | `0 6 * * *` | 08:00 | `whatsapp-notifications` | Comms | LOW |
-| `0 22 * * *` | 00:00+1 | `tarana-sync` | Network | MEDIUM |
+| ~~`0 22 * * *`~~ | — | `tarana-sync` | Network | CUTOVER — Inngest cron removed; use host `run-vendor-cache.sh tarana` |
 | `30 3 * * *` | 05:30 | `sales-engine-orchestrator` | Sales | LOW |
 | `0 8 * * 1` | Mon 10:00 | `marketing-triggers` | Marketing | LOW |
 | `0 1 * * 0` | Sun 03:00 | `zone-demographic-enrichment` | Analytics | LOW |

--- a/lib/inngest/functions/ruijie-sync.ts
+++ b/lib/inngest/functions/ruijie-sync.ts
@@ -7,7 +7,9 @@
  * - Dual triggers: scheduled cron and manual event
  * - Progress tracking via ruijie_sync_logs table
  *
- * Schedule: Every 30 minutes (reduced from 5min to stay within Inngest free tier)
+ * Schedule: VPS vendor-cache crontab every 30 minutes
+ *   (ops/scheduler/run-vendor-cache.sh ruijie → emits ruijie/sync.completed).
+ * Inngest cron removed to avoid dual-fire; keep event trigger for manual runs.
  */
 
 import { inngest } from '../client';
@@ -50,9 +52,7 @@ export const ruijieSyncFunction = inngest.createFunction(
       },
     ],
   triggers: [
-    // Cron trigger: every 30 minutes (reduced to stay within Inngest free tier)
-    { cron: '*/30 * * * *' },
-    // Event trigger: manual requests
+    // Event-only: VPS vendor-cache owns the schedule (avoid dual-fire with Inngest Cloud cron)
     { event: 'ruijie/sync.requested' },
   ],
 }, async ({ event, step }) => {

--- a/lib/inngest/functions/tarana-sync.ts
+++ b/lib/inngest/functions/tarana-sync.ts
@@ -8,7 +8,9 @@
  * - Progress tracking via tarana_sync_logs table
  * - Cancellation support
  *
- * Schedule: Daily at midnight SAST (22:00 UTC)
+ * Schedule: VPS vendor-cache crontab daily at 22:00 UTC (midnight SAST)
+ *   (ops/scheduler/run-vendor-cache.sh tarana).
+ * Inngest cron removed to avoid dual-fire; keep event trigger for manual runs.
  */
 
 import { inngest } from '../client';
@@ -39,9 +41,7 @@ export const taranaSyncFunction = inngest.createFunction(
       },
     ],
   triggers: [
-    // Cron trigger: midnight SAST = 22:00 UTC
-    { cron: '0 22 * * *' },
-    // Event trigger: manual requests
+    // Event-only: VPS vendor-cache owns the schedule (avoid dual-fire with Inngest Cloud cron)
     { event: 'tarana/sync.requested' },
   ],
 }, async ({ event, step }) => {

--- a/lib/vendor-cache/db.ts
+++ b/lib/vendor-cache/db.ts
@@ -1,0 +1,56 @@
+/**
+ * Vendor cache SQLite opener (WAL mode)
+ *
+ * Path: VENDOR_CACHE_DB_PATH or data/vendor-cache/vendor-cache.db
+ * File mode: 0600 after open
+ */
+
+import Database from 'better-sqlite3';
+import { chmodSync, mkdirSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { VENDOR_CACHE_SCHEMA_SQL } from './schema';
+
+let dbInstance: Database.Database | null = null;
+
+export function getVendorCacheDbPath(): string {
+  const fromEnv = process.env.VENDOR_CACHE_DB_PATH?.trim();
+  if (fromEnv) {
+    return resolve(fromEnv);
+  }
+  return resolve(process.cwd(), 'data/vendor-cache/vendor-cache.db');
+}
+
+/**
+ * Open (or return) the shared vendor-cache database.
+ * Creates parent directory, applies schema, enables WAL.
+ */
+export function getVendorCacheDb(): Database.Database {
+  if (dbInstance) {
+    return dbInstance;
+  }
+
+  const dbPath = getVendorCacheDbPath();
+  mkdirSync(dirname(dbPath), { recursive: true });
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(VENDOR_CACHE_SCHEMA_SQL);
+
+  try {
+    chmodSync(dbPath, 0o600);
+  } catch {
+    // Non-fatal on platforms that ignore chmod
+  }
+
+  dbInstance = db;
+  return db;
+}
+
+/** Close the shared connection (tests / process exit). */
+export function closeVendorCacheDb(): void {
+  if (dbInstance) {
+    dbInstance.close();
+    dbInstance = null;
+  }
+}

--- a/lib/vendor-cache/index.ts
+++ b/lib/vendor-cache/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Vendor SQLite staging cache
+ *
+ * VPS-local pull → SQLite stage → Supabase publish for Ruijie, Tarana, Interstellio.
+ */
+
+export { getVendorCacheDb, getVendorCacheDbPath, closeVendorCacheDb } from './db';
+export { syncVendor, syncVendors } from './sync';
+export type {
+  VendorName,
+  SyncOptions,
+  SyncRunResult,
+  SyncRunStatus,
+} from './types';

--- a/lib/vendor-cache/publish/interstellio.ts
+++ b/lib/vendor-cache/publish/interstellio.ts
@@ -1,0 +1,214 @@
+/**
+ * Publish staged Interstellio subscribers + usage to Supabase
+ */
+
+import type Database from 'better-sqlite3';
+import { createClient } from '@/lib/supabase/server';
+import type { InterstellioSubscriber } from '@/lib/interstellio/types';
+
+export interface InterstellioPublishResult {
+  published: number;
+  subscribersUpserted: number;
+  usageUpserted: number;
+  usageSkippedUnlinked: number;
+  errors: string[];
+}
+
+interface ServiceLink {
+  service_id: string;
+  customer_id: string;
+}
+
+async function buildSubscriberServiceMap(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  subscriberIds: string[]
+): Promise<Map<string, ServiceLink>> {
+  const map = new Map<string, ServiceLink>();
+  if (subscriberIds.length === 0) return map;
+
+  // customer_services.connection_id
+  const { data: services } = await supabase
+    .from('customer_services')
+    .select('id, customer_id, connection_id')
+    .in('connection_id', subscriberIds);
+
+  for (const row of services || []) {
+    if (row.connection_id && row.id && row.customer_id) {
+      map.set(String(row.connection_id), {
+        service_id: row.id,
+        customer_id: row.customer_id,
+      });
+    }
+  }
+
+  // pppoe_credentials → customer_services via service linkage when present
+  const { data: pppoe } = await supabase
+    .from('pppoe_credentials')
+    .select('interstellio_subscriber_id, service_id, customer_id')
+    .in('interstellio_subscriber_id', subscriberIds);
+
+  for (const row of pppoe || []) {
+    const sid = row.interstellio_subscriber_id
+      ? String(row.interstellio_subscriber_id)
+      : null;
+    if (!sid || map.has(sid)) continue;
+    if (row.service_id && row.customer_id) {
+      map.set(sid, {
+        service_id: row.service_id,
+        customer_id: row.customer_id,
+      });
+    }
+  }
+
+  // RPC fallback for remaining IDs
+  for (const id of subscriberIds) {
+    if (map.has(id)) continue;
+    const { data, error } = await supabase.rpc(
+      'find_customer_service_by_interstellio_id',
+      { p_interstellio_id: id }
+    );
+    if (error || !data || !Array.isArray(data) || data.length === 0) continue;
+    const first = data[0] as {
+      customer_service_id?: string;
+      customer_id?: string;
+    };
+    if (first.customer_service_id && first.customer_id) {
+      map.set(id, {
+        service_id: first.customer_service_id,
+        customer_id: first.customer_id,
+      });
+    }
+  }
+
+  return map;
+}
+
+export async function publishInterstellioFromStage(
+  db: Database.Database
+): Promise<InterstellioPublishResult> {
+  const errors: string[] = [];
+  const supabase = await createClient();
+  const syncedAt = new Date().toISOString();
+
+  const subRows = db
+    .prepare(
+      `SELECT id, payload_json FROM stage_interstellio_subscribers ORDER BY id`
+    )
+    .all() as Array<{ id: string; payload_json: string }>;
+
+  let subscribersUpserted = 0;
+  const cacheRows: Array<Record<string, unknown>> = [];
+
+  for (const row of subRows) {
+    let sub: InterstellioSubscriber;
+    try {
+      sub = JSON.parse(row.payload_json) as InterstellioSubscriber;
+    } catch (err) {
+      errors.push(
+        `Invalid subscriber JSON ${row.id}: ${err instanceof Error ? err.message : String(err)}`
+      );
+      continue;
+    }
+
+    cacheRows.push({
+      id: sub.id,
+      username: sub.username ?? null,
+      name: sub.name ?? null,
+      enabled: sub.enabled ?? false,
+      domain: sub.domain ?? null,
+      tenant_id: sub.tenant_id ?? null,
+      service: sub.service ?? null,
+      profile: sub.profile ?? null,
+      virtual: sub.virtual ?? null,
+      last_seen: sub.last_seen || null,
+      expire: sub.expire || null,
+      static_ip4: sub.static_ip4 ?? null,
+      uncapped_data: sub.uncapped_data ?? null,
+      raw_json: sub,
+      synced_at: syncedAt,
+      updated_at: syncedAt,
+    });
+  }
+
+  // Upsert in batches of 100
+  const batchSize = 100;
+  for (let i = 0; i < cacheRows.length; i += batchSize) {
+    const batch = cacheRows.slice(i, i + batchSize);
+    const { error } = await supabase
+      .from('interstellio_subscriber_cache')
+      .upsert(batch, { onConflict: 'id' });
+    if (error) {
+      errors.push(`Subscriber cache upsert failed: ${error.message}`);
+    } else {
+      subscribersUpserted += batch.length;
+    }
+  }
+
+  db.prepare(
+    `UPDATE stage_interstellio_subscribers SET published_at = ? WHERE published_at IS NULL`
+  ).run(syncedAt);
+
+  // Usage → usage_history for linked services only
+  const usageRows = db
+    .prepare(
+      `SELECT subscriber_id, date, upload_mb, download_mb
+       FROM stage_interstellio_usage ORDER BY subscriber_id, date`
+    )
+    .all() as Array<{
+    subscriber_id: string;
+    date: string;
+    upload_mb: number;
+    download_mb: number;
+  }>;
+
+  const uniqueSubIds = [...new Set(usageRows.map((u) => u.subscriber_id))];
+  const linkMap = await buildSubscriberServiceMap(supabase, uniqueSubIds);
+
+  let usageUpserted = 0;
+  let usageSkippedUnlinked = 0;
+
+  for (const row of usageRows) {
+    const link = linkMap.get(row.subscriber_id);
+    if (!link) {
+      usageSkippedUnlinked++;
+      continue;
+    }
+
+    const { error } = await supabase.from('usage_history').upsert(
+      {
+        service_id: link.service_id,
+        customer_id: link.customer_id,
+        date: row.date,
+        upload_mb: row.upload_mb,
+        download_mb: row.download_mb,
+        source: 'interstellio',
+        synced_at: syncedAt,
+      },
+      { onConflict: 'service_id,date' }
+    );
+
+    if (error) {
+      errors.push(
+        `usage_history upsert failed ${row.subscriber_id}@${row.date}: ${error.message}`
+      );
+    } else {
+      usageUpserted++;
+    }
+  }
+
+  db.prepare(
+    `UPDATE stage_interstellio_usage SET published_at = ? WHERE published_at IS NULL`
+  ).run(syncedAt);
+
+  console.log(
+    `[VendorCache:Interstellio] Published subscribers=${subscribersUpserted} usage=${usageUpserted} skipped_unlinked=${usageSkippedUnlinked}`
+  );
+
+  return {
+    published: subscribersUpserted + usageUpserted,
+    subscribersUpserted,
+    usageUpserted,
+    usageSkippedUnlinked,
+    errors,
+  };
+}

--- a/lib/vendor-cache/publish/ruijie.ts
+++ b/lib/vendor-cache/publish/ruijie.ts
@@ -1,0 +1,111 @@
+/**
+ * Publish staged Ruijie devices to Supabase + emit Inngest completed event
+ */
+
+import type Database from 'better-sqlite3';
+import {
+  upsertDevices,
+  pruneDevicesNotInSet,
+  createSyncLog,
+  logSyncRun,
+  isMockMode,
+  type RuijieDevice,
+} from '@/lib/ruijie';
+import { inngest } from '@/lib/inngest/client';
+import {
+  ruijieSyncCompleted,
+  ruijieSyncSessions,
+} from '@/lib/inngest/events/ruijie';
+
+export interface RuijiePublishResult {
+  published: number;
+  added: number;
+  updated: number;
+  pruned: number;
+  syncLogId: string;
+  errors: string[];
+}
+
+export async function publishRuijieFromStage(
+  db: Database.Database,
+  options: { durationMs?: number } = {}
+): Promise<RuijiePublishResult> {
+  const errors: string[] = [];
+  const rows = db
+    .prepare(
+      `SELECT sn, payload_json FROM stage_ruijie_devices ORDER BY sn`
+    )
+    .all() as Array<{ sn: string; payload_json: string }>;
+
+  const devices: RuijieDevice[] = [];
+  for (const row of rows) {
+    try {
+      devices.push(JSON.parse(row.payload_json) as RuijieDevice);
+    } catch (err) {
+      errors.push(
+        `Invalid JSON for sn=${row.sn}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  const syncLogId = await createSyncLog('manual');
+  console.log(`[VendorCache:Ruijie] Publishing ${devices.length} devices (log=${syncLogId})`);
+
+  const upsertResult = await upsertDevices(devices, isMockMode());
+  errors.push(...upsertResult.errors);
+
+  const keepSns = devices.map((d) => d.sn);
+  const pruneResult = await pruneDevicesNotInSet(keepSns);
+
+  const durationMs = options.durationMs ?? 0;
+  await logSyncRun(
+    {
+      ...upsertResult,
+      devicesFetched: devices.length,
+      durationMs,
+    },
+    'manual',
+    undefined,
+    syncLogId
+  );
+
+  const publishedAt = new Date().toISOString();
+  db.prepare(
+    `UPDATE stage_ruijie_devices SET published_at = ? WHERE published_at IS NULL`
+  ).run(publishedAt);
+
+  try {
+    await inngest.send(
+      ruijieSyncCompleted.create(
+        {
+          sync_log_id: syncLogId,
+          devices_fetched: devices.length,
+          added: upsertResult.added,
+          updated: upsertResult.updated,
+          pruned: pruneResult.deleted,
+          errors: upsertResult.errors.length,
+          duration_ms: durationMs,
+        },
+        {
+          meta: {
+            sessions: ruijieSyncSessions(syncLogId),
+          },
+        }
+      )
+    );
+    console.log('[VendorCache:Ruijie] Emitted ruijie/sync.completed');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    errors.push(`Inngest emit failed: ${msg}`);
+    console.warn(`[VendorCache:Ruijie] Inngest emit failed: ${msg}`);
+  }
+
+  return {
+    published: devices.length,
+    added: upsertResult.added,
+    updated: upsertResult.updated,
+    pruned: pruneResult.deleted,
+    syncLogId,
+    errors,
+  };
+}

--- a/lib/vendor-cache/publish/tarana.ts
+++ b/lib/vendor-cache/publish/tarana.ts
@@ -1,0 +1,213 @@
+/**
+ * Publish staged Tarana BNs to Supabase (NQS path)
+ */
+
+import type Database from 'better-sqlite3';
+import { createClient } from '@/lib/supabase/server';
+import type { TaranaRadio } from '@/lib/tarana/types';
+import type { NqsDeviceData } from '@/lib/tarana/client';
+
+export interface TaranaPublishResult {
+  published: number;
+  inserted: number;
+  updated: number;
+  deleted: number;
+  syncLogId: string;
+  errors: string[];
+}
+
+function readMeta<T>(db: Database.Database, key: string, fallback: T): T {
+  const row = db
+    .prepare(`SELECT value_json FROM stage_tarana_meta WHERE key = ?`)
+    .get(key) as { value_json: string } | undefined;
+  if (!row) return fallback;
+  try {
+    return JSON.parse(row.value_json) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function publishTaranaFromStage(
+  db: Database.Database,
+  options: { deleteStale?: boolean; durationMs?: number } = {}
+): Promise<TaranaPublishResult> {
+  const { deleteStale = false, durationMs = 0 } = options;
+  const errors: string[] = [];
+  const supabase = await createClient();
+
+  const { data: newLog, error: logError } = await supabase
+    .from('tarana_sync_logs')
+    .insert({
+      status: 'running',
+      trigger_type: 'manual',
+      triggered_by: null,
+      started_at: new Date().toISOString(),
+    })
+    .select('id')
+    .single();
+
+  if (logError || !newLog) {
+    throw new Error(
+      `Failed to create tarana_sync_logs: ${logError?.message || 'unknown'}`
+    );
+  }
+  const syncLogId = newLog.id as string;
+
+  const rows = db
+    .prepare(
+      `SELECT serial_number, payload_json FROM stage_tarana_devices
+       WHERE device_type = 'BN' ORDER BY serial_number`
+    )
+    .all() as Array<{ serial_number: string; payload_json: string }>;
+
+  const baseNodes: TaranaRadio[] = [];
+  for (const row of rows) {
+    try {
+      baseNodes.push(JSON.parse(row.payload_json) as TaranaRadio);
+    } catch (err) {
+      errors.push(
+        `Invalid JSON for ${row.serial_number}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  const rnCountsBySite = readMeta<Record<string, number>>(
+    db,
+    'rnCountsBySite',
+    {}
+  );
+  const deviceCounts = readMeta<NqsDeviceData['deviceCounts']>(db, 'deviceCounts', {
+    bn: { connected: 0, disconnected: 0, total: 0 },
+    rn: { connected: 0, disconnected: 0, total: 0 },
+  });
+
+  const { data: existing, error: existingError } = await supabase
+    .from('tarana_base_stations')
+    .select('serial_number');
+
+  if (existingError) {
+    throw new Error(`Failed to fetch existing BNs: ${existingError.message}`);
+  }
+
+  const existingSet = new Set(existing?.map((e) => e.serial_number) || []);
+  const apiSerials = new Set<string>();
+  let inserted = 0;
+  let updated = 0;
+  let deleted = 0;
+
+  for (const bn of baseNodes) {
+    if (!bn.serialNumber || !bn.latitude || !bn.longitude) {
+      errors.push(`Skipping BN with missing data: ${bn.serialNumber || 'unknown'}`);
+      continue;
+    }
+
+    apiSerials.add(bn.serialNumber);
+
+    const record = {
+      serial_number: bn.serialNumber,
+      hostname: bn.deviceId || bn.serialNumber,
+      site_name: bn.siteName || 'Unknown Site',
+      active_connections: rnCountsBySite[bn.siteName ?? ''] ?? 0,
+      market: bn.marketName || 'Unknown',
+      lat: bn.latitude,
+      lng: bn.longitude,
+      region: bn.regionName || 'South Africa',
+      device_status: bn.deviceStatus ?? 0,
+      height_m: bn.height ?? null,
+      azimuth_deg: bn.azimuth ?? null,
+      band: bn.band ?? null,
+      region_id: bn.regionId ?? null,
+      market_id: bn.marketId ?? null,
+      site_id: bn.siteId ?? null,
+      cell_id: bn.cellId ?? null,
+      cell_name: bn.cellName ?? null,
+      sector_id: bn.sectorId ?? null,
+      sector_name: bn.sectorName ?? null,
+      last_updated: new Date().toISOString(),
+    };
+
+    if (existingSet.has(bn.serialNumber)) {
+      const { error } = await supabase
+        .from('tarana_base_stations')
+        .update(record)
+        .eq('serial_number', bn.serialNumber);
+      if (error) {
+        errors.push(`Update failed for ${bn.serialNumber}: ${error.message}`);
+      } else {
+        updated++;
+      }
+    } else {
+      const { error } = await supabase.from('tarana_base_stations').insert(record);
+      if (error) {
+        errors.push(`Insert failed for ${bn.serialNumber}: ${error.message}`);
+      } else {
+        inserted++;
+      }
+    }
+  }
+
+  const { error: dcError } = await supabase.from('tarana_device_counts').insert({
+    sync_log_id: syncLogId,
+    bn_connected: deviceCounts.bn.connected,
+    bn_disconnected: deviceCounts.bn.disconnected,
+    bn_spectrum_unassigned: 0,
+    bn_new_installs_30d: 0,
+    bn_total: deviceCounts.bn.total,
+    rn_connected: deviceCounts.rn.connected,
+    rn_disconnected: deviceCounts.rn.disconnected,
+    rn_spectrum_unassigned: 0,
+    rn_new_installs_30d: 0,
+    rn_total: deviceCounts.rn.total,
+  });
+  if (dcError) {
+    errors.push(`Device counts insert failed: ${dcError.message}`);
+  }
+
+  if (deleteStale) {
+    const staleSerials = [...existingSet].filter((s) => !apiSerials.has(s));
+    if (staleSerials.length > 0) {
+      const { error } = await supabase
+        .from('tarana_base_stations')
+        .delete()
+        .in('serial_number', staleSerials);
+      if (error) {
+        errors.push(`Delete stale failed: ${error.message}`);
+      } else {
+        deleted = staleSerials.length;
+      }
+    }
+  }
+
+  await supabase
+    .from('tarana_sync_logs')
+    .update({
+      status: 'completed',
+      stations_fetched: baseNodes.length,
+      inserted,
+      updated,
+      deleted,
+      errors: errors.length > 0 ? errors.slice(0, 10) : [],
+      duration_ms: durationMs,
+      completed_at: new Date().toISOString(),
+    })
+    .eq('id', syncLogId);
+
+  const publishedAt = new Date().toISOString();
+  db.prepare(
+    `UPDATE stage_tarana_devices SET published_at = ? WHERE published_at IS NULL`
+  ).run(publishedAt);
+
+  console.log(
+    `[VendorCache:Tarana] Published: +${inserted} ~${updated} -${deleted} (log=${syncLogId})`
+  );
+
+  return {
+    published: inserted + updated,
+    inserted,
+    updated,
+    deleted,
+    syncLogId,
+    errors,
+  };
+}

--- a/lib/vendor-cache/pull/interstellio.ts
+++ b/lib/vendor-cache/pull/interstellio.ts
@@ -1,0 +1,193 @@
+/**
+ * Pull Interstellio subscribers + linked usage into SQLite staging
+ */
+
+import type Database from 'better-sqlite3';
+import { getInterstellioClient } from '@/lib/interstellio';
+import type { InterstellioSubscriber } from '@/lib/interstellio/types';
+import { createClient } from '@/lib/supabase/server';
+
+export interface InterstellioPullResult {
+  fetched: number;
+  subscribers: number;
+  usageRows: number;
+  errors: string[];
+}
+
+function toDateString(isoOrDate: string): string {
+  // Usage time may be ISO; normalize to YYYY-MM-DD (UTC date portion)
+  if (/^\d{4}-\d{2}-\d{2}$/.test(isoOrDate)) return isoOrDate;
+  return isoOrDate.slice(0, 10);
+}
+
+/**
+ * List all subscribers (paged) into stage, then fetch daily usage for
+ * subscribers linked in Supabase (connection_id / pppoe / corporate_sites).
+ */
+export async function pullInterstellioToStage(
+  db: Database.Database,
+  options: { usageDays?: number } = {}
+): Promise<InterstellioPullResult> {
+  const usageDays = options.usageDays ?? 2;
+  const errors: string[] = [];
+  const client = getInterstellioClient();
+  const fetchedAt = new Date().toISOString();
+
+  // Token may be absent/expired on host; fall back to username/password auth
+  if (
+    !process.env.INTERSTELLIO_API_TOKEN &&
+    process.env.INTERSTELLIO_USERNAME &&
+    process.env.INTERSTELLIO_PASSWORD
+  ) {
+    console.log('[VendorCache:Interstellio] Authenticating with username/password…');
+    await client.authenticate({
+      domain: process.env.INTERSTELLIO_DOMAIN || 'circletel.co.za',
+      username: process.env.INTERSTELLIO_USERNAME,
+      password: process.env.INTERSTELLIO_PASSWORD,
+    });
+  }
+
+  console.log('[VendorCache:Interstellio] Listing subscribers…');
+  const subscribers: InterstellioSubscriber[] = [];
+  let page = 1;
+  let pages = 1;
+
+  while (page <= pages) {
+    const resp = await client.listSubscribers({ l: 50, p: page });
+    const batch = resp.payload || [];
+    subscribers.push(...batch);
+    pages = resp.metadata?.pages || 1;
+    console.log(
+      `[VendorCache:Interstellio] page ${page}/${pages} (+${batch.length}, total ${subscribers.length})`
+    );
+    page += 1;
+    if (batch.length === 0) break;
+  }
+
+  const replaceSubs = db.transaction((rows: InterstellioSubscriber[]) => {
+    db.prepare('DELETE FROM stage_interstellio_subscribers').run();
+    const insert = db.prepare(
+      `INSERT INTO stage_interstellio_subscribers (id, payload_json, fetched_at, published_at)
+       VALUES (?, ?, ?, NULL)`
+    );
+    for (const sub of rows) {
+      if (!sub.id) {
+        errors.push('Skipping subscriber with missing id');
+        continue;
+      }
+      // Never persist RADIUS password fields if present on raw payload
+      const safe = { ...sub } as Record<string, unknown>;
+      delete safe.password;
+      insert.run(sub.id, JSON.stringify(safe), fetchedAt);
+    }
+  });
+  replaceSubs(subscribers);
+
+  // Resolve linked Interstellio IDs from Supabase
+  const supabase = await createClient();
+  const linkedIds = new Set<string>();
+
+  const { data: services } = await supabase
+    .from('customer_services')
+    .select('connection_id')
+    .not('connection_id', 'is', null);
+  for (const row of services || []) {
+    if (row.connection_id) linkedIds.add(String(row.connection_id));
+  }
+
+  const { data: pppoe } = await supabase
+    .from('pppoe_credentials')
+    .select('interstellio_subscriber_id')
+    .not('interstellio_subscriber_id', 'is', null);
+  for (const row of pppoe || []) {
+    if (row.interstellio_subscriber_id) {
+      linkedIds.add(String(row.interstellio_subscriber_id));
+    }
+  }
+
+  const { data: sites } = await supabase
+    .from('corporate_sites')
+    .select('interstellio_subscriber_id')
+    .not('interstellio_subscriber_id', 'is', null);
+  for (const row of sites || []) {
+    if (row.interstellio_subscriber_id) {
+      linkedIds.add(String(row.interstellio_subscriber_id));
+    }
+  }
+
+  console.log(
+    `[VendorCache:Interstellio] Fetching daily usage for ${linkedIds.size} linked subscribers (${usageDays}d)…`
+  );
+
+  const end = new Date();
+  const start = new Date();
+  start.setUTCDate(start.getUTCDate() - usageDays);
+  const query = {
+    start: start.toISOString(),
+    end: end.toISOString(),
+  };
+
+  type UsageRow = {
+    subscriber_id: string;
+    date: string;
+    upload_mb: number;
+    download_mb: number;
+  };
+  const usageRows: UsageRow[] = [];
+
+  for (const subscriberId of linkedIds) {
+    try {
+      const entries = await client.getSubscriberUsage(subscriberId, 'daily', query);
+      for (const entry of entries) {
+        const date = toDateString(entry.time);
+        usageRows.push({
+          subscriber_id: subscriberId,
+          date,
+          upload_mb: Math.round(((entry.upload_kb || 0) / 1024) * 100) / 100,
+          download_mb: Math.round(((entry.download_kb || 0) / 1024) * 100) / 100,
+        });
+      }
+    } catch (err) {
+      errors.push(
+        `Usage fetch failed for ${subscriberId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  const replaceUsage = db.transaction((rows: UsageRow[]) => {
+    db.prepare('DELETE FROM stage_interstellio_usage').run();
+    const insert = db.prepare(
+      `INSERT INTO stage_interstellio_usage
+         (subscriber_id, date, upload_mb, download_mb, fetched_at, published_at)
+       VALUES (?, ?, ?, ?, ?, NULL)`
+    );
+    for (const row of rows) {
+      insert.run(
+        row.subscriber_id,
+        row.date,
+        row.upload_mb,
+        row.download_mb,
+        fetchedAt
+      );
+    }
+  });
+  replaceUsage(usageRows);
+
+  const subCount = (
+    db.prepare('SELECT COUNT(*) AS c FROM stage_interstellio_subscribers').get() as {
+      c: number;
+    }
+  ).c;
+  const usageCount = (
+    db.prepare('SELECT COUNT(*) AS c FROM stage_interstellio_usage').get() as {
+      c: number;
+    }
+  ).c;
+
+  return {
+    fetched: subCount + usageCount,
+    subscribers: subCount,
+    usageRows: usageCount,
+    errors,
+  };
+}

--- a/lib/vendor-cache/pull/ruijie.ts
+++ b/lib/vendor-cache/pull/ruijie.ts
@@ -1,0 +1,76 @@
+/**
+ * Pull Ruijie devices into SQLite staging
+ */
+
+import type Database from 'better-sqlite3';
+import {
+  getAllDevices,
+  enrichDevicesWithLiveMetrics,
+  filterActiveDevices,
+  RUIJIE_ACTIVE_WINDOW_DAYS,
+  isMockMode,
+  isCacheEmpty,
+  seedMockData,
+  type RuijieDevice,
+} from '@/lib/ruijie';
+
+export interface RuijiePullResult {
+  fetched: number;
+  active: number;
+  errors: string[];
+}
+
+/**
+ * Fetch Ruijie devices, filter active window, enrich metrics, replace stage table.
+ */
+export async function pullRuijieToStage(
+  db: Database.Database
+): Promise<RuijiePullResult> {
+  const errors: string[] = [];
+
+  if (isMockMode()) {
+    const empty = await isCacheEmpty();
+    if (empty) {
+      console.log('[VendorCache:Ruijie] Mock mode, cache empty — seeding Supabase mock first');
+      await seedMockData();
+    }
+  }
+
+  console.log('[VendorCache:Ruijie] Fetching devices…');
+  const devices = await getAllDevices();
+  console.log(`[VendorCache:Ruijie] Fetched ${devices.length}`);
+
+  const active = filterActiveDevices(devices as RuijieDevice[]);
+  console.log(
+    `[VendorCache:Ruijie] Active window ${RUIJIE_ACTIVE_WINDOW_DAYS}d: ${active.length}/${devices.length}`
+  );
+
+  console.log('[VendorCache:Ruijie] Enriching live metrics…');
+  const enriched = await enrichDevicesWithLiveMetrics(active);
+  const fetchedAt = new Date().toISOString();
+
+  const replace = db.transaction((rows: RuijieDevice[]) => {
+    db.prepare('DELETE FROM stage_ruijie_devices').run();
+    const insert = db.prepare(
+      `INSERT INTO stage_ruijie_devices (sn, payload_json, fetched_at, published_at)
+       VALUES (?, ?, ?, NULL)`
+    );
+    for (const device of rows) {
+      if (!device.sn) {
+        errors.push('Skipping device with missing sn');
+        continue;
+      }
+      insert.run(device.sn, JSON.stringify(device), fetchedAt);
+    }
+  });
+
+  replace(enriched);
+
+  const count = (
+    db.prepare('SELECT COUNT(*) AS c FROM stage_ruijie_devices').get() as {
+      c: number;
+    }
+  ).c;
+
+  return { fetched: count, active: count, errors };
+}

--- a/lib/vendor-cache/pull/tarana.ts
+++ b/lib/vendor-cache/pull/tarana.ts
@@ -1,0 +1,70 @@
+/**
+ * Pull Tarana TCS NQS devices into SQLite staging
+ */
+
+import type Database from 'better-sqlite3';
+import { getAllDevicesNqs, type NqsDeviceData } from '@/lib/tarana/client';
+export interface TaranaPullResult {
+  fetched: number;
+  bnCount: number;
+  errors: string[];
+}
+
+/**
+ * Fetch all devices via NQS v1 and replace stage_tarana_devices + meta.
+ */
+export async function pullTaranaToStage(
+  db: Database.Database
+): Promise<TaranaPullResult> {
+  const errors: string[] = [];
+
+  console.log('[VendorCache:Tarana] Fetching devices via NQS v1…');
+  const data: NqsDeviceData = await getAllDevicesNqs();
+  console.log(
+    `[VendorCache:Tarana] ${data.baseNodes.length} BNs | ` +
+      `${data.deviceCounts.rn.total} RNs (${data.deviceCounts.rn.connected} online)`
+  );
+
+  const fetchedAt = new Date().toISOString();
+
+  const replace = db.transaction((nqs: NqsDeviceData) => {
+    db.prepare('DELETE FROM stage_tarana_devices').run();
+    db.prepare('DELETE FROM stage_tarana_meta').run();
+
+    const insertDevice = db.prepare(
+      `INSERT INTO stage_tarana_devices
+         (serial_number, device_type, payload_json, fetched_at, published_at)
+       VALUES (?, ?, ?, ?, NULL)`
+    );
+
+    for (const bn of nqs.baseNodes) {
+      if (!bn.serialNumber) {
+        errors.push('Skipping BN with missing serialNumber');
+        continue;
+      }
+      insertDevice.run(
+        bn.serialNumber,
+        'BN',
+        JSON.stringify(bn),
+        fetchedAt
+      );
+    }
+
+    const insertMeta = db.prepare(
+      `INSERT INTO stage_tarana_meta (key, value_json, fetched_at)
+       VALUES (?, ?, ?)`
+    );
+    insertMeta.run('rnCountsBySite', JSON.stringify(nqs.rnCountsBySite), fetchedAt);
+    insertMeta.run('deviceCounts', JSON.stringify(nqs.deviceCounts), fetchedAt);
+  });
+
+  replace(data);
+
+  const count = (
+    db.prepare(
+      `SELECT COUNT(*) AS c FROM stage_tarana_devices WHERE device_type = 'BN'`
+    ).get() as { c: number }
+  ).c;
+
+  return { fetched: count, bnCount: count, errors };
+}

--- a/lib/vendor-cache/schema.ts
+++ b/lib/vendor-cache/schema.ts
@@ -1,0 +1,69 @@
+/**
+ * SQLite DDL for vendor staging cache
+ */
+
+export const VENDOR_CACHE_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS sync_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  vendor TEXT NOT NULL,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  status TEXT NOT NULL,
+  fetched INTEGER NOT NULL DEFAULT 0,
+  published INTEGER NOT NULL DEFAULT 0,
+  errors_json TEXT NOT NULL DEFAULT '[]'
+);
+
+CREATE TABLE IF NOT EXISTS stage_ruijie_devices (
+  sn TEXT PRIMARY KEY,
+  payload_json TEXT NOT NULL,
+  fetched_at TEXT NOT NULL,
+  published_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS stage_tarana_devices (
+  serial_number TEXT PRIMARY KEY,
+  device_type TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  fetched_at TEXT NOT NULL,
+  published_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS stage_tarana_meta (
+  key TEXT PRIMARY KEY,
+  value_json TEXT NOT NULL,
+  fetched_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS stage_interstellio_subscribers (
+  id TEXT PRIMARY KEY,
+  payload_json TEXT NOT NULL,
+  fetched_at TEXT NOT NULL,
+  published_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS stage_interstellio_usage (
+  subscriber_id TEXT NOT NULL,
+  date TEXT NOT NULL,
+  upload_mb REAL NOT NULL DEFAULT 0,
+  download_mb REAL NOT NULL DEFAULT 0,
+  fetched_at TEXT NOT NULL,
+  published_at TEXT,
+  PRIMARY KEY (subscriber_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_runs_vendor_started
+  ON sync_runs(vendor, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_stage_ruijie_unpublished
+  ON stage_ruijie_devices(published_at);
+
+CREATE INDEX IF NOT EXISTS idx_stage_tarana_unpublished
+  ON stage_tarana_devices(published_at);
+
+CREATE INDEX IF NOT EXISTS idx_stage_interstellio_sub_unpublished
+  ON stage_interstellio_subscribers(published_at);
+
+CREATE INDEX IF NOT EXISTS idx_stage_interstellio_usage_unpublished
+  ON stage_interstellio_usage(published_at);
+`;

--- a/lib/vendor-cache/sync-runs.ts
+++ b/lib/vendor-cache/sync-runs.ts
@@ -1,0 +1,43 @@
+/**
+ * sync_runs helpers for vendor-cache SQLite
+ */
+
+import type Database from 'better-sqlite3';
+import type { SyncRunStatus, VendorName } from './types';
+
+export function startSyncRun(
+  db: Database.Database,
+  vendor: VendorName
+): number {
+  const result = db
+    .prepare(
+      `INSERT INTO sync_runs (vendor, started_at, status, fetched, published, errors_json)
+       VALUES (?, ?, 'running', 0, 0, '[]')`
+    )
+    .run(vendor, new Date().toISOString());
+  return Number(result.lastInsertRowid);
+}
+
+export function finishSyncRun(
+  db: Database.Database,
+  id: number,
+  input: {
+    status: SyncRunStatus;
+    fetched: number;
+    published: number;
+    errors: string[];
+  }
+): void {
+  db.prepare(
+    `UPDATE sync_runs
+     SET finished_at = ?, status = ?, fetched = ?, published = ?, errors_json = ?
+     WHERE id = ?`
+  ).run(
+    new Date().toISOString(),
+    input.status,
+    input.fetched,
+    input.published,
+    JSON.stringify(input.errors.slice(0, 50)),
+    id
+  );
+}

--- a/lib/vendor-cache/sync.ts
+++ b/lib/vendor-cache/sync.ts
@@ -1,0 +1,226 @@
+/**
+ * Vendor cache orchestrator: pull → stage → publish
+ */
+
+import { getVendorCacheDb } from './db';
+import { startSyncRun, finishSyncRun } from './sync-runs';
+import { pullRuijieToStage } from './pull/ruijie';
+import { publishRuijieFromStage } from './publish/ruijie';
+import { pullTaranaToStage } from './pull/tarana';
+import { publishTaranaFromStage } from './publish/tarana';
+import { pullInterstellioToStage } from './pull/interstellio';
+import { publishInterstellioFromStage } from './publish/interstellio';
+import type { SyncOptions, SyncRunResult, VendorName } from './types';
+
+export async function syncVendor(
+  vendor: VendorName,
+  options: SyncOptions = {}
+): Promise<SyncRunResult> {
+  const dryRun = options.dryRun === true;
+  const publishOnly = options.publishOnly === true;
+  const started = Date.now();
+  const db = getVendorCacheDb();
+  const syncRunId = startSyncRun(db, vendor);
+  const errors: string[] = [];
+  let fetched = 0;
+  let published = 0;
+  let skipped = 0;
+  const details: Record<string, unknown> = {};
+
+  try {
+    if (vendor === 'ruijie') {
+      if (!publishOnly) {
+        const pull = await pullRuijieToStage(db);
+        fetched = pull.fetched;
+        errors.push(...pull.errors);
+        details.pull = pull;
+      } else {
+        fetched = (
+          db.prepare('SELECT COUNT(*) AS c FROM stage_ruijie_devices').get() as {
+            c: number;
+          }
+        ).c;
+      }
+
+      if (dryRun) {
+        skipped = fetched;
+        finishSyncRun(db, syncRunId, {
+          status: 'dry_run',
+          fetched,
+          published: 0,
+          errors,
+        });
+        return {
+          vendor,
+          success: errors.length === 0,
+          dryRun,
+          publishOnly,
+          syncRunId,
+          fetched,
+          published: 0,
+          skipped,
+          errors,
+          durationMs: Date.now() - started,
+          details,
+        };
+      }
+
+      const pub = await publishRuijieFromStage(db, {
+        durationMs: Date.now() - started,
+      });
+      published = pub.published;
+      errors.push(...pub.errors);
+      details.publish = pub;
+    } else if (vendor === 'tarana') {
+      if (!publishOnly) {
+        const pull = await pullTaranaToStage(db);
+        fetched = pull.fetched;
+        errors.push(...pull.errors);
+        details.pull = pull;
+      } else {
+        fetched = (
+          db
+            .prepare(
+              `SELECT COUNT(*) AS c FROM stage_tarana_devices WHERE device_type = 'BN'`
+            )
+            .get() as { c: number }
+        ).c;
+      }
+
+      if (dryRun) {
+        skipped = fetched;
+        finishSyncRun(db, syncRunId, {
+          status: 'dry_run',
+          fetched,
+          published: 0,
+          errors,
+        });
+        return {
+          vendor,
+          success: errors.length === 0,
+          dryRun,
+          publishOnly,
+          syncRunId,
+          fetched,
+          published: 0,
+          skipped,
+          errors,
+          durationMs: Date.now() - started,
+          details,
+        };
+      }
+
+      const pub = await publishTaranaFromStage(db, {
+        deleteStale: options.deleteStale === true,
+        durationMs: Date.now() - started,
+      });
+      published = pub.published;
+      errors.push(...pub.errors);
+      details.publish = pub;
+    } else if (vendor === 'interstellio') {
+      if (!publishOnly) {
+        const pull = await pullInterstellioToStage(db, {
+          usageDays: options.usageDays ?? 2,
+        });
+        fetched = pull.fetched;
+        errors.push(...pull.errors);
+        details.pull = pull;
+      } else {
+        const subs = (
+          db
+            .prepare('SELECT COUNT(*) AS c FROM stage_interstellio_subscribers')
+            .get() as { c: number }
+        ).c;
+        const usage = (
+          db
+            .prepare('SELECT COUNT(*) AS c FROM stage_interstellio_usage')
+            .get() as { c: number }
+        ).c;
+        fetched = subs + usage;
+      }
+
+      if (dryRun) {
+        skipped = fetched;
+        finishSyncRun(db, syncRunId, {
+          status: 'dry_run',
+          fetched,
+          published: 0,
+          errors,
+        });
+        return {
+          vendor,
+          success: errors.length === 0,
+          dryRun,
+          publishOnly,
+          syncRunId,
+          fetched,
+          published: 0,
+          skipped,
+          errors,
+          durationMs: Date.now() - started,
+          details,
+        };
+      }
+
+      const pub = await publishInterstellioFromStage(db);
+      published = pub.published;
+      errors.push(...pub.errors);
+      details.publish = pub;
+    }
+
+    const success = errors.length === 0;
+    finishSyncRun(db, syncRunId, {
+      status: success ? 'completed' : 'completed',
+      fetched,
+      published,
+      errors,
+    });
+
+    return {
+      vendor,
+      success,
+      dryRun,
+      publishOnly,
+      syncRunId,
+      fetched,
+      published,
+      skipped,
+      errors,
+      durationMs: Date.now() - started,
+      details,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    errors.push(msg);
+    finishSyncRun(db, syncRunId, {
+      status: 'failed',
+      fetched,
+      published,
+      errors,
+    });
+    return {
+      vendor,
+      success: false,
+      dryRun,
+      publishOnly,
+      syncRunId,
+      fetched,
+      published,
+      skipped,
+      errors,
+      durationMs: Date.now() - started,
+      details,
+    };
+  }
+}
+
+export async function syncVendors(
+  vendors: VendorName[],
+  options: SyncOptions = {}
+): Promise<SyncRunResult[]> {
+  const results: SyncRunResult[] = [];
+  for (const vendor of vendors) {
+    results.push(await syncVendor(vendor, options));
+  }
+  return results;
+}

--- a/lib/vendor-cache/types.ts
+++ b/lib/vendor-cache/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Vendor SQLite staging cache — shared types
+ */
+
+export type VendorName = 'ruijie' | 'tarana' | 'interstellio';
+
+export type SyncRunStatus = 'running' | 'completed' | 'failed' | 'dry_run';
+
+export interface SyncOptions {
+  /** Stage only; skip Supabase upserts */
+  dryRun?: boolean;
+  /** Skip vendor pull; publish existing staged rows */
+  publishOnly?: boolean;
+  /** Tarana: delete BNs missing from API */
+  deleteStale?: boolean;
+  /** Interstellio: number of trailing days of daily usage to refresh */
+  usageDays?: number;
+}
+
+export interface SyncRunResult {
+  vendor: VendorName;
+  success: boolean;
+  dryRun: boolean;
+  publishOnly: boolean;
+  syncRunId: number;
+  fetched: number;
+  published: number;
+  skipped: number;
+  errors: string[];
+  durationMs: number;
+  details?: Record<string, unknown>;
+}
+
+export interface StageRuijieDeviceRow {
+  sn: string;
+  payload_json: string;
+  fetched_at: string;
+  published_at: string | null;
+}
+
+export interface StageTaranaDeviceRow {
+  serial_number: string;
+  device_type: string;
+  payload_json: string;
+  fetched_at: string;
+  published_at: string | null;
+}
+
+export interface StageInterstellioSubscriberRow {
+  id: string;
+  payload_json: string;
+  fetched_at: string;
+  published_at: string | null;
+}
+
+export interface StageInterstellioUsageRow {
+  subscriber_id: string;
+  date: string;
+  upload_mb: number;
+  download_mb: number;
+  fetched_at: string;
+  published_at: string | null;
+}

--- a/ops/scheduler/generate-crontab.sh
+++ b/ops/scheduler/generate-crontab.sh
@@ -19,3 +19,17 @@ echo "# curl: --connect-timeout 15 --max-time 360 (prevent multi-hour hung clien
 # (incident 2026-07-31: zoho-sync hung ~23min). Slightly above vercel maxDuration 300s
 # for generate-monthly-invoices. --connect-timeout fails fast on DNS/TCP hang.
 jq -r '.crons[] | "\(.schedule) . /root/.cron-env && curl -sf --connect-timeout 15 --max-time 360 -H \"Authorization: Bearer $CRON_SECRET\" \"$APP_URL\(.path)\" >> /var/log/circletel-cron.log 2>&1"' vercel.json
+
+# ---------------------------------------------------------------------------
+# Vendor SQLite staging → Supabase (host-local; not via APP_URL)
+# SQLite must live on the VPS filesystem — do not curl production for these.
+# Logs: /var/log/circletel-vendor-cache.log
+# ---------------------------------------------------------------------------
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RUN="$ROOT/ops/scheduler/run-vendor-cache.sh"
+LOG="/var/log/circletel-vendor-cache.log"
+
+echo "# Vendor SQLite staging (host-local tsx — see docs/architecture/CRON_SCHEDULE.md)"
+echo "*/30 * * * * $RUN ruijie >> $LOG 2>&1"
+echo "0 22 * * * $RUN tarana >> $LOG 2>&1"
+echo "0 * * * * $RUN interstellio >> $LOG 2>&1"

--- a/ops/scheduler/run-vendor-cache.sh
+++ b/ops/scheduler/run-vendor-cache.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Run vendor SQLite staging → Supabase sync on the Coolify VPS host.
+# Must run on the host (not via APP_URL curl) so SQLite persists under
+# data/vendor-cache/ (or VENDOR_CACHE_DB_PATH).
+#
+# Usage: ops/scheduler/run-vendor-cache.sh ruijie|tarana|interstellio [extra flags…]
+set -euo pipefail
+
+VENDOR="${1:-}"
+if [[ -z "$VENDOR" ]]; then
+  echo "usage: $0 ruijie|tarana|interstellio [--dry-run|--publish-only|…]" >&2
+  exit 2
+fi
+shift || true
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+# Load env: production secrets often live in .env / .env.production.local
+# (Interstellio). Later files do not override already-set vars from earlier ones.
+set -a
+for envfile in .env .env.production.local .env.local; do
+  if [[ -f "$envfile" ]]; then
+    # shellcheck disable=SC1090
+    source "$envfile"
+  fi
+done
+set +a
+
+export VENDOR_CACHE_DB_PATH="${VENDOR_CACHE_DB_PATH:-$ROOT/data/vendor-cache/vendor-cache.db}"
+mkdir -p "$(dirname "$VENDOR_CACHE_DB_PATH")"
+
+TSX="$ROOT/node_modules/.bin/tsx"
+if [[ ! -x "$TSX" ]]; then
+  TSX="$(command -v npx)"
+  exec "$TSX" --yes tsx --tsconfig tsconfig.json scripts/vendor-cache/sync.ts --vendor="$VENDOR" "$@"
+fi
+
+exec "$TSX" --tsconfig tsconfig.json scripts/vendor-cache/sync.ts --vendor="$VENDOR" "$@"

--- a/ops/scheduler/run-vendor-cache.sh
+++ b/ops/scheduler/run-vendor-cache.sh
@@ -18,6 +18,10 @@ cd "$ROOT"
 
 # Load env: production secrets often live in .env / .env.production.local
 # (Interstellio). Later files do not override already-set vars from earlier ones.
+#
+# Temporarily disable nounset: .env may contain self-references like
+# DATABASE_URL=$DATABASE_URL which abort under `set -u` when unset.
+set +u
 set -a
 for envfile in .env .env.production.local .env.local; do
   if [[ -f "$envfile" ]]; then
@@ -26,6 +30,7 @@ for envfile in .env .env.production.local .env.local; do
   fi
 done
 set +a
+set -u
 
 export VENDOR_CACHE_DB_PATH="${VENDOR_CACHE_DB_PATH:-$ROOT/data/vendor-cache/vendor-cache.db}"
 mkdir -p "$(dirname "$VENDOR_CACHE_DB_PATH")"

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@vercel/analytics": "^1.5.0",
         "adm-zip": "^0.5.16",
         "axios": "^1.12.2",
+        "better-sqlite3": "^13.0.2",
         "buffer": "^6.0.3",
         "canvas-confetti": "^1.9.3",
         "cheerio": "^1.2.0",
@@ -115,6 +116,7 @@
         "@playwright/test": "^1.55.1",
         "@tailwindcss/typography": "^0.5.15",
         "@types/adm-zip": "^0.5.7",
+        "@types/better-sqlite3": "^9.6.0",
         "@types/canvas-confetti": "^1.9.0",
         "@types/google.maps": "^3.58.1",
         "@types/jest": "^30.0.0",
@@ -130,11 +132,13 @@
         "node-mocks-http": "^1.17.2",
         "pg": "^8.16.3",
         "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
         "react-test-renderer": "^19.2.6",
         "shadcn": "^3.3.1",
         "supabase": "^2.45.5",
         "tailwindcss": "^3.4.11",
         "ts-jest": "^29.4.5",
+        "tsx": "^4.23.4",
         "typescript": "~5.8.0"
       }
     },
@@ -2251,6 +2255,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -10874,6 +11320,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/bunyan": {
       "version": "1.8.11",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.11.tgz",
@@ -12875,6 +13331,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.2.tgz",
+      "integrity": "sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g==",
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/big-integer": {
@@ -15065,6 +15533,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -20076,6 +20586,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -24824,6 +25343,40 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.4.tgz",
+      "integrity": "sha512-ZiUQ8oT/KzN51mJUWPqARYqwFLFJZtGZipRkw1ynHMr9vy3eU77m5yfF3Gzm6meEg/beW+lUu3fHYgskTN2oVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,11 @@
     "vscode:force-cleanup": "powershell -File scripts/force-cleanup-vscode.ps1",
     "clean": "powershell -Command \"Remove-Item -Recurse -Force .next -ErrorAction SilentlyContinue\" && powershell -Command \"Remove-Item -Recurse -Force node_modules/.cache -ErrorAction SilentlyContinue\"",
     "analyze": "cross-env ANALYZE=true npm run build:memory",
-    "orchestrate": "npx tsx scripts/run-orchestrator.ts"
+    "orchestrate": "npx tsx scripts/run-orchestrator.ts",
+    "vendor-cache:sync": "npx tsx --tsconfig tsconfig.json scripts/vendor-cache/sync.ts",
+    "vendor-cache:sync:ruijie": "npx tsx --tsconfig tsconfig.json scripts/vendor-cache/sync.ts --vendor=ruijie",
+    "vendor-cache:sync:tarana": "npx tsx --tsconfig tsconfig.json scripts/vendor-cache/sync.ts --vendor=tarana",
+    "vendor-cache:sync:interstellio": "npx tsx --tsconfig tsconfig.json scripts/vendor-cache/sync.ts --vendor=interstellio"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -116,6 +120,7 @@
     "@vercel/analytics": "^1.5.0",
     "adm-zip": "^0.5.16",
     "axios": "^1.12.2",
+    "better-sqlite3": "^13.0.2",
     "buffer": "^6.0.3",
     "canvas-confetti": "^1.9.3",
     "cheerio": "^1.2.0",
@@ -168,6 +173,7 @@
     "@playwright/test": "^1.55.1",
     "@tailwindcss/typography": "^0.5.15",
     "@types/adm-zip": "^0.5.7",
+    "@types/better-sqlite3": "^9.6.0",
     "@types/canvas-confetti": "^1.9.0",
     "@types/google.maps": "^3.58.1",
     "@types/jest": "^30.0.0",
@@ -189,6 +195,7 @@
     "supabase": "^2.45.5",
     "tailwindcss": "^3.4.11",
     "ts-jest": "^29.4.5",
+    "tsx": "^4.23.4",
     "typescript": "~5.8.0"
   }
 }

--- a/scripts/vendor-cache/sync.ts
+++ b/scripts/vendor-cache/sync.ts
@@ -1,0 +1,109 @@
+/**
+ * Vendor SQLite staging → Supabase sync CLI
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a && npx tsx scripts/vendor-cache/sync.ts --vendor=ruijie
+ *   npx tsx scripts/vendor-cache/sync.ts --vendor=all --dry-run
+ *   npx tsx scripts/vendor-cache/sync.ts --vendor=tarana --publish-only
+ *   npx tsx scripts/vendor-cache/sync.ts --vendor=interstellio --usage-days=3
+ *
+ * Flags:
+ *   --vendor=ruijie|tarana|interstellio|all
+ *   --dry-run          Stage only (or count staged if --publish-only); no Supabase writes
+ *   --publish-only     Skip vendor pull; publish existing staged rows
+ *   --delete-stale     Tarana: delete BNs missing from API
+ *   --usage-days=N     Interstellio: trailing days of daily usage (default 2)
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import type { SyncOptions, VendorName } from '../../lib/vendor-cache/types';
+
+function loadEnvLocal() {
+  const path = resolve(process.cwd(), '.env.local');
+  if (!existsSync(path)) return;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!m) continue;
+    let v = m[2];
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    if (process.env[m[1]] === undefined) process.env[m[1]] = v;
+  }
+}
+
+function parseArgs(argv: string[]): {
+  vendors: VendorName[];
+  options: SyncOptions;
+} {
+  let vendorArg = 'all';
+  const options: SyncOptions = {};
+
+  for (const arg of argv) {
+    if (arg.startsWith('--vendor=')) {
+      vendorArg = arg.slice('--vendor='.length);
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--publish-only') {
+      options.publishOnly = true;
+    } else if (arg === '--delete-stale') {
+      options.deleteStale = true;
+    } else if (arg.startsWith('--usage-days=')) {
+      options.usageDays = Number(arg.slice('--usage-days='.length));
+    }
+  }
+
+  const all: VendorName[] = ['ruijie', 'tarana', 'interstellio'];
+  if (vendorArg === 'all') {
+    return { vendors: all, options };
+  }
+  if (!all.includes(vendorArg as VendorName)) {
+    console.error(
+      `Invalid --vendor=${vendorArg}. Use ruijie|tarana|interstellio|all`
+    );
+    process.exit(1);
+  }
+  return { vendors: [vendorArg as VendorName], options };
+}
+
+async function main() {
+  loadEnvLocal();
+
+  const { vendors, options } = parseArgs(process.argv.slice(2));
+  const { syncVendors, getVendorCacheDbPath, closeVendorCacheDb } = await import(
+    '../../lib/vendor-cache'
+  );
+
+  console.log(`[vendor-cache] db=${getVendorCacheDbPath()}`);
+  console.log(
+    `[vendor-cache] vendors=${vendors.join(',')} dryRun=${!!options.dryRun} publishOnly=${!!options.publishOnly}`
+  );
+
+  const results = await syncVendors(vendors, options);
+
+  for (const r of results) {
+    console.log(
+      `[vendor-cache] ${r.vendor}: success=${r.success} fetched=${r.fetched} published=${r.published} ` +
+        `errors=${r.errors.length} durationMs=${r.durationMs} runId=${r.syncRunId}`
+    );
+    if (r.errors.length > 0) {
+      for (const e of r.errors.slice(0, 10)) {
+        console.warn(`  - ${e}`);
+      }
+    }
+  }
+
+  closeVendorCacheDb();
+
+  const failed = results.some((r) => !r.success);
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('[vendor-cache] fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Restore `lib/vendor-cache`, `scripts/vendor-cache/sync.ts`, and `ops/scheduler/run-vendor-cache.sh` (lost when uncommitted after stash)
- Re-add npm scripts + `better-sqlite3`/`tsx`, crontab generator lines, and CRON docs
- Remove Inngest Cloud `cron:` from `ruijie-sync` / `tarana-sync` so host crontab owns the schedule

## Test plan
- [x] `ops/scheduler/run-vendor-cache.sh ruijie` publishes devices to Supabase/SQLite
- [x] `ops/scheduler/run-vendor-cache.sh interstellio` publishes subscribers + usage
- [ ] Confirm crontab no longer logs `run-vendor-cache.sh: not found`
- [ ] Next scheduled Ruijie (`*/30`) and Interstellio (hourly) runs succeed in `/var/log/circletel-vendor-cache.log`
- [ ] Tarana nightly (`0 22 * * *`) still runs after deploy


Made with [Cursor](https://cursor.com)