### PR TITLE
feat(network): custom period and per-device analytics

### DIFF
--- a/__tests__/lib/network/analytics-aggregates.test.ts
+++ b/__tests__/lib/network/analytics-aggregates.test.ts
@@ -3,8 +3,13 @@ import {
   buildHourlyRollupUpserts,
   computeGroupTrafficCards,
   computeRadioUtilSummary,
+  filterRollupsForScope,
   hourBucketIso,
   HOURLY_ROLLUP_WINDOW,
+  MAX_ANALYTICS_CUSTOM_DAYS,
+  MAX_ANALYTICS_HOURS,
+  parseAnalyticsCustomRange,
+  parseAnalyticsHours,
 } from '@/lib/network/analytics-aggregates';
 
 describe('computeGroupTrafficCards', () => {
@@ -179,5 +184,59 @@ describe('buildHourlyRollupUpserts', () => {
     expect(first.device_sn).not.toBe(second.device_sn);
     expect(first.total_rx_bytes).toBe(1_000);
     expect(second.total_rx_bytes).toBe(5_000);
+  });
+});
+
+describe('parseAnalyticsHours', () => {
+  it('allows a 30-day (720h) window and clamps above that', () => {
+    expect(MAX_ANALYTICS_HOURS).toBe(720);
+    expect(parseAnalyticsHours('720')).toBe(720);
+    expect(parseAnalyticsHours('168')).toBe(168);
+    expect(parseAnalyticsHours('721')).toBe(720);
+    expect(parseAnalyticsHours(null)).toBe(24);
+    expect(parseAnalyticsHours('0')).toBe(24);
+    expect(parseAnalyticsHours('abc')).toBe(24);
+  });
+});
+
+describe('parseAnalyticsCustomRange', () => {
+  it('parses an inclusive SAST range with UTC bounds', () => {
+    expect(MAX_ANALYTICS_CUSTOM_DAYS).toBe(90);
+    const range = parseAnalyticsCustomRange('2026-07-26', '2026-08-02');
+    expect(range).not.toBeNull();
+    expect(range!.startDate).toBe('2026-07-26');
+    expect(range!.endDate).toBe('2026-08-02');
+    expect(range!.inclusiveDayCount).toBe(8);
+    expect(range!.startUtc.toISOString()).toBe('2026-07-25T22:00:00.000Z');
+    expect(range!.endUtc.toISOString()).toBe('2026-08-02T21:59:59.999Z');
+  });
+
+  it('rejects invalid, reversed, or over-long ranges', () => {
+    expect(parseAnalyticsCustomRange(null, '2026-08-02')).toBeNull();
+    expect(parseAnalyticsCustomRange('2026-08-02', '2026-07-26')).toBeNull();
+    expect(parseAnalyticsCustomRange('not-a-date', '2026-08-02')).toBeNull();
+    // 91 inclusive days (1 Jul → 30 Sep)
+    expect(parseAnalyticsCustomRange('2026-07-01', '2026-09-29')).toBeNull();
+  });
+});
+
+describe('filterRollupsForScope', () => {
+  const rows = [
+    { group_id: 'g1', device_sn: 'SN-A', captured_at: '2026-08-01T10:00:00Z', total_rx_bytes: 100 },
+    { group_id: 'g1', device_sn: 'SN-B', captured_at: '2026-08-01T10:00:00Z', total_rx_bytes: 200 },
+    { group_id: 'g2', device_sn: 'SN-C', captured_at: '2026-08-01T10:00:00Z', total_rx_bytes: 50 },
+  ];
+
+  it('keeps all devices in the group when deviceSn is omitted', () => {
+    const filtered = filterRollupsForScope(rows, { groupId: 'g1' });
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((r) => r.device_sn).sort()).toEqual(['SN-A', 'SN-B']);
+  });
+
+  it('keeps only the matching device when deviceSn is set', () => {
+    const filtered = filterRollupsForScope(rows, { groupId: 'g1', deviceSn: 'SN-B' });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].device_sn).toBe('SN-B');
+    expect(filtered[0].total_rx_bytes).toBe(200);
   });
 });

