### PR TITLE
feat(portal): B2B Phase 1 self-service for Unjani NPC

### DIFF
--- a/__tests__/lib/billing/corporate-clinic-line-items.test.ts
+++ b/__tests__/lib/billing/corporate-clinic-line-items.test.ts
@@ -1,0 +1,54 @@
+import {
+  formatClinicLineDescription,
+  buildClinicLineItem,
+} from '@/lib/billing/corporate-clinic-line-items';
+
+describe('corporate-clinic-line-items', () => {
+  it('formats Unjani Connect clinic line descriptions', () => {
+    expect(formatClinicLineDescription('Stinkwater')).toBe(
+      'Unjani Connect — Stinkwater'
+    );
+    expect(
+      formatClinicLineDescription('Suurman', 'Unjani Connect', 'pro-rata 10/31 days')
+    ).toBe('Unjani Connect — Suurman (pro-rata 10/31 days)');
+  });
+
+  it('builds one line item per clinic with UNJ-MC-001 defaults', () => {
+    const line = buildClinicLineItem({
+      id: 'site-1',
+      site_name: 'Bridge City KwaMashu',
+      monthly_fee: 450,
+      package_id: 'pkg-1',
+      service_packages: {
+        name: 'Unjani Managed Connectivity',
+        sku: 'UNJ-MC-001',
+        price: 450,
+      },
+    });
+
+    expect(line.description).toBe('Unjani Connect — Bridge City KwaMashu');
+    expect(line.site_name).toBe('Bridge City KwaMashu');
+    expect(line.sku).toBe('UNJ-MC-001');
+    expect(line.quantity).toBe(1);
+    expect(line.amount).toBe(450);
+    expect(line.unit_price).toBe(450);
+  });
+
+  it('uses amount override for pro-rata lines', () => {
+    const line = buildClinicLineItem(
+      {
+        id: 'site-2',
+        site_name: 'Daggakraal',
+        monthly_fee: 450,
+        package_id: null,
+        service_packages: null,
+      },
+      { type: 'pro_rata', amountOverride: 145.16, suffix: 'pro-rata 10/31 days' }
+    );
+
+    expect(line.type).toBe('pro_rata');
+    expect(line.amount).toBe(145.16);
+    expect(line.description).toContain('Daggakraal');
+    expect(line.description).toContain('pro-rata');
+  });
+});

--- a/__tests__/lib/portal/require-portal-user-labels.test.ts
+++ b/__tests__/lib/portal/require-portal-user-labels.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Role labelling contract for Phase 1 portal:
+ * DB role `admin` === Super User (max one per org).
+ */
+
+describe('portal Super User role contract', () => {
+  it('maps admin role to Super User label', () => {
+    const role: 'admin' | 'site_user' = 'admin';
+    const label = role === 'admin' ? 'Super User' : 'Site User';
+    expect(label).toBe('Super User');
+  });
+
+  it('maps site_user role to Site User label', () => {
+    const role: 'admin' | 'site_user' = 'site_user';
+    const label = role === 'admin' ? 'Super User' : 'Site User';
+    expect(label).toBe('Site User');
+  });
+});

--- a/app/api/admin/b2b-customers/[id]/portal-users/route.ts
+++ b/app/api/admin/b2b-customers/[id]/portal-users/route.ts
@@ -61,6 +61,23 @@ export async function POST(
       return NextResponse.json({ error: 'site_id is required for site_user role' }, { status: 400 });
     }
 
+    // Max one Super User (admin) per organisation
+    if (role === 'admin') {
+      const { data: existingAdmin } = await supabase
+        .from('b2b_portal_users')
+        .select('id')
+        .eq('organisation_id', accountId)
+        .eq('role', 'admin')
+        .maybeSingle();
+
+      if (existingAdmin) {
+        return NextResponse.json(
+          { error: 'This organisation already has a Super User. Only one Super User is allowed.' },
+          { status: 409 }
+        );
+      }
+    }
+
     const { data: { user: invitedUser }, error: inviteError } = await supabase.auth.admin.inviteUserByEmail(email, {
       data: { portal_role: role, organisation_id: accountId },
     });

--- a/app/api/portal/billing/route.ts
+++ b/app/api/portal/billing/route.ts
@@ -1,15 +1,13 @@
 import { NextResponse } from 'next/server';
