### PR TITLE
fix(billing): make PayNow statement recon observable and finalizable

### DIFF
--- a/app/api/admin/billing/reconciliation/status/route.ts
+++ b/app/api/admin/billing/reconciliation/status/route.ts
@@ -27,6 +27,40 @@ export interface ReconciliationStatus {
   }>;
 }
 
+type ExecutionDetails = {
+  duration_ms?: number;
+  total_transactions?: number;
+  totalTransactions?: number;
+  matched?: number;
+  already_paid?: number;
+  alreadyPaid?: number;
+  newly_matched?: number;
+  newlyMatched?: number;
+  unmatched?: number;
+  unmatched_details?: Array<{
+    netcashRef?: string;
+    yourRef?: string;
+    amount?: number;
+    reason?: string;
+  }>;
+  unmatchedDetails?: Array<{
+    netcashRef?: string;
+    yourRef?: string;
+    amount?: number;
+    reason?: string;
+  }>;
+};
+
+function mapRunStatus(
+  dbStatus: string | null | undefined
+): 'success' | 'partial' | 'failed' {
+  if (dbStatus === 'completed' || dbStatus === 'success') return 'success';
+  if (dbStatus === 'completed_with_errors' || dbStatus === 'partial') {
+    return 'partial';
+  }
+  return 'failed';
+}
+
 export async function GET(request: NextRequest) {
   try {
     const authResult = await authenticateAdmin(request);
@@ -34,14 +68,16 @@ export async function GET(request: NextRequest) {
 
     const supabase = await createClient();
 
-    // Get latest reconciliation run
+    // Schema uses execution_start / execution_details (not started_at / result)
     const { data: latestRun, error } = await supabase
       .from('cron_execution_log')
-      .select('*')
+      .select(
+        'status, execution_start, duration_seconds, execution_details, records_processed, records_failed'
+      )
       .eq('job_name', 'paynow-reconciliation')
-      .order('started_at', { ascending: false })
+      .order('execution_start', { ascending: false })
       .limit(1)
-      .single();
+      .maybeSingle();
 
     if (error && error.code !== 'PGRST116') {
       throw new Error(`Database error: ${error.message}`);
@@ -50,28 +86,58 @@ export async function GET(request: NextRequest) {
     if (!latestRun) {
       return NextResponse.json<ReconciliationStatus>({
         lastRun: null,
-        counts: { total: 0, matched: 0, alreadyPaid: 0, newlyMatched: 0, unmatched: 0 },
+        counts: {
+          total: 0,
+          matched: 0,
+          alreadyPaid: 0,
+          newlyMatched: 0,
+          unmatched: 0,
+        },
         unmatchedTransactions: [],
       });
     }
 
-    const result = latestRun.result as any;
+    const details =
+      (latestRun.execution_details as ExecutionDetails | null) ?? {};
+    const durationMs =
+      Number(details.duration_ms ?? 0) ||
+      (typeof latestRun.duration_seconds === 'number'
+        ? Math.round(latestRun.duration_seconds * 1000)
+        : 0);
+
+    const unmatchedDetails =
+      details.unmatchedDetails ?? details.unmatched_details ?? [];
 
     const status: ReconciliationStatus = {
       lastRun: {
-        date: latestRun.started_at,
-        status: latestRun.status === 'completed' ? 'success' :
-                latestRun.status === 'completed_with_errors' ? 'partial' : 'failed',
-        duration_ms: result?.duration_ms || 0,
+        date: latestRun.execution_start,
+        status: mapRunStatus(latestRun.status),
+        duration_ms: durationMs,
       },
       counts: {
-        total: result?.totalTransactions || result?.total_transactions || 0,
-        matched: result?.matched || 0,
-        alreadyPaid: result?.alreadyPaid || result?.already_paid || 0,
-        newlyMatched: result?.newlyMatched || result?.newly_matched || 0,
-        unmatched: result?.unmatched || 0,
+        total:
+          Number(
+            details.total_transactions ??
+              details.totalTransactions ??
+              latestRun.records_processed ??
+              0
+          ) || 0,
+        matched: Number(details.matched ?? 0) || 0,
+        alreadyPaid:
+          Number(details.already_paid ?? details.alreadyPaid ?? 0) || 0,
+        newlyMatched:
+          Number(details.newly_matched ?? details.newlyMatched ?? 0) || 0,
+        unmatched:
+          Number(
+            details.unmatched ?? latestRun.records_failed ?? 0
+          ) || 0,
       },
-      unmatchedTransactions: result?.unmatchedDetails || result?.unmatched_details || [],
+      unmatchedTransactions: unmatchedDetails.map((d) => ({
+        netcashRef: d.netcashRef ?? '',
+        yourRef: d.yourRef ?? '',
+        amount: Number(d.amount ?? 0),
+        reason: d.reason ?? '',
+      })),
     };
 
     return NextResponse.json(status);

--- a/app/api/cron/paynow-reconciliation/route.ts
+++ b/app/api/cron/paynow-reconciliation/route.ts
@@ -21,13 +21,52 @@ import { billingEngine } from '@/lib/billing/engine';
 import { syncPaymentToZohoBilling } from '@/lib/integrations/zoho/payment-sync-service';
 import { cronLogger } from '@/lib/logging';
 import { inngest } from '@/lib/inngest';
-import { randomUUID } from 'crypto';
 
 export const dynamic = 'force-dynamic';
 
 // Vercel cron configuration
 export const runtime = 'nodejs';
 export const maxDuration = 60;
+
+/**
+ * Insert a real cron_execution_log row before handing off to Inngest.
+ * The previous bridge sent a randomUUID that was never inserted, so Inngest
+ * updates were no-ops and runs were invisible in cron_execution_log.
+ */
+async function createProcessLog(params: {
+  triggeredBy: 'cron' | 'manual';
+  reconciliationDate?: string;
+  dryRun?: boolean;
+}): Promise<string> {
+  const supabase = await createClient();
+  const dateStr =
+    params.reconciliationDate ??
+    new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+
+  const { data: newLog, error } = await supabase
+    .from('cron_execution_log')
+    .insert({
+      job_name: 'paynow-reconciliation',
+      status: 'running',
+      execution_start: new Date().toISOString(),
+      trigger_source: params.triggeredBy === 'manual' ? 'manual' : 'vercel_cron',
+      execution_details: {
+        triggered_by: params.triggeredBy,
+        reconciliation_date: dateStr,
+        dry_run: params.dryRun ?? false,
+      },
+    })
+    .select('id')
+    .single();
+
+  if (error || !newLog) {
+    throw new Error(
+      `Failed to create process log: ${error?.message || 'Unknown error'}`
+    );
+  }
+
+  return newLog.id as string;
+}
 
 // PayNow-relevant transaction codes from the NetCash statement
 // These are credit entries representing PayNow gateway collections
@@ -37,6 +76,8 @@ const PAYNOW_TRANSACTION_CODES = new Set([
   'OZW',  // Ozow instant EFT
   'INS',  // Instant payment
   'PNW',  // Pay Now generic
+  'PNA',  // Pay Now authorisation / initiate
+  'PNC',  // Pay Now completed collection
   'WEB',  // Web payment
   'ONL',  // Online payment
 ]);
@@ -73,7 +114,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    const processLogId = randomUUID();
+    const processLogId = await createProcessLog({ triggeredBy: 'cron' });
 
     await inngest.send({
       name: 'paynow/reconciliation.requested',
@@ -122,7 +163,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       .json()
       .catch(() => ({})) as { date?: string; dryRun?: boolean };
 
-    const processLogId = randomUUID();
+    const processLogId = await createProcessLog({
+      triggeredBy: 'manual',
+      reconciliationDate: body.date,
+      dryRun: body.dryRun,
+    });
 
     await inngest.send({
       name: 'paynow/reconciliation.requested',
@@ -258,7 +303,7 @@ export async function runPayNowReconciliation(
   // ── 3. Process each PayNow transaction ─────────────────────────────────────
 
   for (const tx of payNowTransactions) {
-    const reference = tx.accountReference ?? tx.reference ?? tx.description;
+    const reference = tx.accountReference || tx.reference || tx.description;
     if (!reference) {
       result.errors.push(`Transaction with no reference skipped: ${JSON.stringify(tx)}`);
       continue;

--- a/lib/inngest/functions/paynow-reconciliation.ts
+++ b/lib/inngest/functions/paynow-reconciliation.ts
@@ -34,6 +34,8 @@ const PAYNOW_TRANSACTION_CODES = new Set([
   'OZW', // Ozow instant EFT
   'INS', // Instant payment
   'PNW', // Pay Now generic
+  'PNA', // Pay Now authorisation / initiate
+  'PNC', // Pay Now completed collection
   'WEB', // Web payment
   'ONL', // Online payment
 ]);
@@ -60,6 +62,37 @@ export const paynowReconciliationFunction = inngest.createFunction(
         match: 'data.process_log_id',
       },
     ],
+    onFailure: async ({ error, event }) => {
+      const eventData = event?.data as
+        | { process_log_id?: string }
+        | undefined;
+      const processLogId = eventData?.process_log_id;
+      if (!processLogId) return;
+
+      try {
+        const supabase = await createClient();
+        await supabase
+          .from('cron_execution_log')
+          .update({
+            status: 'failed',
+            execution_end: new Date().toISOString(),
+            error_message:
+              error instanceof Error ? error.message : String(error),
+            execution_details: {
+              error: error instanceof Error ? error.message : String(error),
+              failed_via: 'inngest_onFailure',
+            },
+          })
+          .eq('id', processLogId)
+          .eq('status', 'running');
+      } catch (logError) {
+        cronLogger.error('[PayNowRecon] onFailure log update failed', {
+          processLogId,
+          error:
+            logError instanceof Error ? logError.message : String(logError),
+        });
+      }
+    },
   triggers: [
     // Cron trigger: daily at 07:00 UTC (09:00 SAST)
     { cron: '0 7 * * *' },
@@ -100,30 +133,42 @@ export const paynowReconciliationFunction = inngest.createFunction(
     const processLogId = await step.run('create-process-log', async () => {
       const supabase = await createClient();
 
-      // If process_log_id provided (from event), update existing log
+      // If process_log_id provided (from cron bridge / manual), update existing log.
+      // Fall back to insert when the id is a phantom UUID (legacy bridge bug).
       if (eventData?.process_log_id) {
-        const { error } = await supabase
+        const { data: updatedRows, error: updateError } = await supabase
           .from('cron_execution_log')
           .update({
             status: 'running',
             execution_start: new Date().toISOString(),
           })
-          .eq('id', eventData.process_log_id);
+          .eq('id', eventData.process_log_id)
+          .select('id');
 
-        if (error) {
+        if (updateError) {
           cronLogger.error('[PayNowRecon] Failed to update process log', {
-            error: error.message,
+            error: updateError.message,
+            processLogId: eventData.process_log_id,
           });
-          throw new Error(`Failed to update process log: ${error.message}`);
+          throw new Error(
+            `Failed to update process log: ${updateError.message}`
+          );
         }
 
-        console.log(
-          `[PayNowRecon] Updated process log ${eventData.process_log_id} to running`
+        if (updatedRows && updatedRows.length > 0) {
+          console.log(
+            `[PayNowRecon] Updated process log ${eventData.process_log_id} to running`
+          );
+          return eventData.process_log_id;
+        }
+
+        cronLogger.warn(
+          '[PayNowRecon] process_log_id not found — creating new log',
+          { processLogId: eventData.process_log_id }
         );
-        return eventData.process_log_id;
       }
 
-      // Create new process log for cron trigger
+      // Create new process log (Inngest-native cron, or phantom-id fallback)
       const { data: newLog, error } = await supabase
         .from('cron_execution_log')
         .insert({
@@ -137,6 +182,9 @@ export const paynowReconciliationFunction = inngest.createFunction(
             triggered_by_user_id: adminUserId || null,
             reconciliation_date: dateStr,
             dry_run: dryRun,
+            ...(eventData?.process_log_id
+              ? { phantom_process_log_id: eventData.process_log_id }
+              : {}),
           },
         })
         .select('id')
@@ -188,12 +236,11 @@ export const paynowReconciliationFunction = inngest.createFunction(
       await step.run('finalize-log-no-statement', async () => {
         const supabase = await createClient();
         const durationMsNoStmt = Date.now() - startTime;
-        await supabase
+        const { error: finalizeError } = await supabase
           .from('cron_execution_log')
           .update({
             status: 'completed_with_errors',
             execution_end: new Date().toISOString(),
-            duration_seconds: Math.round(durationMsNoStmt / 1000),
             execution_details: {
               reconciliation_date: dateStr,
               statement_fetched: false,
@@ -202,6 +249,16 @@ export const paynowReconciliationFunction = inngest.createFunction(
             },
           })
           .eq('id', processLogId);
+
+        if (finalizeError) {
+          cronLogger.error('[PayNowRecon] Failed to finalize process log', {
+            processLogId,
+            error: finalizeError.message,
+          });
+          throw new Error(
+            `Failed to finalize process log: ${finalizeError.message}`
+          );
+        }
       });
 
       await step.run('send-completion-event-no-statement', async () => {
@@ -273,8 +330,13 @@ export const paynowReconciliationFunction = inngest.createFunction(
       }
 
       for (const tx of payNowTransactions) {
+        // Skip authorisations / zero-value lines (e.g. PNA); only settle real credits
+        if (!(Number(tx.amount) > 0)) {
+          continue;
+        }
+
         const reference =
-          tx.accountReference ?? tx.reference ?? tx.description;
+          tx.accountReference || tx.reference || tx.description;
 
         if (!reference) {
           counters.errors.push(
@@ -472,12 +534,11 @@ export const paynowReconciliationFunction = inngest.createFunction(
     await step.run('update-final-log', async () => {
       const supabase = await createClient();
 
-      await supabase
+      const { error: finalizeError } = await supabase
         .from('cron_execution_log')
         .update({
           status: finalStatus,
           execution_end: new Date().toISOString(),
-          duration_seconds: Math.round(duration / 1000),
           records_processed: processingResult.total_transactions ?? null,
           records_failed: processingResult.unmatched ?? null,
           execution_details: {
@@ -495,6 +556,16 @@ export const paynowReconciliationFunction = inngest.createFunction(
           },
         })
         .eq('id', processLogId);
+
+      if (finalizeError) {
+        cronLogger.error('[PayNowRecon] Failed to finalize process log', {
+          processLogId,
+          error: finalizeError.message,
+        });
+        throw new Error(
+          `Failed to finalize process log: ${finalizeError.message}`
+        );
+      }
 
       cronLogger.info('[PayNowRecon] Reconciliation complete', {
         date: dateStr,

--- a/scripts/verify-paynow-recon-log.ts
+++ b/scripts/verify-paynow-recon-log.ts
@@ -1,0 +1,165 @@
+/**
+ * One-off verify: fixed cron_execution_log lifecycle + dry statement match.
+ * Does NOT write payment_transactions / invoices / reconciliation_queue.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { NetCashStatementService } from '../lib/payments/netcash-statement-service';
+import { matchInvoiceByReference } from '../lib/billing/invoice-matcher';
+
+const PAYNOW_CODES = new Set([
+  'EFT',
+  'CRD',
+  'OZW',
+  'INS',
+  'PNW',
+  'PNA',
+  'PNC',
+  'WEB',
+  'ONL',
+]);
+
+async function main() {
+  const sb = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+  const date = new Date(Date.now() - 86400000);
+  const dateStr = date.toISOString().slice(0, 10);
+  const start = Date.now();
+
+  const { data: log, error: logErr } = await sb
+    .from('cron_execution_log')
+    .insert({
+      job_name: 'paynow-reconciliation',
+      status: 'running',
+      execution_start: new Date().toISOString(),
+      trigger_source: 'manual',
+      execution_details: {
+        triggered_by: 'verify-e2e-dry',
+        reconciliation_date: dateStr,
+        dry_run: true,
+      },
+    })
+    .select('id')
+    .single();
+
+  if (logErr || !log) throw new Error('log insert: ' + logErr?.message);
+  console.log('LOG', log.id, 'DATE', dateStr);
+
+  const svc = new NetCashStatementService();
+  const statement = await svc.getStatement(date);
+  console.log('STATEMENT', {
+    success: statement.success,
+    error: statement.error,
+    count: statement.transactions?.length ?? 0,
+  });
+
+  const counters = {
+    total: 0,
+    matched: 0,
+    already_paid: 0,
+    unmatched: 0,
+    would_queue: 0,
+    already_recorded: 0,
+    errors: [] as string[],
+  };
+
+  if (statement.success) {
+    const payNow = statement.transactions.filter((tx) => {
+      if (tx.effect !== '+') return false;
+      const code = PAYNOW_CODES.has(tx.transactionCode);
+      const desc = (tx.description || '').toLowerCase();
+      return (
+        code ||
+        desc.includes('paynow') ||
+        desc.includes('ozow') ||
+        desc.includes('online') ||
+        desc.includes('web payment')
+      );
+    });
+    counters.total = payNow.length;
+
+    for (const tx of payNow) {
+      if (!(Number(tx.amount) > 0)) continue;
+      const reference = tx.accountReference || tx.reference || tx.description;
+      if (!reference) {
+        counters.errors.push('no-ref');
+        continue;
+      }
+      const { data: existing } = await sb
+        .from('payment_transactions')
+        .select('id')
+        .eq('provider_reference', reference)
+        .maybeSingle();
+      if (existing) {
+        counters.already_recorded++;
+        continue;
+      }
+      const match = await matchInvoiceByReference(reference, sb as never);
+      if (!match.matched || !match.invoice) {
+        counters.unmatched++;
+        counters.would_queue++;
+        continue;
+      }
+      counters.matched++;
+      if (match.invoice.status === 'paid') counters.already_paid++;
+    }
+  }
+
+  const durationMs = Date.now() - start;
+  const finalStatus = statement.success ? 'completed' : 'completed_with_errors';
+
+  // Critical: do NOT write duration_seconds (generated column)
+  const { error: finErr } = await sb
+    .from('cron_execution_log')
+    .update({
+      status: finalStatus,
+      execution_end: new Date().toISOString(),
+      records_processed: counters.total,
+      records_failed: counters.unmatched,
+      execution_details: {
+        reconciliation_date: dateStr,
+        statement_fetched: statement.success,
+        dry_run: true,
+        verify_e2e: true,
+        ...counters,
+        total_transactions: counters.total,
+        newly_matched: 0,
+        duration_ms: durationMs,
+        errors: statement.success
+          ? counters.errors
+          : [statement.error || 'statement unavailable'],
+      },
+    })
+    .eq('id', log.id);
+
+  if (finErr) throw new Error('finalize: ' + finErr.message);
+
+  const { data: latest } = await sb
+    .from('cron_execution_log')
+    .select(
+      'id, status, execution_start, duration_seconds, records_processed, records_failed'
+    )
+    .eq('id', log.id)
+    .single();
+
+  console.log(
+    'RESULT',
+    JSON.stringify(
+      {
+        counters,
+        finalStatus,
+        duration_seconds: latest?.duration_seconds,
+        status: latest?.status,
+        logId: latest?.id,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Fix PayNow daily recon so cron→Inngest handoff inserts a real `cron_execution_log` row (was sending a phantom UUID, so runs were invisible).
- Stop writing generated `duration_seconds` on finalize (this was leaving jobs stuck in `running`).
- Harden Inngest create-log (fall back to insert on missing id) + `onFailure` finalization; fix status API to use `execution_start` / `execution_details`.
- Recognise NetCash `PNA`/`PNC` codes, skip zero-amount lines, and use `||` for empty `accountReference` fallbacks.
- Add `scripts/verify-paynow-recon-log.ts` dry-run helper.

## Test plan
- [ ] CI / type-check on PR
- [ ] Add `deploy-staging` label (optional) and verify staging cron trigger creates a completed/partial `paynow-reconciliation` log
- [ ] After merge to `main` + Coolify deploy: `curl -H "Authorization: Bearer $CRON_SECRET" "$APP_URL/api/cron/paynow-reconciliation"` and confirm log finalizes
- [ ] Confirm `/api/admin/billing/reconciliation/status` returns last-run data without 500
- [ ] Spot-check Aug 3-style `PNC` statement lines are identified (may still queue unmatched if ref is `CT-{uuid}-…`)


Made with [Cursor](https://cursor.com)