--- a/app/admin/network/analytics/page.tsx
+++ b/app/admin/network/analytics/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import Link from 'next/link';
 import {
   PiArrowsClockwiseBold,
@@ -15,6 +15,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -69,10 +70,28 @@ interface AppFlowData {
   upDownFlow: number;
 }
 
+interface AnalyticsDevice {
+  sn: string;
+  device_name: string;
+  status: string;
+}
+
+type AnalyticsPeriod =
+  | { mode: 'hours'; hours: number }
+  | {
+      mode: 'custom';
+      startDate: string;
+      endDate: string;
+      inclusiveDayCount?: number;
+    };
+
 interface AnalyticsApiResponse {
   groups: Array<{ id: string; name: string }>;
   groupId: string | null;
+  deviceSn?: string | null;
+  devices?: AnalyticsDevice[];
   hours: number;
+  period?: AnalyticsPeriod;
   source: 'supabase' | 'live';
   traffic: TrafficSummary;
   appFlow?: AppFlowData[];
@@ -84,10 +103,42 @@ interface AnalyticsApiResponse {
   fetchedAt: string;
 }
 
+const ALL_DEVICES = 'all';
+
 function formatDuration(hours: number): string {
   if (hours < 24) return `${hours} hour${hours > 1 ? 's' : ''}`;
   const days = Math.floor(hours / 24);
   return `${days} day${days > 1 ? 's' : ''}`;
+}
+
+/** Yesterday and 6 days before that in SAST (7 inclusive calendar days). */
+function defaultCustomDates(now = new Date()): { startDate: string; endDate: string } {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Africa/Johannesburg',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const end = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const start = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  return { startDate: fmt.format(start), endDate: fmt.format(end) };
+}
+
+function periodLabel(
+  periodMode: string,
+  selectedHours: string,
+  customStart: string,
+  customEnd: string,
+  period?: AnalyticsPeriod
+): string {
+  if (period?.mode === 'custom') {
+    return `${period.startDate} → ${period.endDate}`;
+  }
+  if (periodMode === 'custom') {
+    return `${customStart} → ${customEnd}`;
+  }
+  const hours = period?.mode === 'hours' ? period.hours : parseInt(selectedHours, 10);
+  return formatDuration(Number.isFinite(hours) ? hours : 24);
 }
 
 const emptyRadio: RadioUtilSummary = {
@@ -102,10 +153,15 @@ const emptyRadio: RadioUtilSummary = {
 };
 
 export default function NetworkAnalyticsPage() {
+  const defaults = useMemo(() => defaultCustomDates(), []);
   const [data, setData] = useState<AnalyticsApiResponse | null>(null);
   const [groups, setGroups] = useState<Array<{ id: string; name: string }>>([]);
+  const [devices, setDevices] = useState<AnalyticsDevice[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>('');
-  const [selectedHours, setSelectedHours] = useState<string>('24');
+  const [selectedDeviceSn, setSelectedDeviceSn] = useState<string>(ALL_DEVICES);
+  const [periodMode, setPeriodMode] = useState<string>('24');
+  const [customStart, setCustomStart] = useState(defaults.startDate);
+  const [customEnd, setCustomEnd] = useState(defaults.endDate);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -117,23 +173,39 @@ export default function NetworkAnalyticsPage() {
       isRefresh?: boolean;
       live?: boolean;
       groupId?: string;
-      hours?: string;
+      deviceSn?: string;
+      periodMode?: string;
+      customStart?: string;
+      customEnd?: string;
     }) => {
       const isRefresh = options?.isRefresh ?? false;
       const live = options?.live ?? preferLive;
       const groupId = options?.groupId ?? selectedGroupId;
-      const hours = options?.hours ?? selectedHours;
+      const deviceSn = options?.deviceSn ?? selectedDeviceSn;
+      const mode = options?.periodMode ?? periodMode;
+      const startDate = options?.customStart ?? customStart;
+      const endDate = options?.customEnd ?? customEnd;
 
       if (isRefresh) setRefreshing(true);
       else setLoading(true);
 
       try {
         const params = new URLSearchParams({
-          hours,
           includeApps: 'true',
         });
         if (groupId) params.set('groupId', groupId);
+        if (deviceSn && deviceSn !== ALL_DEVICES) params.set('deviceSn', deviceSn);
         if (live) params.set('live', 'true');
+
+        // Custom range is Cached-only; Live always uses hour presets.
+        if (!live && mode === 'custom') {
+          params.set('startDate', startDate);
+          params.set('endDate', endDate);
+          params.set('hours', '24'); // fallback if custom parse fails server-side
+        } else {
+          const hours = mode === 'custom' ? '24' : mode;
+          params.set('hours', hours);
+        }
 
         const response = await fetch(`/api/admin/network/analytics?${params}`, {
           credentials: 'include',
@@ -153,6 +225,17 @@ export default function NetworkAnalyticsPage() {
             setSelectedGroupId(String(result.groupId));
           }
         }
+        if (result.devices) {
+          setDevices(
+            result.devices
+              .map((d) => ({
+                sn: String(d.sn),
+                device_name: d.device_name || String(d.sn),
+                status: d.status || 'unknown',
+              }))
+              .filter((d) => d.sn.length > 0)
+          );
+        }
         setError(null);
       } catch (err) {
         setError('Failed to load traffic analytics');
@@ -162,7 +245,14 @@ export default function NetworkAnalyticsPage() {
         setRefreshing(false);
       }
     },
-    [selectedGroupId, selectedHours, preferLive]
+    [
+      selectedGroupId,
+      selectedDeviceSn,
+      periodMode,
+      customStart,
+      customEnd,
+      preferLive,
+    ]
   );
 
   useEffect(() => {
@@ -184,9 +274,42 @@ export default function NetworkAnalyticsPage() {
   const handleGroupChange = (groupId: string) => {
     if (!groupId || groupId === selectedGroupId) return;
     setSelectedGroupId(groupId);
+    setSelectedDeviceSn(ALL_DEVICES);
+  };
+
+  const handlePeriodChange = (value: string) => {
+    if (value === 'custom' && preferLive) {
+      // Custom is Cached-only — leave Live and switch to custom.
+      setPreferLive(false);
+    }
+    setPeriodMode(value);
+  };
+
+  const handleLiveToggle = () => {
+    const next = !preferLive;
+    setPreferLive(next);
+    if (next && periodMode === 'custom') {
+      setPeriodMode('24');
+      void fetchTrafficData({ isRefresh: true, live: true, periodMode: '24' });
+      return;
+    }
+    void fetchTrafficData({ isRefresh: true, live: next });
   };
 
   const selectedGroup = groups.find((g) => g.id === selectedGroupId);
+  const selectedDevice =
+    selectedDeviceSn !== ALL_DEVICES
+      ? devices.find((d) => d.sn === selectedDeviceSn)
+      : null;
+  const scopeLabel = selectedDevice?.device_name || 'All devices';
+  const chartScopeLabel = selectedDevice?.device_name || selectedGroup?.name || 'Network';
+  const activePeriodLabel = periodLabel(
+    periodMode,
+    periodMode === 'custom' ? '24' : periodMode,
+    customStart,
+    customEnd,
+    data?.period
+  );
 
   const bandwidthSeries =
     data?.traffic.dataPoints.map((p) => {
@@ -258,8 +381,21 @@ export default function NetworkAnalyticsPage() {
               ))}
             </SelectContent>
           </Select>
-          <Select value={selectedHours} onValueChange={setSelectedHours}>
-            <SelectTrigger className="w-[140px] rounded-lg border-slate-200">
+          <Select value={selectedDeviceSn} onValueChange={setSelectedDeviceSn}>
+            <SelectTrigger className="w-[220px] rounded-lg border-slate-200">
+              <SelectValue placeholder="All devices in group" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_DEVICES}>All devices in group</SelectItem>
+              {devices.map((device) => (
+                <SelectItem key={device.sn} value={device.sn}>
+                  {device.device_name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={periodMode} onValueChange={handlePeriodChange}>
+            <SelectTrigger className="w-[150px] rounded-lg border-slate-200">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -268,16 +404,32 @@ export default function NetworkAnalyticsPage() {
               <SelectItem value="24">Last 24 hours</SelectItem>
               <SelectItem value="48">Last 2 days</SelectItem>
               <SelectItem value="168">Last 7 days</SelectItem>
+              <SelectItem value="720">Last 30 days</SelectItem>
+              <SelectItem value="custom">Custom</SelectItem>
             </SelectContent>
           </Select>
+          {periodMode === 'custom' && !preferLive ? (
+            <>
+              <Input
+                type="date"
+                value={customStart}
+                onChange={(e) => setCustomStart(e.target.value)}
+                className="w-[150px] rounded-lg border-slate-200"
+                aria-label="Custom start date"
+              />
+              <Input
+                type="date"
+                value={customEnd}
+                onChange={(e) => setCustomEnd(e.target.value)}
+                className="w-[150px] rounded-lg border-slate-200"
+                aria-label="Custom end date"
+              />
+            </>
+          ) : null}
           <Button
             variant={preferLive ? 'default' : 'outline'}
             size="sm"
-            onClick={() => {
-              const next = !preferLive;
-              setPreferLive(next);
-              void fetchTrafficData({ isRefresh: true, live: next });
-            }}
+            onClick={handleLiveToggle}
           >
             <PiBroadcastBold className="w-4 h-4 mr-2" />
             {preferLive ? 'Live' : 'Cached'}
@@ -328,7 +480,7 @@ export default function NetworkAnalyticsPage() {
               {data.source === 'live' ? 'Ruijie live' : 'Supabase rollups'}
             </Badge>
             <span className="text-xs text-slate-400">
-              {selectedGroup?.name || 'Network'} · {formatDuration(parseInt(selectedHours, 10))}
+              {selectedGroup?.name || 'Network'} · {scopeLabel} · {activePeriodLabel}
             </span>
             {data.lastRollupAt ? (
               <span className="text-xs text-slate-500">
@@ -362,7 +514,7 @@ export default function NetworkAnalyticsPage() {
             <MetricCard
               title="Peak Download / window"
               value={formatBytes(data.traffic.peakRxBytes)}
-              subtitle={formatDuration(parseInt(selectedHours, 10))}
+              subtitle={activePeriodLabel}
             >
               <PiLightningBold className="w-5 h-5 text-amber-600" />
             </MetricCard>
@@ -385,7 +537,7 @@ export default function NetworkAnalyticsPage() {
             <div className="xl:col-span-2">
               <TrafficVolumeAreaChart
                 dataPoints={data.traffic.dataPoints}
-                title={`Traffic volume — ${selectedGroup?.name || 'Network'}`}
+                title={`Traffic volume — ${chartScopeLabel}`}
                 description="Stacked download + upload by hour (shadcn area chart)"
               />
             </div>

--- a/app/api/admin/network/analytics/route.ts
+++ b/app/api/admin/network/analytics/route.ts
@@ -2,12 +2,17 @@
  * Network Analytics API (Supabase-backed + live Ruijie)
  *
  * GET /api/admin/network/analytics
- * Query: groupId (optional), hours (default 24, max 168), live=true, includeApps
+ * Query:
+ * - groupId (optional)
+ * - deviceSn (optional — scopes KPI/traffic series to one AP)
+ * - hours (default 24, max 720 = 30 days) OR startDate+endDate (SAST, max 90d, Cached only)
+ * - live=true, includeApps
  *
  * Cache-first (default): traffic KPIs/series + group cards from ruijie_traffic_rollups
  * (hours_window=1). Radio from device cache. No live Ruijie calls.
  *
  * Live (?live=true): traffic + optional app-flow + STA from Ruijie (10s timeout).
+ * Custom date ranges are ignored in live mode (hours presets only).
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -24,7 +29,10 @@ import {
   aggregateSsidActivity,
   computeGroupTrafficCards,
   computeRadioUtilSummary,
+  filterRollupsForScope,
   HOURLY_ROLLUP_WINDOW,
+  parseAnalyticsCustomRange,
+  parseAnalyticsHours,
 } from '@/lib/network/analytics-aggregates';
 
 export const dynamic = 'force-dynamic';
@@ -45,6 +53,7 @@ const emptyTraffic = {
 type RollupRow = {
   group_id: string;
   group_name: string | null;
+  device_sn?: string | null;
   captured_at: string;
   hours_window: number;
   total_rx_bytes: number | null;
@@ -55,6 +64,9 @@ type RollupRow = {
   peak_tx_bps: number | null;
   raw_summary: unknown;
 };
+
+const ROLLUP_SELECT =
+  'group_id, group_name, device_sn, total_rx_bytes, total_tx_bytes, captured_at, hours_window, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, raw_summary';
 
 function maxIso(dates: Array<string | null | undefined>): string | null {
   let best: string | null = null;
@@ -118,12 +130,37 @@ export async function GET(request: NextRequest) {
 
     const searchParams = request.nextUrl.searchParams;
     const groupId = searchParams.get('groupId');
-    const hours = Math.min(parseInt(searchParams.get('hours') || '24', 10), 168);
+    const requestedDeviceSn = searchParams.get('deviceSn')?.trim() || null;
+    const hours = parseAnalyticsHours(searchParams.get('hours'));
     const live = searchParams.get('live') === 'true';
     const includeApps = searchParams.get('includeApps') !== 'false';
 
+    // Custom range is Cached-only; Live always uses hours presets.
+    const customRange =
+      !live
+        ? parseAnalyticsCustomRange(
+            searchParams.get('startDate'),
+            searchParams.get('endDate')
+          )
+        : null;
+
     const supabase = await createClient();
-    const since = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+    const since = customRange
+      ? customRange.startUtc.toISOString()
+      : new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+    const until = customRange ? customRange.endUtc.toISOString() : null;
+
+    const period = customRange
+      ? {
+          mode: 'custom' as const,
+          startDate: customRange.startDate,
+          endDate: customRange.endDate,
+          inclusiveDayCount: customRange.inclusiveDayCount,
+        }
+      : {
+          mode: 'hours' as const,
+          hours,
+        };
 
     const [{ data: deviceGroups }, { data: lastSync }] = await Promise.all([
       supabase
@@ -152,30 +189,33 @@ export async function GET(request: NextRequest) {
     const groups = Array.from(groupMap.entries()).map(([id, name]) => ({ id, name }));
     const effectiveGroupId = groupId || groups[0]?.id || null;
 
-    // Prefer hours_window=1 (true hourly samples). Fall back to legacy window blobs.
-    const { data: hourlyRollups } = await supabase
+    let hourlyQuery = supabase
       .from('ruijie_traffic_rollups')
-      .select(
-        'group_id, group_name, total_rx_bytes, total_tx_bytes, captured_at, hours_window, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, raw_summary'
-      )
+      .select(ROLLUP_SELECT)
       .eq('hours_window', HOURLY_ROLLUP_WINDOW)
       // Legacy group blobs would double-count against per-device rows for the
       // 14-day retention overlap (#702).
       .neq('device_sn', '__legacy_group__')
       .gte('captured_at', since)
       .order('captured_at', { ascending: true });
+    if (until) {
+      hourlyQuery = hourlyQuery.lte('captured_at', until);
+    }
+    const { data: hourlyRollups } = await hourlyQuery;
 
     const usingHourlySeries = (hourlyRollups || []).length > 0;
     let rollupsForCards = (hourlyRollups || []) as RollupRow[];
 
     if (!usingHourlySeries) {
-      const { data: legacyRollups } = await supabase
+      let legacyQuery = supabase
         .from('ruijie_traffic_rollups')
-        .select(
-          'group_id, group_name, total_rx_bytes, total_tx_bytes, captured_at, hours_window, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps, raw_summary'
-        )
+        .select(ROLLUP_SELECT)
         .gte('captured_at', since)
         .order('captured_at', { ascending: true });
+      if (until) {
+        legacyQuery = legacyQuery.lte('captured_at', until);
+      }
+      const { data: legacyRollups } = await legacyQuery;
 
       // Legacy rows are overlapping window totals — keep only the newest per group.
       const latestByGroup = new Map<string, RollupRow>();
@@ -191,6 +231,7 @@ export async function GET(request: NextRequest) {
       rollupsForCards = Array.from(latestByGroup.values());
     }
 
+    // Group cards stay group-scoped (all devices) for the window.
     const groupTraffic = computeGroupTrafficCards(rollupsForCards);
     const lastRollupAt = maxIso([
       ...rollupsForCards.map((r) => r.captured_at),
@@ -198,6 +239,20 @@ export async function GET(request: NextRequest) {
     ]);
 
     const groupDevices = (deviceGroups || []).filter((d) => d.group_id === effectiveGroupId);
+    const devices = groupDevices
+      .map((d) => ({
+        sn: String(d.sn),
+        device_name: d.device_name || String(d.sn),
+        status: d.status || 'unknown',
+      }))
+      .filter((d) => d.sn.length > 0)
+      .sort((a, b) => a.device_name.localeCompare(b.device_name));
+
+    const deviceSnInGroup =
+      requestedDeviceSn && devices.some((d) => d.sn === requestedDeviceSn)
+        ? requestedDeviceSn
+        : null;
+
     const radio = computeRadioUtilSummary(
       groupDevices.map((d) => ({
         sn: d.sn,
@@ -214,7 +269,10 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({
         groups,
         groupId: null,
+        deviceSn: null,
+        devices: [],
         hours,
+        period,
         source: 'supabase',
         traffic: emptyTraffic,
         appFlow: [],
@@ -247,9 +305,11 @@ export async function GET(request: NextRequest) {
         }
       }
 
-      const flowSn = pickFlowDeviceSn(
-        groupDevices.map((d) => ({ sn: d.sn, status: d.status, model: d.model }))
-      );
+      const flowSn =
+        deviceSnInGroup ||
+        pickFlowDeviceSn(
+          groupDevices.map((d) => ({ sn: d.sn, status: d.status, model: d.model }))
+        );
       if (!flowSn) {
         return NextResponse.json(
           { error: 'No device available in group for live flow API' },
@@ -262,8 +322,11 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({
         groups,
         groupId: effectiveGroupId,
+        deviceSn: deviceSnInGroup,
+        devices,
         flowSn,
         hours,
+        period: { mode: 'hours' as const, hours },
         source: 'live',
         traffic: {
           ...trafficSummary,
@@ -280,11 +343,12 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    const seriesRows = rollupsForCards
-      .filter((row) => row.group_id === effectiveGroupId)
-      .sort(
-        (a, b) => new Date(a.captured_at).getTime() - new Date(b.captured_at).getTime()
-      );
+    const seriesRows = filterRollupsForScope(rollupsForCards, {
+      groupId: effectiveGroupId,
+      deviceSn: deviceSnInGroup,
+    }).sort(
+      (a, b) => new Date(a.captured_at).getTime() - new Date(b.captured_at).getTime()
+    );
 
     const traffic = trafficFromHourlyRollups(seriesRows);
     const groupLastRollupAt = maxIso(seriesRows.map((r) => r.captured_at)) ?? lastRollupAt;
@@ -292,7 +356,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       groups,
       groupId: effectiveGroupId,
+      deviceSn: deviceSnInGroup,
+      devices,
       hours,
+      period,
       source: 'supabase',
       traffic,
       appFlow: [],

--- a/lib/network/analytics-aggregates.ts
+++ b/lib/network/analytics-aggregates.ts
@@ -8,6 +8,104 @@ import { avgOrNull, roundPercent } from './performance-aggregates';
 /** Persist one row per Ruijie hourly flow sample (not a rolling 24h window total). */
 export const HOURLY_ROLLUP_WINDOW = 1;
 
+/** Longest preset analytics query window (UI offers up to 30d). */
+export const MAX_ANALYTICS_HOURS = 720;
+export const DEFAULT_ANALYTICS_HOURS = 24;
+/** Longest custom calendar range (matches ruijie_traffic_rollups retention). */
+export const MAX_ANALYTICS_CUSTOM_DAYS = 90;
+
+const SAST_OFFSET = '+02:00';
+
+/** Parse ?hours= for Network Analytics; invalid values fall back to 24h. */
+export function parseAnalyticsHours(raw: string | null): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_ANALYTICS_HOURS;
+  return Math.min(Math.floor(n), MAX_ANALYTICS_HOURS);
+}
+
+export type AnalyticsCustomRange = {
+  startDate: string;
+  endDate: string;
+  startUtc: Date;
+  endUtc: Date;
+  inclusiveDayCount: number;
+};
+
+type SastDateParts = { year: number; month: number; day: number };
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function parseSastDateString(date: string): SastDateParts | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  // Reject non-existent calendar days (e.g. 2026-02-31).
+  const probe = new Date(`${year}-${pad2(month)}-${pad2(day)}T12:00:00${SAST_OFFSET}`);
+  if (Number.isNaN(probe.getTime())) return null;
+  const isoDay = probe.toLocaleDateString('en-CA', { timeZone: 'Africa/Johannesburg' });
+  if (isoDay !== `${year}-${pad2(month)}-${pad2(day)}`) return null;
+  return { year, month, day };
+}
+
+function sastCalendarMs({ year, month, day }: SastDateParts): number {
+  return new Date(`${year}-${pad2(month)}-${pad2(day)}T12:00:00${SAST_OFFSET}`).getTime();
+}
+
+/**
+ * Parse inclusive SAST calendar dates for Cached analytics.
+ * Returns null when missing, invalid, reversed, or longer than 90 days.
+ */
+export function parseAnalyticsCustomRange(
+  startDate: string | null | undefined,
+  endDate: string | null | undefined
+): AnalyticsCustomRange | null {
+  if (!startDate || !endDate) return null;
+  const start = parseSastDateString(startDate);
+  const end = parseSastDateString(endDate);
+  if (!start || !end) return null;
+
+  const startMs = sastCalendarMs(start);
+  const endMs = sastCalendarMs(end);
+  if (endMs < startMs) return null;
+
+  const inclusiveDayCount = Math.round((endMs - startMs) / 86_400_000) + 1;
+  if (inclusiveDayCount < 1 || inclusiveDayCount > MAX_ANALYTICS_CUSTOM_DAYS) {
+    return null;
+  }
+
+  const startUtc = new Date(
+    `${start.year}-${pad2(start.month)}-${pad2(start.day)}T00:00:00.000${SAST_OFFSET}`
+  );
+  const endUtc = new Date(
+    `${end.year}-${pad2(end.month)}-${pad2(end.day)}T23:59:59.999${SAST_OFFSET}`
+  );
+
+  return {
+    startDate: `${start.year}-${pad2(start.month)}-${pad2(start.day)}`,
+    endDate: `${end.year}-${pad2(end.month)}-${pad2(end.day)}`,
+    startUtc,
+    endUtc,
+    inclusiveDayCount,
+  };
+}
+
+/** Filter hourly rollups to one group, optionally one device. */
+export function filterRollupsForScope<
+  T extends { group_id: string; device_sn?: string | null },
+>(rows: T[], options: { groupId: string; deviceSn?: string | null }): T[] {
+  const deviceSn = options.deviceSn?.trim() || null;
+  return rows.filter((row) => {
+    if (row.group_id !== options.groupId) return false;
+    if (deviceSn) return row.device_sn === deviceSn;
+    return true;
+  });
+}
+
 export type GroupRollupRow = {
   group_id: string;
   group_name: string | null;


### PR DESCRIPTION
## Summary
- Add device picker on Network Analytics (default: all devices in group; selecting an AP scopes KPI cards and traffic charts to that device)
- Add Custom SAST date range (Cached/Supabase only, max 90 days) alongside existing hour presets (up to 30 days)
- Extend `/api/admin/network/analytics` with `deviceSn`, `startDate`/`endDate`, and `devices`/`period` response fields

## Test plan
- [x] `npx jest __tests__/lib/network/analytics-aggregates.test.ts` (12/12)
- [ ] Cached + All devices + 7d
- [ ] Cached + one Unjani AP
- [ ] Custom 8-day range
- [ ] Live + one device (custom disabled)


Made with [Cursor](https://cursor.com)