-import { createClientWithSession } from '@/lib/supabase/server';
+import { requirePortalUser } from '@/lib/portal/require-portal-user';
 
 export async function GET() {
-  const supabase = await createClientWithSession();
+  const auth = await requirePortalUser();
+  if (!auth.ok) return auth.response;
 
-  const { data: { user }, error: authError } = await supabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const { portalUser, adminDb } = auth;
 
-  const { data: invoices, error } = await supabase
+  const { data: invoices, error } = await adminDb
     .from('customer_invoices')
     .select(`
       id,
@@ -21,6 +19,7 @@ export async function GET() {
       subtotal,
       vat_rate,
       vat_amount,
+      tax_amount,
       total_amount,
       amount_paid,
       amount_due,
@@ -32,6 +31,7 @@ export async function GET() {
       pdf_url,
       pdf_generated_at
     `)
+    .eq('corporate_account_id', portalUser.organisation_id)
     .order('invoice_date', { ascending: false });
 
   if (error) {
@@ -39,5 +39,10 @@ export async function GET() {
     return NextResponse.json({ error: 'Failed to load invoices' }, { status: 500 });
   }
 
-  return NextResponse.json({ invoices: invoices ?? [] });
+  const normalised = (invoices ?? []).map((inv) => ({
+    ...inv,
+    vat_amount: inv.vat_amount ?? inv.tax_amount ?? 0,
+  }));
+
+  return NextResponse.json({ invoices: normalised });
 }

--- a/app/api/portal/billing/statement/pdf/route.ts
+++ b/app/api/portal/billing/statement/pdf/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requirePortalUser } from '@/lib/portal/require-portal-user';
+import { assembleCorporateStatementData } from '@/lib/billing/corporate-statement-data';
+import { generateStatementPDFBuffer } from '@/lib/billing/statement-pdf-generator';
+import type { StatementOptions } from '@/lib/billing/statement-data';
+
+export async function GET(request: NextRequest) {
+  const auth = await requirePortalUser();
+  if (!auth.ok) return auth.response;
+
+  const { portalUser, adminDb } = auth;
+  const { searchParams } = new URL(request.url);
+
+  const options: StatementOptions = {};
+  const period = searchParams.get('period');
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  if (from && to) {
+    options.from = from;
+    options.to = to;
+  } else if (period === '3m' || period === '6m' || period === '12m' || period === 'all') {
+    options.period = period;
+  } else {
+    options.period = '12m';
+  }
+
+  try {
+    const { statement } = await assembleCorporateStatementData(
+      adminDb,
+      portalUser.organisation_id,
+      options
+    );
+
+    const pdfBuffer = generateStatementPDFBuffer(statement);
+    const filename = `statement-${portalUser.organisation_code || 'org'}-${statement.statementDate}.pdf`;
+
+    return new NextResponse(new Uint8Array(pdfBuffer), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[Portal /billing/statement/pdf]', message);
+    return NextResponse.json(
+      { success: false, error: 'Failed to generate statement PDF' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/portal/billing/statement/route.ts
+++ b/app/api/portal/billing/statement/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requirePortalUser } from '@/lib/portal/require-portal-user';
+import { assembleCorporateStatementData } from '@/lib/billing/corporate-statement-data';
+import type { StatementOptions } from '@/lib/billing/statement-data';
+
+export async function GET(request: NextRequest) {
+  const auth = await requirePortalUser();
+  if (!auth.ok) return auth.response;
+
+  // Site users can view org billing (existing portal behaviour); Super User + site_user
+  const { portalUser, adminDb } = auth;
+  const { searchParams } = new URL(request.url);
+
+  const options: StatementOptions = {};
+  const period = searchParams.get('period');
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+
+  if (from && to) {
+    options.from = from;
+    options.to = to;
+  } else if (period === '3m' || period === '6m' || period === '12m' || period === 'all') {
+    options.period = period;
+  } else {
+    options.period = '12m';
+  }
+
+  try {
+    const { statement, organisationName } = await assembleCorporateStatementData(
+      adminDb,
+      portalUser.organisation_id,
+      options
+    );
+
+    return NextResponse.json({
+      success: true,
+      statement,
+      organisation: { name: organisationName, id: portalUser.organisation_id },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[Portal /billing/statement]', message);
+    return NextResponse.json(
+      { success: false, error: 'Failed to generate statement' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/portal/coverage/onboard/route.ts
+++ b/app/api/portal/coverage/onboard/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+import { requirePortalSuperUser } from '@/lib/portal/require-portal-user';
+
+/**
+ * Proceed to onboard after a coverage check (PDF steps 1–3).
+ * Creates an activation_request ticket (no site_id) and emails onboarding@.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requirePortalSuperUser();
+  if (!auth.ok) return auth.response;
+
+  const { portalUser, adminDb } = auth;
+
+  try {
+    const body = await request.json();
+    const {
+      coverage_check_id,
+      clinic_name,
+      address,
+      contact_name,
+      contact_mobile,
+      contact_email,
+      notes,
+    } = body as {
+      coverage_check_id?: string;
+      clinic_name?: string;
+      address?: string;
+      contact_name?: string;
+      contact_mobile?: string;
+      contact_email?: string;
+      notes?: string;
+    };
+
+    if (!clinic_name?.trim() || !address?.trim() || !contact_name?.trim() || !contact_mobile?.trim()) {
+      return NextResponse.json(
+        {
+          error:
+            'clinic_name, address, contact_name, and contact_mobile are required',
+        },
+        { status: 400 }
+      );
+    }
+
+    let coverageResults: Record<string, unknown> | null = null;
+    let coverageLat: number | null = null;
+    let coverageLng: number | null = null;
+
+    if (coverage_check_id) {
+      const { data: check } = await adminDb
+        .from('b2b_coverage_checks')
+        .select('id, results, latitude, longitude, address')
+        .eq('id', coverage_check_id)
+        .eq('organisation_id', portalUser.organisation_id)
+        .maybeSingle();
+
+      if (!check) {
+        return NextResponse.json(
+          { error: 'Coverage check not found' },
+          { status: 404 }
+        );
+      }
+      coverageResults = check.results as Record<string, unknown>;
+      coverageLat = check.latitude;
+      coverageLng = check.longitude;
+    }
+
+    const summary = coverageResults?.summary as
+      | { tarana?: string; '5g_lte'?: string }
+      | undefined;
+
+    const description = [
+      `ONBOARDING REQUEST (nomination → go-live step 1–3)`,
+      ``,
+      `Clinic: ${clinic_name.trim()}`,
+      `Service address: ${address.trim()}`,
+      `On-site contact: ${contact_name.trim()}`,
+      `Mobile: ${contact_mobile.trim()}`,
+      contact_email ? `Email: ${contact_email.trim()}` : null,
+      coverageLat != null && coverageLng != null
+        ? `Coordinates: ${coverageLat}, ${coverageLng}`
+        : null,
+      ``,
+      `Coverage findings:`,
+      `  Tarana / FWB: ${summary?.tarana ?? 'n/a'}`,
+      `  5G/LTE: ${summary?.['5g_lte'] ?? 'n/a'}`,
+      coverage_check_id ? `  Coverage check ID: ${coverage_check_id}` : null,
+      ``,
+      notes?.trim() ? `Notes:\n${notes.trim()}` : null,
+      ``,
+      `Submitted by: ${portalUser.display_name} (${portalUser.email})`,
+      `Organisation: ${portalUser.organisation_name}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const subject = `Onboard clinic: ${clinic_name.trim()}`;
+
+    const { data: ticket, error: insertError } = await adminDb
+      .from('b2b_support_tickets')
+      .insert({
+        organisation_id: portalUser.organisation_id,
+        site_id: null,
+        submitted_by: portalUser.id,
+        subject,
+        description,
+        priority: 'medium',
+        ticket_type: 'activation_request',
+      })
+      .select('id, subject, status, ticket_type, created_at')
+      .single();
+
+    if (insertError) {
+      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    }
+
+    if (process.env.RESEND_API_KEY) {
+      try {
+        const resend = new Resend(process.env.RESEND_API_KEY);
+        await resend.emails.send({
+          from:
+            process.env.RESEND_FROM_EMAIL ||
+            'noreply@notifications.circletelsa.co.za',
+          to: ['onboarding@circletel.co.za', 'contactus@circletel.co.za'],
+          replyTo: portalUser.email,
+          subject: `[Portal Onboarding] ${subject} — ${portalUser.organisation_name}`,
+          text: description + `\n\n---\nTicket ID: ${ticket.id}`,
+        });
+      } catch (emailError) {
+        console.error('[Portal /coverage/onboard] Email error:', emailError);
+      }
+    }
+
+    return NextResponse.json({ ticket }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/portal/coverage/route.ts
+++ b/app/api/portal/coverage/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requirePortalSuperUser } from '@/lib/portal/require-portal-user';
+import { mtnCspClient } from '@/lib/coverage/skyfibre/csp-client';
+import { MTNConsumerClient } from '@/lib/coverage/mtn/consumer-client';
+
+export async function GET() {
+  const auth = await requirePortalSuperUser();
+  if (!auth.ok) return auth.response;
+
+  const { portalUser, adminDb } = auth;
+
+  const { data, error } = await adminDb
+    .from('b2b_coverage_checks')
+    .select('id, clinic_name, address, latitude, longitude, results, created_at')
+    .eq('organisation_id', portalUser.organisation_id)
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ checks: data ?? [] });
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requirePortalSuperUser();
+  if (!auth.ok) return auth.response;
+
+  const { portalUser, adminDb } = auth;
+
+  try {
+    const body = await request.json();
+    const latitude = Number(body.latitude);
+    const longitude = Number(body.longitude);
+    const address = String(body.address ?? '').trim();
+    const clinicName =
+      typeof body.clinic_name === 'string' ? body.clinic_name.trim() : null;
+
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude) || !address) {
+      return NextResponse.json(
+        { error: 'address, latitude, and longitude are required' },
+        { status: 400 }
+      );
+    }
+
+    let taranaFeasible = false;
+    let taranaDetail: Record<string, unknown> = {};
+    try {
+      const fwb = await mtnCspClient.checkFwbFeasibility({
+        latitude,
+        longitude,
+        capacityMbps: 100,
+      });
+      taranaFeasible = Boolean(fwb.feasible);
+      taranaDetail = {
+        feasible: fwb.feasible,
+        medium: fwb.medium,
+        region: fwb.region,
+        capacityMbps: fwb.capacityMbps,
+        reference: fwb.reference,
+      };
+    } catch (e) {
+      taranaDetail = {
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+
+    let lteAvailable = false;
+    let fiveGAvailable = false;
+    let mobileDetail: Record<string, unknown> = {};
+    try {
+      const mobile = await MTNConsumerClient.checkMobileCoverage(
+        { lat: latitude, lng: longitude },
+        ['lte', '5g']
+      );
+      lteAvailable = Boolean(
+        mobile.services.find((s) => s.type === 'lte')?.available
+      );
+      fiveGAvailable = Boolean(
+        mobile.services.find((s) => s.type === '5g')?.available
+      );
+      mobileDetail = {
+        services: mobile.services.map((s) => ({
+          type: s.type,
+          available: s.available,
+          technology: s.technology,
+        })),
+      };
+    } catch (e) {
+      mobileDetail = {
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+
+    const results = {
+      tarana: {
+        feasible: taranaFeasible,
+        label: taranaFeasible ? 'available' : 'not feasible',
+        ...taranaDetail,
+      },
+      lte: {
+        available: lteAvailable,
+        label: lteAvailable ? 'available' : 'not available',
+      },
+      five_g: {
+        available: fiveGAvailable,
+        label: fiveGAvailable ? 'available' : 'not available',
+      },
+      mobile: mobileDetail,
+      summary: {
+        tarana: taranaFeasible ? 'Available' : 'Not feasible',
+        '5g_lte':
+          lteAvailable || fiveGAvailable ? 'Available' : 'Not available',
+      },
+    };
+
+    const { data: check, error: insertError } = await adminDb
+      .from('b2b_coverage_checks')
+      .insert({
+        organisation_id: portalUser.organisation_id,
+        created_by: portalUser.id,
+        clinic_name: clinicName,
+        address,
+        latitude,
+        longitude,
+        results,
+      })
+      .select('id, clinic_name, address, latitude, longitude, results, created_at')
+      .single();
+
+    if (insertError) {
+      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ check }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/portal/support/route.ts
+++ b/app/api/portal/support/route.ts
@@ -119,11 +119,14 @@ export async function POST(request: NextRequest) {
   if (process.env.RESEND_API_KEY) {
     try {
       const resend = new Resend(process.env.RESEND_API_KEY);
+      const isActivation = resolvedTicketType === 'activation_request';
       await resend.emails.send({
         from: process.env.RESEND_FROM_EMAIL || 'noreply@notifications.circletelsa.co.za',
-        to: 'contactus@circletel.co.za',
+        to: isActivation
+          ? ['onboarding@circletel.co.za', 'contactus@circletel.co.za']
+          : 'contactus@circletel.co.za',
         replyTo: portalUser.email,
-        subject: resolvedTicketType === 'activation_request'
+        subject: isActivation
           ? `[Portal Activation] ${subject} — ${orgName}`
           : `[Portal Support] ${subject} — ${orgName}`,
         text: [
@@ -132,7 +135,7 @@ export async function POST(request: NextRequest) {
           `Organisation: ${orgName}`,
           `Site: ${siteName}`,
           `Submitted by: ${portalUser.display_name} (${portalUser.email})`,
-          `Role: ${portalUser.role}`,
+          `Role: ${portalUser.role === 'admin' ? 'Super User' : portalUser.role}`,
           `Priority: ${ticketPriority}`,
           ``,
           `Subject: ${subject}`,

--- a/app/api/portal/team/[userId]/route.ts
+++ b/app/api/portal/team/[userId]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requirePortalSuperUser } from '@/lib/portal/require-portal-user';
+
+export async function DELETE(
+  _request: NextRequest,
+  context: { params: Promise<{ userId: string }> }
+) {
+  const auth = await requirePortalSuperUser();
+  if (!auth.ok) return auth.response;
+
+  const { portalUser, adminDb } = auth;
+  const { userId } = await context.params;
+
+  const { data: target } = await adminDb
+    .from('b2b_portal_users')
+    .select('id, role, auth_user_id')
+    .eq('id', userId)
+    .eq('organisation_id', portalUser.organisation_id)
+    .maybeSingle();
+
+  if (!target) {
+    return NextResponse.json({ error: 'Portal user not found' }, { status: 404 });
+  }
+
+  if (target.id === portalUser.id) {
+    return NextResponse.json(
+      { error: 'You cannot remove your own Super User account' },
+      { status: 400 }
+    );
+  }
+
+  if (target.role === 'admin') {
+    return NextResponse.json(
+      { error: 'Cannot remove the organisation Super User' },
+      { status: 400 }
+    );
+  }
+
+  const { error: deleteError } = await adminDb
+    .from('b2b_portal_users')
+    .delete()
+    .eq('id', userId);
+
+  if (deleteError) {
+    return NextResponse.json({ error: deleteError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/portal/team/route.ts
+++ b/app/api/portal/team/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requirePortalSuperUser } from '@/lib/portal/require-portal-user';
+
+export async function GET() {
+  const auth = await requirePortalSuperUser();
+  if (!auth.ok) return auth.response;
+
+  const { portalUser, adminDb } = auth;
+
+  const { data: portalUsers, error } = await adminDb
+    .from('b2b_portal_users')
+    .select(
+      'id, auth_user_id, display_name, email, role, site_id, created_at, corporate_sites(id, site_name)'
+    )
+    .eq('organisation_id', portalUser.organisation_id)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ portalUsers: portalUsers ?? [] });
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requirePortalSuperUser();
+  if (!auth.ok) return auth.response;
+
+  const { portalUser, adminDb, authUserId } = auth;
+
+  try {
+    const body = await request.json();
+    const { email, display_name, site_id } = body as {
+      email?: string;
+      display_name?: string;
+      site_id?: string;
+    };
+
+    if (!email || !display_name || !site_id) {
+      return NextResponse.json(
+        { error: 'email, display_name, and site_id are required' },
+        { status: 400 }
+      );
+    }
+
+    // Portal Super Users may only invite site_users (never another Super User)
+    const role = 'site_user' as const;
+
+    const { data: site } = await adminDb
+      .from('corporate_sites')
+      .select('id')
+      .eq('id', site_id)
+      .eq('corporate_id', portalUser.organisation_id)
+      .maybeSingle();
+
+    if (!site) {
+      return NextResponse.json(
+        { error: 'Site not found for this organisation' },
+        { status: 400 }
+      );
+    }
+
+    const {
+      data: { user: invitedUser },
+      error: inviteError,
+    } = await adminDb.auth.admin.inviteUserByEmail(email, {
+      data: {
+        portal_role: role,
+        organisation_id: portalUser.organisation_id,
+      },
+    });
+
+    async function insertPortalUser(authUserIdToLink: string, invited: boolean) {
+      const { data: existingPortalUser } = await adminDb
+        .from('b2b_portal_users')
+        .select('id')
+        .eq('auth_user_id', authUserIdToLink)
+        .eq('organisation_id', portalUser.organisation_id)
+        .maybeSingle();
+
+      if (existingPortalUser) {
+        return NextResponse.json(
+          { error: 'User already has portal access for this organisation' },
+          { status: 409 }
+        );
+      }
+
+      const { data: created, error: insertError } = await adminDb
+        .from('b2b_portal_users')
+        .insert({
+          auth_user_id: authUserIdToLink,
+          organisation_id: portalUser.organisation_id,
+          display_name,
+          email,
+          role,
+          site_id,
+          created_by: authUserId,
+        })
+        .select(
+          'id, auth_user_id, display_name, email, role, site_id, created_at, corporate_sites(id, site_name)'
+        )
+        .single();
+
+      if (insertError) {
+        return NextResponse.json({ error: insertError.message }, { status: 500 });
+      }
+
+      return NextResponse.json({ portalUser: created, invited });
+    }
+
+    if (inviteError) {
+      if (inviteError.message?.includes('already been registered')) {
+        const {
+          data: { users },
+        } = await adminDb.auth.admin.listUsers({ perPage: 1000 });
+        const existingUser = users?.find((u) => u.email === email);
+        if (!existingUser) {
+          return NextResponse.json(
+            { error: 'User exists but could not be found' },
+            { status: 400 }
+          );
+        }
+        return insertPortalUser(existingUser.id, false);
+      }
+
+      return NextResponse.json({ error: inviteError.message }, { status: 500 });
+    }
+
+    if (!invitedUser) {
+      return NextResponse.json(
+        { error: 'Invite succeeded but no user returned' },
+        { status: 500 }
+      );
+    }
+
+    return insertPortalUser(invitedUser.id, true);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/portal/PortalLayoutClient.tsx
+++ b/app/portal/PortalLayoutClient.tsx
@@ -13,14 +13,18 @@ import {
   PiListBold,
   PiXBold,
   PiCaretDownBold,
+  PiUsersThreeBold,
+  PiMapPinAreaBold,
 } from 'react-icons/pi';
 import { useState } from 'react';
 
 const adminNavItems = [
   { href: '/portal', label: 'Dashboard', icon: PiSquaresFourBold, exact: true },
   { href: '/portal/sites', label: 'Sites', icon: PiBuildings },
+  { href: '/portal/coverage', label: 'Coverage', icon: PiMapPinAreaBold },
   { href: '/portal/billing', label: 'Billing', icon: PiCurrencyDollarBold },
   { href: '/portal/support', label: 'Support', icon: PiLifebuoyBold },
+  { href: '/portal/team', label: 'Team', icon: PiUsersThreeBold },
 ];
 
 const siteUserNavItems = [
@@ -40,12 +44,19 @@ function PortalNav() {
   if (!user) return null;
 
   return (
-    <header className="bg-white border-b sticky top-0 z-50">
+    <header
+      className="sticky top-0 z-50 bg-white"
+      style={{ borderBottom: '2px solid color-mix(in srgb, #13274A 28%, transparent)' }}
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           <Link href="/portal" className="flex items-center gap-2">
-            <span className="text-xl font-bold text-circleTel-orange">CircleTel</span>
-            <span className="text-sm text-gray-500">Portal</span>
+            <span className="text-xl font-extrabold" style={{ color: '#F5841E' }}>
+              CircleTel
+            </span>
+            <span className="text-sm font-medium" style={{ color: '#13274A' }}>
+              Portal
+            </span>
           </Link>
 
           <nav className="hidden md:flex items-center gap-1">
@@ -58,11 +69,14 @@ function PortalNav() {
                   key={item.href}
                   href={item.href}
                   className={cn(
-                    'px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-2',
-                    isActive
-                      ? 'bg-circleTel-orange/10 text-circleTel-orange'
-                      : 'text-gray-600 hover:bg-gray-100'
+                    'px-3 py-2 text-sm font-extrabold transition-colors flex items-center gap-2',
+                    isActive ? 'text-white' : 'hover:opacity-80'
                   )}
+                  style={
+                    isActive
+                      ? { background: '#13274A', color: '#FFFFFF' }
+                      : { color: '#13274A' }
+                  }
                 >
                   <item.icon className="w-4 h-4" />
                   {item.label}
@@ -75,39 +89,57 @@ function PortalNav() {
             <div className="relative">
               <button
                 onClick={() => setUserMenuOpen(!userMenuOpen)}
-                className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-gray-100"
+                className="flex items-center gap-2 px-3 py-2"
+                style={{ border: '1px solid color-mix(in srgb, #13274A 28%, transparent)' }}
               >
-                <div className="w-8 h-8 bg-circleTel-orange/10 rounded-full flex items-center justify-center">
-                  <span className="text-sm font-medium text-circleTel-orange">
+                <div
+                  className="w-8 h-8 flex items-center justify-center"
+                  style={{ background: 'color-mix(in srgb, #F5841E 18%, #FFFFFF)' }}
+                >
+                  <span className="text-sm font-extrabold" style={{ color: '#13274A' }}>
                     {user.display_name.charAt(0).toUpperCase()}
                   </span>
                 </div>
                 <div className="hidden sm:block text-left">
-                  <p className="text-sm font-medium text-gray-900 truncate max-w-[140px]">
+                  <p className="text-sm font-extrabold truncate max-w-[140px]" style={{ color: '#13274A' }}>
                     {user.display_name}
                   </p>
-                  <p className="text-xs text-gray-500 truncate max-w-[140px]">
+                  <p className="text-xs truncate max-w-[140px]" style={{ color: '#1F2937' }}>
                     {user.organisation_name}
                   </p>
                 </div>
-                <PiCaretDownBold className="w-4 h-4 text-gray-400" />
+                <PiCaretDownBold className="w-4 h-4" style={{ color: '#13274A' }} />
               </button>
 
               {userMenuOpen && (
                 <>
                   <div className="fixed inset-0 z-40" onClick={() => setUserMenuOpen(false)} />
-                  <div className="absolute right-0 mt-2 w-56 bg-white rounded-lg shadow-lg border z-50">
-                    <div className="p-3 border-b">
-                      <p className="text-sm font-medium text-gray-900">{user.display_name}</p>
-                      <p className="text-xs text-gray-500">{user.email}</p>
-                      <span className="inline-block mt-1 text-xs px-2 py-0.5 rounded-full bg-circleTel-orange/10 text-circleTel-orange capitalize">
-                        {user.role === 'admin' ? 'Head Office' : 'Site User'}
+                  <div
+                    className="absolute right-0 mt-2 w-56 bg-white z-50"
+                    style={{ border: '2px solid color-mix(in srgb, #13274A 28%, transparent)' }}
+                  >
+                    <div
+                      className="p-3"
+                      style={{ borderBottom: '1px solid color-mix(in srgb, #13274A 28%, transparent)' }}
+                    >
+                      <p className="text-sm font-extrabold" style={{ color: '#13274A' }}>
+                        {user.display_name}
+                      </p>
+                      <p className="text-xs" style={{ color: '#1F2937' }}>
+                        {user.email}
+                      </p>
+                      <span
+                        className="inline-block mt-1 text-xs px-2 py-0.5 font-extrabold"
+                        style={{ background: '#13274A', color: '#FFFFFF' }}
+                      >
+                        {user.role === 'admin' ? 'Super User' : 'Site User'}
                       </span>
                     </div>
                     <div className="p-2">
                       <button
                         onClick={signOut}
-                        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg"
+                        className="w-full flex items-center gap-2 px-3 py-2 text-sm font-medium"
+                        style={{ color: '#DC2626' }}
                       >
                         <PiSignOutBold className="w-4 h-4" />
                         Sign Out
@@ -120,7 +152,8 @@ function PortalNav() {
 
             <button
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className="md:hidden p-2 rounded-lg hover:bg-gray-100"
+              className="md:hidden p-2"
+              style={{ border: '1px solid color-mix(in srgb, #13274A 28%, transparent)' }}
             >
               {mobileMenuOpen ? <PiXBold className="w-6 h-6" /> : <PiListBold className="w-6 h-6" />}
             </button>
@@ -129,7 +162,10 @@ function PortalNav() {
       </div>
 
       {mobileMenuOpen && (
-        <nav className="md:hidden border-t bg-white p-4">
+        <nav
+          className="md:hidden bg-white p-4"
+          style={{ borderTop: '1px solid color-mix(in srgb, #13274A 28%, transparent)' }}
+        >
           <div className="space-y-1">
             {navItems.map((item) => {
               const isActive = item.exact
@@ -140,12 +176,12 @@ function PortalNav() {
                   key={item.href}
                   href={item.href}
                   onClick={() => setMobileMenuOpen(false)}
-                  className={cn(
-                    'flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium',
+                  className="flex items-center gap-3 px-4 py-3 text-sm font-extrabold"
+                  style={
                     isActive
-                      ? 'bg-circleTel-orange/10 text-circleTel-orange'
-                      : 'text-gray-600 hover:bg-gray-100'
-                  )}
+                      ? { background: '#13274A', color: '#FFFFFF' }
+                      : { color: '#13274A' }
+                  }
                 >
                   <item.icon className="w-5 h-5" />
                   {item.label}
@@ -170,10 +206,16 @@ function PortalContent({ children }: { children: React.ReactNode }) {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div
+        className="min-h-screen flex items-center justify-center"
+        style={{ background: 'color-mix(in srgb, #13274A 7%, #FFFFFF)' }}
+      >
         <div className="text-center">
-          <div className="w-12 h-12 border-4 border-circleTel-orange border-t-transparent rounded-full animate-spin mx-auto mb-4" />
-          <p className="text-gray-600">Loading portal...</p>
+          <div
+            className="w-12 h-12 border-4 border-t-transparent rounded-full animate-spin mx-auto mb-4"
+            style={{ borderColor: '#F5841E', borderTopColor: 'transparent' }}
+          />
+          <p style={{ color: '#13274A' }}>Loading portal...</p>
         </div>
       </div>
     );
@@ -184,19 +226,34 @@ function PortalContent({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div
+      className="min-h-screen flex flex-col"
+      style={{ background: 'color-mix(in srgb, #13274A 7%, #FFFFFF)' }}
+    >
       <PortalNav />
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8 flex-1">
         {children}
       </main>
-      <footer className="border-t bg-white mt-auto">
+      <footer
+        className="mt-auto bg-white"
+        style={{ borderTop: '2px solid color-mix(in srgb, #13274A 28%, transparent)' }}
+      >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex flex-col sm:flex-row justify-between items-center gap-4 text-sm text-gray-500">
+          <div
+            className="flex flex-col sm:flex-row justify-between items-center gap-4 text-sm"
+            style={{ color: '#1F2937' }}
+          >
             <p>&copy; 2026 CircleTel. All rights reserved.</p>
             <div className="flex gap-6">
-              <Link href="/privacy-policy" className="hover:text-circleTel-orange">Privacy Policy</Link>
-              <Link href="/terms-of-service" className="hover:text-circleTel-orange">Terms of Service</Link>
-              <Link href="/contact" className="hover:text-circleTel-orange">Support</Link>
+              <Link href="/privacy-policy" className="hover:opacity-70">
+                Privacy Policy
+              </Link>
+              <Link href="/terms-of-service" className="hover:opacity-70">
+                Terms of Service
+              </Link>
+              <Link href="/contact" className="hover:opacity-70">
+                Support
+              </Link>
             </div>
           </div>
         </div>

--- a/app/portal/billing/page.tsx
+++ b/app/portal/billing/page.tsx
@@ -1,20 +1,24 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import {
-  PiCurrencyDollarBold,
-  PiDownloadSimpleBold,
-  PiCaretDownBold,
-  PiCaretUpBold,
-  PiWarningBold,
-} from 'react-icons/pi';
+import Link from 'next/link';
 import { usePortalAuth } from '@/lib/portal/portal-auth-provider';
+import {
+  PortalModernistShell,
+  PageHeader,
+  AlertBand,
+  KpiStrip,
+  RuledTable,
+  PmButton,
+} from '@/components/portal/modernist/PortalModernistShell';
 
 interface LineItem {
   description?: string;
   site_name?: string;
   service?: string;
+  sku?: string;
   amount?: number;
+  unit_price?: number;
   quantity?: number;
 }
 
@@ -35,8 +39,14 @@ interface Invoice {
   invoice_type: string | null;
   status: string;
   paid_at: string | null;
-  payment_method: string | null;
   pdf_url: string | null;
+}
+
+function formatZar(n: number) {
+  return `R${Number(n || 0).toLocaleString('en-ZA', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 
 export default function PortalBillingPage() {
@@ -56,7 +66,14 @@ export default function PortalBillingPage() {
 
   if (!user) return null;
 
-  const overdueCount = invoices.filter((i) => i.status === 'overdue').length;
+  const overdue = invoices.filter((i) => i.status === 'overdue');
+  const outstanding = invoices
+    .filter((i) => !['paid', 'cancelled', 'refunded'].includes(i.status))
+    .reduce((sum, i) => sum + Number(i.amount_due || 0), 0);
+  const clinicLines = invoices.reduce(
+    (sum, inv) => sum + (inv.line_items?.length ?? 0),
+    0
+  );
 
   async function handleDownload(invoice: Invoice) {
     setDownloading(invoice.id);
@@ -77,179 +94,163 @@ export default function PortalBillingPage() {
     }
   }
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <div className="w-10 h-10 border-4 border-circleTel-orange border-t-transparent rounded-full animate-spin" />
-      </div>
-    );
-  }
-
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <PiCurrencyDollarBold className="w-7 h-7 text-gray-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Billing</h1>
-          <p className="text-gray-500 mt-0.5">Invoice history for {user.organisation_name}</p>
-        </div>
-      </div>
+    <PortalModernistShell>
+      <PageHeader
+        eyebrow="Billing · Receivables"
+        title="Invoices"
+        subtitle={`Itemised Unjani Connect billing for ${user.organisation_name}`}
+        actions={
+          <Link href="/portal/billing/statement">
+            <PmButton variant="secondary">Account statement</PmButton>
+          </Link>
+        }
+      />
 
-      {overdueCount > 0 && (
-        <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex items-center gap-3">
-          <PiWarningBold className="w-5 h-5 text-red-600 shrink-0" />
-          <p className="text-sm text-red-800">
-            You have <strong>{overdueCount}</strong> overdue invoice{overdueCount > 1 ? 's' : ''}. Please arrange payment as soon as possible.
-          </p>
-        </div>
+      {overdue.length > 0 && (
+        <AlertBand>
+          You have {overdue.length} overdue invoice
+          {overdue.length > 1 ? 's' : ''}. Please arrange payment with CircleTel.
+        </AlertBand>
       )}
 
-      {invoices.length === 0 ? (
-        <div className="text-center py-16 text-gray-500">No invoices found.</div>
+      <KpiStrip
+        items={[
+          {
+            label: 'Outstanding',
+            value: formatZar(outstanding),
+            note: 'Open balance',
+          },
+          {
+            label: 'Invoices',
+            value: String(invoices.length),
+            note: 'All periods',
+          },
+          {
+            label: 'Overdue',
+            value: String(overdue.length),
+            note: 'Need attention',
+          },
+          {
+            label: 'Clinic lines',
+            value: String(clinicLines),
+            note: 'Itemised services',
+          },
+        ]}
+      />
+
+      {loading ? (
+        <div className="py-16 text-center text-sm" style={{ color: 'var(--pm-body)' }}>
+          Loading invoices…
+        </div>
+      ) : invoices.length === 0 ? (
+        <div className="py-16 text-center text-sm" style={{ color: 'var(--pm-body)' }}>
+          No invoices found.
+        </div>
       ) : (
-        <div className="bg-white rounded-xl border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b">
-              <tr>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Invoice</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600 hidden sm:table-cell">Period</th>
-                <th className="text-right px-4 py-3 font-medium text-gray-600">Total</th>
-                <th className="text-right px-4 py-3 font-medium text-gray-600 hidden md:table-cell">Due</th>
-                <th className="text-center px-4 py-3 font-medium text-gray-600">Status</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600 hidden lg:table-cell">Due Date</th>
-                <th className="text-center px-4 py-3 font-medium text-gray-600">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y">
-              {invoices.map((inv) => {
-                const isExpanded = expandedId === inv.id;
-                const isOverdue = inv.status === 'overdue';
-                const lineItems = Array.isArray(inv.line_items) ? inv.line_items : [];
-
-                return (
-                  <React.Fragment key={inv.id}>
-                    <tr className={`hover:bg-gray-50 ${isOverdue ? 'bg-red-50/50' : ''}`}>
-                      <td className="px-4 py-3">
-                        <button
-                          onClick={() => setExpandedId(isExpanded ? null : inv.id)}
-                          className="flex items-center gap-1 font-medium text-gray-900 hover:text-circleTel-orange"
-                        >
-                          {isExpanded ? (
-                            <PiCaretUpBold className="w-3 h-3" />
-                          ) : (
-                            <PiCaretDownBold className="w-3 h-3" />
-                          )}
-                          {inv.invoice_number}
-                        </button>
-                      </td>
-                      <td className="px-4 py-3 text-gray-600 hidden sm:table-cell">
-                        {inv.period_start && inv.period_end
-                          ? `${formatDate(inv.period_start)} – ${formatDate(inv.period_end)}`
-                          : formatDate(inv.invoice_date)}
-                      </td>
-                      <td className="px-4 py-3 text-right font-medium text-gray-900">
-                        R{inv.total_amount.toFixed(2)}
-                      </td>
-                      <td className="px-4 py-3 text-right hidden md:table-cell">
-                        <span className={isOverdue ? 'font-semibold text-red-700' : 'text-gray-600'}>
-                          R{inv.amount_due.toFixed(2)}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-center">
-                        <StatusBadge status={inv.status} />
-                      </td>
-                      <td className="px-4 py-3 text-gray-600 hidden lg:table-cell">
-                        {formatDate(inv.due_date)}
-                      </td>
-                      <td className="px-4 py-3 text-center">
-                        {inv.pdf_url && (
-                          <button
-                            onClick={() => handleDownload(inv)}
-                            disabled={downloading === inv.id}
-                            className="inline-flex items-center gap-1 text-xs text-circleTel-orange hover:underline disabled:opacity-50"
-                          >
-                            <PiDownloadSimpleBold className="w-4 h-4" />
-                            {downloading === inv.id ? '...' : 'PDF'}
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                    {isExpanded && lineItems.length > 0 && (
-                      <tr>
-                        <td colSpan={7} className="bg-gray-50 px-8 py-4">
-                          <p className="text-xs font-medium text-gray-500 mb-2 uppercase tracking-wide">
-                            Line Items
-                          </p>
-                          <table className="w-full text-sm">
-                            <thead>
-                              <tr className="text-gray-500 text-xs">
-                                <th className="text-left pb-2">Description</th>
-                                <th className="text-left pb-2 hidden sm:table-cell">Site</th>
-                                <th className="text-right pb-2">Amount</th>
+        <RuledTable
+          headers={['Invoice', 'Period', 'Total', 'Due', 'Status', 'Actions']}
+        >
+          {invoices.map((inv) => {
+            const expanded = expandedId === inv.id;
+            const lines = inv.line_items ?? [];
+            return (
+              <React.Fragment key={inv.id}>
+                <tr
+                  style={{
+                    borderBottom: '1px solid var(--pm-divider)',
+                    borderLeft:
+                      inv.status === 'overdue'
+                        ? '3px solid #DC2626'
+                        : undefined,
+                  }}
+                >
+                  <td className="px-4 py-3 font-extrabold" style={{ color: 'var(--pm-navy)' }}>
+                    {inv.invoice_number}
+                  </td>
+                  <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+                    {inv.period_start && inv.period_end
+                      ? `${inv.period_start} → ${inv.period_end}`
+                      : '—'}
+                  </td>
+                  <td className="px-4 py-3 font-medium" style={{ color: 'var(--pm-navy)' }}>
+                    {formatZar(inv.total_amount)}
+                  </td>
+                  <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+                    {formatZar(inv.amount_due)}
+                  </td>
+                  <td className="px-4 py-3 capitalize" style={{ color: 'var(--pm-body)' }}>
+                    {inv.status}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-2">
+                      <PmButton
+                        variant="ghost"
+                        onClick={() =>
+                          setExpandedId(expanded ? null : inv.id)
+                        }
+                      >
+                        {expanded ? 'Hide lines' : 'Clinics'}
+                      </PmButton>
+                      <PmButton
+                        variant="secondary"
+                        disabled={downloading === inv.id}
+                        onClick={() => handleDownload(inv)}
+                      >
+                        PDF
+                      </PmButton>
+                    </div>
+                  </td>
+                </tr>
+                {expanded && (
+                  <tr style={{ borderBottom: '1px solid var(--pm-divider)' }}>
+                    <td colSpan={6} className="px-4 py-3" style={{ background: 'var(--pm-surface)' }}>
+                      {lines.length === 0 ? (
+                        <p className="text-sm opacity-70">No line items on this invoice.</p>
+                      ) : (
+                        <table className="w-full text-sm">
+                          <thead>
+                            <tr>
+                              <th className="text-left py-1 font-extrabold text-[11px] uppercase" style={{ color: 'var(--pm-navy)' }}>
+                                Service / clinic
+                              </th>
+                              <th className="text-right py-1 font-extrabold text-[11px] uppercase" style={{ color: 'var(--pm-navy)' }}>
+                                Qty
+                              </th>
+                              <th className="text-right py-1 font-extrabold text-[11px] uppercase" style={{ color: 'var(--pm-navy)' }}>
+                                Amount excl. VAT
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {lines.map((li, idx) => (
+                              <tr key={idx}>
+                                <td className="py-1.5" style={{ color: 'var(--pm-body)' }}>
+                                  {li.description ||
+                                    (li.site_name
+                                      ? `Unjani Connect — ${li.site_name}`
+                                      : li.service) ||
+                                    'Service'}
+                                </td>
+                                <td className="py-1.5 text-right" style={{ color: 'var(--pm-body)' }}>
+                                  {li.quantity ?? 1}
+                                </td>
+                                <td className="py-1.5 text-right font-medium" style={{ color: 'var(--pm-navy)' }}>
+                                  {formatZar(li.amount ?? li.unit_price ?? 0)}
+                                </td>
                               </tr>
-                            </thead>
-                            <tbody className="divide-y divide-gray-200">
-                              {lineItems.map((item, idx) => (
-                                <tr key={idx}>
-                                  <td className="py-1.5 text-gray-900">
-                                    {item.description || item.service || '—'}
-                                  </td>
-                                  <td className="py-1.5 text-gray-500 hidden sm:table-cell">
-                                    {item.site_name || '—'}
-                                  </td>
-                                  <td className="py-1.5 text-right text-gray-900">
-                                    {item.amount != null ? `R${item.amount.toFixed(2)}` : '—'}
-                                  </td>
-                                </tr>
-                              ))}
-                            </tbody>
-                          </table>
-                          <div className="mt-3 pt-2 border-t text-xs text-gray-500 flex justify-between">
-                            <span>
-                              Subtotal: R{inv.subtotal.toFixed(2)} | VAT ({inv.vat_rate}%): R{inv.vat_amount.toFixed(2)}
-                            </span>
-                            <span className="font-medium text-gray-900">
-                              Total: R{inv.total_amount.toFixed(2)}
-                            </span>
-                          </div>
-                        </td>
-                      </tr>
-                    )}
-                  </React.Fragment>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                            ))}
+                          </tbody>
+                        </table>
+                      )}
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </RuledTable>
       )}
-    </div>
+    </PortalModernistShell>
   );
-}
-
-function StatusBadge({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    paid: 'bg-green-100 text-green-700',
-    pending: 'bg-yellow-100 text-yellow-700',
-    overdue: 'bg-red-100 text-red-700',
-    cancelled: 'bg-gray-100 text-gray-500',
-    draft: 'bg-gray-100 text-gray-500',
-  };
-
-  return (
-    <span
-      className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium capitalize ${
-        styles[status] ?? 'bg-gray-100 text-gray-600'
-      }`}
-    >
-      {status}
-    </span>
-  );
-}
-
-function formatDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString('en-ZA', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-  });
 }

--- a/app/portal/billing/statement/page.tsx
+++ b/app/portal/billing/statement/page.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { usePortalAuth } from '@/lib/portal/portal-auth-provider';
+import {
+  PortalModernistShell,
+  PageHeader,
+  KpiStrip,
+  FilterChips,
+  RuledTable,
+  PmButton,
+} from '@/components/portal/modernist/PortalModernistShell';
+import type { StatementData } from '@/lib/billing/statement-pdf-generator';
+
+function formatZar(n: number) {
+  return `R${Number(n || 0).toLocaleString('en-ZA', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+export default function PortalStatementPage() {
+  const { user } = usePortalAuth();
+  const [period, setPeriod] = useState('12m');
+  const [statement, setStatement] = useState<StatementData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [downloading, setDownloading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError('');
+    fetch(`/api/portal/billing/statement?period=${period}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (!data.success) throw new Error(data.error || 'Failed');
+        setStatement(data.statement);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed'))
+      .finally(() => setLoading(false));
+  }, [period]);
+
+  if (!user) return null;
+
+  async function downloadPdf() {
+    if (!user) return;
+    const orgCode = user.organisation_code;
+    setDownloading(true);
+    try {
+      const res = await fetch(`/api/portal/billing/statement/pdf?period=${period}`);
+      if (!res.ok) throw new Error('PDF failed');
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `statement-${orgCode}-${period}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+      setError('Could not download statement PDF');
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  let running = 0;
+
+  return (
+    <PortalModernistShell>
+      <PageHeader
+        eyebrow="Billing · Statement"
+        title="Account statement"
+        subtitle={`Consolidated statement for ${user.organisation_name}`}
+        actions={
+          <>
+            <Link href="/portal/billing">
+              <PmButton variant="ghost">Back to invoices</PmButton>
+            </Link>
+            <PmButton onClick={downloadPdf} disabled={downloading || !statement}>
+              {downloading ? 'Preparing…' : 'Download PDF'}
+            </PmButton>
+          </>
+        }
+      />
+
+      <div className="mt-6">
+        <FilterChips
+          value={period}
+          onChange={setPeriod}
+          options={[
+            { value: '3m', label: '3 months' },
+            { value: '6m', label: '6 months' },
+            { value: '12m', label: '12 months' },
+            { value: 'all', label: 'All' },
+          ]}
+        />
+      </div>
+
+      {error && (
+        <p className="mt-4 text-sm" style={{ color: '#DC2626' }}>
+          {error}
+        </p>
+      )}
+
+      {loading || !statement ? (
+        <div className="py-16 text-center text-sm" style={{ color: 'var(--pm-body)' }}>
+          Loading statement…
+        </div>
+      ) : (
+        <>
+          <KpiStrip
+            items={[
+              {
+                label: 'Total due',
+                value: formatZar(statement.totalDue),
+              },
+              {
+                label: 'Total paid',
+                value: formatZar(statement.totalPaid),
+              },
+              {
+                label: 'Current',
+                value: formatZar(statement.aging.current),
+              },
+              {
+                label: '30+ days',
+                value: formatZar(
+                  statement.aging.days30 +
+                    statement.aging.days60 +
+                    statement.aging.days90 +
+                    statement.aging.over120Days
+                ),
+              },
+            ]}
+          />
+
+          <RuledTable
+            headers={['Date', 'Reference', 'Description', 'Debit', 'Credit', 'Balance']}
+          >
+            {statement.transactions.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center" style={{ color: 'var(--pm-body)' }}>
+                  No transactions in this period.
+                </td>
+              </tr>
+            ) : (
+              statement.transactions.map((tx, i) => {
+                running += (tx.debit ?? 0) - (tx.credit ?? 0);
+                return (
+                  <tr
+                    key={`${tx.reference}-${i}`}
+                    style={{ borderBottom: '1px solid var(--pm-divider)' }}
+                  >
+                    <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+                      {tx.date}
+                    </td>
+                    <td className="px-4 py-3 font-medium" style={{ color: 'var(--pm-navy)' }}>
+                      {tx.reference}
+                    </td>
+                    <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+                      {tx.description}
+                    </td>
+                    <td className="px-4 py-3 text-right" style={{ color: 'var(--pm-body)' }}>
+                      {tx.debit != null ? formatZar(tx.debit) : '—'}
+                    </td>
+                    <td className="px-4 py-3 text-right" style={{ color: '#059669' }}>
+                      {tx.credit != null ? formatZar(tx.credit) : '—'}
+                    </td>
+                    <td className="px-4 py-3 text-right font-medium" style={{ color: 'var(--pm-navy)' }}>
+                      {formatZar(running)}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </RuledTable>
+        </>
+      )}
+    </PortalModernistShell>
+  );
+}

--- a/app/portal/coverage/page.tsx
+++ b/app/portal/coverage/page.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
+import { usePortalAuth } from '@/lib/portal/portal-auth-provider';
+import {
+  PortalModernistShell,
+  PageHeader,
+  PmButton,
+  AlertBand,
+} from '@/components/portal/modernist/PortalModernistShell';
+
+const CoverageMap = dynamic(
+  () => import('@/components/coverage/CoverageMap'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[420px] flex items-center justify-center text-sm" style={{ color: 'var(--pm-body)' }}>
+        Loading map…
+      </div>
+    ),
+  }
+);
+
+interface CoverageCheck {
+  id: string;
+  clinic_name: string | null;
+  address: string;
+  latitude: number;
+  longitude: number;
+  results: {
+    summary?: { tarana?: string; '5g_lte'?: string };
+    tarana?: { feasible?: boolean };
+    lte?: { available?: boolean };
+    five_g?: { available?: boolean };
+  };
+  created_at: string;
+}
+
+export default function PortalCoveragePage() {
+  const { user, isAdmin, loading: authLoading } = usePortalAuth();
+  const router = useRouter();
+
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
+  const [address, setAddress] = useState('');
+  const [clinicName, setClinicName] = useState('');
+  const [running, setRunning] = useState(false);
+  const [latest, setLatest] = useState<CoverageCheck | null>(null);
+  const [history, setHistory] = useState<CoverageCheck[]>([]);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const [showOnboard, setShowOnboard] = useState(false);
+  const [contactName, setContactName] = useState('');
+  const [contactMobile, setContactMobile] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!isAdmin) {
+      router.replace('/portal');
+      return;
+    }
+    fetch('/api/portal/coverage')
+      .then((r) => r.json())
+      .then((data) => setHistory(data.checks ?? []))
+      .catch(console.error);
+  }, [authLoading, isAdmin, router]);
+
+  const onLocationSelect = useCallback(
+    (coordinates: { lat: number; lng: number }, addr?: string) => {
+      setCoords(coordinates);
+      if (addr) setAddress(addr);
+    },
+    []
+  );
+
+  if (!user || !isAdmin) return null;
+
+  async function runCoverageCheck() {
+    if (!coords || !address.trim()) {
+      setError('Select a location on the map and confirm the address');
+      return;
+    }
+    setRunning(true);
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch('/api/portal/coverage', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          latitude: coords.lat,
+          longitude: coords.lng,
+          address: address.trim(),
+          clinic_name: clinicName.trim() || null,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Coverage check failed');
+      setLatest(data.check);
+      setHistory((prev) => [data.check, ...prev]);
+      setShowOnboard(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Coverage check failed');
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  async function proceedOnboard(e: React.FormEvent) {
+    e.preventDefault();
+    if (!latest) return;
+    setSubmitting(true);
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch('/api/portal/coverage/onboard', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          coverage_check_id: latest.id,
+          clinic_name: clinicName.trim() || latest.clinic_name || 'New clinic',
+          address: address.trim() || latest.address,
+          contact_name: contactName.trim(),
+          contact_mobile: contactMobile.trim(),
+          contact_email: contactEmail.trim() || undefined,
+          notes: notes.trim() || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to submit onboarding request');
+      setSuccess(
+        `Onboarding request submitted (ticket ${data.ticket.id.slice(0, 8)}…). CircleTel will coordinate installation after confirmation with the clinic.`
+      );
+      setShowOnboard(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Submit failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const summary = latest?.results?.summary;
+
+  return (
+    <PortalModernistShell>
+      <PageHeader
+        eyebrow="Connectivity · Feasibility"
+        title="Coverage check"
+        subtitle="Desktop research for new clinics (PDF steps 1–3). Tarana/FWB + 5G/LTE — then proceed to nominate for install."
+      />
+
+      {error && (
+        <p className="mt-4 text-sm font-medium" style={{ color: '#DC2626' }}>
+          {error}
+        </p>
+      )}
+      {success && (
+        <AlertBand>{success}</AlertBand>
+      )}
+
+      <div className="mt-6 grid lg:grid-cols-3 gap-0" style={{ border: '2px solid var(--pm-divider)' }}>
+        <div className="lg:col-span-2">
+          <CoverageMap
+            onLocationSelect={onLocationSelect}
+            showAddressSearch
+            showCoverageControls
+            height="420px"
+          />
+        </div>
+        <div className="p-4 space-y-3 bg-white" style={{ borderLeft: '1px solid var(--pm-divider)' }}>
+          <p
+            className="text-[10px] font-extrabold tracking-[0.08em] uppercase"
+            style={{ color: 'var(--pm-navy)' }}
+          >
+            Check details
+          </p>
+          <input
+            type="text"
+            placeholder="Clinic name"
+            value={clinicName}
+            onChange={(e) => setClinicName(e.target.value)}
+            className="w-full px-3 py-2 text-sm"
+            style={{ border: '1px solid var(--pm-divider)' }}
+          />
+          <textarea
+            placeholder="Service address"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            rows={3}
+            className="w-full px-3 py-2 text-sm"
+            style={{ border: '1px solid var(--pm-divider)' }}
+          />
+          {coords && (
+            <p className="text-xs" style={{ color: 'var(--pm-body)' }}>
+              Pin: {coords.lat.toFixed(5)}, {coords.lng.toFixed(5)}
+            </p>
+          )}
+          <PmButton onClick={runCoverageCheck} disabled={running || !coords}>
+            {running ? 'Checking…' : 'Run coverage check'}
+          </PmButton>
+
+          {latest && summary && (
+            <div
+              className="mt-4 p-3 space-y-2"
+              style={{ border: '1px solid var(--pm-divider)', background: 'var(--pm-surface)' }}
+            >
+              <p className="text-sm font-extrabold" style={{ color: 'var(--pm-navy)' }}>
+                Results
+              </p>
+              <p className="text-sm" style={{ color: 'var(--pm-body)' }}>
+                Tarana — {summary.tarana}
+              </p>
+              <p className="text-sm" style={{ color: 'var(--pm-body)' }}>
+                5G/LTE — {summary['5g_lte']}
+              </p>
+              <PmButton variant="secondary" onClick={() => setShowOnboard(true)}>
+                Proceed to onboard
+              </PmButton>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showOnboard && latest && (
+        <form
+          onSubmit={proceedOnboard}
+          className="mt-6 p-4 space-y-3 bg-white"
+          style={{ border: '2px solid var(--pm-divider)' }}
+        >
+          <p
+            className="text-[10px] font-extrabold tracking-[0.08em] uppercase"
+            style={{ color: 'var(--pm-navy)' }}
+          >
+            Nominate clinic (confirm details)
+          </p>
+          <p className="text-sm" style={{ color: 'var(--pm-body)' }}>
+            Sends an onboarding request to CircleTel with coverage findings. No banking details required.
+          </p>
+          <div className="grid sm:grid-cols-2 gap-3">
+            <input
+              required
+              placeholder="On-site contact name"
+              value={contactName}
+              onChange={(e) => setContactName(e.target.value)}
+              className="px-3 py-2 text-sm"
+              style={{ border: '1px solid var(--pm-divider)' }}
+            />
+            <input
+              required
+              placeholder="Contact mobile"
+              value={contactMobile}
+              onChange={(e) => setContactMobile(e.target.value)}
+              className="px-3 py-2 text-sm"
+              style={{ border: '1px solid var(--pm-divider)' }}
+            />
+            <input
+              type="email"
+              placeholder="Contact email (optional)"
+              value={contactEmail}
+              onChange={(e) => setContactEmail(e.target.value)}
+              className="px-3 py-2 text-sm"
+              style={{ border: '1px solid var(--pm-divider)' }}
+            />
+            <input
+              placeholder="Notes (optional)"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              className="px-3 py-2 text-sm"
+              style={{ border: '1px solid var(--pm-divider)' }}
+            />
+          </div>
+          <div className="flex gap-2">
+            <PmButton type="submit" disabled={submitting}>
+              {submitting ? 'Submitting…' : 'Submit onboarding request'}
+            </PmButton>
+            <PmButton type="button" variant="ghost" onClick={() => setShowOnboard(false)}>
+              Cancel
+            </PmButton>
+          </div>
+        </form>
+      )}
+
+      {history.length > 0 && (
+        <div className="mt-8">
+          <p
+            className="text-[10px] font-extrabold tracking-[0.08em] uppercase mb-3"
+            style={{ color: 'var(--pm-navy)' }}
+          >
+            Recent checks
+          </p>
+          <ul className="space-y-2">
+            {history.slice(0, 10).map((c) => (
+              <li
+                key={c.id}
+                className="px-4 py-3 text-sm bg-white"
+                style={{ border: '1px solid var(--pm-divider)' }}
+              >
+                <span className="font-extrabold" style={{ color: 'var(--pm-navy)' }}>
+                  {c.clinic_name || 'Untitled'}
+                </span>
+                {' — '}
+                {c.address}
+                <span className="block text-xs mt-1 opacity-70">
+                  Tarana: {c.results?.summary?.tarana ?? 'n/a'} · 5G/LTE:{' '}
+                  {c.results?.summary?.['5g_lte'] ?? 'n/a'} ·{' '}
+                  {new Date(c.created_at).toLocaleString('en-ZA')}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </PortalModernistShell>
+  );
+}

--- a/app/portal/support/page.tsx
+++ b/app/portal/support/page.tsx
@@ -2,12 +2,15 @@
 
 import { useEffect, useState } from 'react';
 import {
-  PiLifebuoyBold,
   PiPaperPlaneTiltBold,
   PiCheckCircleBold,
   PiClockBold,
 } from 'react-icons/pi';
 import { usePortalAuth } from '@/lib/portal/portal-auth-provider';
+import {
+  PortalModernistShell,
+  PageHeader,
+} from '@/components/portal/modernist/PortalModernistShell';
 
 type TicketType = 'support' | 'fault_report' | 'activation_request' | 'change_request';
 
@@ -178,14 +181,14 @@ export default function PortalSupportPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <PiLifebuoyBold className="w-7 h-7 text-gray-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Support</h1>
-          <p className="text-gray-500 mt-0.5">Submit a support request or view ticket history</p>
-        </div>
-      </div>
+    <PortalModernistShell>
+      <PageHeader
+        eyebrow="Support · Helpdesk"
+        title="Support"
+        subtitle="Log queries and tickets — or use Coverage to nominate a new clinic"
+      />
+
+      <div className="space-y-6 mt-6">
 
       {success && (
         <div className="bg-green-50 border border-green-200 rounded-xl p-4 flex items-center gap-3">
@@ -426,6 +429,7 @@ export default function PortalSupportPage() {
         )}
       </div>
     </div>
+    </PortalModernistShell>
   );
 }
 

--- a/app/portal/team/page.tsx
+++ b/app/portal/team/page.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { usePortalAuth } from '@/lib/portal/portal-auth-provider';
+import {
+  PortalModernistShell,
+  PageHeader,
+  RuledTable,
+  PmButton,
+} from '@/components/portal/modernist/PortalModernistShell';
+
+interface Site {
+  id: string;
+  site_name: string;
+}
+
+interface TeamMember {
+  id: string;
+  display_name: string;
+  email: string;
+  role: 'admin' | 'site_user';
+  site_id: string | null;
+  created_at: string;
+  corporate_sites: { id: string; site_name: string } | null;
+}
+
+export default function PortalTeamPage() {
+  const { user, isAdmin, loading: authLoading } = usePortalAuth();
+  const router = useRouter();
+  const [members, setMembers] = useState<TeamMember[]>([]);
+  const [sites, setSites] = useState<Site[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const [email, setEmail] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [siteId, setSiteId] = useState('');
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!isAdmin) {
+      router.replace('/portal');
+      return;
+    }
+
+    Promise.all([
+      fetch('/api/portal/team').then((r) => r.json()),
+      fetch('/api/portal/sites').then((r) => r.json()),
+    ])
+      .then(([teamData, siteData]) => {
+        if (teamData.error) setError(teamData.error);
+        setMembers(teamData.portalUsers ?? []);
+        setSites(siteData.sites ?? []);
+      })
+      .catch(() => setError('Failed to load team'))
+      .finally(() => setLoading(false));
+  }, [authLoading, isAdmin, router]);
+
+  if (!user || !isAdmin) return null;
+
+  async function handleInvite(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch('/api/portal/team', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          display_name: displayName,
+          site_id: siteId,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Invite failed');
+      setMembers((prev) => [data.portalUser, ...prev]);
+      setSuccess(
+        data.invited
+          ? `Invite sent to ${email}`
+          : `${displayName} added to the portal`
+      );
+      setEmail('');
+      setDisplayName('');
+      setSiteId('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Invite failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRemove(member: TeamMember) {
+    if (!confirm(`Remove ${member.display_name} from the portal?`)) return;
+    setError('');
+    const res = await fetch(`/api/portal/team/${member.id}`, { method: 'DELETE' });
+    const data = await res.json();
+    if (!res.ok) {
+      setError(data.error || 'Remove failed');
+      return;
+    }
+    setMembers((prev) => prev.filter((m) => m.id !== member.id));
+    setSuccess(`${member.display_name} removed`);
+  }
+
+  return (
+    <PortalModernistShell>
+      <PageHeader
+        eyebrow="Organisation · Access"
+        title="Team"
+        subtitle="One Super User per organisation. Invite site users (e.g. clinic nurses) for their assigned site."
+      />
+
+      {error && (
+        <p className="mt-4 text-sm font-medium" style={{ color: '#DC2626' }}>
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="mt-4 text-sm font-medium" style={{ color: '#059669' }}>
+          {success}
+        </p>
+      )}
+
+      <form
+        onSubmit={handleInvite}
+        className="mt-6 p-4 space-y-4 bg-white"
+        style={{ border: '2px solid var(--pm-divider)' }}
+      >
+        <p
+          className="text-[10px] font-extrabold tracking-[0.08em] uppercase"
+          style={{ color: 'var(--pm-navy)' }}
+        >
+          Invite site user
+        </p>
+        <div className="grid sm:grid-cols-3 gap-3">
+          <input
+            required
+            type="text"
+            placeholder="Display name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            className="px-3 py-2 text-sm bg-white"
+            style={{ border: '1px solid var(--pm-divider)', color: 'var(--pm-body)' }}
+          />
+          <input
+            required
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="px-3 py-2 text-sm bg-white"
+            style={{ border: '1px solid var(--pm-divider)', color: 'var(--pm-body)' }}
+          />
+          <select
+            required
+            value={siteId}
+            onChange={(e) => setSiteId(e.target.value)}
+            className="px-3 py-2 text-sm bg-white"
+            style={{ border: '1px solid var(--pm-divider)', color: 'var(--pm-body)' }}
+          >
+            <option value="">Select site…</option>
+            {sites.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.site_name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <PmButton type="submit" disabled={submitting}>
+          {submitting ? 'Sending…' : 'Send invite'}
+        </PmButton>
+      </form>
+
+      {loading ? (
+        <div className="py-16 text-center text-sm" style={{ color: 'var(--pm-body)' }}>
+          Loading team…
+        </div>
+      ) : (
+        <RuledTable headers={['Name', 'Email', 'Role', 'Site', 'Actions']}>
+          {members.map((m) => (
+            <tr
+              key={m.id}
+              style={{ borderBottom: '1px solid var(--pm-divider)' }}
+            >
+              <td className="px-4 py-3 font-medium" style={{ color: 'var(--pm-navy)' }}>
+                {m.display_name}
+              </td>
+              <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+                {m.email}
+              </td>
+              <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+                {m.role === 'admin' ? 'Super User' : 'Site User'}
+              </td>
+              <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+                {m.corporate_sites?.site_name ?? '—'}
+              </td>
+              <td className="px-4 py-3">
+                {m.role === 'site_user' && (
+                  <PmButton variant="ghost" onClick={() => handleRemove(m)}>
+                    Remove
+                  </PmButton>
+                )}
+              </td>
+            </tr>
+          ))}
+        </RuledTable>
+      )}
+    </PortalModernistShell>
+  );
+}

--- a/components/portal/AdminDashboard.tsx
+++ b/components/portal/AdminDashboard.tsx
@@ -2,8 +2,16 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { PiBuildings, PiWifiHighBold, PiHeartbeatBold, PiWarningBold } from 'react-icons/pi';
+import { PiWarningBold } from 'react-icons/pi';
 import type { PortalUser } from '@/lib/portal/portal-auth-provider';
+import {
+  PortalModernistShell,
+  PageHeader,
+  AlertBand,
+  KpiStrip,
+  RuledTable,
+  PmButton,
+} from '@/components/portal/modernist/PortalModernistShell';
 
 interface SiteHealth {
   health_score: number;
@@ -48,141 +56,115 @@ export default function AdminDashboard({ user }: { user: PortalUser }) {
         setInvoices(billingData.invoices ?? []);
       })
       .catch(console.error)
-      .finally(() => { if (mounted) setLoading(false); });
-    return () => { mounted = false; };
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   const totalSites = sites.length;
   const onlineSites = sites.filter((s) => s.health && s.health.health_score > 0).length;
-  const avgHealth = sites.reduce((sum, s) => sum + (s.health?.health_score ?? 0), 0) / (onlineSites || 1);
-  const totalClients = sites.reduce((sum, s) => sum + (s.health?.connected_clients ?? 0), 0);
+  const avgHealth =
+    sites.reduce((sum, s) => sum + (s.health?.health_score ?? 0), 0) /
+    (onlineSites || 1);
+  const totalClients = sites.reduce(
+    (sum, s) => sum + (s.health?.connected_clients ?? 0),
+    0
+  );
   const overdueInvoices = invoices.filter((i) => i.status === 'overdue');
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-20">
-        <div className="w-10 h-10 border-4 border-circleTel-orange border-t-transparent rounded-full animate-spin" />
+      <div className="flex items-center justify-center py-20 text-sm" style={{ color: '#13274A' }}>
+        Loading dashboard…
       </div>
     );
   }
 
   return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-        <p className="text-gray-500 mt-1">Welcome back, {user.display_name} — {user.organisation_name}</p>
-      </div>
+    <PortalModernistShell>
+      <PageHeader
+        eyebrow="Organisation · Overview"
+        title="Dashboard"
+        subtitle={`Welcome back, ${user.display_name} — ${user.organisation_name}`}
+        actions={
+          <>
+            <Link href="/portal/coverage">
+              <PmButton variant="secondary">Coverage check</PmButton>
+            </Link>
+            <Link href="/portal/team">
+              <PmButton>Manage team</PmButton>
+            </Link>
+          </>
+        }
+      />
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard icon={<PiBuildings className="w-6 h-6" />} label="Total Sites" value={totalSites} color="blue" />
-        <StatCard icon={<PiWifiHighBold className="w-6 h-6" />} label="Online Sites" value={`${onlineSites}/${totalSites}`} color="green" />
-        <StatCard icon={<PiHeartbeatBold className="w-6 h-6" />} label="Avg Health Score" value={`${Math.round(avgHealth)}%`} color="orange" />
-        <StatCard icon={<PiWifiHighBold className="w-6 h-6" />} label="Connected Clients" value={totalClients} color="purple" />
-      </div>
+      <KpiStrip
+        items={[
+          { label: 'Total sites', value: String(totalSites) },
+          { label: 'Online', value: `${onlineSites}/${totalSites}` },
+          { label: 'Avg health', value: `${Math.round(avgHealth)}%` },
+          { label: 'Clients', value: String(totalClients) },
+        ]}
+      />
 
       {overdueInvoices.length > 0 && (
-        <div className="bg-red-50 border border-red-200 rounded-xl p-4">
-          <div className="flex items-center gap-2 mb-2">
-            <PiWarningBold className="w-5 h-5 text-red-600" />
-            <h3 className="font-semibold text-red-900">Overdue Invoices</h3>
-          </div>
-          <ul className="space-y-1 text-sm text-red-800">
-            {overdueInvoices.map((inv) => (
-              <li key={inv.id}>
-                {inv.invoice_number} — R{inv.amount_due.toFixed(2)} due {new Date(inv.due_date).toLocaleDateString('en-ZA')}
-              </li>
-            ))}
-          </ul>
-          <Link href="/portal/billing" className="text-sm font-medium text-red-700 hover:underline mt-2 inline-block">
-            View billing →
-          </Link>
-        </div>
+        <AlertBand
+          action={
+            <Link href="/portal/billing">
+              <PmButton>View billing</PmButton>
+            </Link>
+          }
+        >
+          <span className="inline-flex items-center gap-2">
+            <PiWarningBold className="w-4 h-4" />
+            {overdueInvoices.length} overdue invoice
+            {overdueInvoices.length > 1 ? 's' : ''}
+          </span>
+        </AlertBand>
       )}
 
-      <div>
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Site Overview</h2>
-          <Link href="/portal/sites" className="text-sm text-circleTel-orange hover:underline">
-            View all sites →
-          </Link>
-        </div>
-        <div className="bg-white rounded-xl border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b">
-              <tr>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Site</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600 hidden sm:table-cell">Location</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600 hidden md:table-cell">Technology</th>
-                <th className="text-center px-4 py-3 font-medium text-gray-600">Health</th>
-                <th className="text-center px-4 py-3 font-medium text-gray-600">Clients</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y">
-              {sites.slice(0, 10).map((site) => (
-                <tr key={site.id} className="hover:bg-gray-50">
-                  <td className="px-4 py-3">
-                    <Link href={`/portal/sites/${site.id}`} className="font-medium text-gray-900 hover:text-circleTel-orange">
-                      {site.site_name}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-gray-600 hidden sm:table-cell">
-                    {[site.city, site.province].filter(Boolean).join(', ') || '—'}
-                  </td>
-                  <td className="px-4 py-3 text-gray-600 hidden md:table-cell">
-                    {site.technology_type ?? '—'}
-                  </td>
-                  <td className="px-4 py-3 text-center">
-                    {site.health ? (
-                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${
-                        site.health.health_score >= 80 ? 'bg-green-100 text-green-700' :
-                        site.health.health_score >= 50 ? 'bg-yellow-100 text-yellow-700' :
-                        'bg-red-100 text-red-700'
-                      }`}>
-                        {site.health.health_score}%
-                      </span>
-                    ) : (
-                      <span className="text-xs text-gray-400">N/A</span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-center text-gray-600">
-                    {site.health?.connected_clients ?? '—'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          {sites.length > 10 && (
-            <div className="px-4 py-3 bg-gray-50 border-t text-center">
-              <Link href="/portal/sites" className="text-sm text-circleTel-orange hover:underline">
-                View all {sites.length} sites →
+      <div className="mt-8 flex items-center justify-between">
+        <p
+          className="text-[10px] font-extrabold tracking-[0.08em] uppercase"
+          style={{ color: 'var(--pm-navy)' }}
+        >
+          Site overview
+        </p>
+        <Link href="/portal/sites" className="text-sm font-extrabold" style={{ color: '#D76026' }}>
+          View all sites →
+        </Link>
+      </div>
+
+      <RuledTable headers={['Site', 'Location', 'Technology', 'Health', 'Clients']}>
+        {sites.slice(0, 10).map((site) => (
+          <tr key={site.id} style={{ borderBottom: '1px solid var(--pm-divider)' }}>
+            <td className="px-4 py-3">
+              <Link
+                href={`/portal/sites/${site.id}`}
+                className="font-extrabold hover:opacity-80"
+                style={{ color: 'var(--pm-navy)' }}
+              >
+                {site.site_name}
               </Link>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function StatCard({ icon, label, value, color }: { icon: React.ReactNode; label: string; value: string | number; color: string }) {
-  const colorMap: Record<string, string> = {
-    blue: 'bg-blue-50 text-blue-600',
-    green: 'bg-green-50 text-green-600',
-    orange: 'bg-orange-50 text-orange-600',
-    purple: 'bg-purple-50 text-purple-600',
-  };
-
-  return (
-    <div className="bg-white rounded-xl border p-4">
-      <div className="flex items-center gap-3">
-        <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${colorMap[color]}`}>
-          {icon}
-        </div>
-        <div>
-          <p className="text-sm text-gray-500">{label}</p>
-          <p className="text-xl font-bold text-gray-900">{value}</p>
-        </div>
-      </div>
-    </div>
+            </td>
+            <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+              {[site.city, site.province].filter(Boolean).join(', ') || '—'}
+            </td>
+            <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+              {site.technology_type ?? '—'}
+            </td>
+            <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+              {site.health ? `${site.health.health_score}%` : 'N/A'}
+            </td>
+            <td className="px-4 py-3" style={{ color: 'var(--pm-body)' }}>
+              {site.health?.connected_clients ?? '—'}
+            </td>
+          </tr>
+        ))}
+      </RuledTable>
+    </PortalModernistShell>
   );
 }

--- a/components/portal/modernist/PortalModernistShell.tsx
+++ b/components/portal/modernist/PortalModernistShell.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import type { ReactNode } from 'react';
+
+export function PortalModernistShell({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn('portal-modernist space-y-0', className)}
+      style={{
+        ['--pm-navy' as string]: '#13274A',
+        ['--pm-body' as string]: '#1F2937',
+        ['--pm-accent' as string]: '#F5841E',
+        ['--pm-divider' as string]:
+          'color-mix(in srgb, #13274A 28%, transparent)',
+        ['--pm-ground' as string]:
+          'color-mix(in srgb, #13274A 7%, #FFFFFF)',
+        ['--pm-surface' as string]:
+          'color-mix(in srgb, #13274A 6%, #FFFFFF)',
+        fontFamily: 'var(--font-archivo, ui-sans-serif, system-ui, sans-serif)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function PageHeader({
+  eyebrow,
+  title,
+  subtitle,
+  actions,
+}: {
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <div
+      className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between pb-6 mb-0"
+      style={{ borderBottom: '2px solid var(--pm-divider)' }}
+    >
+      <div>
+        {eyebrow && (
+          <p
+            className="text-[10px] font-extrabold tracking-[0.08em] uppercase mb-2"
+            style={{ color: 'var(--pm-navy)' }}
+          >
+            {eyebrow}
+          </p>
+        )}
+        <h1
+          className="text-3xl sm:text-[40px] font-extrabold leading-tight"
+          style={{ color: 'var(--pm-navy)' }}
+        >
+          {title}
+        </h1>
+        {subtitle && (
+          <p className="mt-1 text-sm" style={{ color: 'var(--pm-body)' }}>
+            {subtitle}
+          </p>
+        )}
+      </div>
+      {actions && <div className="flex flex-wrap gap-2">{actions}</div>}
+    </div>
+  );
+}
+
+export function AlertBand({
+  children,
+  action,
+}: {
+  children: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <div
+      className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 mt-6"
+      style={{ background: 'var(--pm-navy)', color: '#FFFFFF' }}
+    >
+      <div className="text-sm font-medium">{children}</div>
+      {action}
+    </div>
+  );
+}
+
+export function KpiStrip({
+  items,
+}: {
+  items: Array<{ label: string; value: string; note?: string }>;
+}) {
+  return (
+    <div
+      className="grid grid-cols-2 lg:grid-cols-4 mt-6"
+      style={{ border: '2px solid var(--pm-divider)' }}
+    >
+      {items.map((item, i) => (
+        <div
+          key={item.label}
+          className="px-4 py-4"
+          style={{
+            background: 'var(--pm-surface)',
+            borderRight:
+              i < items.length - 1 ? '1px solid var(--pm-divider)' : undefined,
+          }}
+        >
+          <p
+            className="text-[10px] font-extrabold tracking-[0.08em] uppercase"
+            style={{ color: 'var(--pm-navy)' }}
+          >
+            {item.label}
+          </p>
+          <p
+            className="text-2xl font-extrabold mt-1"
+            style={{ color: 'var(--pm-navy)' }}
+          >
+            {item.value}
+          </p>
+          {item.note && (
+            <p className="text-xs mt-1 opacity-70" style={{ color: 'var(--pm-body)' }}>
+              {item.note}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function FilterChips({
+  options,
+  value,
+  onChange,
+}: {
+  options: Array<{ value: string; label: string }>;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div
+      className="inline-flex flex-wrap"
+      style={{ border: '2px solid var(--pm-divider)' }}
+    >
+      {options.map((opt, i) => {
+        const active = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className="px-3 py-2 text-xs font-extrabold tracking-wide uppercase"
+            style={{
+              background: active ? 'var(--pm-navy)' : '#FFFFFF',
+              color: active ? '#FFFFFF' : 'var(--pm-navy)',
+              borderRight:
+                i < options.length - 1
+                  ? '1px solid var(--pm-divider)'
+                  : undefined,
+            }}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function RuledTable({
+  headers,
+  children,
+}: {
+  headers: string[];
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className="mt-6 overflow-x-auto bg-white"
+      style={{ border: '2px solid var(--pm-divider)' }}
+    >
+      <table className="w-full text-sm">
+        <thead>
+          <tr style={{ borderBottom: '2px solid var(--pm-divider)' }}>
+            {headers.map((h) => (
+              <th
+                key={h}
+                className="text-left px-4 py-3 font-extrabold text-[11px] tracking-wide uppercase"
+                style={{ color: 'var(--pm-navy)' }}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}
+
+export function PmButton({
+  children,
+  variant = 'primary',
+  className,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary' | 'ghost';
+}) {
+  const styles: Record<string, React.CSSProperties> = {
+    primary: {
+      background: 'var(--pm-accent)',
+      color: 'var(--pm-navy)',
+      border: 'none',
+    },
+    secondary: {
+      background: '#FFFFFF',
+      color: 'var(--pm-navy)',
+      border: '2px solid var(--pm-divider)',
+    },
+    ghost: {
+      background: 'transparent',
+      color: '#D76026',
+      border: 'none',
+    },
+  };
+
+  const { type = 'button', ...rest } = props;
+
+  return (
+    <button
+      type={type}
+      className={cn(
+        'px-4 py-2 text-sm font-extrabold disabled:opacity-50',
+        className
+      )}
+      style={styles[variant]}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/components/portal/modernist/index.ts
+++ b/components/portal/modernist/index.ts
@@ -1,0 +1,10 @@
+export {
+  PortalModernistShell,
+  PageHeader,
+  AlertBand,
+  KpiStrip,
+  FilterChips,
+  RuledTable,
+  PmButton,
+} from './PortalModernistShell';
+export { portalModernist } from './tokens';

--- a/components/portal/modernist/tokens.ts
+++ b/components/portal/modernist/tokens.ts
@@ -1,0 +1,12 @@
+/** Portal modernist ruled-ledger tokens (CircleTel navy/orange). */
+export const portalModernist = {
+  navy: '#13274A',
+  body: '#1F2937',
+  accent: '#F5841E',
+  accentPressed: '#E97B26',
+  accentDeep: '#D76026',
+  divider: 'color-mix(in srgb, #13274A 28%, transparent)',
+  pageGround: 'color-mix(in srgb, #13274A 7%, #FFFFFF)',
+  surface: 'color-mix(in srgb, #13274A 6%, #FFFFFF)',
+  danger: '#DC2626',
+} as const;

--- a/lib/billing/corporate-clinic-line-items.ts
+++ b/lib/billing/corporate-clinic-line-items.ts
@@ -1,0 +1,117 @@
+/**
+ * Builds itemised invoice line items for B2B corporate accounts:
+ * one Unjani Connect (or package) line per active clinic/site.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface CorporateClinicLineItem {
+  description: string;
+  site_name: string;
+  site_id: string;
+  service: string;
+  sku: string | null;
+  quantity: number;
+  unit_price: number;
+  amount: number;
+  type: 'recurring' | 'pro_rata';
+}
+
+export interface ActiveCorporateSite {
+  id: string;
+  site_name: string;
+  monthly_fee: number | null;
+  package_id: string | null;
+  service_packages?: {
+    name: string | null;
+    sku: string | null;
+    price: number | null;
+  } | null;
+}
+
+const DEFAULT_PRODUCT_NAME = 'Unjani Connect';
+const DEFAULT_SKU = 'UNJ-MC-001';
+const DEFAULT_FEE = 450;
+
+export function formatClinicLineDescription(
+  siteName: string,
+  productName: string = DEFAULT_PRODUCT_NAME,
+  suffix?: string
+): string {
+  const base = `${productName} — ${siteName}`;
+  return suffix ? `${base} (${suffix})` : base;
+}
+
+export function buildClinicLineItem(
+  site: ActiveCorporateSite,
+  options: {
+    type?: 'recurring' | 'pro_rata';
+    amountOverride?: number;
+    suffix?: string;
+  } = {}
+): CorporateClinicLineItem {
+  const pkg = site.service_packages;
+  const productName =
+    pkg?.sku === DEFAULT_SKU || !pkg?.name
+      ? DEFAULT_PRODUCT_NAME
+      : pkg.name;
+  const sku = pkg?.sku ?? DEFAULT_SKU;
+  const unitPrice =
+    options.amountOverride ??
+    Number(site.monthly_fee ?? pkg?.price ?? DEFAULT_FEE);
+  const amount = Math.round(unitPrice * 100) / 100;
+
+  return {
+    description: formatClinicLineDescription(
+      site.site_name,
+      productName,
+      options.suffix
+    ),
+    site_name: site.site_name,
+    site_id: site.id,
+    service: productName,
+    sku,
+    quantity: 1,
+    unit_price: amount,
+    amount,
+    type: options.type ?? 'recurring',
+  };
+}
+
+export async function fetchActiveCorporateSites(
+  supabase: SupabaseClient,
+  organisationId: string
+): Promise<ActiveCorporateSite[]> {
+  const { data, error } = await supabase
+    .from('corporate_sites')
+    .select(
+      `
+      id,
+      site_name,
+      monthly_fee,
+      package_id,
+      service_packages (
+        name,
+        sku,
+        price
+      )
+    `
+    )
+    .eq('corporate_id', organisationId)
+    .eq('status', 'active')
+    .order('site_name', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load active sites: ${error.message}`);
+  }
+
+  return (data ?? []) as unknown as ActiveCorporateSite[];
+}
+
+export async function buildActiveClinicLineItems(
+  supabase: SupabaseClient,
+  organisationId: string
+): Promise<CorporateClinicLineItem[]> {
+  const sites = await fetchActiveCorporateSites(supabase, organisationId);
+  return sites.map((site) => buildClinicLineItem(site));
+}

--- a/lib/billing/corporate-statement-data.ts
+++ b/lib/billing/corporate-statement-data.ts
@@ -1,0 +1,164 @@
+/**
+ * Assemble account statement data for a B2B corporate organisation
+ * (scoped by corporate_account_id, not consumer customer_id).
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  StatementData,
+  StatementTransaction,
+  AgingBuckets,
+} from './statement-pdf-generator';
+import type { StatementOptions } from './statement-data';
+
+function toYMD(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function subtractMonths(date: Date, months: number): Date {
+  const d = new Date(date);
+  d.setMonth(d.getMonth() - months);
+  return d;
+}
+
+function formatMonthYear(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-ZA', { month: 'long', year: 'numeric' });
+}
+
+function computeAging(
+  invoices: Array<{
+    due_date: string;
+    amount_due: string | number | null;
+    status: string | null;
+  }>,
+  today: Date
+): AgingBuckets {
+  const buckets: AgingBuckets = {
+    over120Days: 0,
+    days90: 0,
+    days60: 0,
+    days30: 0,
+    current: 0,
+  };
+
+  for (const inv of invoices) {
+    if (['paid', 'cancelled', 'refunded'].includes(inv.status ?? '')) continue;
+    const dueDate = new Date(inv.due_date);
+    const daysOverdue = Math.floor(
+      (today.getTime() - dueDate.getTime()) / 86400000
+    );
+    const outstanding = parseFloat(String(inv.amount_due ?? '0'));
+
+    if (daysOverdue > 120) buckets.over120Days += outstanding;
+    else if (daysOverdue > 90) buckets.days90 += outstanding;
+    else if (daysOverdue > 60) buckets.days60 += outstanding;
+    else if (daysOverdue > 30) buckets.days30 += outstanding;
+    else buckets.current += outstanding;
+  }
+
+  return buckets;
+}
+
+export async function assembleCorporateStatementData(
+  supabase: SupabaseClient,
+  organisationId: string,
+  options: StatementOptions = {}
+): Promise<{ statement: StatementData; organisationName: string }> {
+  const today = new Date();
+
+  let fromDate: string | null = null;
+  let toDate: string | null = null;
+
+  if (options.from && options.to) {
+    fromDate = options.from;
+    toDate = options.to;
+  } else if (options.period && options.period !== 'all') {
+    const monthsMap: Record<'3m' | '6m' | '12m', number> = {
+      '3m': 3,
+      '6m': 6,
+      '12m': 12,
+    };
+    fromDate = toYMD(subtractMonths(today, monthsMap[options.period]));
+    toDate = toYMD(today);
+  }
+
+  const { data: account, error: accountError } = await supabase
+    .from('corporate_accounts')
+    .select(
+      'id, company_name, corporate_code, primary_contact_email, primary_contact_phone'
+    )
+    .eq('id', organisationId)
+    .single();
+
+  if (accountError || !account) {
+    throw new Error(`Organisation ${organisationId} not found`);
+  }
+
+  let query = supabase
+    .from('customer_invoices')
+    .select(
+      'id, invoice_number, invoice_date, due_date, total_amount, amount_paid, amount_due, status, period_start, period_end, paynow_transaction_ref'
+    )
+    .eq('corporate_account_id', organisationId)
+    .order('invoice_date', { ascending: true });
+
+  if (fromDate !== null && toDate !== null) {
+    query = query.gte('invoice_date', fromDate).lte('invoice_date', toDate);
+  }
+
+  const { data: invoicesRaw, error: invoicesError } = await query;
+  if (invoicesError) {
+    throw new Error(`Failed to fetch invoices: ${invoicesError.message}`);
+  }
+
+  const invoices = invoicesRaw ?? [];
+  const transactions: StatementTransaction[] = [];
+
+  for (const inv of invoices) {
+    const periodLabel =
+      inv.period_start && inv.period_end
+        ? `Unjani Connect — ${formatMonthYear(inv.period_start)}`
+        : 'Service Invoice';
+
+    transactions.push({
+      date: inv.invoice_date,
+      reference: inv.invoice_number ?? inv.id,
+      description: periodLabel,
+      debit: parseFloat(String(inv.total_amount ?? 0)),
+    });
+
+    const paid = parseFloat(String(inv.amount_paid ?? 0));
+    if (paid > 0) {
+      transactions.push({
+        date: inv.invoice_date,
+        reference: inv.paynow_transaction_ref ?? inv.invoice_number ?? inv.id,
+        description: `Payment — ${inv.invoice_number ?? ''}`,
+        credit: paid,
+      });
+    }
+  }
+
+  const aging = computeAging(invoices, today);
+  const totalDue = Object.values(aging).reduce((a, b) => a + b, 0);
+  const totalPaid = invoices.reduce(
+    (sum, inv) => sum + parseFloat(String(inv.amount_paid ?? 0)),
+    0
+  );
+
+  const statement: StatementData = {
+    statementDate: toYMD(today),
+    customer: {
+      name: account.company_name,
+      accountNumber: account.corporate_code ?? `ORG-${organisationId.slice(0, 8)}`,
+      email: account.primary_contact_email ?? undefined,
+      phone: account.primary_contact_phone ?? undefined,
+    },
+    transactions,
+    aging,
+    totalDue,
+    totalPaid,
+  };
+
+  return { statement, organisationName: account.company_name };
+}

--- a/lib/billing/generate-corporate-consolidated-invoice.ts
+++ b/lib/billing/generate-corporate-consolidated-invoice.ts
@@ -1,0 +1,157 @@
+/**
+ * Generate a consolidated corporate invoice with one line per active clinic.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { buildActiveClinicLineItems } from './corporate-clinic-line-items';
+
+const VAT_RATE = 0.15;
+
+export interface GenerateCorporateInvoiceOptions {
+  organisationId: string;
+  periodStart: string; // YYYY-MM-DD
+  periodEnd: string;
+  invoiceDate?: string;
+  dueDate?: string;
+  invoiceType?: string;
+}
+
+export async function generateCorporateConsolidatedInvoice(
+  supabase: SupabaseClient,
+  options: GenerateCorporateInvoiceOptions
+) {
+  const {
+    organisationId,
+    periodStart,
+    periodEnd,
+    invoiceType = 'recurring',
+  } = options;
+
+  const lineItems = await buildActiveClinicLineItems(supabase, organisationId);
+
+  if (lineItems.length === 0) {
+    return { skipped: true as const, reason: 'no_active_sites' };
+  }
+
+  const subtotal =
+    Math.round(lineItems.reduce((sum, li) => sum + li.amount, 0) * 100) / 100;
+  const vatAmount = Math.round(subtotal * VAT_RATE * 100) / 100;
+  const totalAmount = Math.round((subtotal + vatAmount) * 100) / 100;
+
+  const { data: account, error: accountError } = await supabase
+    .from('corporate_accounts')
+    .select(
+      'id, company_name, primary_contact_name, primary_contact_email, primary_contact_phone'
+    )
+    .eq('id', organisationId)
+    .single();
+
+  if (accountError || !account) {
+    throw new Error(`Corporate account ${organisationId} not found`);
+  }
+
+  const email =
+    account.primary_contact_email ||
+    `billing@${account.company_name.toLowerCase().replace(/\s+/g, '')}.co.za`;
+
+  let customerId: string;
+  const { data: existing } = await supabase
+    .from('customers')
+    .select('id')
+    .eq('email', email)
+    .limit(1);
+
+  if (existing && existing.length > 0) {
+    customerId = existing[0].id;
+  } else {
+    const nameParts = (
+      account.primary_contact_name || account.company_name
+    ).split(' ');
+    const { data: created, error: createError } = await supabase
+      .from('customers')
+      .insert({
+        first_name: nameParts[0] || account.company_name,
+        last_name: nameParts.slice(1).join(' ') || 'B2B',
+        email,
+        phone: account.primary_contact_phone || '0000000000',
+      })
+      .select('id')
+      .single();
+
+    if (createError || !created) {
+      throw new Error(
+        `Failed to create customer: ${createError?.message ?? 'unknown'}`
+      );
+    }
+    customerId = created.id;
+  }
+
+  // Idempotency: one recurring consolidated invoice per org per period
+  const { data: dup } = await supabase
+    .from('customer_invoices')
+    .select('id, invoice_number')
+    .eq('corporate_account_id', organisationId)
+    .eq('invoice_type', invoiceType)
+    .eq('period_start', periodStart)
+    .eq('period_end', periodEnd)
+    .is('corporate_site_id', null)
+    .limit(1);
+
+  if (dup && dup.length > 0) {
+    return {
+      skipped: true as const,
+      reason: 'duplicate',
+      invoice_id: dup[0].id,
+      invoice_number: dup[0].invoice_number,
+    };
+  }
+
+  const invoiceDate = options.invoiceDate ?? periodStart;
+  const dueDate =
+    options.dueDate ??
+    (() => {
+      const d = new Date(periodEnd);
+      d.setDate(d.getDate() + 7);
+      return d.toISOString().split('T')[0];
+    })();
+
+  const year = new Date(invoiceDate).getFullYear();
+  const invoiceNumber = `INV-${year}-${String(Math.floor(Math.random() * 99999) + 1).padStart(5, '0')}`;
+
+  const { data: invoice, error } = await supabase
+    .from('customer_invoices')
+    .insert({
+      customer_id: customerId,
+      corporate_account_id: organisationId,
+      corporate_site_id: null,
+      invoice_number: invoiceNumber,
+      invoice_type: invoiceType,
+      invoice_date: invoiceDate,
+      due_date: dueDate,
+      period_start: periodStart,
+      period_end: periodEnd,
+      subtotal,
+      vat_rate: VAT_RATE,
+      tax_amount: vatAmount,
+      total_amount: totalAmount,
+      amount_due: totalAmount,
+      amount_paid: 0,
+      line_items: lineItems,
+      status: 'unpaid',
+      notes: `Consolidated Unjani Connect invoice for ${account.company_name} — ${lineItems.length} active clinic(s)`,
+    })
+    .select('id, invoice_number, total_amount, line_items')
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create consolidated invoice: ${error.message}`);
+  }
+
+  return {
+    skipped: false as const,
+    invoice_id: invoice.id,
+    invoice_number: invoice.invoice_number,
+    total_amount: invoice.total_amount,
+    line_count: lineItems.length,
+  };
+}

--- a/lib/inngest/functions/b2b-site-activation-invoice.ts
+++ b/lib/inngest/functions/b2b-site-activation-invoice.ts
@@ -115,7 +115,11 @@ export const b2bSiteActivationInvoice = inngest.createFunction(
 
         const lineItems = [
           {
-            description: `Pro-rata: ${siteName} — ${remainingDays}/${daysInMonth} days (${periodStart} to ${periodEnd})`,
+            description: `Unjani Connect — ${siteName} (pro-rata ${remainingDays}/${daysInMonth} days, ${periodStart} to ${periodEnd})`,
+            site_name: siteName,
+            site_id: site_id,
+            service: 'Unjani Connect',
+            sku: 'UNJ-MC-001',
             quantity: 1,
             unit_price: proRataAmount,
             amount: proRataAmount,

--- a/lib/portal/portal-auth-provider.tsx
+++ b/lib/portal/portal-auth-provider.tsx
@@ -22,6 +22,8 @@ interface PortalAuthContextType {
   loading: boolean;
   isAuthenticated: boolean;
   isAdmin: boolean;
+  /** Alias: Super User = DB role admin (max one per org) */
+  isSuperUser: boolean;
   isSiteUser: boolean;
   signOut: () => Promise<void>;
   refresh: () => Promise<void>;
@@ -87,6 +89,7 @@ export function PortalAuthProvider({ children }: { children: React.ReactNode }) 
     loading,
     isAuthenticated: !!user,
     isAdmin: user?.role === 'admin',
+    isSuperUser: user?.role === 'admin',
     isSiteUser: user?.role === 'site_user',
     signOut,
     refresh: fetchPortalUser,

--- a/lib/portal/require-portal-user.ts
+++ b/lib/portal/require-portal-user.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from 'next/server';
+import { createClient, createClientWithSession } from '@/lib/supabase/server';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface PortalUserRow {
+  id: string;
+  auth_user_id: string;
+  organisation_id: string;
+  site_id: string | null;
+  role: 'admin' | 'site_user';
+  display_name: string;
+  email: string;
+  organisation_name: string;
+  organisation_code: string;
+}
+
+type PortalAuthSuccess = {
+  ok: true;
+  authUserId: string;
+  portalUser: PortalUserRow;
+  /** Service-role client for privileged writes after authz */
+  adminDb: SupabaseClient;
+  /** Session client (RLS) */
+  sessionDb: SupabaseClient;
+};
+
+type PortalAuthFailure = {
+  ok: false;
+  response: NextResponse;
+};
+
+export type PortalAuthResult = PortalAuthSuccess | PortalAuthFailure;
+
+async function loadPortalUser(
+  adminDb: SupabaseClient,
+  authUserId: string
+): Promise<PortalUserRow | null> {
+  const { data, error } = await adminDb
+    .from('b2b_portal_users')
+    .select(`
+      id,
+      auth_user_id,
+      organisation_id,
+      site_id,
+      role,
+      display_name,
+      email,
+      corporate_accounts!inner (
+        company_name,
+        corporate_code
+      )
+    `)
+    .eq('auth_user_id', authUserId)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  const org = data.corporate_accounts as unknown as {
+    company_name: string;
+    corporate_code: string;
+  };
+
+  return {
+    id: data.id,
+    auth_user_id: data.auth_user_id,
+    organisation_id: data.organisation_id,
+    site_id: data.site_id,
+    role: data.role as 'admin' | 'site_user',
+    display_name: data.display_name,
+    email: data.email,
+    organisation_name: org?.company_name ?? '',
+    organisation_code: org?.corporate_code ?? '',
+  };
+}
+
+export async function requirePortalUser(): Promise<PortalAuthResult> {
+  const sessionDb = await createClientWithSession();
+  const {
+    data: { user },
+    error: authError,
+  } = await sessionDb.auth.getUser();
+
+  if (authError || !user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    };
+  }
+
+  const adminDb = await createClient();
+  const portalUser = await loadPortalUser(adminDb, user.id);
+
+  if (!portalUser) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'No portal access' }, { status: 403 }),
+    };
+  }
+
+  return {
+    ok: true,
+    authUserId: user.id,
+    portalUser,
+    adminDb,
+    sessionDb,
+  };
+}
+
+/** Super User = DB role `admin` (max one per organisation). */
+export async function requirePortalSuperUser(): Promise<PortalAuthResult> {
+  const result = await requirePortalUser();
+  if (!result.ok) return result;
+
+  if (result.portalUser.role !== 'admin') {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Super User access required' },
+        { status: 403 }
+      ),
+    };
+  }
+
+  return result;
+}

--- a/middleware/portal-auth.ts
+++ b/middleware/portal-auth.ts
@@ -56,5 +56,29 @@ export async function handlePortalAuth(
     };
   }
 
+  // Require a b2b_portal_users mapping (RLS: own row)
+  const { data: portalUser, error: portalError } = await supabase
+    .from('b2b_portal_users')
+    .select('id')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (portalError) {
+    console.warn('Portal user lookup error', { error: portalError.message });
+  }
+
+  if (!portalUser) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = '/portal/login';
+    redirectUrl.searchParams.set('error', 'no_portal_access');
+
+    // Sign-out is client-side; redirect away from protected pages
+    return {
+      shouldRedirect: true,
+      redirectResponse: NextResponse.redirect(redirectUrl),
+      user: null,
+    };
+  }
+
   return { shouldRedirect: false, user };
 }

