### PR TITLE
feat(network): analytics PDF/Excel export

### DIFF
--- a/__tests__/lib/network/analytics-export.test.ts
+++ b/__tests__/lib/network/analytics-export.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Analytics export — pure period/filename helpers + model assembly with mocks.
+ */
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+jest.mock('@/lib/ruijie/client', () => ({
+  getDeviceClients: jest.fn(),
+}));
+
+jest.mock('@/lib/usage-reports/core-traffic', () => ({
+  loadInterstellioSubscriberId: jest.fn(),
+  loadInterstellioDailyEntries: jest.fn(),
+}));
+
+import { createClient } from '@/lib/supabase/server';
+import { getDeviceClients } from '@/lib/ruijie/client';
+import {
+  loadInterstellioSubscriberId,
+  loadInterstellioDailyEntries,
+} from '@/lib/usage-reports/core-traffic';
+import {
+  analyticsExportFilename,
+  buildAnalyticsExportModel,
+  periodToReportPeriod,
+  resolveAnalyticsExportPeriod,
+  shapeInterstellioSection,
+  trafficFromAnalyticsRollups,
+  type AnalyticsExportModel,
+} from '@/lib/network/analytics-export';
+import { generateAnalyticsReportPdf } from '@/lib/network/analytics-report-pdf';
+import { generateAnalyticsReportExcel } from '@/lib/network/analytics-report-excel';
+import ExcelJS from 'exceljs';
+
+describe('resolveAnalyticsExportPeriod', () => {
+  it('uses custom SAST range when both dates are valid', () => {
+    const period = resolveAnalyticsExportPeriod({
+      hoursRaw: '24',
+      startDate: '2026-07-26',
+      endDate: '2026-08-02',
+    });
+    expect(period.mode).toBe('custom');
+    if (period.mode !== 'custom') return;
+    expect(period.startDate).toBe('2026-07-26');
+    expect(period.endDate).toBe('2026-08-02');
+    expect(period.inclusiveDayCount).toBe(8);
+    expect(period.label).toBe('2026-07-26 → 2026-08-02');
+  });
+
+  it('falls back to hours when custom is invalid', () => {
+    const period = resolveAnalyticsExportPeriod({
+      hoursRaw: '168',
+      startDate: '2026-08-02',
+      endDate: '2026-07-26',
+    });
+    expect(period.mode).toBe('hours');
+    if (period.mode !== 'hours') return;
+    expect(period.hours).toBe(168);
+    expect(period.label).toBe('Last 7 days');
+  });
+});
+
+describe('analyticsExportFilename', () => {
+  it('names group and device exports with period suffix', () => {
+    const hoursPeriod = resolveAnalyticsExportPeriod({
+      hoursRaw: '168',
+      startDate: null,
+      endDate: null,
+    });
+    expect(
+      analyticsExportFilename({
+        scope: 'group',
+        groupName: 'Unjani',
+        deviceSn: null,
+        period: hoursPeriod,
+        extension: 'pdf',
+      })
+    ).toMatch(/^CircleTel_Analytics_Unjani_\d{4}-\d{2}-\d{2}_7d\.pdf$/);
+
+    expect(
+      analyticsExportFilename({
+        scope: 'device',
+        groupName: 'Unjani',
+        deviceSn: 'G1U52HL00261B',
+        period: hoursPeriod,
+        extension: 'xlsx',
+      })
+    ).toMatch(/^CircleTel_Analytics_G1U52HL00261B_\d{4}-\d{2}-\d{2}_7d\.xlsx$/);
+  });
+});
+
+describe('trafficFromAnalyticsRollups', () => {
+  it('sums scoped rollup rows into a traffic summary', () => {
+    const summary = trafficFromAnalyticsRollups([
+      {
+        captured_at: '2026-08-01T10:00:00Z',
+        total_rx_bytes: 1000,
+        total_tx_bytes: 100,
+        avg_rx_bps: 8000,
+        avg_tx_bps: 800,
+      },
+      {
+        captured_at: '2026-08-01T11:00:00Z',
+        total_rx_bytes: 2000,
+        total_tx_bytes: 200,
+        avg_rx_bps: 16000,
+        avg_tx_bps: 1600,
+      },
+    ]);
+    expect(summary.totalRxBytes).toBe(3000);
+    expect(summary.totalTxBytes).toBe(300);
+    expect(summary.dataPoints).toHaveLength(2);
+    expect(summary.peakRxBytes).toBe(2000);
+  });
+});
+
+describe('shapeInterstellioSection', () => {
+  it('marks unmapped sites as not linked', () => {
+    const section = shapeInterstellioSection({
+      siteId: null,
+      siteName: null,
+      subscriberId: null,
+      entries: [],
+      dayCount: 3,
+    });
+    expect(section.linked).toBe(false);
+    expect(section.note).toMatch(/not linked/i);
+    expect(section.dailyDownloadBytes).toEqual([0, 0, 0]);
+  });
+
+  it('maps daily entries into download/upload byte arrays', () => {
+    const section = shapeInterstellioSection({
+      siteId: 'site-1',
+      siteName: 'Unjani Alex',
+      subscriberId: 'sub-1',
+      dayCount: 2,
+      startUtc: new Date('2026-07-31T22:00:00.000Z'), // 2026-08-01 00:00 SAST
+      entries: [
+        {
+          time: '2026-08-01T12:00:00+02:00',
+          download_kb: 1000,
+          upload_kb: 100,
+          combined_kb: 1100,
+        },
+        {
+          time: '2026-08-02T12:00:00+02:00',
+          download_kb: 2000,
+          upload_kb: 200,
+          combined_kb: 2200,
+        },
+      ],
+    });
+    expect(section.linked).toBe(true);
+    expect(section.dailyDownloadBytes.length).toBe(2);
+    expect(section.dailyUploadBytes?.length).toBe(2);
+    expect(section.dailyDownloadBytes[0]).toBe(1000 * 1024);
+    expect(section.dailyUploadBytes?.[0]).toBe(100 * 1024);
+    expect(section.siteName).toBe('Unjani Alex');
+  });
+});
+
+describe('periodToReportPeriod', () => {
+  it('builds a ReportPeriod for Interstellio loaders', () => {
+    const period = resolveAnalyticsExportPeriod({
+      hoursRaw: null,
+      startDate: '2026-07-26',
+      endDate: '2026-08-02',
+    });
+    const report = periodToReportPeriod(period);
+    expect(report.preset).toBe('custom');
+    expect(report.inclusiveDayCount).toBe(8);
+    expect(report.timezone).toBe('Africa/Johannesburg');
+  });
+});
+
+describe('buildAnalyticsExportModel', () => {
+  const deviceRows = [
+    {
+      group_id: '9058218',
+      group_name: 'Unjani',
+      sn: 'G1U52HL00261B',
+      device_name: 'UNJANIALEX2',
+      model: 'RAP2200(F)',
+      status: 'online',
+      radio_2g_utilization: 20,
+      radio_5g_utilization: 5,
+      radio_2g_channel: 1,
+      radio_5g_channel: 36,
+    },
+    {
+      group_id: '9058218',
+      group_name: 'Unjani',
+      sn: 'G1U52HL044404',
+      device_name: 'UNJANISICELO',
+      model: 'RAP2200(F)',
+      status: 'online',
+      radio_2g_utilization: 10,
+      radio_5g_utilization: 2,
+      radio_2g_channel: 6,
+      radio_5g_channel: 40,
+    },
+  ];
+
+  const rollups = [
+    {
+      group_id: '9058218',
+      group_name: 'Unjani',
+      device_sn: 'G1U52HL00261B',
+      captured_at: '2026-08-01T10:00:00Z',
+      hours_window: 1,
+      total_rx_bytes: 5_000_000,
+      total_tx_bytes: 500_000,
+      avg_rx_bps: 10_000,
+      avg_tx_bps: 1_000,
+      peak_rx_bps: 20_000,
+      peak_tx_bps: 2_000,
+      raw_summary: null,
+    },
+    {
+      group_id: '9058218',
+      group_name: 'Unjani',
+      device_sn: 'G1U52HL044404',
+      captured_at: '2026-08-01T10:00:00Z',
+      hours_window: 1,
+      total_rx_bytes: 1_000_000,
+      total_tx_bytes: 100_000,
+      avg_rx_bps: 2_000,
+      avg_tx_bps: 200,
+      peak_rx_bps: 4_000,
+      peak_tx_bps: 400,
+      raw_summary: null,
+    },
+  ];
+
+  function mockSupabase(opts?: {
+    siteLink?: { corporate_site_id: string; site_name: string } | null;
+  }) {
+    const siteLink = opts?.siteLink ?? null;
+    const from = jest.fn((table: string) => {
+      if (table === 'ruijie_device_cache') {
+        return {
+          select: () => ({
+            not: () => Promise.resolve({ data: deviceRows, error: null }),
+          }),
+        };
+      }
+      if (table === 'ruijie_traffic_rollups') {
+        const chain: Record<string, unknown> = {};
+        const self = () => chain;
+        chain.select = self;
+        chain.eq = self;
+        chain.neq = self;
+        chain.gte = self;
+        chain.lte = self;
+        chain.order = () => Promise.resolve({ data: rollups, error: null });
+        return chain;
+      }
+      if (table === 'network_devices') {
+        return {
+          select: () => ({
+            eq: () => ({
+              not: () => ({
+                limit: () => ({
+                  maybeSingle: () =>
+                    Promise.resolve({
+                      data: siteLink
+                        ? { corporate_site_id: siteLink.corporate_site_id }
+                        : null,
+                      error: null,
+                    }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'corporate_sites') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () =>
+                Promise.resolve({
+                  data: siteLink
+                    ? {
+                        id: siteLink.corporate_site_id,
+                        site_name: siteLink.site_name,
+                        interstellio_subscriber_id: 'sub-1',
+                      }
+                    : null,
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+      return { select: () => ({}) };
+    });
+    (createClient as jest.Mock).mockResolvedValue({ from });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getDeviceClients as jest.Mock).mockResolvedValue([
+      {
+        mac: 'AA:BB:CC:DD:EE:FF',
+        userIp: '192.168.77.10',
+        ssid: 'Unjani Clinic Staff',
+        rssi: -50,
+        band: '5G',
+        channel: 36,
+        sn: 'G1U52HL00261B',
+        signalQuality: 'excellent',
+        utilization: null,
+        uplinkRate: 1_000_000,
+        downlinkRate: 10_000_000,
+        pktLoseRate: 0,
+        latencyMs: 12,
+        score: 95,
+        scoreReason: null,
+        hostname: 'phone',
+        vendor: 'Apple',
+        sessionBytes: 1000,
+        sessionMs: 1000,
+      },
+    ]);
+    (loadInterstellioSubscriberId as jest.Mock).mockResolvedValue(null);
+    (loadInterstellioDailyEntries as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('builds a group-scoped model without clients or Interstellio', async () => {
+    mockSupabase();
+    const model = await buildAnalyticsExportModel({
+      groupId: '9058218',
+      deviceSn: null,
+      hoursRaw: '24',
+      startDate: null,
+      endDate: null,
+    });
+    expect(model).not.toBeNull();
+    expect(model!.scope).toBe('group');
+    expect(model!.traffic.totalRxBytes).toBe(6_000_000);
+    expect(model!.clients).toEqual([]);
+    expect(model!.interstellio).toBeNull();
+    expect(model!.unavailable.clients).toMatch(/Select an AP/i);
+  });
+
+  it('builds a device-scoped model with clients and unmapped Interstellio', async () => {
+    mockSupabase({ siteLink: null });
+    const model = await buildAnalyticsExportModel({
+      groupId: '9058218',
+      deviceSn: 'G1U52HL00261B',
+      hoursRaw: '24',
+      startDate: null,
+      endDate: null,
+    });
+    expect(model!.scope).toBe('device');
+    expect(model!.device?.sn).toBe('G1U52HL00261B');
+    expect(model!.traffic.totalRxBytes).toBe(5_000_000);
+    expect(model!.clients).toHaveLength(1);
+    expect(model!.interstellio?.linked).toBe(false);
+  });
+
+  it('attaches Interstellio when the AP is linked to a mapped site', async () => {
+    mockSupabase({
+      siteLink: { corporate_site_id: 'site-alex', site_name: 'Unjani Alex' },
+    });
+    (loadInterstellioSubscriberId as jest.Mock).mockResolvedValue('sub-1');
+    (loadInterstellioDailyEntries as jest.Mock).mockResolvedValue([
+      {
+        time: '2026-08-03T12:00:00+02:00',
+        download_kb: 100,
+        upload_kb: 10,
+        combined_kb: 110,
+      },
+      {
+        time: '2026-08-04T12:00:00+02:00',
+        download_kb: 200,
+        upload_kb: 20,
+        combined_kb: 220,
+      },
+    ]);
+
+    const model = await buildAnalyticsExportModel({
+      groupId: '9058218',
+      deviceSn: 'G1U52HL00261B',
+      hoursRaw: '48',
+      startDate: null,
+      endDate: null,
+    });
+
+    expect(model!.interstellio?.linked).toBe(true);
+    expect(model!.interstellio?.siteName).toBe('Unjani Alex');
+    expect(loadInterstellioDailyEntries).toHaveBeenCalled();
+  });
+});
+
+describe('analytics report generators', () => {
+  const baseModel = (): AnalyticsExportModel => ({
+    scope: 'device',
+    group: { id: '9058218', name: 'Unjani' },
+    device: {
+      sn: 'G1U52HL00261B',
+      device_name: 'UNJANIALEX2',
+      model: 'RAP2200(F)',
+      status: 'online',
+      group_id: '9058218',
+      group_name: 'Unjani',
+    },
+    period: {
+      mode: 'hours',
+      hours: 24,
+      label: 'Last 24 hours',
+      startUtc: new Date('2026-08-03T00:00:00Z'),
+      endUtc: new Date('2026-08-04T00:00:00Z'),
+    },
+    traffic: trafficFromAnalyticsRollups([
+      {
+        captured_at: '2026-08-03T10:00:00Z',
+        total_rx_bytes: 1_000_000,
+        total_tx_bytes: 100_000,
+        avg_rx_bps: 1000,
+        avg_tx_bps: 100,
+      },
+    ]),
+    groupTraffic: [
+      {
+        groupId: '9058218',
+        groupName: 'Unjani',
+        totalRxBytes: 1_000_000,
+        totalTxBytes: 100_000,
+        totalBytes: 1_100_000,
+        sampleCount: 1,
+        lastCapturedAt: '2026-08-03T10:00:00Z',
+      },
+    ],
+    radio: {
+      avg2g: 20,
+      avg5g: 5,
+      avgBlended: 12,
+      devicesWithRadio: 1,
+      totalDevices: 1,
+      channels2g: [1],
+      channels5g: [36],
+      byDevice: [],
+    },
+    clients: [],
+    interstellio: {
+      linked: true,
+      siteName: 'Unjani Alex',
+      dailyDownloadBytes: [1024],
+      dailyUploadBytes: [128],
+      totalDownloadBytes: 1024,
+      totalUploadBytes: 128,
+      note: 'Secondary source',
+    },
+    generatedAtIso: '2026-08-04T10:00:00.000Z',
+    unavailable: {},
+  });
+
+  it('produces a PDF for a device-scoped model', () => {
+    const pdf = generateAnalyticsReportPdf(baseModel());
+    expect(Buffer.from(pdf.slice(0, 4)).toString('ascii')).toBe('%PDF');
+    expect(pdf.byteLength).toBeGreaterThan(2_000);
+  });
+
+  it('produces an Excel workbook with expected sheets', async () => {
+    const buffer = await generateAnalyticsReportExcel(baseModel());
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer as unknown as ArrayBuffer);
+    expect(workbook.worksheets.map((s) => s.name)).toEqual([
+      'Overview',
+      'Traffic',
+      'Group cards',
+      'Radio',
+      'Clients',
+      'Interstellio',
+    ]);
+  });
+});

--- a/app/admin/network/analytics/page.tsx
+++ b/app/admin/network/analytics/page.tsx
@@ -35,6 +35,7 @@ import {
   ThroughputAreaChart,
 } from '@/components/admin/network/performance';
 import type { GroupTrafficCard, RadioUtilSummary, SsidActivityCard } from '@/lib/network/analytics-aggregates';
+import { AnalyticsExportMenu } from '@/components/admin/network/AnalyticsExportMenu';
 import { formatRelative } from '@/lib/dates';
 
 interface TrafficDataPoint {
@@ -426,6 +427,14 @@ export default function NetworkAnalyticsPage() {
               />
             </>
           ) : null}
+          <AnalyticsExportMenu
+            groupId={selectedGroupId}
+            deviceSn={selectedDeviceSn === ALL_DEVICES ? null : selectedDeviceSn}
+            periodMode={preferLive && periodMode === 'custom' ? '24' : periodMode}
+            customStart={customStart}
+            customEnd={customEnd}
+            disabled={loading || refreshing}
+          />
           <Button
             variant={preferLive ? 'default' : 'outline'}
             size="sm"

--- a/app/api/admin/network/analytics/export/route.ts
+++ b/app/api/admin/network/analytics/export/route.ts
@@ -1,0 +1,104 @@
+/**
+ * Network Analytics export
+ * GET /api/admin/network/analytics/export
+ *   ?groupId=&deviceSn=&hours=24|startDate=&endDate=&format=pdf|excel
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { authenticateAdmin } from '@/lib/auth/admin-api-auth';
+import { apiLogger } from '@/lib/logging/logger';
+import {
+  analyticsExportFilename,
+  buildAnalyticsExportModel,
+} from '@/lib/network/analytics-export';
+import { generateAnalyticsReportPdf } from '@/lib/network/analytics-report-pdf';
+import { generateAnalyticsReportExcel } from '@/lib/network/analytics-report-excel';
+
+export const dynamic = 'force-dynamic';
+
+const EXCEL_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await authenticateAdmin(request);
+    if (!authResult.success) {
+      return authResult.response;
+    }
+
+    const { searchParams } = new URL(request.url);
+    const format = searchParams.get('format');
+    if (format !== 'pdf' && format !== 'excel') {
+      return NextResponse.json(
+        { error: "format must be 'pdf' or 'excel'" },
+        { status: 400 }
+      );
+    }
+
+    const model = await buildAnalyticsExportModel({
+      groupId: searchParams.get('groupId'),
+      deviceSn: searchParams.get('deviceSn'),
+      hoursRaw: searchParams.get('hours'),
+      startDate: searchParams.get('startDate'),
+      endDate: searchParams.get('endDate'),
+    });
+
+    if (!model) {
+      return NextResponse.json(
+        { error: 'No network group available for export' },
+        { status: 404 }
+      );
+    }
+
+    const supabase = await createClient();
+    const clientIp =
+      request.headers.get('x-forwarded-for') ||
+      request.headers.get('x-real-ip') ||
+      'unknown';
+
+    await supabase.from('ruijie_audit_log').insert({
+      admin_user_id: authResult.adminUser.id,
+      device_sn: model.device?.sn ?? null,
+      action: 'analytics_export',
+      action_detail: {
+        format,
+        scope: model.scope,
+        groupId: model.group.id,
+        period: model.period,
+      },
+      ip_address: clientIp,
+      status: 'success',
+    });
+
+    const extension = format === 'pdf' ? 'pdf' : 'xlsx';
+    const filename = analyticsExportFilename({
+      scope: model.scope,
+      groupName: model.group.name,
+      deviceSn: model.device?.sn ?? null,
+      period: model.period,
+      extension,
+    });
+
+    if (format === 'pdf') {
+      const buffer = generateAnalyticsReportPdf(model);
+      return new NextResponse(buffer, {
+        headers: {
+          'Content-Type': 'application/pdf',
+          'Content-Disposition': `attachment; filename="${filename}"`,
+        },
+      });
+    }
+
+    const excel = await generateAnalyticsReportExcel(model);
+    return new NextResponse(new Uint8Array(excel), {
+      headers: {
+        'Content-Type': EXCEL_MIME,
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    apiLogger.error('Analytics export failed', { error });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/components/admin/network/AnalyticsExportMenu.tsx
+++ b/components/admin/network/AnalyticsExportMenu.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+/**
+ * Download dropdown for Network Analytics — exports the current group/device
+ * view as PDF or Excel via /api/admin/network/analytics/export.
+ */
+
+import { useState } from 'react';
+import {
+  PiCaretDownBold,
+  PiDownloadSimpleBold,
+  PiFilePdfBold,
+  PiFileXlsBold,
+  PiSpinnerGapBold,
+} from 'react-icons/pi';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export interface AnalyticsExportMenuProps {
+  groupId: string;
+  deviceSn: string | null;
+  /** Preset hours string, or 'custom' when using start/end dates. */
+  periodMode: string;
+  customStart: string;
+  customEnd: string;
+  disabled?: boolean;
+}
+
+export function AnalyticsExportMenu({
+  groupId,
+  deviceSn,
+  periodMode,
+  customStart,
+  customEnd,
+  disabled,
+}: AnalyticsExportMenuProps) {
+  const [downloading, setDownloading] = useState<'pdf' | 'excel' | null>(null);
+
+  const handleDownload = async (format: 'pdf' | 'excel') => {
+    setDownloading(format);
+    try {
+      const params = new URLSearchParams({ format });
+      if (groupId) params.set('groupId', groupId);
+      if (deviceSn) params.set('deviceSn', deviceSn);
+      if (periodMode === 'custom') {
+        params.set('startDate', customStart);
+        params.set('endDate', customEnd);
+        params.set('hours', '24');
+      } else {
+        params.set('hours', periodMode);
+      }
+
+      const response = await fetch(
+        `/api/admin/network/analytics/export?${params.toString()}`,
+        { credentials: 'include' }
+      );
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error || `Export failed (${response.status})`);
+      }
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download =
+        response.headers
+          .get('content-disposition')
+          ?.match(/filename="([^"]+)"/i)?.[1] ??
+        `CircleTel_Analytics.${format === 'pdf' ? 'pdf' : 'xlsx'}`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => window.URL.revokeObjectURL(url), 0);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : `Failed to download ${format.toUpperCase()} report`
+      );
+    } finally {
+      setDownloading(null);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-2"
+          disabled={disabled || downloading !== null || !groupId}
+        >
+          {downloading ? (
+            <PiSpinnerGapBold className="w-4 h-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <PiDownloadSimpleBold className="w-4 h-4" aria-hidden="true" />
+          )}
+          Download
+          <PiCaretDownBold className="w-3.5 h-3.5" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onClick={() => void handleDownload('pdf')}
+          disabled={downloading !== null}
+        >
+          <PiFilePdfBold className="mr-2 h-4 w-4" aria-hidden="true" />
+          PDF report
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => void handleDownload('excel')}
+          disabled={downloading !== null}
+        >
+          <PiFileXlsBold className="mr-2 h-4 w-4" aria-hidden="true" />
+          Excel workbook
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/lib/network/analytics-export.ts
+++ b/lib/network/analytics-export.ts
@@ -1,0 +1,567 @@
+/**
+ * Network Analytics export model — group aggregate or single AP.
+ *
+ * Traffic comes from Supabase rollups (same as Cached Analytics). Connected
+ * clients are a live STA snapshot at generation time. Interstellio is an
+ * optional secondary series when the AP is linked to a corporate site with a
+ * subscriber id.
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import { getDeviceClients, type RuijieClient } from '@/lib/ruijie/client';
+import { bpsToMbps, roundPercent } from '@/lib/network/performance-aggregates';
+import {
+  computeGroupTrafficCards,
+  computeRadioUtilSummary,
+  filterRollupsForScope,
+  HOURLY_ROLLUP_WINDOW,
+  parseAnalyticsCustomRange,
+  parseAnalyticsHours,
+  type GroupTrafficCard,
+  type RadioUtilSummary,
+} from '@/lib/network/analytics-aggregates';
+import {
+  loadInterstellioDailyEntries,
+  loadInterstellioSubscriberId,
+} from '@/lib/usage-reports/core-traffic';
+import type { DataUsageEntry } from '@/lib/interstellio/types';
+import type { ReportPeriod } from '@/lib/usage-reports/types';
+import { SAST_TIMEZONE } from '@/lib/dates';
+
+const BYTES_PER_INTERSTELLIO_KB = 1_024;
+
+export type AnalyticsExportPeriod =
+  | {
+      mode: 'hours';
+      hours: number;
+      label: string;
+      startUtc: Date;
+      endUtc: Date;
+    }
+  | {
+      mode: 'custom';
+      startDate: string;
+      endDate: string;
+      label: string;
+      startUtc: Date;
+      endUtc: Date;
+      inclusiveDayCount: number;
+    };
+
+export type AnalyticsExportInterstellio = {
+  linked: boolean;
+  siteId?: string;
+  siteName?: string;
+  dailyDownloadBytes: number[];
+  dailyUploadBytes: number[];
+  totalDownloadBytes: number;
+  totalUploadBytes: number;
+  note?: string;
+};
+
+export type AnalyticsExportTraffic = {
+  totalRxBytes: number;
+  totalTxBytes: number;
+  totalBytes: number;
+  avgRxRate: number;
+  avgTxRate: number;
+  peakRxBytes: number;
+  peakTxBytes: number;
+  avgRxMbps: number;
+  avgTxMbps: number;
+  dataPoints: Array<{
+    timestamp: number;
+    timeString: string;
+    rxBytes: number;
+    txBytes: number;
+    avgRxMbps: number;
+    avgTxMbps: number;
+  }>;
+};
+
+export type AnalyticsExportDevice = {
+  sn: string;
+  device_name: string;
+  model: string | null;
+  status: string;
+  group_id: string;
+  group_name: string | null;
+};
+
+export type AnalyticsExportModel = {
+  scope: 'group' | 'device';
+  group: { id: string; name: string };
+  device?: AnalyticsExportDevice;
+  period: AnalyticsExportPeriod;
+  traffic: AnalyticsExportTraffic;
+  groupTraffic: GroupTrafficCard[];
+  radio: RadioUtilSummary;
+  clients: RuijieClient[];
+  /** null for group scope; object (possibly unlinked) for device scope */
+  interstellio: AnalyticsExportInterstellio | null;
+  generatedAtIso: string;
+  unavailable: Record<string, string>;
+};
+
+export type BuildAnalyticsExportInput = {
+  groupId: string | null;
+  deviceSn: string | null;
+  hoursRaw: string | null;
+  startDate: string | null;
+  endDate: string | null;
+};
+
+type RollupRow = {
+  group_id: string;
+  group_name: string | null;
+  device_sn?: string | null;
+  captured_at: string;
+  hours_window: number;
+  total_rx_bytes: number | null;
+  total_tx_bytes: number | null;
+  avg_rx_bps: number | null;
+  avg_tx_bps: number | null;
+  peak_rx_bps: number | null;
+  peak_tx_bps: number | null;
+};
+
+function hoursLabel(hours: number): string {
+  if (hours % 24 === 0 && hours >= 24) {
+    const days = hours / 24;
+    return `Last ${days} day${days > 1 ? 's' : ''}`;
+  }
+  return `Last ${hours} hours`;
+}
+
+function periodSuffix(period: AnalyticsExportPeriod): string {
+  if (period.mode === 'custom') {
+    return `${period.startDate}_${period.endDate}`;
+  }
+  if (period.hours % 24 === 0) return `${period.hours / 24}d`;
+  return `${period.hours}h`;
+}
+
+function sanitizeFilenamePart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^_+|_+$/g, '') || 'Network';
+}
+
+function sastDayKey(value: Date | string): string | null {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Africa/Johannesburg',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+function emptyTraffic(): AnalyticsExportTraffic {
+  return {
+    totalRxBytes: 0,
+    totalTxBytes: 0,
+    totalBytes: 0,
+    avgRxRate: 0,
+    avgTxRate: 0,
+    peakRxBytes: 0,
+    peakTxBytes: 0,
+    avgRxMbps: 0,
+    avgTxMbps: 0,
+    dataPoints: [],
+  };
+}
+
+export function resolveAnalyticsExportPeriod(opts: {
+  hoursRaw: string | null;
+  startDate: string | null;
+  endDate: string | null;
+}): AnalyticsExportPeriod {
+  const custom = parseAnalyticsCustomRange(opts.startDate, opts.endDate);
+  if (custom) {
+    return {
+      mode: 'custom',
+      startDate: custom.startDate,
+      endDate: custom.endDate,
+      label: `${custom.startDate} → ${custom.endDate}`,
+      startUtc: custom.startUtc,
+      endUtc: custom.endUtc,
+      inclusiveDayCount: custom.inclusiveDayCount,
+    };
+  }
+
+  const hours = parseAnalyticsHours(opts.hoursRaw);
+  const endUtc = new Date();
+  const startUtc = new Date(endUtc.getTime() - hours * 60 * 60 * 1000);
+  return {
+    mode: 'hours',
+    hours,
+    label: hoursLabel(hours),
+    startUtc,
+    endUtc,
+  };
+}
+
+export function periodToReportPeriod(period: AnalyticsExportPeriod): ReportPeriod {
+  const inclusiveDayCount =
+    period.mode === 'custom'
+      ? period.inclusiveDayCount
+      : Math.max(
+          1,
+          Math.round(
+            (period.endUtc.getTime() - period.startUtc.getTime()) / 86_400_000
+          ) + 1
+        );
+
+  return {
+    preset: 'custom',
+    timezone: SAST_TIMEZONE,
+    startIso: period.startUtc.toISOString(),
+    endIso: period.endUtc.toISOString(),
+    startUtc: period.startUtc,
+    endUtc: period.endUtc,
+    label: period.label,
+    rangeLabel: period.label,
+    inclusiveDayCount,
+    isShortPeriod: inclusiveDayCount <= 7,
+  };
+}
+
+export function analyticsExportFilename(opts: {
+  scope: 'group' | 'device';
+  groupName: string;
+  deviceSn: string | null;
+  period: AnalyticsExportPeriod;
+  extension: 'pdf' | 'xlsx';
+}): string {
+  const date = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Africa/Johannesburg',
+  }).format(new Date());
+  const scopePart =
+    opts.scope === 'device' && opts.deviceSn
+      ? sanitizeFilenamePart(opts.deviceSn)
+      : sanitizeFilenamePart(opts.groupName);
+  return `CircleTel_Analytics_${scopePart}_${date}_${periodSuffix(opts.period)}.${opts.extension}`;
+}
+
+export function trafficFromAnalyticsRollups(
+  rows: Array<{
+    captured_at: string;
+    total_rx_bytes: number | null;
+    total_tx_bytes: number | null;
+    avg_rx_bps?: number | null;
+    avg_tx_bps?: number | null;
+  }>
+): AnalyticsExportTraffic {
+  if (rows.length === 0) return emptyTraffic();
+
+  const dataPoints = rows.map((row) => {
+    const avgRx = Number(row.avg_rx_bps) || 0;
+    const avgTx = Number(row.avg_tx_bps) || 0;
+    return {
+      timestamp: new Date(row.captured_at).getTime(),
+      timeString: row.captured_at,
+      rxBytes: Number(row.total_rx_bytes) || 0,
+      txBytes: Number(row.total_tx_bytes) || 0,
+      avgRxMbps: roundPercent(bpsToMbps(avgRx)),
+      avgTxMbps: roundPercent(bpsToMbps(avgTx)),
+    };
+  });
+
+  const totalRxBytes = dataPoints.reduce((s, p) => s + p.rxBytes, 0);
+  const totalTxBytes = dataPoints.reduce((s, p) => s + p.txBytes, 0);
+  const avgRxRate =
+    rows.reduce((s, r) => s + (Number(r.avg_rx_bps) || 0), 0) / rows.length;
+  const avgTxRate =
+    rows.reduce((s, r) => s + (Number(r.avg_tx_bps) || 0), 0) / rows.length;
+
+  return {
+    totalRxBytes,
+    totalTxBytes,
+    totalBytes: totalRxBytes + totalTxBytes,
+    avgRxRate,
+    avgTxRate,
+    peakRxBytes: Math.max(0, ...dataPoints.map((p) => p.rxBytes), 0),
+    peakTxBytes: Math.max(0, ...dataPoints.map((p) => p.txBytes), 0),
+    avgRxMbps: roundPercent(bpsToMbps(avgRxRate)),
+    avgTxMbps: roundPercent(bpsToMbps(avgTxRate)),
+    dataPoints,
+  };
+}
+
+export function shapeInterstellioSection(input: {
+  siteId: string | null;
+  siteName: string | null;
+  subscriberId: string | null;
+  entries: DataUsageEntry[];
+  dayCount: number;
+  startUtc?: Date;
+}): AnalyticsExportInterstellio {
+  const dayCount = Math.max(1, input.dayCount);
+  const dailyDownloadBytes = Array.from({ length: dayCount }, () => 0);
+  const dailyUploadBytes = Array.from({ length: dayCount }, () => 0);
+
+  if (!input.siteId || !input.subscriberId) {
+    return {
+      linked: false,
+      siteId: input.siteId ?? undefined,
+      siteName: input.siteName ?? undefined,
+      dailyDownloadBytes,
+      dailyUploadBytes,
+      totalDownloadBytes: 0,
+      totalUploadBytes: 0,
+      note: 'Interstellio not linked for this AP — set corporate_sites.interstellio_subscriber_id on the linked site.',
+    };
+  }
+
+  const start = input.startUtc ?? new Date();
+  const indexByDay = new Map<string, number>();
+  for (let i = 0; i < dayCount; i++) {
+    const day = new Date(start.getTime() + i * 86_400_000);
+    const key = sastDayKey(day);
+    if (key) indexByDay.set(key, i);
+  }
+
+  let totalDownloadBytes = 0;
+  let totalUploadBytes = 0;
+  for (const entry of input.entries) {
+    const download = (Number(entry.download_kb) || 0) * BYTES_PER_INTERSTELLIO_KB;
+    const upload = (Number(entry.upload_kb) || 0) * BYTES_PER_INTERSTELLIO_KB;
+    totalDownloadBytes += download;
+    totalUploadBytes += upload;
+    const index = indexByDay.get(sastDayKey(entry.time) ?? '');
+    if (index !== undefined) {
+      dailyDownloadBytes[index] += download;
+      dailyUploadBytes[index] += upload;
+    }
+  }
+
+  return {
+    linked: true,
+    siteId: input.siteId,
+    siteName: input.siteName ?? undefined,
+    dailyDownloadBytes,
+    dailyUploadBytes,
+    totalDownloadBytes,
+    totalUploadBytes,
+    note: 'Secondary source: Interstellio BNG daily subscriber usage for the linked corporate site. Not summed into Ruijie AP traffic.',
+  };
+}
+
+/**
+ * Resolve corporate site + Interstellio for one Ruijie SN.
+ * Shared by Analytics export and device-page export.
+ */
+export async function loadInterstellioForDeviceSn(
+  sn: string,
+  period: AnalyticsExportPeriod
+): Promise<AnalyticsExportInterstellio> {
+  const supabase = await createClient();
+  const reportPeriod = periodToReportPeriod(period);
+
+  const { data: link } = await supabase
+    .from('network_devices')
+    .select('corporate_site_id')
+    .eq('ruijie_device_sn', sn)
+    .not('corporate_site_id', 'is', null)
+    .limit(1)
+    .maybeSingle();
+
+  const siteId = (link?.corporate_site_id as string | null) ?? null;
+  if (!siteId) {
+    return shapeInterstellioSection({
+      siteId: null,
+      siteName: null,
+      subscriberId: null,
+      entries: [],
+      dayCount: reportPeriod.inclusiveDayCount,
+      startUtc: period.startUtc,
+    });
+  }
+
+  const { data: site } = await supabase
+    .from('corporate_sites')
+    .select('id, site_name, interstellio_subscriber_id')
+    .eq('id', siteId)
+    .maybeSingle();
+
+  const siteName = (site?.site_name as string | null) || null;
+
+  let subscriberId: string | null = null;
+  try {
+    subscriberId = await loadInterstellioSubscriberId(supabase, siteId);
+  } catch {
+    subscriberId =
+      (site?.interstellio_subscriber_id as string | null | undefined) ?? null;
+  }
+
+  if (!subscriberId) {
+    return shapeInterstellioSection({
+      siteId,
+      siteName,
+      subscriberId: null,
+      entries: [],
+      dayCount: reportPeriod.inclusiveDayCount,
+      startUtc: period.startUtc,
+    });
+  }
+
+  let entries: DataUsageEntry[] = [];
+  try {
+    entries = await loadInterstellioDailyEntries(subscriberId, reportPeriod);
+  } catch {
+    return {
+      ...shapeInterstellioSection({
+        siteId,
+        siteName,
+        subscriberId,
+        entries: [],
+        dayCount: reportPeriod.inclusiveDayCount,
+        startUtc: period.startUtc,
+      }),
+      note: 'Interstellio linked but usage fetch failed for this period.',
+    };
+  }
+
+  return shapeInterstellioSection({
+    siteId,
+    siteName,
+    subscriberId,
+    entries,
+    dayCount: reportPeriod.inclusiveDayCount,
+    startUtc: period.startUtc,
+  });
+}
+
+export async function buildAnalyticsExportModel(
+  input: BuildAnalyticsExportInput
+): Promise<AnalyticsExportModel | null> {
+  const supabase = await createClient();
+  const period = resolveAnalyticsExportPeriod({
+    hoursRaw: input.hoursRaw,
+    startDate: input.startDate,
+    endDate: input.endDate,
+  });
+
+  const { data: deviceGroups } = await supabase
+    .from('ruijie_device_cache')
+    .select(
+      'group_id, group_name, sn, device_name, model, status, radio_2g_utilization, radio_5g_utilization, radio_2g_channel, radio_5g_channel'
+    )
+    .not('group_id', 'is', null);
+
+  const groupMap = new Map<string, string>();
+  for (const row of deviceGroups || []) {
+    if (row.group_id && !groupMap.has(row.group_id)) {
+      groupMap.set(row.group_id, row.group_name || row.group_id);
+    }
+  }
+
+  const effectiveGroupId = input.groupId || groupMap.keys().next().value || null;
+  if (!effectiveGroupId) return null;
+
+  const groupName = groupMap.get(effectiveGroupId) || effectiveGroupId;
+  const groupDevices = (deviceGroups || []).filter(
+    (d) => d.group_id === effectiveGroupId
+  );
+
+  const requestedSn = input.deviceSn?.trim() || null;
+  const deviceRow =
+    requestedSn && groupDevices.find((d) => d.sn === requestedSn)
+      ? groupDevices.find((d) => d.sn === requestedSn)!
+      : null;
+  const scope: 'group' | 'device' = deviceRow ? 'device' : 'group';
+  const deviceSn = deviceRow?.sn ?? null;
+
+  let rollupQuery = supabase
+    .from('ruijie_traffic_rollups')
+    .select(
+      'group_id, group_name, device_sn, total_rx_bytes, total_tx_bytes, captured_at, hours_window, avg_rx_bps, avg_tx_bps, peak_rx_bps, peak_tx_bps'
+    )
+    .eq('hours_window', HOURLY_ROLLUP_WINDOW)
+    .neq('device_sn', '__legacy_group__')
+    .gte('captured_at', period.startUtc.toISOString())
+    .lte('captured_at', period.endUtc.toISOString())
+    .order('captured_at', { ascending: true });
+
+  const { data: rollups } = await rollupQuery;
+  const allRollups = (rollups || []) as RollupRow[];
+
+  const groupTraffic = computeGroupTrafficCards(allRollups);
+  const radio = computeRadioUtilSummary(
+    groupDevices.map((d) => ({
+      sn: d.sn,
+      device_name: d.device_name,
+      status: d.status,
+      radio_2g_utilization: d.radio_2g_utilization,
+      radio_5g_utilization: d.radio_5g_utilization,
+      radio_2g_channel: d.radio_2g_channel,
+      radio_5g_channel: d.radio_5g_channel,
+    }))
+  );
+
+  const seriesRows = filterRollupsForScope(allRollups, {
+    groupId: effectiveGroupId,
+    deviceSn,
+  }).sort(
+    (a, b) =>
+      new Date(a.captured_at).getTime() - new Date(b.captured_at).getTime()
+  );
+
+  const traffic = trafficFromAnalyticsRollups(seriesRows);
+  const unavailable: Record<string, string> = {};
+  if (traffic.dataPoints.length === 0) {
+    unavailable.traffic = 'No rollup samples in this window';
+  }
+
+  let clients: RuijieClient[] = [];
+  let interstellio: AnalyticsExportInterstellio | null = null;
+
+  if (scope === 'group') {
+    unavailable.clients =
+      'Select an AP for a live connected-clients snapshot at generation time.';
+  } else if (deviceSn) {
+    try {
+      clients = await getDeviceClients(deviceSn, effectiveGroupId);
+    } catch (err) {
+      unavailable.clients =
+        err instanceof Error ? err.message : 'Failed to fetch connected clients';
+    }
+    try {
+      interstellio = await loadInterstellioForDeviceSn(deviceSn, period);
+    } catch (err) {
+      interstellio = shapeInterstellioSection({
+        siteId: null,
+        siteName: null,
+        subscriberId: null,
+        entries: [],
+        dayCount: periodToReportPeriod(period).inclusiveDayCount,
+        startUtc: period.startUtc,
+      });
+      unavailable.interstellio =
+        err instanceof Error ? err.message : 'Interstellio lookup failed';
+    }
+  }
+
+  return {
+    scope,
+    group: { id: effectiveGroupId, name: groupName },
+    device: deviceRow
+      ? {
+          sn: String(deviceRow.sn),
+          device_name: deviceRow.device_name || String(deviceRow.sn),
+          model: deviceRow.model ?? null,
+          status: deviceRow.status || 'unknown',
+          group_id: effectiveGroupId,
+          group_name: groupName,
+        }
+      : undefined,
+    period,
+    traffic,
+    groupTraffic,
+    radio,
+    clients,
+    interstellio,
+    generatedAtIso: new Date().toISOString(),
+    unavailable,
+  };
+}

--- a/lib/network/analytics-report-excel.ts
+++ b/lib/network/analytics-report-excel.ts
@@ -1,0 +1,246 @@
+/**
+ * Network Analytics Excel workbook — group aggregate or single AP.
+ */
+
+import ExcelJS from 'exceljs';
+import type { AnalyticsExportModel } from './analytics-export';
+
+const HEADER_FILL: ExcelJS.Fill = {
+  type: 'pattern',
+  pattern: 'solid',
+  fgColor: { argb: 'FFF3F4F6' },
+};
+
+function sastTimestamp(input: string | number): string {
+  return new Intl.DateTimeFormat('en-ZA', {
+    timeZone: 'Africa/Johannesburg',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(new Date(input));
+}
+
+function styleHeaderRow(row: ExcelJS.Row): void {
+  row.font = { bold: true };
+  row.eachCell((cell) => {
+    cell.fill = HEADER_FILL;
+  });
+}
+
+export async function generateAnalyticsReportExcel(
+  model: AnalyticsExportModel
+): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'CircleTel';
+  workbook.created = new Date(model.generatedAtIso);
+
+  const overview = workbook.addWorksheet('Overview');
+  overview.columns = [
+    { key: 'label', width: 28 },
+    { key: 'value', width: 48 },
+  ];
+  const rows: Array<[string, string | number]> = [
+    ['Scope', model.scope === 'device' ? 'Device' : 'Group'],
+    ['Group', model.group.name],
+    ['Group ID', model.group.id],
+  ];
+  if (model.device) {
+    rows.push(
+      ['Device name', model.device.device_name],
+      ['Serial number', model.device.sn],
+      ['Model', model.device.model ?? '—'],
+      ['Status', model.device.status]
+    );
+  }
+  rows.push(
+    ['Report period', model.period.label],
+    ['Downloaded', model.traffic.totalRxBytes],
+    ['Uploaded', model.traffic.totalTxBytes],
+    ['Total traffic', model.traffic.totalBytes],
+    ['Data points', model.traffic.dataPoints.length],
+    ['Generated (SAST)', sastTimestamp(model.generatedAtIso)]
+  );
+  if (model.interstellio) {
+    rows.push(
+      ['Interstellio linked', model.interstellio.linked ? 'Yes' : 'No'],
+      ['Interstellio site', model.interstellio.siteName ?? '—'],
+      ['Interstellio download bytes', model.interstellio.totalDownloadBytes],
+      ['Interstellio upload bytes', model.interstellio.totalUploadBytes]
+    );
+  }
+  rows.forEach(([label, value]) => {
+    const row = overview.addRow({ label, value });
+    row.getCell(1).font = { bold: true };
+  });
+  Object.entries(model.unavailable).forEach(([section, reason]) => {
+    const row = overview.addRow({ label: `Note — ${section}`, value: reason });
+    row.getCell(1).font = { bold: true, color: { argb: 'FF9CA3AF' } };
+  });
+
+  const trafficSheet = workbook.addWorksheet('Traffic');
+  trafficSheet.columns = [
+    { header: 'Timestamp (SAST)', key: 'time', width: 22 },
+    { header: 'Download bytes', key: 'rx', width: 18 },
+    { header: 'Upload bytes', key: 'tx', width: 18 },
+  ];
+  styleHeaderRow(trafficSheet.getRow(1));
+  model.traffic.dataPoints.forEach((point) => {
+    trafficSheet.addRow({
+      time: sastTimestamp(point.timestamp),
+      rx: point.rxBytes,
+      tx: point.txBytes,
+    });
+  });
+  if (model.traffic.dataPoints.length === 0) {
+    trafficSheet.addRow({
+      time: model.unavailable.traffic ?? 'No traffic samples',
+    });
+  } else {
+    const totals = trafficSheet.addRow({
+      time: 'TOTAL',
+      rx: model.traffic.totalRxBytes,
+      tx: model.traffic.totalTxBytes,
+    });
+    totals.font = { bold: true };
+  }
+  trafficSheet.getColumn('rx').numFmt = '#,##0';
+  trafficSheet.getColumn('tx').numFmt = '#,##0';
+
+  const groupsSheet = workbook.addWorksheet('Group cards');
+  groupsSheet.columns = [
+    { header: 'Group', key: 'name', width: 24 },
+    { header: 'Group ID', key: 'id', width: 14 },
+    { header: 'Total bytes', key: 'total', width: 16 },
+    { header: 'Download bytes', key: 'rx', width: 16 },
+    { header: 'Upload bytes', key: 'tx', width: 16 },
+    { header: 'Samples', key: 'samples', width: 10 },
+  ];
+  styleHeaderRow(groupsSheet.getRow(1));
+  model.groupTraffic.forEach((g) => {
+    groupsSheet.addRow({
+      name: g.groupName,
+      id: g.groupId,
+      total: g.totalBytes,
+      rx: g.totalRxBytes,
+      tx: g.totalTxBytes,
+      samples: g.sampleCount,
+    });
+  });
+
+  const radioSheet = workbook.addWorksheet('Radio');
+  radioSheet.columns = [
+    { key: 'label', width: 28 },
+    { key: 'value', width: 40 },
+  ];
+  (
+    [
+      ['Avg 2.4 GHz util %', model.radio.avg2g ?? '—'],
+      ['Avg 5 GHz util %', model.radio.avg5g ?? '—'],
+      ['Blended util %', model.radio.avgBlended ?? '—'],
+      ['Devices with radio', model.radio.devicesWithRadio],
+      ['Total devices', model.radio.totalDevices],
+      ['2.4 GHz channels', model.radio.channels2g.join(', ') || '—'],
+      ['5 GHz channels', model.radio.channels5g.join(', ') || '—'],
+    ] as Array<[string, string | number]>
+  ).forEach(([label, value]) => {
+    const row = radioSheet.addRow({ label, value });
+    row.getCell(1).font = { bold: true };
+  });
+  if (model.radio.byDevice.length > 0) {
+    radioSheet.addRow({});
+    const header = radioSheet.addRow({
+      label: 'Device',
+      value: '2.4 / 5 GHz util %',
+    });
+    header.font = { bold: true };
+    model.radio.byDevice.forEach((d) => {
+      radioSheet.addRow({
+        label: d.device_name || d.sn,
+        value: `${d.radio_2g_utilization ?? '—'} / ${d.radio_5g_utilization ?? '—'}`,
+      });
+    });
+  }
+
+  if (model.scope === 'device') {
+    const clientsSheet = workbook.addWorksheet('Clients');
+    clientsSheet.columns = [
+      { header: 'Hostname', key: 'hostname', width: 22 },
+      { header: 'MAC', key: 'mac', width: 18 },
+      { header: 'IP', key: 'ip', width: 15 },
+      { header: 'SSID', key: 'ssid', width: 22 },
+      { header: 'Band', key: 'band', width: 8 },
+      { header: 'Channel', key: 'channel', width: 9 },
+      { header: 'RSSI (dBm)', key: 'rssi', width: 11 },
+      { header: 'Quality', key: 'quality', width: 11 },
+      { header: 'Latency (ms)', key: 'latency', width: 12 },
+      { header: 'Score', key: 'score', width: 8 },
+      { header: 'Down rate (bps)', key: 'down', width: 15 },
+      { header: 'Up rate (bps)', key: 'up', width: 15 },
+      { header: 'Loss', key: 'loss', width: 10 },
+      { header: 'Air util', key: 'air', width: 10 },
+    ];
+    styleHeaderRow(clientsSheet.getRow(1));
+    model.clients.forEach((client) => {
+      clientsSheet.addRow({
+        hostname: client.hostname ?? '—',
+        mac: client.mac,
+        ip: client.userIp,
+        ssid: client.ssid,
+        band: client.band,
+        channel: client.channel,
+        rssi: client.rssi,
+        quality: client.signalQuality,
+        latency: client.latencyMs,
+        score: client.score,
+        down: client.downlinkRate,
+        up: client.uplinkRate,
+        loss: client.pktLoseRate,
+        air: client.utilization,
+      });
+    });
+    if (model.clients.length === 0) {
+      clientsSheet.addRow({
+        hostname:
+          model.unavailable.clients ??
+          'No clients connected (live snapshot at generation time)',
+      });
+    }
+
+    if (model.interstellio) {
+      const interSheet = workbook.addWorksheet('Interstellio');
+      interSheet.columns = [
+        { header: 'Day index', key: 'day', width: 12 },
+        { header: 'Download bytes', key: 'rx', width: 18 },
+        { header: 'Upload bytes', key: 'tx', width: 18 },
+      ];
+      styleHeaderRow(interSheet.getRow(1));
+      interSheet.insertRow(1, [
+        'Linked',
+        model.interstellio.linked ? 'Yes' : 'No',
+      ]);
+      interSheet.insertRow(2, [
+        'Site',
+        model.interstellio.siteName ?? '—',
+      ]);
+      interSheet.insertRow(3, [
+        'Note',
+        model.interstellio.note ?? '',
+      ]);
+      interSheet.insertRow(4, []);
+      model.interstellio.dailyDownloadBytes.forEach((rx, index) => {
+        interSheet.addRow({
+          day: index + 1,
+          rx,
+          tx: model.interstellio?.dailyUploadBytes[index] ?? 0,
+        });
+      });
+    }
+  }
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return Buffer.from(buffer);
+}

--- a/lib/network/analytics-report-pdf.ts
+++ b/lib/network/analytics-report-pdf.ts
@@ -1,0 +1,415 @@
+/**
+ * Network Analytics PDF — group aggregate or single AP.
+ */
+
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { circleTelLogoBase64 } from '@/lib/quotes/circletel-logo-base64';
+import type { AnalyticsExportModel } from './analytics-export';
+
+const COLORS = {
+  orange: '#F5831F',
+  navy: '#1B2A4A',
+  dark: '#1F2937',
+  gray: '#6B7280',
+  muted: '#9CA3AF',
+  border: '#E5E7EB',
+  panel: '#F9FAFB',
+  white: '#FFFFFF',
+};
+
+const MAX_CHART_BARS = 84;
+
+function addLogo(doc: jsPDF, x: number, y: number, size: number): void {
+  try {
+    doc.addImage(circleTelLogoBase64, 'PNG', x, y, size, size);
+  } catch {
+    doc.setFillColor(COLORS.orange);
+    doc.roundedRect(x, y, size, size, 2, 2, 'F');
+    doc.setTextColor(COLORS.white);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(13);
+    doc.text('CT', x + size / 2, y + size / 2 + 2, { align: 'center' });
+  }
+}
+
+function formatGeneratedAt(iso: string): string {
+  return new Intl.DateTimeFormat('en-ZA', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'Africa/Johannesburg',
+  }).format(new Date(iso));
+}
+
+function sectionTitle(doc: jsPDF, title: string, x: number, y: number): void {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  doc.setTextColor(COLORS.dark);
+  doc.text(title, x, y);
+}
+
+function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes) || bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
+}
+
+function formatBps(bps: number | null | undefined): string {
+  if (bps == null || !Number.isFinite(bps) || bps === 0) return '0 bps';
+  const units = ['bps', 'Kbps', 'Mbps', 'Gbps'];
+  const i = Math.min(Math.floor(Math.log(bps) / Math.log(1000)), units.length - 1);
+  return `${(bps / Math.pow(1000, i)).toFixed(1)} ${units[i]}`;
+}
+
+function formatSastTime(timestampMs: number, hoursHint: number): string {
+  return new Intl.DateTimeFormat('en-ZA', {
+    timeZone: 'Africa/Johannesburg',
+    ...(hoursHint <= 24
+      ? { hour: '2-digit', minute: '2-digit' }
+      : { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' }),
+  }).format(new Date(timestampMs));
+}
+
+function hoursHint(model: AnalyticsExportModel): number {
+  if (model.period.mode === 'hours') return model.period.hours;
+  return model.period.inclusiveDayCount * 24;
+}
+
+function resampleForChart(
+  points: AnalyticsExportModel['traffic']['dataPoints']
+): Array<{ timestamp: number; rxBytes: number; txBytes: number }> {
+  if (points.length <= MAX_CHART_BARS) {
+    return points.map((p) => ({
+      timestamp: p.timestamp,
+      rxBytes: p.rxBytes,
+      txBytes: p.txBytes,
+    }));
+  }
+  const groupSize = Math.ceil(points.length / MAX_CHART_BARS);
+  const bars: Array<{ timestamp: number; rxBytes: number; txBytes: number }> = [];
+  for (let start = 0; start < points.length; start += groupSize) {
+    const group = points.slice(start, start + groupSize);
+    bars.push({
+      timestamp: group[0].timestamp,
+      rxBytes: group.reduce((sum, p) => sum + p.rxBytes, 0),
+      txBytes: group.reduce((sum, p) => sum + p.txBytes, 0),
+    });
+  }
+  return bars;
+}
+
+function ensureSpace(doc: jsPDF, y: number, needed: number): number {
+  const pageHeight = doc.internal.pageSize.getHeight();
+  if (y + needed > pageHeight - 20) {
+    doc.addPage();
+    return 20;
+  }
+  return y;
+}
+
+export function generateAnalyticsReportPdf(model: AnalyticsExportModel): ArrayBuffer {
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const margin = 15;
+  const contentWidth = pageWidth - margin * 2;
+  const { traffic } = model;
+  const hint = hoursHint(model);
+
+  addLogo(doc, margin, 14, 24);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(18);
+  doc.setTextColor(COLORS.dark);
+  doc.text('NETWORK ANALYTICS', pageWidth - margin, 23, { align: 'right' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(COLORS.gray);
+  doc.text(`Generated ${formatGeneratedAt(model.generatedAtIso)} SAST`, pageWidth - margin, 30, {
+    align: 'right',
+  });
+  doc.setDrawColor(COLORS.orange);
+  doc.setLineWidth(0.8);
+  doc.line(margin, 43, pageWidth - margin, 43);
+
+  doc.setFontSize(7);
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(COLORS.gray);
+  doc.text(model.scope === 'device' ? 'DEVICE' : 'GROUP', margin, 51);
+  doc.text('REPORT PERIOD', pageWidth - margin, 51, { align: 'right' });
+  doc.setFontSize(12);
+  doc.setTextColor(COLORS.dark);
+  const title =
+    model.scope === 'device' && model.device
+      ? model.device.device_name
+      : model.group.name;
+  doc.text(title, margin, 58);
+  doc.text(model.period.label, pageWidth - margin, 58, { align: 'right' });
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(COLORS.gray);
+  const subtitle =
+    model.scope === 'device' && model.device
+      ? [model.device.model, `SN ${model.device.sn}`, model.group.name]
+          .filter(Boolean)
+          .join(' · ')
+      : `All devices in group · Ruijie rollups`;
+  doc.text(subtitle, margin, 63);
+  doc.text('Times in SAST', pageWidth - margin, 63, { align: 'right' });
+
+  const kpiY = 72;
+  sectionTitle(doc, `Traffic — ${model.period.label}`, margin, kpiY - 2);
+  const kpis: Array<[string, string]> = [
+    ['DOWNLOADED', formatBytes(traffic.totalRxBytes)],
+    ['UPLOADED', formatBytes(traffic.totalTxBytes)],
+    ['AVG RATE', formatBps(traffic.avgRxRate)],
+    ['PEAK BUCKET', formatBytes(traffic.peakRxBytes)],
+  ];
+  const kpiWidth = contentWidth / 4;
+  doc.setFillColor(COLORS.panel);
+  doc.rect(margin, kpiY, contentWidth, 18, 'F');
+  kpis.forEach(([label, value], index) => {
+    const x = margin + index * kpiWidth + 3;
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(6.5);
+    doc.setTextColor(COLORS.gray);
+    doc.text(label, x, kpiY + 6);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9.5);
+    doc.setTextColor(COLORS.dark);
+    doc.text(value, x, kpiY + 13);
+  });
+
+  const chartBoxY = kpiY + 22;
+  const chartBoxHeight = 52;
+  const chartHeight = 32;
+  const bars = resampleForChart(traffic.dataPoints);
+  doc.setFillColor(COLORS.panel);
+  doc.setDrawColor(COLORS.border);
+  doc.roundedRect(margin, chartBoxY, contentWidth, chartBoxHeight, 1.5, 1.5, 'FD');
+  if (bars.length === 0) {
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(8);
+    doc.setTextColor(COLORS.gray);
+    doc.text(
+      model.unavailable.traffic ?? 'No traffic samples in this window',
+      pageWidth / 2,
+      chartBoxY + chartBoxHeight / 2 + 1,
+      { align: 'center' }
+    );
+  } else {
+    const chartX = margin + 18;
+    const chartY = chartBoxY + 6;
+    const chartWidth = contentWidth - 24;
+    const maxValue = Math.max(1, ...bars.map((bar) => bar.rxBytes + bar.txBytes));
+    for (let i = 0; i <= 4; i++) {
+      const fraction = i / 4;
+      const y = chartY + chartHeight * (1 - fraction);
+      doc.setDrawColor(i === 0 ? COLORS.muted : COLORS.border);
+      doc.setLineWidth(i === 0 ? 0.3 : 0.15);
+      doc.line(chartX, y, chartX + chartWidth, y);
+      if (i % 2 === 0) {
+        doc.setFont('helvetica', 'normal');
+        doc.setFontSize(5);
+        doc.setTextColor(COLORS.gray);
+        doc.text(formatBytes(maxValue * fraction), chartX - 1.5, y + 1, { align: 'right' });
+      }
+    }
+    const barWidth = chartWidth / bars.length;
+    const barGap = bars.length > 40 ? 0.3 : 0.6;
+    const scale = chartHeight / maxValue;
+    bars.forEach((bar, index) => {
+      if (bar.rxBytes + bar.txBytes === 0) return;
+      const x = chartX + index * barWidth + barGap / 2;
+      const width = Math.max(0.3, barWidth - barGap);
+      const rxDraw = bar.rxBytes > 0 ? Math.max(bar.rxBytes * scale, 0.4) : 0;
+      const txDraw = bar.txBytes > 0 ? Math.max(bar.txBytes * scale, 0.4) : 0;
+      if (rxDraw > 0) {
+        doc.setFillColor(COLORS.orange);
+        doc.rect(x, chartY + chartHeight - rxDraw, width, rxDraw, 'F');
+      }
+      if (txDraw > 0) {
+        doc.setFillColor(COLORS.navy);
+        doc.rect(x, chartY + chartHeight - rxDraw - txDraw, width, txDraw, 'F');
+      }
+    });
+    doc.setFont('courier', 'normal');
+    doc.setFontSize(5.5);
+    doc.setTextColor(COLORS.gray);
+    for (let i = 0; i < 5; i++) {
+      const barIndex = Math.min(bars.length - 1, Math.round((i / 4) * (bars.length - 1)));
+      const x = chartX + (barIndex + 0.5) * barWidth;
+      doc.text(formatSastTime(bars[barIndex].timestamp, hint), x, chartY + chartHeight + 4, {
+        align: 'center',
+      });
+    }
+  }
+
+  let y = chartBoxY + chartBoxHeight + 10;
+
+  if (model.scope === 'group' && model.groupTraffic.length > 0) {
+    y = ensureSpace(doc, y, 40);
+    sectionTitle(doc, 'Group traffic breakdown', margin, y);
+    autoTable(doc, {
+      startY: y + 3,
+      margin: { left: margin, right: margin },
+      head: [['Group', 'Total', 'Download', 'Upload', 'Samples']],
+      body: model.groupTraffic.map((g) => [
+        g.groupName,
+        formatBytes(g.totalBytes),
+        formatBytes(g.totalRxBytes),
+        formatBytes(g.totalTxBytes),
+        String(g.sampleCount),
+      ]),
+      theme: 'plain',
+      styles: {
+        fontSize: 7,
+        cellPadding: 1.8,
+        textColor: COLORS.dark,
+        lineColor: COLORS.border,
+        lineWidth: 0.2,
+      },
+      headStyles: { fillColor: COLORS.panel, textColor: COLORS.gray, fontStyle: 'bold' },
+    });
+    y =
+      (doc as jsPDF & { lastAutoTable?: { finalY: number } }).lastAutoTable?.finalY ?? y + 20;
+    y += 8;
+  }
+
+  y = ensureSpace(doc, y, 30);
+  sectionTitle(doc, 'Radio utilisation (group)', margin, y);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(COLORS.dark);
+  const radioLines = [
+    `2.4 GHz avg: ${model.radio.avg2g != null ? `${model.radio.avg2g}%` : '—'}`,
+    `5 GHz avg: ${model.radio.avg5g != null ? `${model.radio.avg5g}%` : '—'}`,
+    `Blended: ${model.radio.avgBlended != null ? `${model.radio.avgBlended}%` : '—'}`,
+    `Devices with radio: ${model.radio.devicesWithRadio}/${model.radio.totalDevices}`,
+  ];
+  radioLines.forEach((line, i) => {
+    doc.text(line, margin, y + 6 + i * 5);
+  });
+  y += 6 + radioLines.length * 5 + 6;
+
+  if (model.scope === 'device') {
+    y = ensureSpace(doc, y, 40);
+    sectionTitle(
+      doc,
+      `Connected clients at generation time (${model.clients.length})`,
+      margin,
+      y
+    );
+    if (model.clients.length === 0) {
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(7.5);
+      doc.setTextColor(COLORS.gray);
+      doc.text(
+        model.unavailable.clients ?? 'No clients connected right now',
+        margin,
+        y + 6
+      );
+      y += 14;
+    } else {
+      autoTable(doc, {
+        startY: y + 3,
+        margin: { left: margin, right: margin },
+        head: [['Device', 'MAC', 'IP', 'SSID', 'Band', 'RSSI', 'Quality', 'Latency', 'Score', 'Down']],
+        body: model.clients.map((client) => [
+          client.hostname ?? client.vendor ?? '—',
+          client.mac,
+          client.userIp,
+          client.ssid,
+          `${client.band} ch ${client.channel}`,
+          `${client.rssi} dBm`,
+          client.signalQuality,
+          client.latencyMs != null ? `${client.latencyMs} ms` : '—',
+          client.score != null ? String(client.score) : '—',
+          formatBps(client.downlinkRate),
+        ]),
+        theme: 'plain',
+        styles: {
+          fontSize: 6.5,
+          cellPadding: 1.4,
+          textColor: COLORS.dark,
+          lineColor: COLORS.border,
+          lineWidth: 0.2,
+        },
+        headStyles: { fillColor: COLORS.panel, textColor: COLORS.gray, fontStyle: 'bold' },
+      });
+      y =
+        (doc as jsPDF & { lastAutoTable?: { finalY: number } }).lastAutoTable?.finalY ??
+        y + 20;
+      y += 8;
+    }
+
+    if (model.interstellio) {
+      y = ensureSpace(doc, y, 40);
+      sectionTitle(doc, 'Interstellio BNG (secondary)', margin, y);
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(7.5);
+      doc.setTextColor(COLORS.gray);
+      if (!model.interstellio.linked) {
+        doc.text(model.interstellio.note ?? 'Interstellio not linked', margin, y + 6);
+        y += 14;
+      } else {
+        doc.setTextColor(COLORS.dark);
+        doc.text(
+          [
+            model.interstellio.siteName ?? 'Linked site',
+            `Download ${formatBytes(model.interstellio.totalDownloadBytes)}`,
+            `Upload ${formatBytes(model.interstellio.totalUploadBytes)}`,
+          ].join(' · '),
+          margin,
+          y + 6
+        );
+        if (model.interstellio.note) {
+          doc.setTextColor(COLORS.gray);
+          doc.setFontSize(6.5);
+          doc.text(model.interstellio.note, margin, y + 11, {
+            maxWidth: contentWidth,
+          });
+        }
+        autoTable(doc, {
+          startY: y + 16,
+          margin: { left: margin, right: margin },
+          head: [['Day', 'Download', 'Upload']],
+          body: model.interstellio.dailyDownloadBytes.map((rx, index) => [
+            `Day ${index + 1}`,
+            formatBytes(rx),
+            formatBytes(model.interstellio?.dailyUploadBytes[index] ?? 0),
+          ]),
+          theme: 'plain',
+          styles: {
+            fontSize: 7,
+            cellPadding: 1.6,
+            textColor: COLORS.dark,
+            lineColor: COLORS.border,
+            lineWidth: 0.2,
+          },
+          headStyles: { fillColor: COLORS.panel, textColor: COLORS.gray, fontStyle: 'bold' },
+        });
+      }
+    }
+  }
+
+  const pageCount = doc.getNumberOfPages();
+  const footerId =
+    model.scope === 'device' && model.device ? model.device.sn : model.group.name;
+  for (let page = 1; page <= pageCount; page++) {
+    doc.setPage(page);
+    doc.setDrawColor(COLORS.border);
+    doc.line(margin, pageHeight - 14, pageWidth - margin, pageHeight - 14);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(6.5);
+    doc.setTextColor(COLORS.muted);
+    doc.text(
+      `CircleTel · Analytics · ${footerId} · ${model.period.label} · Page ${page} of ${pageCount}`,
+      pageWidth / 2,
+      pageHeight - 9,
+      { align: 'center' }
+    );
+  }
+
+  return doc.output('arraybuffer');
+}

--- a/lib/ruijie/__tests__/device-export.test.ts
+++ b/lib/ruijie/__tests__/device-export.test.ts
@@ -17,6 +17,24 @@ jest.mock('../client', () => ({
   getNetworkTraffic: jest.fn(),
 }));
 
+jest.mock('@/lib/network/analytics-export', () => ({
+  resolveAnalyticsExportPeriod: jest.fn(() => ({
+    mode: 'hours',
+    hours: 24,
+    label: 'Last 24 hours',
+    startUtc: new Date('2026-08-01T00:00:00Z'),
+    endUtc: new Date('2026-08-02T00:00:00Z'),
+  })),
+  loadInterstellioForDeviceSn: jest.fn(async () => ({
+    linked: false,
+    dailyDownloadBytes: [0],
+    dailyUploadBytes: [0],
+    totalDownloadBytes: 0,
+    totalUploadBytes: 0,
+    note: 'Interstellio not linked for this AP — set corporate_sites.interstellio_subscriber_id on the linked site.',
+  })),
+}));
+
 import { createClient } from '@/lib/supabase/server';
 import {
   getDeviceMetrics,
@@ -24,6 +42,7 @@ import {
   getDeviceLogs,
   getNetworkTraffic,
 } from '../client';
+import { loadInterstellioForDeviceSn } from '@/lib/network/analytics-export';
 import {
   buildDeviceExportModel,
   clampHours,
@@ -140,6 +159,14 @@ function fullFixtureModel(): DeviceExportModel {
     traffic: TRAFFIC,
     clients: CLIENTS,
     logs: LOGS,
+    interstellio: {
+      linked: false,
+      dailyDownloadBytes: [0],
+      dailyUploadBytes: [0],
+      totalDownloadBytes: 0,
+      totalUploadBytes: 0,
+      note: 'Interstellio not linked',
+    },
     hours: 168,
     generatedAtIso: '2026-08-02T15:00:00.000Z',
     unavailable: {},
@@ -148,6 +175,14 @@ function fullFixtureModel(): DeviceExportModel {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  (loadInterstellioForDeviceSn as jest.Mock).mockResolvedValue({
+    linked: false,
+    dailyDownloadBytes: [0],
+    dailyUploadBytes: [0],
+    totalDownloadBytes: 0,
+    totalUploadBytes: 0,
+    note: 'Interstellio not linked for this AP — set corporate_sites.interstellio_subscriber_id on the linked site.',
+  });
 });
 
 describe('clampHours', () => {
@@ -183,7 +218,9 @@ describe('buildDeviceExportModel', () => {
     expect(model!.clients).toHaveLength(1);
     expect(model!.logs).toHaveLength(1);
     expect(model!.unavailable).toEqual({});
+    expect(model!.interstellio?.linked).toBe(false);
     expect(getDeviceClients).toHaveBeenCalledWith('G1U52HL044467', '9058218');
+    expect(loadInterstellioForDeviceSn).toHaveBeenCalled();
   });
 
   it('degrades failed sections to unavailable notes instead of throwing', async () => {
@@ -248,7 +285,7 @@ describe('generateDeviceReportPdf', () => {
 });
 
 describe('generateDeviceReportExcel', () => {
-  it('produces a 4-sheet workbook with raw traffic buckets', async () => {
+  it('produces a workbook with traffic buckets and Interstellio sheet', async () => {
     const buffer = await generateDeviceReportExcel(fullFixtureModel());
 
     const workbook = new ExcelJS.Workbook();
@@ -258,6 +295,7 @@ describe('generateDeviceReportExcel', () => {
       'Overview',
       'Traffic',
       'Clients',
+      'Interstellio',
       'Logs',
     ]);
 

--- a/lib/ruijie/device-export.ts
+++ b/lib/ruijie/device-export.ts
@@ -19,6 +19,11 @@ import {
   type RuijieLogEntry,
   type TrafficSummary,
 } from './client';
+import {
+  loadInterstellioForDeviceSn,
+  resolveAnalyticsExportPeriod,
+  type AnalyticsExportInterstellio,
+} from '@/lib/network/analytics-export';
 
 export const EXPORT_WINDOW_HOURS = [6, 24, 72, 168] as const;
 
@@ -61,6 +66,8 @@ export interface DeviceExportModel {
   traffic: TrafficSummary | null;
   clients: RuijieClient[];
   logs: RuijieLogEntry[];
+  /** Secondary BNG usage when the AP is linked to a corporate site. */
+  interstellio: AnalyticsExportInterstellio | null;
   hours: number;
   generatedAtIso: string;
   unavailable: {
@@ -68,6 +75,7 @@ export interface DeviceExportModel {
     traffic?: string;
     clients?: string;
     logs?: string;
+    interstellio?: string;
   };
 }
 
@@ -143,12 +151,26 @@ export async function buildDeviceExportModel(
     unavailable.logs = reasonFrom(logsResult);
   }
 
+  let interstellio: AnalyticsExportInterstellio | null = null;
+  try {
+    const period = resolveAnalyticsExportPeriod({
+      hoursRaw: String(window),
+      startDate: null,
+      endDate: null,
+    });
+    interstellio = await loadInterstellioForDeviceSn(sn, period);
+  } catch (err) {
+    unavailable.interstellio =
+      err instanceof Error ? err.message : 'Interstellio lookup failed';
+  }
+
   return {
     device: device as DeviceExportDevice,
     metrics,
     traffic,
     clients,
     logs,
+    interstellio,
     hours: window,
     generatedAtIso: new Date().toISOString(),
     unavailable,

--- a/lib/ruijie/device-report-excel.ts
+++ b/lib/ruijie/device-report-excel.ts
@@ -152,6 +152,27 @@ export async function generateDeviceReportExcel(model: DeviceExportModel): Promi
     });
   }
 
+  if (model.interstellio) {
+    const interSheet = workbook.addWorksheet('Interstellio');
+    interSheet.columns = [
+      { header: 'Day index', key: 'day', width: 12 },
+      { header: 'Download bytes', key: 'rx', width: 18 },
+      { header: 'Upload bytes', key: 'tx', width: 18 },
+    ];
+    styleHeaderRow(interSheet.getRow(1));
+    interSheet.insertRow(1, ['Linked', model.interstellio.linked ? 'Yes' : 'No']);
+    interSheet.insertRow(2, ['Site', model.interstellio.siteName ?? '—']);
+    interSheet.insertRow(3, ['Note', model.interstellio.note ?? '']);
+    interSheet.insertRow(4, []);
+    model.interstellio.dailyDownloadBytes.forEach((rx, index) => {
+      interSheet.addRow({
+        day: index + 1,
+        rx,
+        tx: model.interstellio?.dailyUploadBytes[index] ?? 0,
+      });
+    });
+  }
+
   // --- Logs ---
   const logsSheet = workbook.addWorksheet('Logs');
   logsSheet.columns = [

--- a/lib/ruijie/device-report-pdf.ts
+++ b/lib/ruijie/device-report-pdf.ts
@@ -319,7 +319,12 @@ export function generateDeviceReportPdf(model: DeviceExportModel): ArrayBuffer {
 
   // Connected clients table
   const clientsStartY = chartBoxY + chartBoxHeight + 8;
-  sectionTitle(doc, `Connected clients (${model.clients.length})`, margin, clientsStartY);
+  sectionTitle(
+    doc,
+    `Connected clients at generation time (${model.clients.length})`,
+    margin,
+    clientsStartY
+  );
   if (model.clients.length === 0) {
     doc.setFont('helvetica', 'normal');
     doc.setFontSize(7.5);
@@ -351,10 +356,57 @@ export function generateDeviceReportPdf(model: DeviceExportModel): ArrayBuffer {
     });
   }
 
-  // Recent logs table
-  const afterClientsY =
+  let afterClientsY =
     (doc as jsPDF & { lastAutoTable?: { finalY: number } }).lastAutoTable?.finalY ??
     clientsStartY + 10;
+
+  if (model.interstellio) {
+    const interY =
+      afterClientsY + 10 > pageHeight - 40 ? (doc.addPage(), 20) : afterClientsY + 10;
+    sectionTitle(doc, 'Interstellio BNG (secondary)', margin, interY);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(7.5);
+    if (!model.interstellio.linked) {
+      doc.setTextColor(COLORS.gray);
+      doc.text(model.interstellio.note ?? 'Interstellio not linked', margin, interY + 6);
+      afterClientsY = interY + 12;
+    } else {
+      doc.setTextColor(COLORS.dark);
+      doc.text(
+        [
+          model.interstellio.siteName ?? 'Linked site',
+          `Download ${formatBytes(model.interstellio.totalDownloadBytes)}`,
+          `Upload ${formatBytes(model.interstellio.totalUploadBytes)}`,
+        ].join(' · '),
+        margin,
+        interY + 6
+      );
+      autoTable(doc, {
+        startY: interY + 10,
+        margin: { left: margin, right: margin },
+        head: [['Day', 'Download', 'Upload']],
+        body: model.interstellio.dailyDownloadBytes.map((rx, index) => [
+          `Day ${index + 1}`,
+          formatBytes(rx),
+          formatBytes(model.interstellio?.dailyUploadBytes[index] ?? 0),
+        ]),
+        theme: 'plain',
+        styles: {
+          fontSize: 7,
+          cellPadding: 1.6,
+          textColor: COLORS.dark,
+          lineColor: COLORS.border,
+          lineWidth: 0.2,
+        },
+        headStyles: { fillColor: COLORS.panel, textColor: COLORS.gray, fontStyle: 'bold' },
+      });
+      afterClientsY =
+        (doc as jsPDF & { lastAutoTable?: { finalY: number } }).lastAutoTable?.finalY ??
+        interY + 20;
+    }
+  }
+
+  // Recent logs table
   const logs = model.logs.slice(0, MAX_LOG_ROWS);
   const logsTitleY = afterClientsY + 10 > pageHeight - 30 ? (doc.addPage(), 20) : afterClientsY + 10;
   sectionTitle(doc, `Recent device logs${model.logs.length > MAX_LOG_ROWS ? ` (latest ${MAX_LOG_ROWS} of ${model.logs.length})` : ` (${model.logs.length})`}`, margin, logsTitleY);


### PR DESCRIPTION
## Summary
- Adds **Export** menu on Network Analytics for PDF/Excel of the current group/device + period scope.
- New API `POST/GET /api/admin/network/analytics/export` plus report builders under `lib/network/`.
- Hardens Ruijie device export (Interstellio sheet, empty traffic window notes).

## Test plan
- [x] Jest: `__tests__/lib/network/analytics-export.test.ts` + `lib/ruijie/__tests__/device-export.test.ts` (21 passed)
- [ ] Admin → Network → Analytics → Export PDF/Excel for a group and a single device
- [ ] Confirm auth required on export API


Made with [Cursor](https://cursor.com)