--- a/supabase/migrations/20260806220000_b2b_portal_phase1.sql
+++ b/supabase/migrations/20260806220000_b2b_portal_phase1.sql
@@ -1,0 +1,60 @@
+-- B2B Portal Phase 1: one Super User (admin) per org + coverage check history
+
+-- At most one Super User (role = admin) per organisation
+CREATE UNIQUE INDEX IF NOT EXISTS idx_b2b_portal_users_one_admin_per_org
+  ON public.b2b_portal_users (organisation_id)
+  WHERE role = 'admin';
+
+COMMENT ON INDEX public.idx_b2b_portal_users_one_admin_per_org IS
+  'Enforces max one Super User (admin) per corporate organisation';
+
+-- Coverage check audit trail for portal (and future B2B tenants)
+CREATE TABLE IF NOT EXISTS public.b2b_coverage_checks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organisation_id uuid NOT NULL REFERENCES public.corporate_accounts(id) ON DELETE CASCADE,
+  created_by uuid NOT NULL REFERENCES public.b2b_portal_users(id) ON DELETE CASCADE,
+  clinic_name text,
+  address text NOT NULL,
+  latitude double precision NOT NULL,
+  longitude double precision NOT NULL,
+  results jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_b2b_coverage_checks_org
+  ON public.b2b_coverage_checks (organisation_id, created_at DESC);
+
+COMMENT ON TABLE public.b2b_coverage_checks IS
+  'Portal coverage/feasibility checks (Tarana/FWB + LTE/5G) for B2B onboarding';
+
+ALTER TABLE public.b2b_coverage_checks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on b2b_coverage_checks"
+  ON public.b2b_coverage_checks FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY "Portal users can read own org coverage checks"
+  ON public.b2b_coverage_checks FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.b2b_portal_users pu
+      WHERE pu.auth_user_id = auth.uid()
+        AND pu.organisation_id = b2b_coverage_checks.organisation_id
+    )
+  );
+
+CREATE POLICY "Portal admins can insert coverage checks"
+  ON public.b2b_coverage_checks FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.b2b_portal_users pu
+      WHERE pu.auth_user_id = auth.uid()
+        AND pu.organisation_id = b2b_coverage_checks.organisation_id
+        AND pu.role = 'admin'
+        AND pu.id = b2b_coverage_checks.created_by
+    )
+  );
+
+-- Note: Super Users list teammates via service-role portal team APIs
+-- (avoid recursive RLS on b2b_portal_users).


### PR DESCRIPTION
## Summary
- Extend `/portal` with Super User team management (max one `admin` per org), coverage checks that raise onboarding tickets (PDF steps 1–3), and itemised Unjani Connect billing + corporate statements.
- Add modernist ruled-ledger portal chrome and migration for `b2b_coverage_checks` + unique Super User index.
- Keep modules tenant-generic (`corporate_accounts`) so future B2B orgs reuse the same paths — no DebiCheck/nurse banking in this slice.

## Test plan
- [ ] Bootstrap Unjani Super User via admin B2B customers (if missing); confirm second Super User invite is rejected
- [ ] `/portal/team` — invite and remove a `site_user` for a clinic site
- [ ] `/portal/coverage` — run Tarana + 5G/LTE check, Proceed → ticket emailed to `onboarding@circletel.co.za`
- [ ] `/portal/billing` — expand invoice to see one Unjani Connect line per clinic; download invoice PDF
- [ ] `/portal/billing/statement` — period filter + PDF download
- [ ] `/portal/support` — log a support ticket as Super User
- [ ] Confirm middleware blocks authenticated users without `b2b_portal_users` mapping
- [ ] Unit tests: `npx jest __tests__/lib/billing/corporate-clinic-line-items.test.ts __tests__/lib/portal/require-portal-user-labels.test.ts`


Made with [Cursor](https://cursor.com)